### PR TITLE
Add root-linked website deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ test-results/
 # roborev snapshots
 /.roborev/
 
+# Vercel CLI project link
+/.vercel/
+
 # Claude Code local state (agent worktrees, personal settings)
 .claude/worktrees/
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ test-results/
 # Claude Code local state (agent worktrees, personal settings)
 .claude/worktrees/
 .claude/settings.local.json
+.vercel
+.env*

--- a/.vercelignore
+++ b/.vercelignore
@@ -6,7 +6,7 @@
 website/node_modules
 website/dist
 website/.astro
-website/.env*.local
+website/.env*
 website/.vercel
 
 # Editor state and backup files at any website depth.

--- a/.vercelignore
+++ b/.vercelignore
@@ -7,6 +7,7 @@ website/node_modules
 website/dist
 website/.astro
 website/.env*
+website/**/.env*
 website/.vercel
 
 # Editor state and backup files at any website depth.

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,22 @@
+# The Vercel project is linked at the repository root but builds from website/.
+/*
+!website
+
+# Build and machine-local state under the allowed website tree.
+website/node_modules
+website/dist
+website/.astro
+website/.env*.local
+website/.vercel
+
+# Editor state and backup files at any website depth.
+website/.idea
+website/**/.idea/**
+website/.vscode
+website/**/.vscode/**
+website/*.swp
+website/**/*.swp
+website/*~
+website/**/*~
+website/.DS_Store
+website/**/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL = /bin/bash
 PYTHON ?= python3
 UV ?= uv
 SWIFT ?= swift
+PNPM ?= pnpm
+VERCEL ?= vercel
 GHOSTHUB_APP ?= Ghosthub
 HOST_KEY ?= local
 LIBGHOSTTY_ZIG ?=
@@ -30,7 +32,7 @@ KWT_VERSION ?= development
 KWT_SOURCE_REVISION ?= unpinned
 SWIFT_TEST_FILTER ?=
 
-.PHONY: help bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach python-test test smoke-test docs-build docs-serve reset-app-state install-hooks
+.PHONY: help bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach python-test test smoke-test docs-build docs-serve site-deploy reset-app-state install-hooks
 
 help:
 	@printf '%s\n' \
@@ -77,6 +79,8 @@ help:
 		'      Build the Zensical documentation site under docs/site.' \
 		'  make docs-serve' \
 		'      Serve the Zensical documentation site locally.' \
+		'  make site-deploy' \
+		'      Build the marketing site and deploy it to production with Vercel.' \
 		'  make reset-app-state' \
 		'      Delete all Ghosthub preferences, database, config, and window state to simulate a first-run experience.' \
 		'' \
@@ -322,6 +326,10 @@ docs-build:
 
 docs-serve:
 	@cd docs && $(UV) run --frozen ./zensical-docs.sh serve
+
+site-deploy:
+	@cd website && $(PNPM) build
+	@$(VERCEL) deploy --prod
 
 reset-app-state:
 	@set -euo pipefail; \

--- a/website/README.md
+++ b/website/README.md
@@ -1,8 +1,8 @@
 # ghosthub.ai
 
 Marketing site for Ghosthub. Astro static site, deployed through Vercel's
-Git integration. `.github/workflows/website.yml` is CI only (check, lint,
-test, build); it does not deploy.
+CLI. `.github/workflows/website.yml` is CI only (check, lint, test, build); it
+does not deploy.
 
     pnpm install
     pnpm dev        # local dev server
@@ -12,6 +12,21 @@ test, build); it does not deploy.
     pnpm build      # production build to dist/
 
 Constants (repo slug, Discord invite) live in `src/config.ts`.
+
+## Deployment
+
+Link the repository root to the Vercel project once. Keep the Vercel project
+root directory set to `website`; do not link from inside `website/`:
+
+    vercel link
+
+Then deploy the current workspace to production from the repository root:
+
+    make site-deploy
+
+The target builds the site first, which hydrates the hero screenshot from the
+`website-assets` branch, then runs `vercel deploy --prod`. The repository-root
+`.vercelignore` limits the upload to the website project.
 
 ## Hero screenshot
 


### PR DESCRIPTION
Ghosthub needs a deliberate way to publish pre-launch site updates without coupling production deployment to repository pushes. The root-linked Vercel workflow builds the real asset-backed Astro site before publishing and restricts the upload context to `website/`, avoiding accidental framework detection from the app repository.

The one-time project-root requirement is documented so future deploys remain predictable. Validation covered Astro type checks, lint, 11 unit tests, the production build, and a successful Vercel production deployment. The `ghosthub.ai` attachment remains pending only on its Cloudflare DNS ownership record.