### PR TITLE
Reload terminal configuration safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ The file uses
 [Ghostty's configuration format](https://ghostty.org/docs/config/reference),
 but remains separate from Ghostty.app so the two applications can evolve
 independently. Appearance, keyboard, worktree, agent, and host preferences are
-also available in **Settings**.
+also available in **Settings**. Ghosthub automatically reloads the active
+configuration when the base file, a project override, or a recursively included
+file changes. Use **Ghosthub → Reload Configuration** when you want an explicit
+reload and diagnostic result.
 
 ## Useful shortcuts
 
@@ -164,6 +167,7 @@ also available in **Settings**.
 | <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> | Open Quick Launch |
 | <kbd>⌘</kbd><kbd>B</kbd> | Show or hide the sidebar |
 | <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> | Create a worktree in the selected project |
+| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>,</kbd> | Reload terminal configuration |
 | <kbd>⌘</kbd><kbd>,</kbd> | Open Settings |
 | <kbd>⌘</kbd><kbd>W</kbd> | Detach the current presentation |
 

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -90,7 +90,7 @@ struct GhosthubApp: App {
                 }
                 .keyboardShortcut(",")
                 Button("Reload Configuration") {
-                    terminalRuntime.reloadActiveConfig()
+                    focusedSceneModel?.reloadTerminalConfig()
                 }
                 .keyboardShortcut(
                     ",",

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -89,6 +89,13 @@ struct GhosthubApp: App {
                         .isSettingsPresented = true
                 }
                 .keyboardShortcut(",")
+                Button("Reload Configuration") {
+                    terminalRuntime.reloadActiveConfig()
+                }
+                .keyboardShortcut(
+                    ",",
+                    modifiers: [.command, .shift]
+                )
                 Divider()
                 Button("Application Log") {
                     focusedSceneModel?

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -134,7 +134,12 @@ final class WorkspaceSceneModel: ObservableObject {
     /// window is the key window.  Used to disambiguate app-wide
     /// events (keyboard shortcuts, split actions without source
     /// identity) so only the focused window handles them.
-    var isFocusedWindow = false
+    var isFocusedWindow = false {
+        didSet {
+            guard isFocusedWindow, !oldValue else { return }
+            syncTerminalConfig()
+        }
+    }
     @Published var selection: WorkspaceSelection {
         didSet {
             syncTerminalConfig()
@@ -1178,10 +1183,21 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func syncTerminalConfig() {
+        guard isFocusedWindow else { return }
         terminalRuntime.reloadConfig(
             projectRoot: selection.terminalConfigRoot(
                 in: snapshot
             )
+        )
+    }
+
+    func reloadTerminalConfig() {
+        terminalRuntime.reloadConfig(
+            projectRoot: selection.terminalConfigRoot(
+                in: snapshot
+            ),
+            force: true,
+            notifyOnSuccess: true
         )
     }
 

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import GhosthubSettings
 import GhosthubTerminal
+import GhosthubTerminalSupport
 import GhosthubUI
 import GhosthubWorkspace
 #if canImport(AppKit)
@@ -420,6 +421,8 @@ struct WorkspaceWindow: View {
     @StateObject private var sceneModel = WorkspaceSceneModel()
     @EnvironmentObject private var terminalRuntime: LibghosttyRuntime
     @ObservedObject private var settingsStore = SettingsStore.shared
+    @State private var visibleConfigReloadNotice:
+        LibghosttyConfigReloadNotice?
     private let registry = WindowRegistry.shared
 
     var body: some View {
@@ -509,6 +512,9 @@ struct WorkspaceWindow: View {
                 dismissLogViewer: { [sceneModel] in
                     sceneModel.dismissLogViewer()
                 },
+                reloadTerminalConfig: {
+                    terminalRuntime.reloadActiveConfig()
+                },
                 openTmuxSession: { [sceneModel] selection in
                     sceneModel.openBorrowedTmuxSession(selection)
                 },
@@ -552,6 +558,23 @@ struct WorkspaceWindow: View {
         )
         .focusedSceneValue(\.sceneModel, sceneModel)
         .background(WorkspaceSurfaceColor.color.ignoresSafeArea())
+        .overlay(alignment: .top) {
+            if let notice = visibleConfigReloadNotice {
+                ConfigReloadNoticeView(
+                    notice: notice,
+                    onDismiss: {
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            visibleConfigReloadNotice = nil
+                        }
+                    }
+                )
+                .padding(.top, 8)
+                .padding(.horizontal, 12)
+                .transition(
+                    .move(edge: .top).combined(with: .opacity)
+                )
+            }
+        }
         #if canImport(AppKit)
             .background(
                 WindowFocusTracker(
@@ -594,6 +617,25 @@ struct WorkspaceWindow: View {
             .onAppear {
                 registry.register(sceneModel)
             }
+            .onReceive(
+                terminalRuntime.$configReloadNotice
+            ) { notice in
+                guard let notice else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    visibleConfigReloadNotice = notice
+                }
+            }
+            .task(id: visibleConfigReloadNotice?.id) {
+                guard visibleConfigReloadNotice?.kind == .success
+                else { return }
+                try? await Task.sleep(
+                    nanoseconds: 2_500_000_000
+                )
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    visibleConfigReloadNotice = nil
+                }
+            }
             .onDisappear {
                 registry.unregister(sceneModel)
                 Task { [sceneModel] in
@@ -608,5 +650,47 @@ struct WorkspaceWindow: View {
             selection: sceneModel.selection
         ) else { return false }
         return sceneModel.snapshot.canCreateWorktree(in: project)
+    }
+}
+
+private struct ConfigReloadNoticeView: View {
+    let notice: LibghosttyConfigReloadNotice
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(
+                systemName: notice.kind == .success
+                    ? "checkmark.circle.fill"
+                    : "exclamationmark.triangle.fill"
+            )
+            .foregroundStyle(
+                notice.kind == .success ? .green : .orange
+            )
+
+            Text(notice.message)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(3)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss configuration message")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(
+            cornerRadius: 8,
+            style: .continuous
+        ))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(.separator.opacity(0.7), lineWidth: 0.5)
+        }
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 3)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(notice.message)
     }
 }

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -493,7 +493,7 @@ struct WorkspaceWindow: View {
                                         .peerLoadResult
                                 },
                                 reloadTerminalConfig: {
-                                    terminalRuntime.reloadActiveConfig()
+                                    sceneModel.reloadTerminalConfig()
                                 }
                             )
                         )
@@ -513,7 +513,7 @@ struct WorkspaceWindow: View {
                     sceneModel.dismissLogViewer()
                 },
                 reloadTerminalConfig: {
-                    terminalRuntime.reloadActiveConfig()
+                    sceneModel.reloadTerminalConfig()
                 },
                 openTmuxSession: { [sceneModel] selection in
                     sceneModel.openBorrowedTmuxSession(selection)

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -620,7 +620,6 @@ struct WorkspaceWindow: View {
             .onReceive(
                 terminalRuntime.$configReloadNotice
             ) { notice in
-                guard let notice else { return }
                 withAnimation(.easeOut(duration: 0.15)) {
                     visibleConfigReloadNotice = notice
                 }

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -323,7 +323,12 @@ public final class LibghosttyRuntime: ObservableObject {
         guard configMonitor == nil else { return }
 
         let monitor = LibghosttyConfigFileMonitor(
-            fileURLs: plan.watchedConfigFiles
+            fileURLs: plan.watchedConfigFiles,
+            errorHandler: { [weak self] error in
+                Task { @MainActor in
+                    self?.diagnostics.append(error.localizedDescription)
+                }
+            }
         ) { [weak self] in
                 guard let self else { return }
                 Task { @MainActor in
@@ -339,6 +344,7 @@ public final class LibghosttyRuntime: ObservableObject {
             configMonitor = monitor
         } catch {
             diagnostics.append(error.localizedDescription)
+            configMonitor = monitor
         }
     }
 

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -212,6 +212,7 @@ public final class LibghosttyRuntime: ObservableObject {
             }
             clearMonitorFailure()
             diagnostics = []
+            configReloadNotice = nil
             if notifyOnSuccess {
                 configReloadNotice = LibghosttyConfigReloadNotice(
                     kind: .success,

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -275,7 +275,8 @@ public final class LibghosttyRuntime: ObservableObject {
         }
 
         do {
-            let plan = try pipeline.loadPlan()
+            let prepared = try prepareConfigLoad(projectRoot: nil)
+            let plan = prepared.plan
             let config = try loadConfig(plan: plan)
             var runtimeConfig = ghostty_runtime_config_s()
             runtimeConfig.userdata = Unmanaged.passUnretained(self).toOpaque()
@@ -301,7 +302,11 @@ public final class LibghosttyRuntime: ObservableObject {
             configPlan = plan
             diagnostics = readDiagnostics(from: config)
             installApplicationObservers()
-            installConfigMonitorIfNeeded(plan: plan)
+            if let monitorFailure = prepared.monitorFailure {
+                recordMonitorFailure(monitorFailure)
+            } else {
+                clearMonitorFailure()
+            }
             phase = .ready
         } catch {
             phase = .failed(error.localizedDescription)
@@ -404,22 +409,6 @@ public final class LibghosttyRuntime: ObservableObject {
                 ghostty_app_set_focus(appHandle, false)
             }
         )
-    }
-
-    private func installConfigMonitorIfNeeded(
-        plan: LibghosttyConfigLoadPlan
-    ) {
-        guard configMonitor == nil else { return }
-        let monitor = makeConfigMonitor(for: plan)
-
-        do {
-            try monitor.start()
-            configMonitor = monitor
-            clearMonitorFailure()
-        } catch {
-            configMonitor = monitor
-            recordMonitorFailure(error.localizedDescription)
-        }
     }
 
     private func updateConfigMonitor(

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -448,6 +448,7 @@ public final class LibghosttyRuntime: ObservableObject {
         publishNotice: Bool = true
     ) {
         let isDuplicate = monitorFailureMessage == message
+            && configReloadNotice?.id == monitorFailureNoticeID
         if let previous = monitorFailureMessage,
            previous != message {
             diagnostics.removeAll { $0 == previous }

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -8,6 +8,16 @@ import UniformTypeIdentifiers
 
 @MainActor
 public final class LibghosttyRuntime: ObservableObject {
+    struct ConfigMonitorRequest {
+        let files: [URL]
+        let errorHandler: LibghosttyConfigFileMonitor.ErrorHandler
+        let changeHandler: LibghosttyConfigFileMonitor.ChangeHandler
+    }
+
+    typealias ConfigMonitorFactory = (
+        ConfigMonitorRequest
+    ) -> LibghosttyConfigFileMonitor
+
     struct ClipboardWriteEntry: Equatable {
         let mime: String
         let data: String
@@ -34,6 +44,7 @@ public final class LibghosttyRuntime: ObservableObject {
     public let renderTracker = SurfaceRenderTracker()
 
     private let pipeline: LibghosttyConfigPipeline
+    private let configMonitorFactory: ConfigMonitorFactory
     private nonisolated(unsafe) var appHandle: ghostty_app_t?
     private nonisolated(unsafe) var configHandle: ghostty_config_t?
     private var activeConfigRoot: URL?
@@ -58,11 +69,30 @@ public final class LibghosttyRuntime: ObservableObject {
         configHandle
     }
 
-    public init(
+    public convenience init(
         pipeline: LibghosttyConfigPipeline = .live,
         runtimeState: LibghosttyRuntimeState? = nil
     ) {
+        self.init(
+            pipeline: pipeline,
+            runtimeState: runtimeState,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            }
+        )
+    }
+
+    init(
+        pipeline: LibghosttyConfigPipeline,
+        runtimeState: LibghosttyRuntimeState? = nil,
+        configMonitorFactory: @escaping ConfigMonitorFactory
+    ) {
         self.pipeline = pipeline
+        self.configMonitorFactory = configMonitorFactory
         self.runtimeState = runtimeState ?? LibghosttyRuntimeState()
         bootstrapStatus = .ready()
         phase = .loadingConfig
@@ -138,14 +168,23 @@ public final class LibghosttyRuntime: ObservableObject {
             let plan = try pipeline.loadPlan(projectRoot: projectRoot)
             let config = try loadConfig(plan: plan)
             let candidateDiagnostics = readDiagnostics(from: config)
-            updateConfigMonitor(for: plan)
+            let monitorFailure: String?
+            do {
+                try updateConfigMonitor(for: plan)
+                monitorFailure = nil
+            } catch {
+                monitorFailure = error.localizedDescription
+            }
 
             guard candidateDiagnostics.isEmpty else {
                 ghostty_config_free(config)
                 diagnostics = candidateDiagnostics
+                if let monitorFailure {
+                    diagnostics.append(monitorFailure)
+                }
                 phase = .ready
-                publishReloadFailure(candidateDiagnostics)
-                return .rejected(candidateDiagnostics)
+                publishReloadFailure(diagnostics)
+                return .rejected(diagnostics)
             }
 
             if let target,
@@ -158,8 +197,13 @@ public final class LibghosttyRuntime: ObservableObject {
                 replaceConfigHandle(with: config)
             }
             configPlan = plan
-            diagnostics = []
             phase = .ready
+            if let monitorFailure {
+                diagnostics = [monitorFailure]
+                publishMonitorFailure(monitorFailure)
+                return .appliedWithWarnings(diagnostics)
+            }
+            diagnostics = []
             if notifyOnSuccess {
                 configReloadNotice = LibghosttyConfigReloadNotice(
                     kind: .success,
@@ -321,23 +365,7 @@ public final class LibghosttyRuntime: ObservableObject {
         plan: LibghosttyConfigLoadPlan
     ) {
         guard configMonitor == nil else { return }
-
-        let monitor = LibghosttyConfigFileMonitor(
-            fileURLs: plan.watchedConfigFiles,
-            errorHandler: { [weak self] error in
-                Task { @MainActor in
-                    self?.diagnostics.append(error.localizedDescription)
-                }
-            }
-        ) { [weak self] in
-                guard let self else { return }
-                Task { @MainActor in
-                    self.reloadActiveConfig(
-                        force: true,
-                        notifyOnSuccess: true
-                    )
-                }
-            }
+        let monitor = makeConfigMonitor(for: plan)
 
         do {
             try monitor.start()
@@ -350,18 +378,48 @@ public final class LibghosttyRuntime: ObservableObject {
 
     private func updateConfigMonitor(
         for plan: LibghosttyConfigLoadPlan
-    ) {
-        guard let configMonitor else {
-            installConfigMonitorIfNeeded(plan: plan)
-            return
-        }
-        do {
+    ) throws {
+        if let configMonitor {
             try configMonitor.update(
                 fileURLs: plan.watchedConfigFiles
             )
-        } catch {
-            diagnostics.append(error.localizedDescription)
+            return
         }
+
+        let monitor = makeConfigMonitor(for: plan)
+        do {
+            try monitor.start()
+            configMonitor = monitor
+        } catch {
+            configMonitor = monitor
+            throw error
+        }
+    }
+
+    private func makeConfigMonitor(
+        for plan: LibghosttyConfigLoadPlan
+    ) -> LibghosttyConfigFileMonitor {
+        configMonitorFactory(
+            ConfigMonitorRequest(
+                files: plan.watchedConfigFiles,
+                errorHandler: { [weak self] error in
+                    Task { @MainActor in
+                        self?.diagnostics.append(
+                            error.localizedDescription
+                        )
+                    }
+                },
+                changeHandler: { [weak self] in
+                    guard let self else { return }
+                    Task { @MainActor in
+                        self.reloadActiveConfig(
+                            force: true,
+                            notifyOnSuccess: true
+                        )
+                    }
+                }
+            )
+        )
     }
 
     private func publishReloadFailure(_ messages: [String]) {
@@ -373,6 +431,16 @@ public final class LibghosttyRuntime: ObservableObject {
         configReloadNotice = LibghosttyConfigReloadNotice(
             kind: .error,
             message: "Configuration not reloaded: \(first)\(suffix)"
+        )
+    }
+
+    private func publishMonitorFailure(_ message: String) {
+        configReloadNotice = LibghosttyConfigReloadNotice(
+            kind: .error,
+            message: """
+            Terminal configuration reloaded, but automatic reload monitoring \
+            is degraded: \(message)
+            """
         )
     }
 

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -128,13 +128,14 @@ public final class LibghosttyRuntime: ObservableObject {
     @discardableResult
     public func reloadConfig(
         projectRoot: URL? = nil,
-        force: Bool = false
+        force: Bool = false,
+        notifyOnSuccess: Bool = false
     ) -> LibghosttyConfigReloadResult {
         reloadConfig(
             target: nil,
             projectRoot: projectRoot,
             force: force,
-            notifyOnSuccess: false
+            notifyOnSuccess: notifyOnSuccess
         )
     }
 
@@ -167,16 +168,13 @@ public final class LibghosttyRuntime: ObservableObject {
         activeConfigRoot = projectRoot
 
         do {
-            let plan = try pipeline.loadPlan(projectRoot: projectRoot)
+            let prepared = try prepareConfigLoad(
+                projectRoot: projectRoot
+            )
+            let plan = prepared.plan
+            let monitorFailure = prepared.monitorFailure
             let config = try loadConfig(plan: plan)
             let candidateDiagnostics = readDiagnostics(from: config)
-            let monitorFailure: String?
-            do {
-                try updateConfigMonitor(for: plan)
-                monitorFailure = nil
-            } catch {
-                monitorFailure = error.localizedDescription
-            }
 
             guard candidateDiagnostics.isEmpty else {
                 ghostty_config_free(config)
@@ -225,6 +223,44 @@ public final class LibghosttyRuntime: ObservableObject {
             diagnostics = [error.localizedDescription]
             publishReloadFailure(diagnostics)
             return .failed(error.localizedDescription)
+        }
+    }
+
+    private func prepareConfigLoad(
+        projectRoot: URL?
+    ) throws -> (
+        plan: LibghosttyConfigLoadPlan,
+        monitorFailure: String?
+    ) {
+        var plan = try pipeline.loadPlan(projectRoot: projectRoot)
+        var remainingAttempts = 4
+
+        while true {
+            let monitorFailure: String?
+            do {
+                try updateConfigMonitor(for: plan)
+                monitorFailure = nil
+            } catch {
+                monitorFailure = error.localizedDescription
+            }
+
+            let refreshedPlan = try pipeline.loadPlan(
+                projectRoot: projectRoot
+            )
+            let graphIsStable =
+                plan.orderedConfigFiles
+                    == refreshedPlan.orderedConfigFiles
+                && plan.watchedConfigFiles
+                    == refreshedPlan.watchedConfigFiles
+            if graphIsStable {
+                return (refreshedPlan, monitorFailure)
+            }
+            guard remainingAttempts > 0 else {
+                throw LibghosttyInitializationError
+                    .unstableConfigGraph
+            }
+            remainingAttempts -= 1
+            plan = refreshedPlan
         }
     }
 
@@ -1002,6 +1038,7 @@ private func resizeSplitDirection(
 private enum LibghosttyInitializationError: LocalizedError {
     case createConfig
     case createApp
+    case unstableConfigGraph
 
     var errorDescription: String? {
         switch self {
@@ -1009,6 +1046,8 @@ private enum LibghosttyInitializationError: LocalizedError {
             return "ghostty_config_new failed"
         case .createApp:
             return "ghostty_app_new failed"
+        case .unstableConfigGraph:
+            return "Terminal configuration changed repeatedly while reloading."
         }
     }
 }

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -49,6 +49,8 @@ public final class LibghosttyRuntime: ObservableObject {
     private nonisolated(unsafe) var configHandle: ghostty_config_t?
     private var activeConfigRoot: URL?
     private var configMonitor: LibghosttyConfigFileMonitor?
+    private var monitorFailureMessage: String?
+    private var monitorFailureNoticeID: UUID?
     private nonisolated(unsafe) var notificationObservers: [NSObjectProtocol] = []
     private static var didInitializeLibrary = false
 
@@ -180,7 +182,12 @@ public final class LibghosttyRuntime: ObservableObject {
                 ghostty_config_free(config)
                 diagnostics = candidateDiagnostics
                 if let monitorFailure {
-                    diagnostics.append(monitorFailure)
+                    recordMonitorFailure(
+                        monitorFailure,
+                        publishNotice: false
+                    )
+                } else {
+                    clearMonitorFailure()
                 }
                 phase = .ready
                 publishReloadFailure(diagnostics)
@@ -199,10 +206,11 @@ public final class LibghosttyRuntime: ObservableObject {
             configPlan = plan
             phase = .ready
             if let monitorFailure {
-                diagnostics = [monitorFailure]
-                publishMonitorFailure(monitorFailure)
+                diagnostics = []
+                recordMonitorFailure(monitorFailure)
                 return .appliedWithWarnings(diagnostics)
             }
+            clearMonitorFailure()
             diagnostics = []
             if notifyOnSuccess {
                 configReloadNotice = LibghosttyConfigReloadNotice(
@@ -370,9 +378,10 @@ public final class LibghosttyRuntime: ObservableObject {
         do {
             try monitor.start()
             configMonitor = monitor
+            clearMonitorFailure()
         } catch {
-            diagnostics.append(error.localizedDescription)
             configMonitor = monitor
+            recordMonitorFailure(error.localizedDescription)
         }
     }
 
@@ -404,7 +413,7 @@ public final class LibghosttyRuntime: ObservableObject {
                 files: plan.watchedConfigFiles,
                 errorHandler: { [weak self] error in
                     Task { @MainActor in
-                        self?.diagnostics.append(
+                        self?.recordMonitorFailure(
                             error.localizedDescription
                         )
                     }
@@ -434,14 +443,40 @@ public final class LibghosttyRuntime: ObservableObject {
         )
     }
 
-    private func publishMonitorFailure(_ message: String) {
-        configReloadNotice = LibghosttyConfigReloadNotice(
+    private func recordMonitorFailure(
+        _ message: String,
+        publishNotice: Bool = true
+    ) {
+        let isDuplicate = monitorFailureMessage == message
+        if let previous = monitorFailureMessage,
+           previous != message {
+            diagnostics.removeAll { $0 == previous }
+        }
+        monitorFailureMessage = message
+        if !diagnostics.contains(message) {
+            diagnostics.append(message)
+        }
+        guard publishNotice, !isDuplicate else { return }
+
+        let notice = LibghosttyConfigReloadNotice(
             kind: .error,
             message: """
-            Terminal configuration reloaded, but automatic reload monitoring \
-            is degraded: \(message)
+            Automatic terminal configuration reload monitoring is degraded: \
+            \(message)
             """
         )
+        monitorFailureNoticeID = notice.id
+        configReloadNotice = notice
+    }
+
+    private func clearMonitorFailure() {
+        guard let message = monitorFailureMessage else { return }
+        diagnostics.removeAll { $0 == message }
+        monitorFailureMessage = nil
+        if configReloadNotice?.id == monitorFailureNoticeID {
+            configReloadNotice = nil
+        }
+        monitorFailureNoticeID = nil
     }
 
     private static func ensureLibraryInitialized() -> Bool {

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -27,6 +27,8 @@ public final class LibghosttyRuntime: ObservableObject {
     @Published public private(set) var phase: LibghosttyRuntimePhase
     @Published public private(set) var configPlan: LibghosttyConfigLoadPlan?
     @Published public private(set) var diagnostics: [String]
+    @Published public private(set) var configReloadNotice:
+        LibghosttyConfigReloadNotice?
 
     public let runtimeState: LibghosttyRuntimeState
     public let renderTracker = SurfaceRenderTracker()
@@ -52,6 +54,10 @@ public final class LibghosttyRuntime: ObservableObject {
         appHandle
     }
 
+    var unsafeConfigHandle: ghostty_config_t? {
+        configHandle
+    }
+
     public init(
         pipeline: LibghosttyConfigPipeline = .live,
         runtimeState: LibghosttyRuntimeState? = nil
@@ -61,6 +67,7 @@ public final class LibghosttyRuntime: ObservableObject {
         bootstrapStatus = .ready()
         phase = .loadingConfig
         diagnostics = []
+        configReloadNotice = nil
 
         initializeLibghostty()
     }
@@ -86,28 +93,60 @@ public final class LibghosttyRuntime: ObservableObject {
         }
     }
 
-    public func reloadConfig(projectRoot: URL? = nil, force: Bool = false) {
-        reloadConfig(target: nil, projectRoot: projectRoot, force: force)
+    @discardableResult
+    public func reloadConfig(
+        projectRoot: URL? = nil,
+        force: Bool = false
+    ) -> LibghosttyConfigReloadResult {
+        reloadConfig(
+            target: nil,
+            projectRoot: projectRoot,
+            force: force,
+            notifyOnSuccess: false
+        )
     }
 
-    public func reloadActiveConfig(force: Bool = true) {
-        reloadConfig(projectRoot: activeConfigRoot, force: force)
+    @discardableResult
+    public func reloadActiveConfig(
+        force: Bool = true,
+        notifyOnSuccess: Bool = true
+    ) -> LibghosttyConfigReloadResult {
+        reloadConfig(
+            target: nil,
+            projectRoot: activeConfigRoot,
+            force: force,
+            notifyOnSuccess: notifyOnSuccess
+        )
     }
 
+    @discardableResult
     public func reloadConfig(
         target: ghostty_target_s?,
         projectRoot: URL? = nil,
-        force: Bool = false
-    ) {
-        guard let appHandle else { return }
-        guard force || activeConfigRoot != projectRoot else { return }
+        force: Bool = false,
+        notifyOnSuccess: Bool = false
+    ) -> LibghosttyConfigReloadResult {
+        guard let appHandle else {
+            return .failed("libghostty is not initialized.")
+        }
+        guard force || activeConfigRoot != projectRoot else {
+            return .unchanged
+        }
         activeConfigRoot = projectRoot
 
         do {
             let plan = try pipeline.loadPlan(projectRoot: projectRoot)
             let config = try loadConfig(plan: plan)
-            configPlan = plan
-            diagnostics = readDiagnostics(from: config)
+            let candidateDiagnostics = readDiagnostics(from: config)
+            updateConfigMonitor(for: plan)
+
+            guard candidateDiagnostics.isEmpty else {
+                ghostty_config_free(config)
+                diagnostics = candidateDiagnostics
+                phase = .ready
+                publishReloadFailure(candidateDiagnostics)
+                return .rejected(candidateDiagnostics)
+            }
 
             if let target,
                target.tag == GHOSTTY_TARGET_SURFACE,
@@ -118,10 +157,21 @@ public final class LibghosttyRuntime: ObservableObject {
                 ghostty_app_update_config(appHandle, config)
                 replaceConfigHandle(with: config)
             }
+            configPlan = plan
+            diagnostics = []
             phase = .ready
+            if notifyOnSuccess {
+                configReloadNotice = LibghosttyConfigReloadNotice(
+                    kind: .success,
+                    message: "Terminal configuration reloaded."
+                )
+            }
+            return .applied
         } catch {
-            phase = .failed(error.localizedDescription)
+            phase = .ready
             diagnostics = [error.localizedDescription]
+            publishReloadFailure(diagnostics)
+            return .failed(error.localizedDescription)
         }
     }
 
@@ -162,7 +212,7 @@ public final class LibghosttyRuntime: ObservableObject {
             configPlan = plan
             diagnostics = readDiagnostics(from: config)
             installApplicationObservers()
-            installConfigMonitorIfNeeded()
+            installConfigMonitorIfNeeded(plan: plan)
             phase = .ready
         } catch {
             phase = .failed(error.localizedDescription)
@@ -267,14 +317,20 @@ public final class LibghosttyRuntime: ObservableObject {
         )
     }
 
-    private func installConfigMonitorIfNeeded() {
+    private func installConfigMonitorIfNeeded(
+        plan: LibghosttyConfigLoadPlan
+    ) {
         guard configMonitor == nil else { return }
 
-        let monitor = LibghosttyConfigFileMonitor(fileURL: configPaths
-            .globalConfigFile) { [weak self] in
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: plan.watchedConfigFiles
+        ) { [weak self] in
                 guard let self else { return }
                 Task { @MainActor in
-                    self.reloadConfig(projectRoot: self.activeConfigRoot, force: true)
+                    self.reloadActiveConfig(
+                        force: true,
+                        notifyOnSuccess: true
+                    )
                 }
             }
 
@@ -284,6 +340,34 @@ public final class LibghosttyRuntime: ObservableObject {
         } catch {
             diagnostics.append(error.localizedDescription)
         }
+    }
+
+    private func updateConfigMonitor(
+        for plan: LibghosttyConfigLoadPlan
+    ) {
+        guard let configMonitor else {
+            installConfigMonitorIfNeeded(plan: plan)
+            return
+        }
+        do {
+            try configMonitor.update(
+                fileURLs: plan.watchedConfigFiles
+            )
+        } catch {
+            diagnostics.append(error.localizedDescription)
+        }
+    }
+
+    private func publishReloadFailure(_ messages: [String]) {
+        let first = messages.first
+            ?? "The configuration could not be loaded."
+        let suffix = messages.count > 1
+            ? " (+\(messages.count - 1) more)"
+            : ""
+        configReloadNotice = LibghosttyConfigReloadNotice(
+            kind: .error,
+            message: "Configuration not reloaded: \(first)\(suffix)"
+        )
     }
 
     private static func ensureLibraryInitialized() -> Bool {

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -26,11 +26,17 @@ public final class LibghosttyConfigFileMonitor {
         let exists: Bool
         let resolvedPath: String
         let resourceIdentifier: String
+        let modificationSeconds: Int64
+        let modificationNanoseconds: Int64
+        let fileSize: Int64
 
         static let missing = FileIdentity(
             exists: false,
             resolvedPath: "",
-            resourceIdentifier: ""
+            resourceIdentifier: "",
+            modificationSeconds: 0,
+            modificationNanoseconds: 0,
+            fileSize: 0
         )
     }
 
@@ -672,18 +678,27 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     private func fileIdentity(for file: URL) -> FileIdentity {
-        guard FileManager.default.fileExists(atPath: file.path) else {
+        var metadata = stat()
+        guard stat(file.path, &metadata) == 0 else {
             return .missing
         }
         let values = try? file.resourceValues(
             forKeys: [.fileResourceIdentifierKey]
         )
+        let isRegularFile = metadata.st_mode & S_IFMT == S_IFREG
         return FileIdentity(
             exists: true,
             resolvedPath: file.resolvingSymlinksInPath().path,
             resourceIdentifier: String(
                 describing: values?.fileResourceIdentifier
-            )
+            ),
+            modificationSeconds: isRegularFile
+                ? Int64(metadata.st_mtimespec.tv_sec)
+                : 0,
+            modificationNanoseconds: isRegularFile
+                ? Int64(metadata.st_mtimespec.tv_nsec)
+                : 0,
+            fileSize: isRegularFile ? Int64(metadata.st_size) : 0
         )
     }
 

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -131,17 +131,23 @@ public final class LibghosttyConfigFileMonitor {
                 )
             }
             isStarted = true
-            try configureSourcesLocked()
+            try reconfigureSourcesLocked(
+                to: desiredFiles,
+                keepStagedSourcesOnFailure: true
+            )
         }
     }
 
     public func update(fileURLs: [URL]) throws {
         try synchronized {
-            desiredFiles = Set(
+            let updatedFiles = Set(
                 fileURLs.map(\.standardizedFileURL)
             )
             guard isStarted else { return }
-            try configureSourcesLocked()
+            guard updatedFiles != desiredFiles
+                || !sourcesAreCurrentLocked(for: updatedFiles)
+            else { return }
+            try reconfigureSourcesLocked(to: updatedFiles)
         }
     }
 
@@ -163,31 +169,10 @@ public final class LibghosttyConfigFileMonitor {
         isStarted = false
     }
 
-    private func configureSourcesLocked() throws {
-        fileSources.values.forEach { $0.cancel() }
-        fileSources.removeAll()
-        directorySources.values.forEach { $0.cancel() }
-        directorySources.removeAll()
-        knownDirectoryIdentity.removeAll()
-
-        knownIdentity = Dictionary(
-            uniqueKeysWithValues: desiredFiles.map {
-                ($0, fileIdentity(for: $0))
-            }
-        )
-
-        for file in desiredFiles
-        where knownIdentity[file]?.exists == true {
-            try startFileWatchLocked(file)
-        }
-        try rebuildDirectoryWatchesLocked()
-    }
-
-    private func startFileWatchLocked(_ file: URL) throws {
-        guard fileSources[file] == nil else { return }
-        guard let descriptor = try openDescriptor(for: file)
-        else { return }
-
+    private func installFileSourceLocked(
+        for file: URL,
+        descriptor: Int32
+    ) {
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: descriptor,
             eventMask: [.write, .delete, .rename],
@@ -214,85 +199,196 @@ public final class LibghosttyConfigFileMonitor {
         source.resume()
     }
 
-    private func rebuildDirectoryWatchesLocked() throws {
-        let directories = watchedDirectories()
-        let retainExtraSources = desiredFiles.contains {
-            fileIdentity(for: $0).exists == false
+    private func installDirectorySourceLocked(
+        for directory: URL,
+        descriptor: Int32,
+        identity: FileIdentity
+    ) {
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .delete, .rename],
+            queue: queue
+        )
+        source.setEventHandler { [weak self, weak source] in
+            guard let self, let source,
+                  self.directorySources[directory] === source
+            else { return }
+            self.refreshAfterDirectoryChangeLocked()
+        }
+        source.setCancelHandler { [descriptor] in
+            close(descriptor)
+        }
+        directorySources[directory] = source
+        knownDirectoryIdentity[directory] = identity
+        source.resume()
+    }
+
+    private func reconfigureSourcesLocked(
+        to updatedFiles: Set<URL>,
+        keepStagedSourcesOnFailure: Bool = false,
+        recheckAfterInstall: Bool = true
+    ) throws {
+        let updatedIdentities = Dictionary(
+            uniqueKeysWithValues: updatedFiles.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+        let updatedDirectories = watchedDirectories(
+            for: updatedFiles
+        )
+        let updatedDirectoryIdentities = Dictionary(
+            uniqueKeysWithValues: updatedDirectories.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+        var stagedFiles: [URL: Int32] = [:]
+        var stagedDirectories: [URL: Int32] = [:]
+
+        do {
+            for file in updatedFiles
+            where updatedIdentities[file]?.exists == true {
+                let sourceIsCurrent = fileSources[file] != nil
+                    && knownIdentity[file] == updatedIdentities[file]
+                guard !sourceIsCurrent,
+                      let descriptor = try openDescriptor(for: file)
+                else { continue }
+                stagedFiles[file] = descriptor
+            }
+            for directory in updatedDirectories {
+                let sourceIsCurrent = directorySources[directory] != nil
+                    && knownDirectoryIdentity[directory]
+                        == updatedDirectoryIdentities[directory]
+                guard !sourceIsCurrent,
+                      let descriptor = try openDescriptor(for: directory)
+                else { continue }
+                stagedDirectories[directory] = descriptor
+            }
+        } catch {
+            if keepStagedSourcesOnFailure {
+                applyStagedSourcesLocked(
+                    files: updatedFiles,
+                    identities: updatedIdentities,
+                    directories: updatedDirectories,
+                    directoryIdentities: updatedDirectoryIdentities,
+                    stagedFiles: stagedFiles,
+                    stagedDirectories: stagedDirectories
+                )
+            } else {
+                stagedFiles.values.forEach { close($0) }
+                stagedDirectories.values.forEach { close($0) }
+            }
+            throw error
         }
 
+        applyStagedSourcesLocked(
+            files: updatedFiles,
+            identities: updatedIdentities,
+            directories: updatedDirectories,
+            directoryIdentities: updatedDirectoryIdentities,
+            stagedFiles: stagedFiles,
+            stagedDirectories: stagedDirectories
+        )
+
+        if recheckAfterInstall {
+            let changedDuringInstall = updatedFiles.contains {
+                fileIdentity(for: $0) != updatedIdentities[$0]
+            }
+            if changedDuringInstall {
+                try reconfigureSourcesLocked(
+                    to: updatedFiles,
+                    recheckAfterInstall: false
+                )
+            }
+        }
+    }
+
+    private func sourcesAreCurrentLocked(
+        for files: Set<URL>
+    ) -> Bool {
+        let identities = Dictionary(
+            uniqueKeysWithValues: files.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+        guard knownIdentity == identities else { return false }
+        for (file, identity) in identities
+        where identity.exists && fileSources[file] == nil {
+            return false
+        }
+
+        let directories = watchedDirectories(for: files)
+        for directory in directories {
+            guard directorySources[directory] != nil,
+                  knownDirectoryIdentity[directory]
+                    == fileIdentity(for: directory)
+            else { return false }
+        }
+        return true
+    }
+
+    private func applyStagedSourcesLocked(
+        files: Set<URL>,
+        identities: [URL: FileIdentity],
+        directories: Set<URL>,
+        directoryIdentities: [URL: FileIdentity],
+        stagedFiles: [URL: Int32],
+        stagedDirectories: [URL: Int32]
+    ) {
+        let retainExtraDirectories = identities.values.contains {
+            !$0.exists
+        }
+        for file in Set(fileSources.keys) {
+            let shouldRemove = !files.contains(file)
+                || knownIdentity[file] != identities[file]
+            guard shouldRemove else { continue }
+            fileSources[file]?.cancel()
+            fileSources[file] = nil
+        }
         for directory in Set(directorySources.keys) {
-            let isNoLongerNeeded = !directories.contains(directory)
+            let isNoLongerNeeded = !directories.contains(
+                directory
+            )
             let identityChanged = directories.contains(directory)
                 && knownDirectoryIdentity[directory]
-                    != fileIdentity(for: directory)
+                    != directoryIdentities[directory]
             guard identityChanged
-                || (isNoLongerNeeded && !retainExtraSources)
+                || (
+                    isNoLongerNeeded
+                        && !retainExtraDirectories
+                )
             else { continue }
             directorySources[directory]?.cancel()
             directorySources[directory] = nil
             knownDirectoryIdentity[directory] = nil
         }
 
-        for directory in directories where directorySources[directory] == nil {
-            guard let descriptor = try openDescriptor(for: directory)
-            else { continue }
-            let source = DispatchSource.makeFileSystemObjectSource(
-                fileDescriptor: descriptor,
-                eventMask: [.write, .delete, .rename],
-                queue: queue
+        desiredFiles = files
+        knownIdentity = identities
+
+        for (file, descriptor) in stagedFiles {
+            installFileSourceLocked(
+                for: file,
+                descriptor: descriptor
             )
-            source.setEventHandler { [weak self, weak source] in
-                guard let self, let source,
-                      self.directorySources[directory] === source
-                else { return }
-                self.refreshAfterDirectoryChangeLocked()
-            }
-            source.setCancelHandler { [descriptor] in
-                close(descriptor)
-            }
-            directorySources[directory] = source
-            knownDirectoryIdentity[directory] = fileIdentity(
-                for: directory
+        }
+        for (directory, descriptor) in stagedDirectories {
+            installDirectorySourceLocked(
+                for: directory,
+                descriptor: descriptor,
+                identity: directoryIdentities[directory] ?? .missing
             )
-            source.resume()
         }
     }
 
     private func refreshAfterDirectoryChangeLocked() {
         guard isStarted else { return }
-        var identityChanged = reconcileFileSourcesLocked()
+        let previousIdentity = knownIdentity
         reportingErrors {
-            try rebuildDirectoryWatchesLocked()
+            try reconfigureSourcesLocked(to: desiredFiles)
         }
-        let changedDuringRebind = reconcileFileSourcesLocked()
-        identityChanged = identityChanged || changedDuringRebind
-        if changedDuringRebind {
-            reportingErrors {
-                try rebuildDirectoryWatchesLocked()
-            }
-        }
-        if identityChanged {
+        if previousIdentity != knownIdentity {
             scheduleChangeLocked()
         }
-    }
-
-    private func reconcileFileSourcesLocked() -> Bool {
-        var identityChanged = false
-        for file in desiredFiles {
-            let identity = fileIdentity(for: file)
-            if knownIdentity[file] != identity {
-                fileSources[file]?.cancel()
-                fileSources[file] = nil
-                knownIdentity[file] = identity
-                identityChanged = true
-            }
-            if identity.exists, fileSources[file] == nil {
-                reportingErrors {
-                    try startFileWatchLocked(file)
-                }
-            }
-        }
-        return identityChanged
     }
 
     private func openDescriptor(for url: URL) throws -> Int32? {
@@ -316,8 +412,14 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     func watchedDirectories() -> Set<URL> {
+        watchedDirectories(for: desiredFiles)
+    }
+
+    private func watchedDirectories(
+        for files: Set<URL>
+    ) -> Set<URL> {
         var directories: Set<URL> = []
-        for desiredFile in desiredFiles {
+        for desiredFile in files {
             var pending = [
                 SymlinkCandidate(
                     file: desiredFile,

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -40,6 +40,7 @@ public final class LibghosttyConfigFileMonitor {
         [URL: DispatchSourceFileSystemObject] = [:]
     private var directorySources:
         [URL: DispatchSourceFileSystemObject] = [:]
+    private var knownDirectoryIdentity: [URL: FileIdentity] = [:]
     private var pendingChange: DispatchWorkItem?
     private var isStarted = false
 
@@ -120,6 +121,7 @@ public final class LibghosttyConfigFileMonitor {
         fileSources.removeAll()
         directorySources.values.forEach { $0.cancel() }
         directorySources.removeAll()
+        knownDirectoryIdentity.removeAll()
         knownIdentity.removeAll()
         isStarted = false
     }
@@ -129,6 +131,7 @@ public final class LibghosttyConfigFileMonitor {
         fileSources.removeAll()
         directorySources.values.forEach { $0.cancel() }
         directorySources.removeAll()
+        knownDirectoryIdentity.removeAll()
 
         knownIdentity = Dictionary(
             uniqueKeysWithValues: desiredFiles.map {
@@ -182,13 +185,25 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     private func rebuildDirectoryWatchesLocked() throws {
-        let directories = Set(desiredFiles.map(nearestExistingDirectory))
-        guard directories != Set(directorySources.keys) else { return }
+        let directories = watchedDirectories()
+        let retainExtraSources = desiredFiles.contains {
+            fileIdentity(for: $0).exists == false
+        }
 
-        directorySources.values.forEach { $0.cancel() }
-        directorySources.removeAll()
+        for directory in Set(directorySources.keys) {
+            let isNoLongerNeeded = !directories.contains(directory)
+            let identityChanged = directories.contains(directory)
+                && knownDirectoryIdentity[directory]
+                    != fileIdentity(for: directory)
+            guard identityChanged
+                || (isNoLongerNeeded && !retainExtraSources)
+            else { continue }
+            directorySources[directory]?.cancel()
+            directorySources[directory] = nil
+            knownDirectoryIdentity[directory] = nil
+        }
 
-        for directory in directories {
+        for directory in directories where directorySources[directory] == nil {
             let descriptor = open(directory.path, O_EVTONLY)
             guard descriptor >= 0 else {
                 if requiringExistingFiles {
@@ -213,17 +228,34 @@ public final class LibghosttyConfigFileMonitor {
                 close(descriptor)
             }
             directorySources[directory] = source
+            knownDirectoryIdentity[directory] = fileIdentity(
+                for: directory
+            )
             source.resume()
         }
     }
 
     private func refreshAfterDirectoryChangeLocked() {
         guard isStarted else { return }
-        var identityChanged = false
+        var identityChanged = reconcileFileSourcesLocked()
+        try? rebuildDirectoryWatchesLocked()
+        let changedDuringRebind = reconcileFileSourcesLocked()
+        identityChanged = identityChanged || changedDuringRebind
+        if changedDuringRebind {
+            try? rebuildDirectoryWatchesLocked()
+        }
+        if identityChanged {
+            scheduleChangeLocked()
+        }
+    }
 
+    private func reconcileFileSourcesLocked() -> Bool {
+        var identityChanged = false
         for file in desiredFiles {
             let identity = fileIdentity(for: file)
             if knownIdentity[file] != identity {
+                fileSources[file]?.cancel()
+                fileSources[file] = nil
                 knownIdentity[file] = identity
                 identityChanged = true
             }
@@ -231,11 +263,39 @@ public final class LibghosttyConfigFileMonitor {
                 try? startFileWatchLocked(file)
             }
         }
+        return identityChanged
+    }
 
-        try? rebuildDirectoryWatchesLocked()
-        if identityChanged {
-            scheduleChangeLocked()
+    private func watchedDirectories() -> Set<URL> {
+        var directories = Set(
+            desiredFiles.map(nearestExistingDirectory)
+        )
+        for file in desiredFiles {
+            var component = URL(
+                fileURLWithPath: "/",
+                isDirectory: true
+            )
+            for pathComponent in file.pathComponents
+                .dropFirst()
+                .dropLast() {
+                component.appendPathComponent(
+                    pathComponent,
+                    isDirectory: true
+                )
+                guard isSymbolicLink(component) else { continue }
+                directories.insert(
+                    component.deletingLastPathComponent()
+                        .standardizedFileURL
+                )
+            }
         }
+        return directories
+    }
+
+    private func isSymbolicLink(_ url: URL) -> Bool {
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0 else { return false }
+        return metadata.st_mode & S_IFMT == S_IFLNK
     }
 
     private func nearestExistingDirectory(for file: URL) -> URL {

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -53,6 +53,7 @@ public final class LibghosttyConfigFileMonitor {
     private var directorySources:
         [URL: DispatchSourceFileSystemObject] = [:]
     private var knownDirectoryIdentity: [URL: FileIdentity] = [:]
+    private var pendingDirectoryRecheck: DispatchWorkItem?
     private var pendingChange: DispatchWorkItem?
     private var isStarted = false
 
@@ -158,6 +159,8 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     private func stopLocked() {
+        pendingDirectoryRecheck?.cancel()
+        pendingDirectoryRecheck = nil
         pendingChange?.cancel()
         pendingChange = nil
         fileSources.values.forEach { $0.cancel() }
@@ -334,6 +337,14 @@ public final class LibghosttyConfigFileMonitor {
         stagedFiles: [URL: Int32],
         stagedDirectories: [URL: Int32]
     ) {
+        let missingFiles = Set(
+            identities.compactMap { file, identity in
+                identity.exists ? nil : file
+            }
+        )
+        let missingDirectories = watchedDirectories(
+            for: missingFiles
+        )
         for file in Set(fileSources.keys) {
             let shouldRemove = !files.contains(file)
                 || knownIdentity[file] != identities[file]
@@ -348,7 +359,11 @@ public final class LibghosttyConfigFileMonitor {
             let identityChanged = directories.contains(directory)
                 && knownDirectoryIdentity[directory]
                     != directoryIdentities[directory]
-            guard identityChanged || isNoLongerNeeded
+            let isRequiredAncestor = missingDirectories.contains {
+                isAncestor(directory, of: $0)
+            }
+            guard identityChanged
+                || (isNoLongerNeeded && !isRequiredAncestor)
             else { continue }
             directorySources[directory]?.cancel()
             directorySources[directory] = nil
@@ -373,15 +388,69 @@ public final class LibghosttyConfigFileMonitor {
         }
     }
 
+    private func isAncestor(
+        _ candidate: URL,
+        of descendant: URL
+    ) -> Bool {
+        let candidateComponents = candidate.standardizedFileURL
+            .pathComponents
+        let descendantComponents = descendant.standardizedFileURL
+            .pathComponents
+        guard candidateComponents.count <= descendantComponents.count
+        else { return false }
+        return zip(
+            candidateComponents,
+            descendantComponents
+        ).allSatisfy { candidate, descendant in
+            candidate == descendant
+        }
+    }
+
     private func refreshAfterDirectoryChangeLocked() {
         guard isStarted else { return }
         let previousIdentity = knownIdentity
+        let observedIdentity = Dictionary(
+            uniqueKeysWithValues: desiredFiles.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
         reportingErrors {
             try reconfigureSourcesLocked(to: desiredFiles)
         }
-        if previousIdentity != knownIdentity {
+        if previousIdentity != observedIdentity
+            || previousIdentity != knownIdentity {
             scheduleChangeLocked()
+        } else {
+            scheduleDirectoryRecheckLocked()
         }
+    }
+
+    private func scheduleDirectoryRecheckLocked() {
+        pendingDirectoryRecheck?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingDirectoryRecheck = nil
+            let previousIdentity = self.knownIdentity
+            let observedIdentity = Dictionary(
+                uniqueKeysWithValues: self.desiredFiles.map {
+                    ($0, self.fileIdentity(for: $0))
+                }
+            )
+            self.reportingErrors {
+                try self.reconfigureSourcesLocked(
+                    to: self.desiredFiles
+                )
+            }
+            if previousIdentity != observedIdentity
+                || previousIdentity != self.knownIdentity {
+                self.scheduleChangeLocked()
+            }
+        }
+        pendingDirectoryRecheck = work
+        queue.asyncAfter(
+            deadline: .now() + debounceInterval,
+            execute: work
+        )
     }
 
     private func openDescriptor(for url: URL) throws -> Int32? {

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -29,6 +29,11 @@ public final class LibghosttyConfigFileMonitor {
         )
     }
 
+    private struct SymlinkCandidate {
+        let file: URL
+        let expansionDepth: Int
+    }
+
     private let queue: DispatchQueue
     private let queueKey = DispatchSpecificKey<UInt8>()
     private let changeHandler: ChangeHandler
@@ -267,44 +272,56 @@ public final class LibghosttyConfigFileMonitor {
         return identityChanged
     }
 
-    private func watchedDirectories() -> Set<URL> {
+    func watchedDirectories() -> Set<URL> {
         var directories: Set<URL> = []
-        var pending = Array(desiredFiles)
-        var visited: Set<URL> = []
-
-        while let file = pending.popLast() {
-            guard visited.count < Self.symlinkTraversalLimit else {
-                break
-            }
-            let standardizedFile = file.standardizedFileURL
-            guard visited.insert(standardizedFile).inserted else {
-                continue
-            }
-            directories.insert(
-                nearestExistingDirectory(for: standardizedFile)
-            )
-
-            var component = URL(
-                fileURLWithPath: "/",
-                isDirectory: true
-            )
-            let pathComponents = Array(
-                standardizedFile.pathComponents.dropFirst()
-            )
-            for (index, pathComponent) in pathComponents.enumerated() {
-                component.appendPathComponent(pathComponent)
-                guard isSymbolicLink(component) else { continue }
-                directories.insert(
-                    component.deletingLastPathComponent()
-                        .standardizedFileURL
+        for desiredFile in desiredFiles {
+            var pending = [
+                SymlinkCandidate(
+                    file: desiredFile,
+                    expansionDepth: 0
                 )
-                guard var destination = symlinkDestination(
-                    for: component
-                ) else { continue }
-                for remaining in pathComponents.dropFirst(index + 1) {
-                    destination.appendPathComponent(remaining)
+            ]
+            var visited: Set<URL> = []
+
+            while let candidate = pending.popLast() {
+                let standardizedFile = candidate.file.standardizedFileURL
+                guard visited.insert(standardizedFile).inserted else {
+                    continue
                 }
-                pending.append(destination.standardizedFileURL)
+                directories.insert(
+                    nearestExistingDirectory(for: standardizedFile)
+                )
+
+                var component = URL(
+                    fileURLWithPath: "/",
+                    isDirectory: true
+                )
+                let pathComponents = Array(
+                    standardizedFile.pathComponents.dropFirst()
+                )
+                for (index, pathComponent) in pathComponents.enumerated() {
+                    component.appendPathComponent(pathComponent)
+                    guard isSymbolicLink(component) else { continue }
+                    directories.insert(
+                        component.deletingLastPathComponent()
+                            .standardizedFileURL
+                    )
+                    guard candidate.expansionDepth
+                        < Self.symlinkTraversalLimit,
+                        var destination = symlinkDestination(
+                            for: component
+                        )
+                    else { continue }
+                    for remaining in pathComponents.dropFirst(index + 1) {
+                        destination.appendPathComponent(remaining)
+                    }
+                    pending.append(
+                        SymlinkCandidate(
+                            file: destination.standardizedFileURL,
+                            expansionDepth: candidate.expansionDepth + 1
+                        )
+                    )
+                }
             }
         }
         return directories

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -19,6 +19,7 @@ public final class LibghosttyConfigFileMonitor {
         LibghosttyConfigFileMonitorError
     ) -> Void
     typealias OpenHandler = (_ path: String, _ flags: Int32) -> Int32
+    private static let coverageRetryLimit = 4
     private static let symlinkTraversalLimit = 64
 
     private struct FileIdentity: Equatable {
@@ -229,7 +230,8 @@ public final class LibghosttyConfigFileMonitor {
     private func reconfigureSourcesLocked(
         to updatedFiles: Set<URL>,
         keepStagedSourcesOnFailure: Bool = false,
-        recheckAfterInstall: Bool = true
+        remainingCoverageRetries: Int =
+            LibghosttyConfigFileMonitor.coverageRetryLimit
     ) throws {
         let updatedIdentities = Dictionary(
             uniqueKeysWithValues: updatedFiles.map {
@@ -292,31 +294,47 @@ public final class LibghosttyConfigFileMonitor {
             stagedDirectories: stagedDirectories
         )
 
-        if recheckAfterInstall {
-            let changedDuringInstall = updatedFiles.contains {
-                fileIdentity(for: $0) != updatedIdentities[$0]
-            }
-            if changedDuringInstall {
-                try reconfigureSourcesLocked(
-                    to: updatedFiles,
-                    recheckAfterInstall: false
-                )
-            }
+        // Paths can disappear or be replaced between discovery and open.
+        // Success means the freshly observed graph is fully covered, not
+        // merely that every open attempted from the older snapshot returned.
+        guard let uncovered = coverageGapLocked(
+            for: updatedFiles
+        ) else { return }
+        guard remainingCoverageRetries > 0 else {
+            throw LibghosttyConfigFileMonitorError.openFile(
+                uncovered,
+                ENOENT
+            )
         }
+        try reconfigureSourcesLocked(
+            to: updatedFiles,
+            keepStagedSourcesOnFailure: keepStagedSourcesOnFailure,
+            remainingCoverageRetries: remainingCoverageRetries - 1
+        )
     }
 
     private func sourcesAreCurrentLocked(
         for files: Set<URL>
     ) -> Bool {
+        coverageGapLocked(for: files) == nil
+    }
+
+    private func coverageGapLocked(
+        for files: Set<URL>
+    ) -> URL? {
         let identities = Dictionary(
             uniqueKeysWithValues: files.map {
                 ($0, fileIdentity(for: $0))
             }
         )
-        guard knownIdentity == identities else { return false }
+        if knownIdentity != identities {
+            return files.first {
+                knownIdentity[$0] != identities[$0]
+            }
+        }
         for (file, identity) in identities
         where identity.exists && fileSources[file] == nil {
-            return false
+            return file
         }
 
         let directories = watchedDirectories(for: files)
@@ -324,9 +342,9 @@ public final class LibghosttyConfigFileMonitor {
             guard directorySources[directory] != nil,
                   knownDirectoryIdentity[directory]
                     == fileIdentity(for: directory)
-            else { return false }
+            else { return directory }
         }
-        return true
+        return nil
     }
 
     private func applyStagedSourcesLocked(

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -34,6 +34,13 @@ public final class LibghosttyConfigFileMonitor {
         )
     }
 
+    private struct WatchGraph: Equatable {
+        let files: Set<URL>
+        let fileIdentities: [URL: FileIdentity]
+        let directories: Set<URL>
+        let directoryIdentities: [URL: FileIdentity]
+    }
+
     private struct SymlinkCandidate {
         let file: URL
         let expansionDepth: Int
@@ -233,36 +240,25 @@ public final class LibghosttyConfigFileMonitor {
         remainingCoverageRetries: Int =
             LibghosttyConfigFileMonitor.coverageRetryLimit
     ) throws {
-        let updatedIdentities = Dictionary(
-            uniqueKeysWithValues: updatedFiles.map {
-                ($0, fileIdentity(for: $0))
-            }
-        )
-        let updatedDirectories = watchedDirectories(
-            for: updatedFiles
-        )
-        let updatedDirectoryIdentities = Dictionary(
-            uniqueKeysWithValues: updatedDirectories.map {
-                ($0, fileIdentity(for: $0))
-            }
-        )
+        let graph = watchGraphLocked(for: updatedFiles)
         var stagedFiles: [URL: Int32] = [:]
         var stagedDirectories: [URL: Int32] = [:]
 
         do {
-            for file in updatedFiles
-            where updatedIdentities[file]?.exists == true {
+            for file in graph.files
+            where graph.fileIdentities[file]?.exists == true {
                 let sourceIsCurrent = fileSources[file] != nil
-                    && knownIdentity[file] == updatedIdentities[file]
+                    && knownIdentity[file]
+                        == graph.fileIdentities[file]
                 guard !sourceIsCurrent,
                       let descriptor = try openDescriptor(for: file)
                 else { continue }
                 stagedFiles[file] = descriptor
             }
-            for directory in updatedDirectories {
+            for directory in graph.directories {
                 let sourceIsCurrent = directorySources[directory] != nil
                     && knownDirectoryIdentity[directory]
-                        == updatedDirectoryIdentities[directory]
+                        == graph.directoryIdentities[directory]
                 guard !sourceIsCurrent,
                       let descriptor = try openDescriptor(for: directory)
                 else { continue }
@@ -271,46 +267,136 @@ public final class LibghosttyConfigFileMonitor {
         } catch {
             if keepStagedSourcesOnFailure {
                 applyStagedSourcesLocked(
-                    files: updatedFiles,
-                    identities: updatedIdentities,
-                    directories: updatedDirectories,
-                    directoryIdentities: updatedDirectoryIdentities,
+                    files: graph.files,
+                    identities: graph.fileIdentities,
+                    directories: graph.directories,
+                    directoryIdentities: graph.directoryIdentities,
                     stagedFiles: stagedFiles,
                     stagedDirectories: stagedDirectories
                 )
             } else {
-                stagedFiles.values.forEach { close($0) }
-                stagedDirectories.values.forEach { close($0) }
+                closeStagedDescriptors(
+                    files: stagedFiles,
+                    directories: stagedDirectories
+                )
             }
             throw error
         }
 
-        applyStagedSourcesLocked(
-            files: updatedFiles,
-            identities: updatedIdentities,
-            directories: updatedDirectories,
-            directoryIdentities: updatedDirectoryIdentities,
+        let refreshedGraph = watchGraphLocked(for: updatedFiles)
+        let uncovered = proposedCoverageGapLocked(
+            graph: graph,
             stagedFiles: stagedFiles,
             stagedDirectories: stagedDirectories
         )
-
-        // Paths can disappear or be replaced between discovery and open.
-        // Success means the freshly observed graph is fully covered, not
-        // merely that every open attempted from the older snapshot returned.
-        guard let uncovered = coverageGapLocked(
-            for: updatedFiles
-        ) else { return }
-        guard remainingCoverageRetries > 0 else {
-            throw LibghosttyConfigFileMonitorError.openFile(
-                uncovered,
-                ENOENT
+        guard graph == refreshedGraph, uncovered == nil else {
+            closeStagedDescriptors(
+                files: stagedFiles,
+                directories: stagedDirectories
             )
+            guard remainingCoverageRetries > 0 else {
+                throw LibghosttyConfigFileMonitorError.openFile(
+                    uncovered
+                        ?? graphDifferenceURL(
+                            graph,
+                            refreshedGraph
+                        ),
+                    ENOENT
+                )
+            }
+            try reconfigureSourcesLocked(
+                to: updatedFiles,
+                keepStagedSourcesOnFailure: keepStagedSourcesOnFailure,
+                remainingCoverageRetries:
+                    remainingCoverageRetries - 1
+            )
+            return
         }
-        try reconfigureSourcesLocked(
-            to: updatedFiles,
-            keepStagedSourcesOnFailure: keepStagedSourcesOnFailure,
-            remainingCoverageRetries: remainingCoverageRetries - 1
+
+        // No live source is cancelled until the proposed graph has complete
+        // coverage and the filesystem snapshot is stable.
+        applyStagedSourcesLocked(
+            files: graph.files,
+            identities: graph.fileIdentities,
+            directories: graph.directories,
+            directoryIdentities: graph.directoryIdentities,
+            stagedFiles: stagedFiles,
+            stagedDirectories: stagedDirectories
         )
+    }
+
+    private func watchGraphLocked(
+        for files: Set<URL>
+    ) -> WatchGraph {
+        let fileIdentities = Dictionary(
+            uniqueKeysWithValues: files.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+        let directories = watchedDirectories(for: files)
+        let directoryIdentities = Dictionary(
+            uniqueKeysWithValues: directories.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+        return WatchGraph(
+            files: files,
+            fileIdentities: fileIdentities,
+            directories: directories,
+            directoryIdentities: directoryIdentities
+        )
+    }
+
+    private func proposedCoverageGapLocked(
+        graph: WatchGraph,
+        stagedFiles: [URL: Int32],
+        stagedDirectories: [URL: Int32]
+    ) -> URL? {
+        for (file, identity) in graph.fileIdentities
+        where identity.exists {
+            let existingSourceIsCurrent = fileSources[file] != nil
+                && knownIdentity[file] == identity
+            if !existingSourceIsCurrent, stagedFiles[file] == nil {
+                return file
+            }
+        }
+        for directory in graph.directories {
+            let existingSourceIsCurrent =
+                directorySources[directory] != nil
+                    && knownDirectoryIdentity[directory]
+                        == graph.directoryIdentities[directory]
+            if !existingSourceIsCurrent,
+               stagedDirectories[directory] == nil {
+                return directory
+            }
+        }
+        return nil
+    }
+
+    private func graphDifferenceURL(
+        _ first: WatchGraph,
+        _ second: WatchGraph
+    ) -> URL {
+        for file in first.files.union(second.files)
+        where first.fileIdentities[file] != second.fileIdentities[file] {
+            return file
+        }
+        for directory in first.directories.union(second.directories)
+        where first.directoryIdentities[directory]
+            != second.directoryIdentities[directory] {
+            return directory
+        }
+        return first.files.first
+            ?? first.directories.first
+            ?? URL(fileURLWithPath: "/")
+    }
+
+    private func closeStagedDescriptors(
+        files: [URL: Int32],
+        directories: [URL: Int32]
+    ) {
+        files.values.forEach { close($0) }
+        directories.values.forEach { close($0) }
     }
 
     private func sourcesAreCurrentLocked(
@@ -322,26 +408,20 @@ public final class LibghosttyConfigFileMonitor {
     private func coverageGapLocked(
         for files: Set<URL>
     ) -> URL? {
-        let identities = Dictionary(
-            uniqueKeysWithValues: files.map {
-                ($0, fileIdentity(for: $0))
-            }
-        )
-        if knownIdentity != identities {
+        let graph = watchGraphLocked(for: files)
+        if knownIdentity != graph.fileIdentities {
             return files.first {
-                knownIdentity[$0] != identities[$0]
+                knownIdentity[$0] != graph.fileIdentities[$0]
             }
         }
-        for (file, identity) in identities
+        for (file, identity) in graph.fileIdentities
         where identity.exists && fileSources[file] == nil {
             return file
         }
-
-        let directories = watchedDirectories(for: files)
-        for directory in directories {
+        for directory in graph.directories {
             guard directorySources[directory] != nil,
                   knownDirectoryIdentity[directory]
-                    == fileIdentity(for: directory)
+                    == graph.directoryIdentities[directory]
             else { return directory }
         }
         return nil

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -272,7 +272,8 @@ public final class LibghosttyConfigFileMonitor {
                     directories: graph.directories,
                     directoryIdentities: graph.directoryIdentities,
                     stagedFiles: stagedFiles,
-                    stagedDirectories: stagedDirectories
+                    stagedDirectories: stagedDirectories,
+                    retainFallbackAncestors: true
                 )
             } else {
                 closeStagedDescriptors(
@@ -321,7 +322,8 @@ public final class LibghosttyConfigFileMonitor {
             directories: graph.directories,
             directoryIdentities: graph.directoryIdentities,
             stagedFiles: stagedFiles,
-            stagedDirectories: stagedDirectories
+            stagedDirectories: stagedDirectories,
+            retainFallbackAncestors: false
         )
     }
 
@@ -433,16 +435,17 @@ public final class LibghosttyConfigFileMonitor {
         directories: Set<URL>,
         directoryIdentities: [URL: FileIdentity],
         stagedFiles: [URL: Int32],
-        stagedDirectories: [URL: Int32]
+        stagedDirectories: [URL: Int32],
+        retainFallbackAncestors: Bool
     ) {
         let missingFiles = Set(
             identities.compactMap { file, identity in
                 identity.exists ? nil : file
             }
         )
-        let missingDirectories = watchedDirectories(
-            for: missingFiles
-        )
+        let fallbackDirectories = retainFallbackAncestors
+            ? watchedDirectories(for: missingFiles)
+            : []
         for file in Set(fileSources.keys) {
             let shouldRemove = !files.contains(file)
                 || knownIdentity[file] != identities[file]
@@ -457,7 +460,7 @@ public final class LibghosttyConfigFileMonitor {
             let identityChanged = directories.contains(directory)
                 && knownDirectoryIdentity[directory]
                     != directoryIdentities[directory]
-            let isRequiredAncestor = missingDirectories.contains {
+            let isRequiredAncestor = fallbackDirectories.contains {
                 isAncestor(directory, of: $0)
             }
             guard identityChanged

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -334,9 +334,6 @@ public final class LibghosttyConfigFileMonitor {
         stagedFiles: [URL: Int32],
         stagedDirectories: [URL: Int32]
     ) {
-        let retainExtraDirectories = identities.values.contains {
-            !$0.exists
-        }
         for file in Set(fileSources.keys) {
             let shouldRemove = !files.contains(file)
                 || knownIdentity[file] != identities[file]
@@ -351,11 +348,7 @@ public final class LibghosttyConfigFileMonitor {
             let identityChanged = directories.contains(directory)
                 && knownDirectoryIdentity[directory]
                     != directoryIdentities[directory]
-            guard identityChanged
-                || (
-                    isNoLongerNeeded
-                        && !retainExtraDirectories
-                )
+            guard identityChanged || isNoLongerNeeded
             else { continue }
             directorySources[directory]?.cancel()
             directorySources[directory] = nil
@@ -413,6 +406,12 @@ public final class LibghosttyConfigFileMonitor {
 
     func watchedDirectories() -> Set<URL> {
         watchedDirectories(for: desiredFiles)
+    }
+
+    func activeWatchedDirectories() -> Set<URL> {
+        synchronized {
+            Set(directorySources.keys)
+        }
     }
 
     private func watchedDirectories(

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -15,6 +15,7 @@ public enum LibghosttyConfigFileMonitorError: LocalizedError, Equatable {
 
 public final class LibghosttyConfigFileMonitor {
     public typealias ChangeHandler = @Sendable () -> Void
+    private static let symlinkTraversalLimit = 64
 
     private struct FileIdentity: Equatable {
         let exists: Bool
@@ -267,29 +268,57 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     private func watchedDirectories() -> Set<URL> {
-        var directories = Set(
-            desiredFiles.map(nearestExistingDirectory)
-        )
-        for file in desiredFiles {
+        var directories: Set<URL> = []
+        var pending = Array(desiredFiles)
+        var visited: Set<URL> = []
+
+        while let file = pending.popLast() {
+            guard visited.count < Self.symlinkTraversalLimit else {
+                break
+            }
+            let standardizedFile = file.standardizedFileURL
+            guard visited.insert(standardizedFile).inserted else {
+                continue
+            }
+            directories.insert(
+                nearestExistingDirectory(for: standardizedFile)
+            )
+
             var component = URL(
                 fileURLWithPath: "/",
                 isDirectory: true
             )
-            for pathComponent in file.pathComponents
-                .dropFirst()
-                .dropLast() {
-                component.appendPathComponent(
-                    pathComponent,
-                    isDirectory: true
-                )
+            let pathComponents = Array(
+                standardizedFile.pathComponents.dropFirst()
+            )
+            for (index, pathComponent) in pathComponents.enumerated() {
+                component.appendPathComponent(pathComponent)
                 guard isSymbolicLink(component) else { continue }
                 directories.insert(
                     component.deletingLastPathComponent()
                         .standardizedFileURL
                 )
+                guard var destination = symlinkDestination(
+                    for: component
+                ) else { continue }
+                for remaining in pathComponents.dropFirst(index + 1) {
+                    destination.appendPathComponent(remaining)
+                }
+                pending.append(destination.standardizedFileURL)
             }
         }
         return directories
+    }
+
+    private func symlinkDestination(for url: URL) -> URL? {
+        guard let destination = try? FileManager.default
+            .destinationOfSymbolicLink(atPath: url.path)
+        else { return nil }
+        if destination.hasPrefix("/") {
+            return URL(fileURLWithPath: destination)
+        }
+        return url.deletingLastPathComponent()
+            .appendingPathComponent(destination)
     }
 
     private func isSymbolicLink(_ url: URL) -> Bool {

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -15,6 +15,10 @@ public enum LibghosttyConfigFileMonitorError: LocalizedError, Equatable {
 
 public final class LibghosttyConfigFileMonitor {
     public typealias ChangeHandler = @Sendable () -> Void
+    public typealias ErrorHandler = @Sendable (
+        LibghosttyConfigFileMonitorError
+    ) -> Void
+    typealias OpenHandler = (_ path: String, _ flags: Int32) -> Int32
     private static let symlinkTraversalLimit = 64
 
     private struct FileIdentity: Equatable {
@@ -37,6 +41,8 @@ public final class LibghosttyConfigFileMonitor {
     private let queue: DispatchQueue
     private let queueKey = DispatchSpecificKey<UInt8>()
     private let changeHandler: ChangeHandler
+    private let errorHandler: ErrorHandler
+    private let openHandler: OpenHandler
     private let debounceInterval: DispatchTimeInterval
     private let requiringExistingFiles: Bool
 
@@ -67,19 +73,44 @@ public final class LibghosttyConfigFileMonitor {
         )
     }
 
-    public init(
+    public convenience init(
         fileURLs: [URL],
         queue: DispatchQueue = DispatchQueue(
             label: "com.ghosthub.terminal.config-monitor"
         ),
         debounceInterval: DispatchTimeInterval = .milliseconds(150),
         requiringExistingFiles: Bool = false,
+        errorHandler: @escaping ErrorHandler = { _ in },
+        changeHandler: @escaping ChangeHandler
+    ) {
+        self.init(
+            fileURLs: fileURLs,
+            queue: queue,
+            debounceInterval: debounceInterval,
+            requiringExistingFiles: requiringExistingFiles,
+            openHandler: { path, flags in
+                open(path, flags)
+            },
+            errorHandler: errorHandler,
+            changeHandler: changeHandler
+        )
+    }
+
+    init(
+        fileURLs: [URL],
+        queue: DispatchQueue,
+        debounceInterval: DispatchTimeInterval,
+        requiringExistingFiles: Bool,
+        openHandler: @escaping OpenHandler,
+        errorHandler: @escaping ErrorHandler = { _ in },
         changeHandler: @escaping ChangeHandler
     ) {
         desiredFiles = Set(fileURLs.map(\.standardizedFileURL))
         self.queue = queue
         self.debounceInterval = debounceInterval
         self.requiringExistingFiles = requiringExistingFiles
+        self.openHandler = openHandler
+        self.errorHandler = errorHandler
         self.changeHandler = changeHandler
         queue.setSpecific(key: queueKey, value: 1)
     }
@@ -154,15 +185,8 @@ public final class LibghosttyConfigFileMonitor {
 
     private func startFileWatchLocked(_ file: URL) throws {
         guard fileSources[file] == nil else { return }
-        let descriptor = open(file.path, O_EVTONLY)
-        guard descriptor >= 0 else {
-            if requiringExistingFiles {
-                throw LibghosttyConfigFileMonitorError.openFile(
-                    file, errno
-                )
-            }
-            return
-        }
+        guard let descriptor = try openDescriptor(for: file)
+        else { return }
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: descriptor,
@@ -210,15 +234,8 @@ public final class LibghosttyConfigFileMonitor {
         }
 
         for directory in directories where directorySources[directory] == nil {
-            let descriptor = open(directory.path, O_EVTONLY)
-            guard descriptor >= 0 else {
-                if requiringExistingFiles {
-                    throw LibghosttyConfigFileMonitorError.openFile(
-                        directory, errno
-                    )
-                }
-                continue
-            }
+            guard let descriptor = try openDescriptor(for: directory)
+            else { continue }
             let source = DispatchSource.makeFileSystemObjectSource(
                 fileDescriptor: descriptor,
                 eventMask: [.write, .delete, .rename],
@@ -244,11 +261,15 @@ public final class LibghosttyConfigFileMonitor {
     private func refreshAfterDirectoryChangeLocked() {
         guard isStarted else { return }
         var identityChanged = reconcileFileSourcesLocked()
-        try? rebuildDirectoryWatchesLocked()
+        reportingErrors {
+            try rebuildDirectoryWatchesLocked()
+        }
         let changedDuringRebind = reconcileFileSourcesLocked()
         identityChanged = identityChanged || changedDuringRebind
         if changedDuringRebind {
-            try? rebuildDirectoryWatchesLocked()
+            reportingErrors {
+                try rebuildDirectoryWatchesLocked()
+            }
         }
         if identityChanged {
             scheduleChangeLocked()
@@ -266,10 +287,32 @@ public final class LibghosttyConfigFileMonitor {
                 identityChanged = true
             }
             if identity.exists, fileSources[file] == nil {
-                try? startFileWatchLocked(file)
+                reportingErrors {
+                    try startFileWatchLocked(file)
+                }
             }
         }
         return identityChanged
+    }
+
+    private func openDescriptor(for url: URL) throws -> Int32? {
+        let descriptor = openHandler(url.path, O_EVTONLY)
+        guard descriptor < 0 else { return descriptor }
+        let openError = errno
+        if !requiringExistingFiles, openError == ENOENT {
+            return nil
+        }
+        throw LibghosttyConfigFileMonitorError.openFile(
+            url, openError
+        )
+    }
+
+    private func reportingErrors(_ operation: () throws -> Void) {
+        do {
+            try operation()
+        } catch let error as LibghosttyConfigFileMonitorError {
+            errorHandler(error)
+        } catch {}
     }
 
     func watchedDirectories() -> Set<URL> {

--- a/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigFileMonitor.swift
@@ -1,6 +1,6 @@
+import Darwin
 import Dispatch
 import Foundation
-import Darwin
 
 public enum LibghosttyConfigFileMonitorError: LocalizedError, Equatable {
     case openFile(URL, Int32)
@@ -16,25 +16,65 @@ public enum LibghosttyConfigFileMonitorError: LocalizedError, Equatable {
 public final class LibghosttyConfigFileMonitor {
     public typealias ChangeHandler = @Sendable () -> Void
 
-    private let fileURL: URL
-    private let directoryURL: URL
+    private struct FileIdentity: Equatable {
+        let exists: Bool
+        let resolvedPath: String
+        let resourceIdentifier: String
+
+        static let missing = FileIdentity(
+            exists: false,
+            resolvedPath: "",
+            resourceIdentifier: ""
+        )
+    }
+
     private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<UInt8>()
     private let changeHandler: ChangeHandler
+    private let debounceInterval: DispatchTimeInterval
+    private let requiringExistingFiles: Bool
 
-    private var fileDescriptor: Int32 = -1
-    private var fileSource: DispatchSourceFileSystemObject?
-    private var directoryDescriptor: Int32 = -1
-    private var directorySource: DispatchSourceFileSystemObject?
+    private var desiredFiles: Set<URL>
+    private var knownIdentity: [URL: FileIdentity] = [:]
+    private var fileSources:
+        [URL: DispatchSourceFileSystemObject] = [:]
+    private var directorySources:
+        [URL: DispatchSourceFileSystemObject] = [:]
+    private var pendingChange: DispatchWorkItem?
+    private var isStarted = false
 
-    public init(
+    public convenience init(
         fileURL: URL,
-        queue: DispatchQueue = DispatchQueue(label: "com.ghosthub.terminal.config-monitor"),
+        queue: DispatchQueue = DispatchQueue(
+            label: "com.ghosthub.terminal.config-monitor"
+        ),
+        debounceInterval: DispatchTimeInterval = .milliseconds(150),
         changeHandler: @escaping ChangeHandler
     ) {
-        self.fileURL = fileURL
-        directoryURL = fileURL.deletingLastPathComponent()
+        self.init(
+            fileURLs: [fileURL],
+            queue: queue,
+            debounceInterval: debounceInterval,
+            requiringExistingFiles: true,
+            changeHandler: changeHandler
+        )
+    }
+
+    public init(
+        fileURLs: [URL],
+        queue: DispatchQueue = DispatchQueue(
+            label: "com.ghosthub.terminal.config-monitor"
+        ),
+        debounceInterval: DispatchTimeInterval = .milliseconds(150),
+        requiringExistingFiles: Bool = false,
+        changeHandler: @escaping ChangeHandler
+    ) {
+        desiredFiles = Set(fileURLs.map(\.standardizedFileURL))
         self.queue = queue
+        self.debounceInterval = debounceInterval
+        self.requiringExistingFiles = requiringExistingFiles
         self.changeHandler = changeHandler
+        queue.setSpecific(key: queueKey, value: 1)
     }
 
     deinit {
@@ -42,26 +82,75 @@ public final class LibghosttyConfigFileMonitor {
     }
 
     public func start() throws {
-        stop()
-        try startDirectoryWatch()
-        try startFileWatch(requiringExistingFile: true)
+        try synchronized {
+            stopLocked()
+            if requiringExistingFiles,
+               let missing = desiredFiles.first(where: {
+                   !fileIdentity(for: $0).exists
+               }) {
+                throw LibghosttyConfigFileMonitorError.openFile(
+                    missing, ENOENT
+                )
+            }
+            isStarted = true
+            try configureSourcesLocked()
+        }
+    }
+
+    public func update(fileURLs: [URL]) throws {
+        try synchronized {
+            desiredFiles = Set(
+                fileURLs.map(\.standardizedFileURL)
+            )
+            guard isStarted else { return }
+            try configureSourcesLocked()
+        }
     }
 
     public func stop() {
-        fileSource?.cancel()
-        fileSource = nil
-        fileDescriptor = -1
-
-        directorySource?.cancel()
-        directorySource = nil
-        directoryDescriptor = -1
+        synchronized {
+            stopLocked()
+        }
     }
 
-    private func startFileWatch(requiringExistingFile: Bool) throws {
-        let descriptor = open(fileURL.path, O_EVTONLY)
+    private func stopLocked() {
+        pendingChange?.cancel()
+        pendingChange = nil
+        fileSources.values.forEach { $0.cancel() }
+        fileSources.removeAll()
+        directorySources.values.forEach { $0.cancel() }
+        directorySources.removeAll()
+        knownIdentity.removeAll()
+        isStarted = false
+    }
+
+    private func configureSourcesLocked() throws {
+        fileSources.values.forEach { $0.cancel() }
+        fileSources.removeAll()
+        directorySources.values.forEach { $0.cancel() }
+        directorySources.removeAll()
+
+        knownIdentity = Dictionary(
+            uniqueKeysWithValues: desiredFiles.map {
+                ($0, fileIdentity(for: $0))
+            }
+        )
+
+        for file in desiredFiles
+        where knownIdentity[file]?.exists == true {
+            try startFileWatchLocked(file)
+        }
+        try rebuildDirectoryWatchesLocked()
+    }
+
+    private func startFileWatchLocked(_ file: URL) throws {
+        guard fileSources[file] == nil else { return }
+        let descriptor = open(file.path, O_EVTONLY)
         guard descriptor >= 0 else {
-            if requiringExistingFile {
-                throw LibghosttyConfigFileMonitorError.openFile(fileURL, errno)
+            if requiringExistingFiles {
+                throw LibghosttyConfigFileMonitorError.openFile(
+                    file, errno
+                )
             }
             return
         }
@@ -71,69 +160,133 @@ public final class LibghosttyConfigFileMonitor {
             eventMask: [.write, .delete, .rename],
             queue: queue
         )
-
         source.setEventHandler { [weak self, weak source] in
-            guard let self, let source else { return }
+            guard let self, let source,
+                  self.fileSources[file] === source
+            else { return }
             let events = source.data
-
             if events.contains(.delete) || events.contains(.rename) {
-                handleWatchedFileReplaced()
+                source.cancel()
+                self.fileSources[file] = nil
+                self.refreshAfterDirectoryChangeLocked()
+                self.scheduleChangeLocked()
             } else {
-                changeHandler()
+                self.scheduleChangeLocked()
+            }
+        }
+        source.setCancelHandler { [descriptor] in
+            close(descriptor)
+        }
+        fileSources[file] = source
+        source.resume()
+    }
+
+    private func rebuildDirectoryWatchesLocked() throws {
+        let directories = Set(desiredFiles.map(nearestExistingDirectory))
+        guard directories != Set(directorySources.keys) else { return }
+
+        directorySources.values.forEach { $0.cancel() }
+        directorySources.removeAll()
+
+        for directory in directories {
+            let descriptor = open(directory.path, O_EVTONLY)
+            guard descriptor >= 0 else {
+                if requiringExistingFiles {
+                    throw LibghosttyConfigFileMonitorError.openFile(
+                        directory, errno
+                    )
+                }
+                continue
+            }
+            let source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: descriptor,
+                eventMask: [.write, .delete, .rename],
+                queue: queue
+            )
+            source.setEventHandler { [weak self, weak source] in
+                guard let self, let source,
+                      self.directorySources[directory] === source
+                else { return }
+                self.refreshAfterDirectoryChangeLocked()
+            }
+            source.setCancelHandler { [descriptor] in
+                close(descriptor)
+            }
+            directorySources[directory] = source
+            source.resume()
+        }
+    }
+
+    private func refreshAfterDirectoryChangeLocked() {
+        guard isStarted else { return }
+        var identityChanged = false
+
+        for file in desiredFiles {
+            let identity = fileIdentity(for: file)
+            if knownIdentity[file] != identity {
+                knownIdentity[file] = identity
+                identityChanged = true
+            }
+            if identity.exists, fileSources[file] == nil {
+                try? startFileWatchLocked(file)
             }
         }
 
-        source.setCancelHandler { [descriptor] in
-            close(descriptor)
+        try? rebuildDirectoryWatchesLocked()
+        if identityChanged {
+            scheduleChangeLocked()
         }
-
-        fileDescriptor = descriptor
-        fileSource = source
-        source.resume()
     }
 
-    private func startDirectoryWatch() throws {
-        let descriptor = open(directoryURL.path, O_EVTONLY)
-        guard descriptor >= 0 else {
-            throw LibghosttyConfigFileMonitorError.openFile(directoryURL, errno)
+    private func nearestExistingDirectory(for file: URL) -> URL {
+        var directory = file.deletingLastPathComponent()
+            .standardizedFileURL
+        while !FileManager.default.fileExists(
+            atPath: directory.path
+        ) {
+            let parent = directory.deletingLastPathComponent()
+            guard parent.path != directory.path else { break }
+            directory = parent
         }
+        return directory
+    }
 
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: descriptor,
-            eventMask: [.write, .delete, .rename],
-            queue: queue
+    private func fileIdentity(for file: URL) -> FileIdentity {
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            return .missing
+        }
+        let values = try? file.resourceValues(
+            forKeys: [.fileResourceIdentifierKey]
         )
-
-        source.setEventHandler { [weak self] in
-            self?.reattachFileWatchIfNeeded()
-        }
-
-        source.setCancelHandler { [descriptor] in
-            close(descriptor)
-        }
-
-        directoryDescriptor = descriptor
-        directorySource = source
-        source.resume()
+        return FileIdentity(
+            exists: true,
+            resolvedPath: file.resolvingSymlinksInPath().path,
+            resourceIdentifier: String(
+                describing: values?.fileResourceIdentifier
+            )
+        )
     }
 
-    private func handleWatchedFileReplaced() {
-        fileSource?.cancel()
-        fileSource = nil
-        fileDescriptor = -1
-        reattachFileWatchIfNeeded()
+    private func scheduleChangeLocked() {
+        pendingChange?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingChange = nil
+            self.changeHandler()
+        }
+        pendingChange = work
+        queue.asyncAfter(
+            deadline: .now() + debounceInterval,
+            execute: work
+        )
     }
 
-    private func reattachFileWatchIfNeeded() {
-        guard fileSource == nil else {
-            return
+    private func synchronized<T>(
+        _ operation: () throws -> T
+    ) rethrows -> T {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return try operation()
         }
-
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return
-        }
-
-        try? startFileWatch(requiringExistingFile: false)
-        changeHandler()
+        return try queue.sync(execute: operation)
     }
 }

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -136,6 +136,7 @@ public struct LibghosttyConfigLoadPlan: Equatable, Sendable {
     public var projectConfigFile: URL?
     public var terminalAppearanceConfigFile: URL?
     public var orderedConfigFiles: [URL]
+    public var watchedConfigFiles: [URL]
     public var createdGlobalConfig: Bool
 
     public init(
@@ -143,12 +144,14 @@ public struct LibghosttyConfigLoadPlan: Equatable, Sendable {
         projectConfigFile: URL?,
         terminalAppearanceConfigFile: URL?,
         orderedConfigFiles: [URL],
+        watchedConfigFiles: [URL],
         createdGlobalConfig: Bool
     ) {
         self.globalConfigFile = globalConfigFile
         self.projectConfigFile = projectConfigFile
         self.terminalAppearanceConfigFile = terminalAppearanceConfigFile
         self.orderedConfigFiles = orderedConfigFiles
+        self.watchedConfigFiles = watchedConfigFiles
         self.createdGlobalConfig = createdGlobalConfig
     }
 }
@@ -328,12 +331,108 @@ public struct LibghosttyConfigPipeline {
             orderedConfigFiles.append(existingAppearanceConfig)
         }
 
+        let watchedConfigFiles = resolveWatchedConfigFiles(
+            roots: [
+                paths.globalConfigFile,
+                projectConfigFile,
+                paths.terminalAppearanceConfigFile,
+            ].compactMap { $0 }
+        )
+
         return LibghosttyConfigLoadPlan(
             globalConfigFile: paths.globalConfigFile,
             projectConfigFile: existingProjectConfig,
             terminalAppearanceConfigFile: existingAppearanceConfig,
             orderedConfigFiles: orderedConfigFiles,
+            watchedConfigFiles: watchedConfigFiles,
             createdGlobalConfig: createdGlobalConfig
         )
+    }
+
+    /// Resolve the complete active `config-file` graph plus absent candidate
+    /// files whose later creation should trigger a reload.
+    ///
+    /// libghostty remains authoritative for parsing configuration values.
+    /// This lightweight traversal recognizes only the documented
+    /// `config-file = path` directive so filesystem watching follows the same
+    /// relative-path, optional-file, and recursive-include semantics.
+    private func resolveWatchedConfigFiles(roots: [URL]) -> [URL] {
+        var watched = Set<URL>()
+        var parsed = Set<URL>()
+        var ordered: [URL] = []
+
+        func visit(_ input: URL) {
+            let file = input.standardizedFileURL
+            if watched.insert(file).inserted {
+                ordered.append(file)
+            }
+            let canonicalFile = file.resolvingSymlinksInPath()
+                .standardizedFileURL
+            guard parsed.insert(canonicalFile).inserted else {
+                return
+            }
+
+            guard let contents = try? String(
+                contentsOf: file,
+                encoding: .utf8
+            ) else { return }
+
+            for line in contents.split(
+                omittingEmptySubsequences: false,
+                whereSeparator: \.isNewline
+            ) {
+                guard let included = includedConfigFile(
+                    from: String(line),
+                    relativeTo: file
+                ) else { continue }
+                visit(included)
+            }
+        }
+
+        roots.forEach(visit)
+        return ordered
+    }
+
+    private func includedConfigFile(
+        from line: String,
+        relativeTo containingFile: URL
+    ) -> URL? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#"),
+              let equals = trimmed.firstIndex(of: "=")
+        else { return nil }
+
+        let key = trimmed[..<equals]
+            .trimmingCharacters(in: .whitespaces)
+        guard key == "config-file" else { return nil }
+
+        var value = trimmed[trimmed.index(after: equals)...]
+            .trimmingCharacters(in: .whitespaces)
+        guard !value.isEmpty else { return nil }
+
+        let isQuoted = value.count >= 2
+            && ((value.first == "\"" && value.last == "\"")
+                || (value.first == "'" && value.last == "'"))
+        if isQuoted {
+            value.removeFirst()
+            value.removeLast()
+        } else if value.hasPrefix("?") {
+            value.removeFirst()
+        }
+        guard !value.isEmpty else { return nil }
+
+        if value == "~" {
+            return fileManager.homeDirectoryForCurrentUser
+        }
+        if value.hasPrefix("~/") {
+            return fileManager.homeDirectoryForCurrentUser
+                .appendingPathComponent(String(value.dropFirst(2)))
+        }
+
+        if value.hasPrefix("/") {
+            return URL(fileURLWithPath: value)
+        }
+        return containingFile.deletingLastPathComponent()
+            .appendingPathComponent(value)
     }
 }

--- a/Sources/TerminalSupport/LibghosttyConfigReloadState.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigReloadState.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum LibghosttyConfigReloadResult: Equatable, Sendable {
+    case unchanged
+    case applied
+    case rejected([String])
+    case failed(String)
+}
+
+public struct LibghosttyConfigReloadNotice:
+    Equatable, Identifiable, Sendable {
+    public enum Kind: Equatable, Sendable {
+        case success
+        case error
+    }
+
+    public let id: UUID
+    public let kind: Kind
+    public let message: String
+
+    public init(
+        id: UUID = UUID(),
+        kind: Kind,
+        message: String
+    ) {
+        self.id = id
+        self.kind = kind
+        self.message = message
+    }
+}

--- a/Sources/TerminalSupport/LibghosttyConfigReloadState.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigReloadState.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum LibghosttyConfigReloadResult: Equatable, Sendable {
     case unchanged
     case applied
+    case appliedWithWarnings([String])
     case rejected([String])
     case failed(String)
 }

--- a/Sources/TerminalUnavailable/LibghosttyRuntime.swift
+++ b/Sources/TerminalUnavailable/LibghosttyRuntime.swift
@@ -87,7 +87,12 @@ public final class LibghosttyRuntime: ObservableObject {
         guard let plan else { return }
 
         let monitor = LibghosttyConfigFileMonitor(
-            fileURLs: plan.watchedConfigFiles
+            fileURLs: plan.watchedConfigFiles,
+            errorHandler: { [weak self] error in
+                Task { @MainActor in
+                    self?.diagnostics.append(error.localizedDescription)
+                }
+            }
         ) { [weak self] in
                 guard let self else { return }
                 Task { @MainActor in
@@ -100,6 +105,7 @@ public final class LibghosttyRuntime: ObservableObject {
             configMonitor = monitor
         } catch {
             diagnostics.append(error.localizedDescription)
+            configMonitor = monitor
         }
     }
 
@@ -110,6 +116,10 @@ public final class LibghosttyRuntime: ObservableObject {
             installConfigMonitorIfNeeded(plan: plan)
             return
         }
-        try? configMonitor.update(fileURLs: plan.watchedConfigFiles)
+        do {
+            try configMonitor.update(fileURLs: plan.watchedConfigFiles)
+        } catch {
+            diagnostics.append(error.localizedDescription)
+        }
     }
 }

--- a/Sources/TerminalUnavailable/LibghosttyRuntime.swift
+++ b/Sources/TerminalUnavailable/LibghosttyRuntime.swift
@@ -17,6 +17,8 @@ public final class LibghosttyRuntime: ObservableObject {
     @Published public private(set) var phase: LibghosttyRuntimePhase
     @Published public private(set) var configPlan: LibghosttyConfigLoadPlan?
     @Published public private(set) var diagnostics: [String]
+    @Published public private(set) var configReloadNotice:
+        LibghosttyConfigReloadNotice?
 
     public let runtimeState: LibghosttyRuntimeState
     public let renderTracker = SurfaceRenderTracker()
@@ -41,8 +43,9 @@ public final class LibghosttyRuntime: ObservableObject {
         self.bootstrapStatus = bootstrapStatus
         phase = .unavailable
         diagnostics = bootstrapStatus.message.map { [$0] } ?? []
+        configReloadNotice = nil
         configPlan = try? pipeline.loadPlan()
-        installConfigMonitorIfNeeded()
+        installConfigMonitorIfNeeded(plan: configPlan)
     }
 
     public func preconditionReady(file: StaticString = #file, line: UInt = #line) {
@@ -53,24 +56,42 @@ public final class LibghosttyRuntime: ObservableObject {
         )
     }
 
-    public func reloadConfig(projectRoot: URL? = nil, force: Bool = false) {
-        guard force || activeConfigRoot != projectRoot else { return }
+    @discardableResult
+    public func reloadConfig(
+        projectRoot: URL? = nil,
+        force: Bool = false
+    ) -> LibghosttyConfigReloadResult {
+        guard force || activeConfigRoot != projectRoot else {
+            return .unchanged
+        }
         activeConfigRoot = projectRoot
         configPlan = try? pipeline.loadPlan(projectRoot: projectRoot)
+        if let configPlan {
+            updateConfigMonitor(for: configPlan)
+        }
+        return .failed("libghostty is unavailable.")
     }
 
-    public func reloadActiveConfig(force: Bool = true) {
+    @discardableResult
+    public func reloadActiveConfig(
+        force: Bool = true,
+        notifyOnSuccess: Bool = true
+    ) -> LibghosttyConfigReloadResult {
         reloadConfig(projectRoot: activeConfigRoot, force: force)
     }
 
-    private func installConfigMonitorIfNeeded() {
+    private func installConfigMonitorIfNeeded(
+        plan: LibghosttyConfigLoadPlan?
+    ) {
         guard configMonitor == nil else { return }
+        guard let plan else { return }
 
-        let monitor = LibghosttyConfigFileMonitor(fileURL: configPaths
-            .globalConfigFile) { [weak self] in
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: plan.watchedConfigFiles
+        ) { [weak self] in
                 guard let self else { return }
                 Task { @MainActor in
-                    self.reloadConfig(projectRoot: self.activeConfigRoot, force: true)
+                    self.reloadActiveConfig(force: true)
                 }
             }
 
@@ -80,5 +101,15 @@ public final class LibghosttyRuntime: ObservableObject {
         } catch {
             diagnostics.append(error.localizedDescription)
         }
+    }
+
+    private func updateConfigMonitor(
+        for plan: LibghosttyConfigLoadPlan
+    ) {
+        guard let configMonitor else {
+            installConfigMonitorIfNeeded(plan: plan)
+            return
+        }
+        try? configMonitor.update(fileURLs: plan.watchedConfigFiles)
     }
 }

--- a/Sources/TerminalUnavailable/LibghosttyRuntime.swift
+++ b/Sources/TerminalUnavailable/LibghosttyRuntime.swift
@@ -59,7 +59,8 @@ public final class LibghosttyRuntime: ObservableObject {
     @discardableResult
     public func reloadConfig(
         projectRoot: URL? = nil,
-        force: Bool = false
+        force: Bool = false,
+        notifyOnSuccess: Bool = false
     ) -> LibghosttyConfigReloadResult {
         guard force || activeConfigRoot != projectRoot else {
             return .unchanged

--- a/Sources/UI/ApplicationShortcutsView.swift
+++ b/Sources/UI/ApplicationShortcutsView.swift
@@ -10,6 +10,7 @@ enum ApplicationShortcutReference {
 
     static let shortcuts = [
         Shortcut(title: "Settings", keys: "⌘,"),
+        Shortcut(title: "Reload configuration", keys: "⇧⌘,"),
         Shortcut(title: "Command palette", keys: "⇧⌘P"),
         Shortcut(title: "Toggle sidebar", keys: "⌘B"),
         Shortcut(title: "Select worktree 1–9", keys: "⌘1–⌘9"),

--- a/Sources/UI/CommandPaletteModel.swift
+++ b/Sources/UI/CommandPaletteModel.swift
@@ -5,6 +5,7 @@ import GhosthubWorkspace
 public enum WorkspaceCommandShortcut: Equatable, Sendable {
     case commandB
     case commandShiftP
+    case commandShiftComma
     case commandShiftN
     case commandShiftI
     case commandShiftDelete
@@ -18,6 +19,8 @@ public enum WorkspaceCommandShortcut: Equatable, Sendable {
             return "Cmd+B"
         case .commandShiftP:
             return "Cmd+Shift+P"
+        case .commandShiftComma:
+            return "Cmd+Shift+,"
         case .commandShiftN:
             return "Cmd+Shift+N"
         case .commandShiftI:
@@ -37,6 +40,7 @@ public enum WorkspaceCommandShortcut: Equatable, Sendable {
 public enum WorkspaceCommandAction: Equatable, Sendable {
     case toggleSidebar
     case openConfigDirectory
+    case reloadTerminalConfig
     case previousWorktree
     case nextWorktree
     case newWorktree(UUID)
@@ -130,6 +134,16 @@ public enum CommandPaletteModel {
                 subtitle: "Open ~/.config/ghosthub in Finder.",
                 keywords: ["open", "ghosthub", "config", "directory", "finder", "settings"],
                 action: .openConfigDirectory
+            ),
+            WorkspaceCommandItem(
+                id: "reload-terminal-config",
+                title: "Reload Configuration",
+                subtitle: "Reload the active Ghosthub terminal configuration.",
+                keywords: [
+                    "reload", "terminal", "config", "ghostty.conf",
+                ],
+                shortcut: .commandShiftComma,
+                action: .reloadTerminalConfig
             ),
             WorkspaceCommandItem(
                 id: "show-log-viewer",

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -523,6 +523,8 @@ public struct RootView: View {
             toggleSidebar()
         case .openConfigDirectory:
             openConfigDirectory()
+        case .reloadTerminalConfig:
+            handlers.reloadTerminalConfig?()
         case .previousWorktree:
             if let updatedSelection = KeyboardNavigationModel.steppedSelection(
                 from: selection,

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -80,6 +80,7 @@ public struct ContentBuilders {
 public struct InteractionHandlers {
     public let closeWindow: (() -> Void)?
     public let dismissLogViewer: (() -> Void)?
+    public let reloadTerminalConfig: (() -> Void)?
     public let openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
@@ -90,6 +91,7 @@ public struct InteractionHandlers {
     public init(
         closeWindow: (() -> Void)? = nil,
         dismissLogViewer: (() -> Void)? = nil,
+        reloadTerminalConfig: (() -> Void)? = nil,
         openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
@@ -99,6 +101,7 @@ public struct InteractionHandlers {
     ) {
         self.closeWindow = closeWindow
         self.dismissLogViewer = dismissLogViewer
+        self.reloadTerminalConfig = reloadTerminalConfig
         self.openTmuxSession = openTmuxSession
         self.closeTmuxSession = closeTmuxSession
         self.createTmuxSession = createTmuxSession

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -254,6 +254,7 @@ func makeModel(
     localHostID: UUID,
     snapshot: WorkspaceSnapshot? = nil,
     configuration: WorkspaceConfiguration = .defaults(),
+    terminalRuntime: LibghosttyRuntime = .shared,
     notificationService: any NotificationService = NotificationServiceStub(),
     nativeTmuxSurfaceStore: (any TmuxSurfaceStoring)? = nil,
     nativeTmuxPathProvider:
@@ -295,6 +296,7 @@ func makeModel(
     return try WorkspaceSceneModel(
         database: database,
         workspaceConfiguration: configuration,
+        terminalRuntime: terminalRuntime,
         notificationService: notificationService,
         nativeTmuxSurfaceStore: nativeTmuxSurfaceStore,
         nativeTmuxPathProvider: nativeTmuxPathProvider,

--- a/Tests/App/WorkspaceTerminalConfigTests.swift
+++ b/Tests/App/WorkspaceTerminalConfigTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import GhosthubPersistence
+import GhosthubTerminalSupport
+import GhosthubTestSupport
+import GhosthubWorkspace
+import Testing
+@testable import GhosthubApp
+@testable import GhosthubTerminal
+
+@Suite("Workspace terminal configuration")
+@MainActor
+struct WorkspaceTerminalConfigTests {
+    @Test("only the focused window selects the app-wide project config")
+    func focusedWindowSelectsProjectConfig() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let pipeline = LibghosttyConfigPipeline(
+            paths: LibghosttyConfigPaths(
+                configDirectory: tempRoot.appendingPathComponent(
+                    "config",
+                    isDirectory: true
+                )
+            )
+        )
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtime = LibghosttyRuntime(pipeline: pipeline)
+        let hostID = UUID()
+        let firstProject = ProjectSummary.fixture(
+            hostID: hostID,
+            rootPath: tempRoot.appendingPathComponent("first").path
+        )
+        let secondProject = ProjectSummary.fixture(
+            hostID: hostID,
+            rootPath: tempRoot.appendingPathComponent("second").path
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [firstProject, secondProject],
+            worktrees: []
+        )
+        let firstModel = try makeModel(
+            database: .inMemory(),
+            localHostID: hostID,
+            snapshot: snapshot,
+            terminalRuntime: runtime
+        )
+        let secondModel = try makeModel(
+            database: .inMemory(),
+            localHostID: hostID,
+            snapshot: snapshot,
+            terminalRuntime: runtime
+        )
+
+        firstModel.selection = WorkspaceSelection(
+            selectedHostID: hostID,
+            selectedProjectID: firstProject.id
+        )
+        secondModel.selection = WorkspaceSelection(
+            selectedHostID: hostID,
+            selectedProjectID: secondProject.id
+        )
+        firstModel.isFocusedWindow = true
+        let firstConfig = pipeline.paths.projectConfigFile(
+            for: URL(fileURLWithPath: firstProject.rootPath)
+        )
+        #expect(
+            runtime.configPlan?.watchedConfigFiles.contains(firstConfig)
+                == true
+        )
+
+        #expect(
+            runtime.configPlan?.watchedConfigFiles.contains(firstConfig)
+                == true
+        )
+
+        firstModel.isFocusedWindow = false
+        secondModel.isFocusedWindow = true
+        let secondConfig = pipeline.paths.projectConfigFile(
+            for: URL(fileURLWithPath: secondProject.rootPath)
+        )
+        #expect(
+            runtime.configPlan?.watchedConfigFiles.contains(secondConfig)
+                == true
+        )
+    }
+}

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GhosthubTestSupport
 import Testing
@@ -40,6 +41,76 @@ struct LibghosttyConfigFileMonitorTests {
                 try monitor.start()
             }
         }
+    }
+
+    @Test(
+        "runtime monitor surfaces non-missing open failures",
+        arguments: [Int32(EACCES), Int32(EMFILE)]
+    )
+    func runtimeMonitorSurfacesOpenFailure(openError: Int32) throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        try fixture.writeConfig("font-size = 13\n")
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard path == fixture.configFile.path else {
+                    return open(path, flags)
+                }
+                errno = openError
+                return -1
+            },
+            changeHandler: {}
+        )
+
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                fixture.configFile, openError
+            )
+        ) {
+            try monitor.start()
+        }
+    }
+
+    @Test("monitor retains successful sources after a later open failure")
+    func monitorRetainsSuccessfulSourcesAfterOpenFailure() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        try fixture.writeConfig("font-size = 13\n")
+        let changed = DispatchSemaphore(value: 0)
+        let blockedDirectory = fixture.tempDirectory.standardizedFileURL
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard path == blockedDirectory.path else {
+                    return open(path, flags)
+                }
+                errno = EACCES
+                return -1
+            }
+        ) {
+            changed.signal()
+        }
+        defer { monitor.stop() }
+
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                blockedDirectory, EACCES
+            )
+        ) {
+            try monitor.start()
+        }
+
+        try fixture.writeConfig("font-size = 14\n")
+        #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
     @Test("monitor reattaches after delete and recreate")

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -381,6 +381,94 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("directory disappearance falls back to an existing ancestor")
+    func directoryDisappearanceFallsBackToExistingAncestor() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let transientDirectory = fixture.tempDirectory.appendingPathComponent(
+            "transient",
+            isDirectory: true
+        )
+        let config = transientDirectory.appendingPathComponent(
+            "terminal.conf"
+        )
+        try FileManager.default.createDirectory(
+            at: transientDirectory,
+            withIntermediateDirectories: false
+        )
+        var removedTransientDirectory = false
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [config],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                if !removedTransientDirectory,
+                   path == transientDirectory.path {
+                    removedTransientDirectory = true
+                    try? FileManager.default.removeItem(
+                        at: transientDirectory
+                    )
+                }
+                return open(path, flags)
+            },
+            changeHandler: {
+                changed.signal()
+            }
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+        #expect(
+            monitor.activeWatchedDirectories().contains(
+                fixture.tempDirectory.standardizedFileURL
+            )
+        )
+
+        try FileManager.default.createDirectory(
+            at: transientDirectory,
+            withIntermediateDirectories: false
+        )
+        try fixture.writeConfig("font-size = 14\n", to: config)
+
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("unstable directory coverage is reported")
+    func unstableDirectoryCoverageIsReported() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let missingConfig = fixture.tempDirectory.appendingPathComponent(
+            "terminal.conf"
+        )
+        let blockedDirectory = fixture.tempDirectory.standardizedFileURL
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [missingConfig],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard path == blockedDirectory.path else {
+                    return open(path, flags)
+                }
+                errno = ENOENT
+                return -1
+            },
+            changeHandler: {}
+        )
+
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                blockedDirectory,
+                ENOENT
+            )
+        ) {
+            try monitor.start()
+        }
+    }
+
     @Test("monitor replaces its watched config graph")
     func monitorUpdatesConfigGraph() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -185,6 +185,48 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(openCount == startOpenCount)
     }
 
+    @Test("in-place writes invalidate a staged file snapshot")
+    func inPlaceWriteInvalidatesStagedSnapshot() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let replacement = fixture.tempDirectory
+            .appendingPathComponent("replacement.conf")
+        try fixture.writeConfig("font-size = 13\n")
+        try fixture.writeConfig("font-size = 14\n", to: replacement)
+        var replacementOpenCount = 0
+        var didRewriteReplacement = false
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                let descriptor = open(path, flags)
+                guard path == replacement.path else {
+                    return descriptor
+                }
+                replacementOpenCount += 1
+                if !didRewriteReplacement {
+                    try? "font-size = 123\n".write(
+                        to: replacement,
+                        atomically: false,
+                        encoding: .utf8
+                    )
+                    didRewriteReplacement = true
+                }
+                return descriptor
+            },
+            changeHandler: {}
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try monitor.update(fileURLs: [replacement])
+
+        #expect(replacementOpenCount == 2)
+    }
+
     @Test("failed graph replacement retains the previous watch graph")
     func failedGraphReplacementRetainsExistingSources() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -59,4 +59,119 @@ struct LibghosttyConfigFileMonitorTests {
             }
         }
     }
+
+    @Test("monitor coalesces writes across the active config graph")
+    func monitorDebouncesConfigGraphWrites() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let included = fixture.tempDirectory
+            .appendingPathComponent("included.conf")
+        try fixture.writeConfig("font-size = 13\n")
+        try fixture.writeConfig("foreground = ffffff\n", to: included)
+
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile, included],
+            debounceInterval: .milliseconds(250)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try fixture.writeConfig("font-size = 14\n")
+        try fixture.writeConfig("foreground = eeeeee\n", to: included)
+
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+        #expect(
+            changed.wait(timeout: .now() + 0.4) == .timedOut
+        )
+    }
+
+    @Test("monitor notices creation of a config under an absent directory")
+    func monitorNoticesMissingConfigCreation() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let nested = fixture.tempDirectory
+            .appendingPathComponent("project/.ghosthub/terminal.conf")
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [nested],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try FileManager.default.createDirectory(
+            at: nested.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fixture.writeConfig(
+            "font-size = 15\n",
+            to: nested
+        )
+
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("monitor replaces its watched config graph")
+    func monitorUpdatesConfigGraph() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let replacement = fixture.tempDirectory
+            .appendingPathComponent("replacement.conf")
+        try fixture.writeConfig("font-size = 13\n")
+        try fixture.writeConfig("font-size = 14\n", to: replacement)
+
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+        try monitor.update(fileURLs: [replacement])
+
+        try fixture.writeConfig("font-size = 16\n")
+        #expect(
+            changed.wait(timeout: .now() + 0.25) == .timedOut
+        )
+
+        try fixture.writeConfig("font-size = 17\n", to: replacement)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("monitor notices when a config symlink changes targets")
+    func monitorNoticesSymlinkRetargeting() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let first = fixture.tempDirectory
+            .appendingPathComponent("first.conf")
+        let second = fixture.tempDirectory
+            .appendingPathComponent("second.conf")
+        try fixture.writeConfig("font-size = 13\n", to: first)
+        try fixture.writeConfig("font-size = 14\n", to: second)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.configFile,
+            withDestinationURL: first
+        )
+
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try FileManager.default.removeItem(at: fixture.configFile)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.configFile,
+            withDestinationURL: second
+        )
+
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
 }

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -236,6 +236,66 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("failed retry does not commit an unstable staged graph")
+    func failedRetryPreservesPreviousGraph() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let replacementDirectory = fixture.tempDirectory
+            .appendingPathComponent("replacement", isDirectory: true)
+        let replacement = replacementDirectory
+            .appendingPathComponent("terminal.conf")
+        try FileManager.default.createDirectory(
+            at: replacementDirectory,
+            withIntermediateDirectories: false
+        )
+        try fixture.writeConfig("font-size = 13\n")
+        try fixture.writeConfig("font-size = 14\n", to: replacement)
+        var didInvalidateSnapshot = false
+        var replacementDirectoryOpenCount = 0
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                if path == replacement.path,
+                   !didInvalidateSnapshot {
+                    let descriptor = open(path, flags)
+                    try? FileManager.default.removeItem(at: replacement)
+                    didInvalidateSnapshot = true
+                    return descriptor
+                }
+                if path == replacementDirectory.path {
+                    replacementDirectoryOpenCount += 1
+                    if replacementDirectoryOpenCount > 1 {
+                        errno = EACCES
+                        return -1
+                    }
+                }
+                return open(path, flags)
+            },
+            changeHandler: {
+                changed.signal()
+            }
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                replacementDirectory,
+                EACCES
+            )
+        ) {
+            try monitor.update(fileURLs: [replacement])
+        }
+
+        try fixture.writeConfig("font-size = 15\n")
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
     @Test("missing graph replacements prune obsolete directories")
     func missingGraphReplacementsPruneObsoleteDirectories() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -236,6 +236,40 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("missing graph replacements prune obsolete directories")
+    func missingGraphReplacementsPruneObsoleteDirectories() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        var missingConfigs: [URL] = []
+        for index in 0..<8 {
+            let directory = fixture.tempDirectory.appendingPathComponent(
+                "missing-\(index)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false
+            )
+            missingConfigs.append(
+                directory.appendingPathComponent("terminal.conf")
+            )
+        }
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [missingConfigs[0]],
+            debounceInterval: .milliseconds(25),
+            changeHandler: {}
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+
+        for config in missingConfigs.dropFirst() {
+            try monitor.update(fileURLs: [config])
+            #expect(
+                monitor.activeWatchedDirectories()
+                    == monitor.watchedDirectories()
+            )
+        }
+    }
+
     @Test("monitor reattaches after delete and recreate")
     func monitorReattachesAfterFileIsDeletedAndRecreatedLater()
         throws {

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -113,6 +113,129 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("unchanged update retries a degraded watch graph")
+    func unchangedUpdateRetriesMissingSources() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        try fixture.writeConfig("font-size = 13\n")
+        let blockedDirectory = fixture.tempDirectory.standardizedFileURL
+        var blocksDirectory = true
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard blocksDirectory,
+                      path == blockedDirectory.path
+                else {
+                    return open(path, flags)
+                }
+                errno = EMFILE
+                return -1
+            }
+        ) {
+            changed.signal()
+        }
+        defer { monitor.stop() }
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                blockedDirectory, EMFILE
+            )
+        ) {
+            try monitor.start()
+        }
+
+        blocksDirectory = false
+        try monitor.update(fileURLs: [fixture.configFile])
+        try FileManager.default.removeItem(at: fixture.configFile)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+        while changed.wait(timeout: .now()) == .success {}
+
+        try fixture.writeConfig("font-size = 14\n")
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("unchanged graph updates do not reopen descriptors")
+    func unchangedGraphUpdateIsNoOp() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        try fixture.writeConfig("font-size = 13\n")
+        var openCount = 0
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                openCount += 1
+                return open(path, flags)
+            },
+            changeHandler: {}
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+        let startOpenCount = openCount
+
+        try monitor.update(fileURLs: [fixture.configFile])
+
+        #expect(openCount == startOpenCount)
+    }
+
+    @Test("failed graph replacement retains the previous watch graph")
+    func failedGraphReplacementRetainsExistingSources() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let replacement = fixture.tempDirectory
+            .appendingPathComponent("replacement.conf")
+        try fixture.writeConfig("font-size = 13\n")
+        try fixture.writeConfig("font-size = 14\n", to: replacement)
+        var blockedPath: String?
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard path == blockedPath else {
+                    return open(path, flags)
+                }
+                errno = EMFILE
+                return -1
+            }
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        blockedPath = replacement.path
+        expectThrowsEqual(
+            LibghosttyConfigFileMonitorError.openFile(
+                replacement, EMFILE
+            )
+        ) {
+            try monitor.update(fileURLs: [replacement])
+        }
+
+        try fixture.writeConfig("font-size = 15\n")
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+
+        blockedPath = nil
+        try monitor.update(fileURLs: [replacement])
+        try fixture.writeConfig("font-size = 16\n")
+        #expect(
+            changed.wait(timeout: .now() + 0.25) == .timedOut
+        )
+        try fixture.writeConfig("font-size = 17\n", to: replacement)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
     @Test("monitor reattaches after delete and recreate")
     func monitorReattachesAfterFileIsDeletedAndRecreatedLater()
         throws {

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -330,6 +330,41 @@ struct LibghosttyConfigFileMonitorTests {
         }
     }
 
+    @Test("deeper missing graphs prune obsolete ancestor fallbacks")
+    func deeperMissingGraphsPruneObsoleteAncestorFallbacks() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        var directory = fixture.tempDirectory
+        var missingConfigs: [URL] = []
+        for index in 0..<8 {
+            directory = directory.appendingPathComponent(
+                "level-\(index)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false
+            )
+            missingConfigs.append(
+                directory.appendingPathComponent("terminal.conf")
+            )
+        }
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [missingConfigs[0]],
+            debounceInterval: .milliseconds(25),
+            changeHandler: {}
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+
+        for config in missingConfigs.dropFirst() {
+            try monitor.update(fileURLs: [config])
+            #expect(
+                monitor.activeWatchedDirectories()
+                    == monitor.watchedDirectories()
+            )
+        }
+    }
+
     @Test("monitor reattaches after delete and recreate")
     func monitorReattachesAfterFileIsDeletedAndRecreatedLater()
         throws {

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -175,6 +175,83 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("monitor notices creation of a dangling symlink target")
+    func monitorNoticesDanglingSymlinkTargetCreation() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let lexicalDirectory = fixture.tempDirectory
+            .appendingPathComponent("lexical", isDirectory: true)
+        let targetDirectory = fixture.tempDirectory
+            .appendingPathComponent("targets", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: lexicalDirectory,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: targetDirectory,
+            withIntermediateDirectories: false
+        )
+        let config = lexicalDirectory.appendingPathComponent("terminal.conf")
+        let target = targetDirectory.appendingPathComponent("terminal.conf")
+        try FileManager.default.createSymbolicLink(
+            at: config,
+            withDestinationURL: target
+        )
+
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [config],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try fixture.writeConfig("font-size = 14\n", to: target)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("monitor notices recreation of a deleted symlink target")
+    func monitorNoticesDelayedSymlinkTargetRecreation() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let lexicalDirectory = fixture.tempDirectory
+            .appendingPathComponent("lexical", isDirectory: true)
+        let targetDirectory = fixture.tempDirectory
+            .appendingPathComponent("targets", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: lexicalDirectory,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: targetDirectory,
+            withIntermediateDirectories: false
+        )
+        let config = lexicalDirectory.appendingPathComponent("terminal.conf")
+        let target = targetDirectory.appendingPathComponent("terminal.conf")
+        try fixture.writeConfig("font-size = 13\n", to: target)
+        try FileManager.default.createSymbolicLink(
+            at: config,
+            withDestinationURL: target
+        )
+
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [config],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try FileManager.default.removeItem(at: target)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+        while changed.wait(timeout: .now()) == .success {}
+
+        try fixture.writeConfig("font-size = 14\n", to: target)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
     @Test("monitor rebinds when an ancestor symlink changes targets")
     func monitorRebindsAfterAncestorSymlinkRetargeting() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -342,6 +342,45 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("new config reloads even when its watcher cannot be installed")
+    func newConfigReloadsWhenWatcherInstallFails() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        var blocksConfig = false
+        let changed = DispatchSemaphore(value: 0)
+        let failed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [fixture.configFile],
+            queue: DispatchQueue(
+                label: "com.ghosthub.terminal.config-monitor-test"
+            ),
+            debounceInterval: .milliseconds(25),
+            requiringExistingFiles: false,
+            openHandler: { path, flags in
+                guard blocksConfig,
+                      path == fixture.configFile.path
+                else {
+                    return open(path, flags)
+                }
+                errno = EMFILE
+                return -1
+            },
+            errorHandler: { _ in
+                failed.signal()
+            },
+            changeHandler: {
+                changed.signal()
+            }
+        )
+        try monitor.start()
+        defer { monitor.stop() }
+
+        blocksConfig = true
+        try fixture.writeConfig("font-size = 14\n")
+
+        #expect(failed.wait(timeout: .now() + 2) == .success)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
+
     @Test("monitor replaces its watched config graph")
     func monitorUpdatesConfigGraph() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()
@@ -471,10 +510,20 @@ struct LibghosttyConfigFileMonitorTests {
         }
         try monitor.start()
         defer { monitor.stop() }
+        #expect(
+            monitor.activeWatchedDirectories().contains(
+                targetDirectory.standardizedFileURL
+            )
+        )
 
         try FileManager.default.removeItem(at: target)
         #expect(changed.wait(timeout: .now() + 2) == .success)
         while changed.wait(timeout: .now()) == .success {}
+        #expect(
+            monitor.activeWatchedDirectories().contains(
+                targetDirectory.standardizedFileURL
+            )
+        )
 
         try fixture.writeConfig("font-size = 14\n", to: target)
         #expect(changed.wait(timeout: .now() + 2) == .success)

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -252,6 +252,36 @@ struct LibghosttyConfigFileMonitorTests {
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
 
+    @Test("watch graph processes more than 64 desired files")
+    func watchGraphDoesNotSpendSymlinkBudgetOnDesiredFiles() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        var configFiles: [URL] = []
+        var expectedDirectories: Set<URL> = []
+
+        for index in 0..<80 {
+            let directory = fixture.tempDirectory.appendingPathComponent(
+                "config-\(index)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false
+            )
+            expectedDirectories.insert(directory.standardizedFileURL)
+            configFiles.append(
+                directory.appendingPathComponent("terminal.conf")
+            )
+        }
+
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: configFiles,
+            changeHandler: {}
+        )
+        let watchedDirectories = monitor.watchedDirectories()
+
+        #expect(expectedDirectories.isSubset(of: watchedDirectories))
+    }
+
     @Test("monitor rebinds when an ancestor symlink changes targets")
     func monitorRebindsAfterAncestorSymlinkRetargeting() throws {
         let fixture = try TemporaryConfigMonitorFixture.create()

--- a/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
+++ b/Tests/Terminal/LibghosttyConfigFileMonitorTests.swift
@@ -174,4 +174,58 @@ struct LibghosttyConfigFileMonitorTests {
 
         #expect(changed.wait(timeout: .now() + 2) == .success)
     }
+
+    @Test("monitor rebinds when an ancestor symlink changes targets")
+    func monitorRebindsAfterAncestorSymlinkRetargeting() throws {
+        let fixture = try TemporaryConfigMonitorFixture.create()
+        let firstDirectory = fixture.tempDirectory
+            .appendingPathComponent("first", isDirectory: true)
+        let secondDirectory = fixture.tempDirectory
+            .appendingPathComponent("second", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: firstDirectory,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: secondDirectory,
+            withIntermediateDirectories: false
+        )
+        let first = firstDirectory.appendingPathComponent("terminal.conf")
+        let second = secondDirectory.appendingPathComponent("terminal.conf")
+        try fixture.writeConfig("font-size = 13\n", to: first)
+        try fixture.writeConfig("font-size = 14\n", to: second)
+
+        let current = fixture.tempDirectory
+            .appendingPathComponent("current", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: current,
+            withDestinationURL: firstDirectory
+        )
+        let config = current.appendingPathComponent("terminal.conf")
+        let changed = DispatchSemaphore(value: 0)
+        let monitor = LibghosttyConfigFileMonitor(
+            fileURLs: [config],
+            debounceInterval: .milliseconds(25)
+        ) {
+            changed.signal()
+        }
+        try monitor.start()
+        defer { monitor.stop() }
+
+        try FileManager.default.removeItem(at: current)
+        try FileManager.default.createSymbolicLink(
+            at: current,
+            withDestinationURL: secondDirectory
+        )
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+        while changed.wait(timeout: .now()) == .success {}
+
+        try fixture.writeConfig("font-size = 15\n", to: first)
+        #expect(
+            changed.wait(timeout: .now() + 0.25) == .timedOut
+        )
+
+        try fixture.writeConfig("font-size = 16\n", to: second)
+        #expect(changed.wait(timeout: .now() + 2) == .success)
+    }
 }

--- a/Tests/Terminal/LibghosttyConfigPipelineTests.swift
+++ b/Tests/Terminal/LibghosttyConfigPipelineTests.swift
@@ -14,6 +14,12 @@ struct LibghosttyConfigPipelineTests {
         #expect(plan.globalConfigFile == fixture.paths.globalConfigFile)
         #expect(plan.projectConfigFile == nil)
         #expect(plan.orderedConfigFiles == [fixture.paths.globalConfigFile])
+        #expect(
+            plan.watchedConfigFiles == [
+                fixture.paths.globalConfigFile,
+                fixture.paths.terminalAppearanceConfigFile,
+            ]
+        )
         #expect(FileManager.default.fileExists(
             atPath: fixture.paths.globalConfigFile.path
         ))
@@ -29,6 +35,92 @@ struct LibghosttyConfigPipelineTests {
             "shell-integration = detect",
         ], omits: [
             "shell-integration-features",
+        ])
+    }
+
+    @Test("loadPlan watches recursive and absent optional config files")
+    func loadPlanWatchesCompleteConfigGraph() throws {
+        let fixture = try ConfigPipelineFixture.create()
+        let nestedDirectory = fixture.paths.configDirectory
+            .appendingPathComponent("nested", isDirectory: true)
+        let nestedConfig = nestedDirectory
+            .appendingPathComponent("base.conf")
+        let optionalConfig = nestedDirectory
+            .appendingPathComponent("machine.conf")
+        let literalQuestionConfig = nestedDirectory
+            .appendingPathComponent("?literal.conf")
+
+        try FileManager.default.createDirectory(
+            at: nestedDirectory,
+            withIntermediateDirectories: true
+        )
+        try """
+        config-file = ?machine.conf
+        config-file = "?literal.conf"
+        font-size = 14
+        """.write(
+            to: nestedConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        try fixture.writeGlobalConfig(
+            """
+            config-file = nested/base.conf
+            font-family = Berkeley Mono
+            """
+        )
+
+        let plan = try fixture.pipeline.loadPlan()
+
+        #expect(plan.watchedConfigFiles == [
+            fixture.paths.globalConfigFile,
+            nestedConfig,
+            optionalConfig,
+            literalQuestionConfig,
+            fixture.paths.terminalAppearanceConfigFile,
+        ])
+    }
+
+    @Test("loadPlan watches a project override before it exists")
+    func loadPlanWatchesAbsentProjectOverride() throws {
+        let fixture = try ConfigPipelineFixture.create()
+        let projectRoot = fixture.tempRoot
+            .appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: projectRoot,
+            withIntermediateDirectories: true
+        )
+        let candidate = fixture.paths.projectConfigFile(
+            for: projectRoot
+        )
+
+        let plan = try fixture.pipeline.loadPlan(
+            projectRoot: projectRoot
+        )
+
+        #expect(plan.projectConfigFile == nil)
+        #expect(plan.watchedConfigFiles.contains(candidate))
+    }
+
+    @Test("loadPlan bounds recursive includes through symlink aliases")
+    func loadPlanBoundsSymlinkIncludeCycles() throws {
+        let fixture = try ConfigPipelineFixture.create()
+        let loop = fixture.paths.configDirectory
+            .appendingPathComponent("loop")
+        try FileManager.default.createSymbolicLink(
+            at: loop,
+            withDestinationURL: fixture.paths.configDirectory
+        )
+        try fixture.writeGlobalConfig(
+            "config-file = loop/ghostty.conf\n"
+        )
+
+        let plan = try fixture.pipeline.loadPlan()
+
+        #expect(plan.watchedConfigFiles == [
+            fixture.paths.globalConfigFile,
+            loop.appendingPathComponent("ghostty.conf"),
+            fixture.paths.terminalAppearanceConfigFile,
         ])
     }
 

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -329,6 +329,101 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testMonitorFailureRepublishesAfterConfigErrorNotice() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        var blockedPath: String?
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    queue: DispatchQueue(
+                        label: "com.ghosthub.terminal.config-monitor-test"
+                    ),
+                    debounceInterval: .milliseconds(25),
+                    requiringExistingFiles: false,
+                    openHandler: { path, flags in
+                        guard path == blockedPath else {
+                            return open(path, flags)
+                        }
+                        errno = EMFILE
+                        return -1
+                    },
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            }
+        )
+        let projectRoot = tempRoot.appendingPathComponent(
+            "project",
+            isDirectory: true
+        )
+        let projectConfig = pipeline.paths.projectConfigFile(
+            for: projectRoot
+        )
+        try FileManager.default.createDirectory(
+            at: projectConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = definitely-not-a-number\n".write(
+            to: projectConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        blockedPath = projectConfig.path
+
+        let rejected = runtime.reloadConfig(
+            projectRoot: projectRoot,
+            force: true
+        )
+        guard case .rejected = rejected else {
+            return XCTFail(
+                "Expected invalid configuration rejection, got \(rejected)"
+            )
+        }
+        XCTAssertTrue(
+            runtime.configReloadNotice?.message.hasPrefix(
+                "Configuration not reloaded:"
+            ) == true
+        )
+        let rejectedNoticeID = runtime.configReloadNotice?.id
+
+        try "font-size = 15\n".write(
+            to: projectConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        let applied = runtime.reloadConfig(
+            projectRoot: projectRoot,
+            force: true
+        )
+
+        guard case .appliedWithWarnings = applied else {
+            return XCTFail(
+                "Expected degraded reload success, got \(applied)"
+            )
+        }
+        XCTAssertNotEqual(runtime.configReloadNotice?.id, rejectedNoticeID)
+        XCTAssertTrue(
+            runtime.configReloadNotice?.message.hasPrefix(
+                "Automatic terminal configuration reload monitoring is degraded:"
+            ) == true
+        )
+    }
+
     func testInitialMonitorFailurePublishesDegradedNotice() throws {
         try skipUnlessLibghosttyReady()
         let (pipeline, tempRoot) = makeIsolatedPipeline()

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import Foundation
 import GhosttyKit
 import GhosthubWorkspace
@@ -236,6 +237,91 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         XCTAssertEqual(
             ctx.runtime.configReloadNotice?.kind,
             .error
+        )
+    }
+
+    func testMonitorUpdateFailurePublishesDegradedReload() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        var blockedPath: String?
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    queue: DispatchQueue(
+                        label: "com.ghosthub.terminal.config-monitor-test"
+                    ),
+                    debounceInterval: .milliseconds(25),
+                    requiringExistingFiles: false,
+                    openHandler: { path, flags in
+                        guard path == blockedPath else {
+                            return open(path, flags)
+                        }
+                        errno = EMFILE
+                        return -1
+                    },
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            }
+        )
+        let projectRoot = tempRoot.appendingPathComponent(
+            "project",
+            isDirectory: true
+        )
+        let projectConfig = pipeline.paths.projectConfigFile(
+            for: projectRoot
+        )
+        try FileManager.default.createDirectory(
+            at: projectConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 15\n".write(
+            to: projectConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        blockedPath = projectConfig.path
+
+        let result = runtime.reloadConfig(
+            projectRoot: projectRoot,
+            force: true
+        )
+
+        guard case let .appliedWithWarnings(warnings) = result else {
+            return XCTFail(
+                "Expected degraded monitoring warning, got \(result)"
+            )
+        }
+        XCTAssertEqual(runtime.diagnostics, warnings)
+        XCTAssertTrue(
+            warnings.contains {
+                $0.contains("errno \(EMFILE)")
+            }
+        )
+        XCTAssertEqual(runtime.configReloadNotice?.kind, .error)
+        XCTAssertTrue(
+            runtime.configReloadNotice?.message.contains(
+                "automatic reload monitoring is degraded"
+            ) == true
+        )
+        XCTAssertTrue(
+            runtime.configPlan?.watchedConfigFiles.contains(
+                projectConfig
+            ) == true
         )
     }
 

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -205,6 +205,81 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testInvalidConfigReloadKeepsLastValidConfig() throws {
+        let ctx = try makeIsolatedRuntime()
+        let originalHandle = try XCTUnwrap(
+            ctx.runtime.unsafeConfigHandle
+        )
+        try "font-size = definitely-not-a-number\n".write(
+            to: ctx.pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = ctx.runtime.reloadActiveConfig()
+
+        guard case let .rejected(messages) = result else {
+            return XCTFail(
+                "Expected invalid configuration to be rejected, got \(result)"
+            )
+        }
+        XCTAssertFalse(messages.isEmpty)
+        XCTAssertEqual(ctx.runtime.phase, .ready)
+        let retainedHandle = try XCTUnwrap(
+            ctx.runtime.unsafeConfigHandle
+        )
+        XCTAssertEqual(
+            UInt(bitPattern: retainedHandle),
+            UInt(bitPattern: originalHandle),
+            "A rejected reload must retain the last valid config handle."
+        )
+        XCTAssertEqual(
+            ctx.runtime.configReloadNotice?.kind,
+            .error
+        )
+    }
+
+    func testIncludedConfigAutomaticallyReloads() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        _ = try pipeline.prepareGlobalConfig()
+        let included = pipeline.paths.configDirectory
+            .appendingPathComponent("colors.conf")
+        try "foreground = ffffff\n".write(
+            to: included,
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        config-file = colors.conf
+        font-size = 13
+        """.write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtime = LibghosttyRuntime(pipeline: pipeline)
+        XCTAssertEqual(runtime.phase, .ready)
+        XCTAssertTrue(
+            runtime.configPlan?.watchedConfigFiles.contains(included)
+                == true
+        )
+
+        try "foreground = eeeeee\n".write(
+            to: included,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        waitUntil(timeout: 3) {
+            runtime.configReloadNotice?.kind == .success
+        }
+        XCTAssertEqual(runtime.diagnostics, [])
+    }
+
     func testPasteboardTypeMappingPreservesMimeSpecificTypes() {
         XCTAssertEqual(
             LibghosttyRuntime.pasteboardType(forMIMEType: "text/plain"),

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -210,6 +210,81 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testReloadInstallsProjectWatcherBeforeReadingCandidate() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        var rewritePath: String?
+        var didRewrite = false
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    queue: DispatchQueue(
+                        label: "com.ghosthub.terminal.config-monitor-test"
+                    ),
+                    debounceInterval: .milliseconds(25),
+                    requiringExistingFiles: false,
+                    openHandler: { path, flags in
+                        let descriptor = open(path, flags)
+                        guard path == rewritePath, !didRewrite else {
+                            return descriptor
+                        }
+                        try? "font-size = not-a-number\n".write(
+                            to: URL(fileURLWithPath: path),
+                            atomically: false,
+                            encoding: .utf8
+                        )
+                        didRewrite = true
+                        return descriptor
+                    },
+                    errorHandler: request.errorHandler,
+                    changeHandler: {}
+                )
+            }
+        )
+        let projectRoot = tempRoot.appendingPathComponent(
+            "project",
+            isDirectory: true
+        )
+        let projectConfig = pipeline.paths.projectConfigFile(
+            for: projectRoot
+        )
+        try FileManager.default.createDirectory(
+            at: projectConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 15\n".write(
+            to: projectConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        rewritePath = projectConfig.path
+
+        let result = runtime.reloadConfig(
+            projectRoot: projectRoot,
+            force: true
+        )
+
+        guard case .rejected = result else {
+            return XCTFail(
+                "Expected the post-watch invalid config to be rejected, got \(result)"
+            )
+        }
+    }
+
     func testInvalidConfigReloadKeepsLastValidConfig() throws {
         let ctx = try makeIsolatedRuntime()
         let originalHandle = try XCTUnwrap(

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -152,6 +152,62 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testStartupInstallsWatcherBeforeReadingInitialConfig() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        var didRewrite = false
+
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    queue: DispatchQueue(
+                        label: "com.ghosthub.terminal.config-monitor-test"
+                    ),
+                    debounceInterval: .milliseconds(25),
+                    requiringExistingFiles: false,
+                    openHandler: { path, flags in
+                        let descriptor = open(path, flags)
+                        guard path
+                            == pipeline.paths.globalConfigFile.path,
+                            !didRewrite
+                        else {
+                            return descriptor
+                        }
+                        try? "font-size = not-a-number\n".write(
+                            to: pipeline.paths.globalConfigFile,
+                            atomically: false,
+                            encoding: .utf8
+                        )
+                        didRewrite = true
+                        return descriptor
+                    },
+                    errorHandler: request.errorHandler,
+                    changeHandler: {}
+                )
+            }
+        )
+
+        XCTAssertTrue(
+            runtime.diagnostics.contains {
+                $0.contains("font-size")
+            }
+        )
+    }
+
     func testAppHandleIsNonNil() throws {
         let ctx = try makeIsolatedRuntime()
 

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -8,6 +8,10 @@ import XCTest
 @testable import GhosthubTerminal
 @testable import GhosthubTerminalSupport
 
+private final class MonitorErrorHandlerBox: @unchecked Sendable {
+    var handler: LibghosttyConfigFileMonitor.ErrorHandler?
+}
+
 @MainActor
 final class LibghosttyRuntimeSmokeTests: XCTestCase {
 
@@ -314,14 +318,111 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
         XCTAssertEqual(runtime.configReloadNotice?.kind, .error)
         XCTAssertTrue(
-            runtime.configReloadNotice?.message.contains(
-                "automatic reload monitoring is degraded"
+            runtime.configReloadNotice?.message.lowercased().contains(
+                "reload monitoring is degraded"
             ) == true
         )
         XCTAssertTrue(
             runtime.configPlan?.watchedConfigFiles.contains(
                 projectConfig
             ) == true
+        )
+    }
+
+    func testInitialMonitorFailurePublishesDegradedNotice() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    queue: DispatchQueue(
+                        label: "com.ghosthub.terminal.config-monitor-test"
+                    ),
+                    debounceInterval: .milliseconds(25),
+                    requiringExistingFiles: false,
+                    openHandler: { path, flags in
+                        guard path == pipeline.paths.globalConfigFile.path
+                        else {
+                            return open(path, flags)
+                        }
+                        errno = EMFILE
+                        return -1
+                    },
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            }
+        )
+
+        XCTAssertEqual(runtime.configReloadNotice?.kind, .error)
+        XCTAssertTrue(
+            runtime.configReloadNotice?.message.contains(
+                "errno \(EMFILE)"
+            ) == true
+        )
+        XCTAssertEqual(
+            runtime.diagnostics.filter {
+                $0.contains("errno \(EMFILE)")
+            }.count,
+            1
+        )
+    }
+
+    func testAsyncMonitorFailuresPublishOnceUntilRecovery() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        let handlerBox = MonitorErrorHandlerBox()
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                handlerBox.handler = request.errorHandler
+                return LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            }
+        )
+        let error = LibghosttyConfigFileMonitorError.openFile(
+            pipeline.paths.globalConfigFile,
+            EMFILE
+        )
+        let handler = try XCTUnwrap(handlerBox.handler)
+
+        handler(error)
+        waitUntil {
+            runtime.configReloadNotice?.message.contains(
+                "errno \(EMFILE)"
+            ) == true
+        }
+        let firstNoticeID = runtime.configReloadNotice?.id
+
+        handler(error)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        XCTAssertEqual(runtime.configReloadNotice?.id, firstNoticeID)
+        XCTAssertEqual(
+            runtime.diagnostics.filter {
+                $0.contains("errno \(EMFILE)")
+            }.count,
+            1
         )
     }
 

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -244,6 +244,55 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testSilentSuccessfulReloadClearsFailureNotice() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    errorHandler: request.errorHandler,
+                    changeHandler: {}
+                )
+            }
+        )
+        try "font-size = definitely-not-a-number\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        guard case .rejected = runtime.reloadActiveConfig() else {
+            return XCTFail("Expected invalid configuration rejection")
+        }
+        XCTAssertEqual(runtime.configReloadNotice?.kind, .error)
+
+        try "font-size = 15\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let result = runtime.reloadConfig(
+            projectRoot: nil,
+            force: true
+        )
+
+        XCTAssertEqual(result, .applied)
+        XCTAssertNil(runtime.configReloadNotice)
+    }
+
     func testMonitorUpdateFailurePublishesDegradedReload() throws {
         try skipUnlessLibghosttyReady()
         let (pipeline, tempRoot) = makeIsolatedPipeline()

--- a/Tests/UI/ApplicationShortcutsViewTests.swift
+++ b/Tests/UI/ApplicationShortcutsViewTests.swift
@@ -14,5 +14,6 @@ struct ApplicationShortcutsViewTests {
         #expect(shortcuts["Previous worktree"] == "⌥⌘↑")
         #expect(shortcuts["Next worktree"] == "⌥⌘↓")
         #expect(shortcuts["New worktree"] == "⇧⌘N")
+        #expect(shortcuts["Reload configuration"] == "⇧⌘,")
     }
 }

--- a/Tests/UI/CommandPaletteModelTests.swift
+++ b/Tests/UI/CommandPaletteModelTests.swift
@@ -48,6 +48,10 @@ struct CommandPaletteModelTests {
             title: "Open Ghosthub config directory",
             expectNilShortcut: true
         )
+        commands.expectCommandContains(
+            title: "Reload Configuration",
+            shortcut: .commandShiftComma
+        )
         commands.expectCommandNotContains(title: "Launch Layout: Claude Driver")
         commands.expectCommandNotContains(title: "Focus Worktree Shell")
         commands.expectCommandNotContains(title: "Focus Agent Session")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,12 @@ once kwt exposes one; until then project registration remains in kwt itself.
 | `tools/` | Python bootstrap and packaging automation |
 | `Tests/` | Swift and Python tests |
 
+Terminal configuration is Ghosthub-owned and applied transactionally through
+libghostty. The runtime watches the active base, project, appearance, and
+recursive include graph with debouncing. Invalid candidates never replace the
+last valid configuration, and both automatic and explicit reloads publish a
+user-visible result.
+
 ## Session Attachment
 
 Kwt workspaces and otherwise-unbound host sessions use the same native tmux

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -135,6 +135,23 @@ session model and die with the app process.
 - Do not disable libghostty shell integration to work around keybinding
   bugs.
 
+## Configuration Reloading
+
+Ghosthub automatically watches the complete active terminal-configuration
+graph: `~/.config/ghosthub/ghostty.conf`, the selected local project's
+`.ghosthub/terminal.conf`, the app-owned appearance overlay, and recursive
+`config-file` includes. Missing optional includes and absent project or
+appearance files remain watched so creating them triggers a reload. Filesystem
+events are debounced before rebuilding the graph.
+
+Reloading is transactional. A candidate with diagnostics is rejected and the
+last valid libghostty configuration remains active. The app presents the result
+of automatic and explicit reloads; errors remain visible until dismissed or
+superseded. **Ghosthub → Reload Configuration**, Quick Launch, and
+<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> all provide the explicit path.
+Options that libghostty cannot apply to existing surfaces retain their upstream
+restart or new-surface semantics.
+
 ## Verification
 
 For terminal startup, environment, config layering, libghostty bootstrap, key


### PR DESCRIPTION
Ghosthub previously watched only the top-level `ghostty.conf`. Project overrides, appearance overlays, and recursive `config-file` includes could change without reaching active terminals, while users had no discoverable way to force a reload or understand why one failed.

This makes automatic reload the normal path without allowing a bad edit to destabilize an active tmux session. Ghosthub follows the complete active configuration graph, including absent optional and project files, coalesces filesystem saves, and applies a candidate only when libghostty reports no diagnostics. The last valid configuration remains live after rejection. Symlinked configurations and recursive aliases are handled explicitly because dotfile repositories commonly use both.

A **Reload Configuration** command is now available from the Ghosthub menu, Quick Launch, and ⇧⌘,. Successful reloads produce brief confirmation; errors remain visible until dismissed or superseded. Options that libghostty cannot update at runtime retain their upstream restart or new-surface behavior.

Validation covered 503 Swift Testing cases and 135 XCTest cases, the libghostty-unavailable fallback build, Swift warning gate, 42 bootstrap tests, 101 Python tests, the documentation build, and the app build. Filesystem-focused coverage exercises atomic multi-file saves, delayed optional-file creation, graph replacement, symlink retargeting, recursive symlink cycles, and retention of the exact live config handle after an invalid candidate.