### PR TITLE
Support non-POSIX login shells for tool discovery

### DIFF
--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -265,7 +265,7 @@ struct TmuxBinaryResolver: Sendable {
     ) -> (status: Int32, stdout: String) {
         runProcess(
             executable: shell,
-            arguments: ["-lc", command],
+            arguments: ["-lc", posixCommand(command)],
             timeout: timeout
         )
     }
@@ -281,14 +281,22 @@ struct TmuxBinaryResolver: Sendable {
             arguments.append(contentsOf: ["-p", String(port)])
         }
         let target = host.user.map { "\($0)@\(host.hostname)" } ?? host.hostname
-        let loginCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
-            + shellQuotedCommandArgument(command)
+        let accountShellCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
+            + shellQuotedCommandArgument(posixCommand(command))
+        let loginCommand = posixCommand(accountShellCommand)
         arguments.append(contentsOf: ["--", target, loginCommand])
         return runProcess(
             executable: "/usr/bin/ssh",
             arguments: arguments,
             timeout: timeout
         )
+    }
+
+    /// The account shell owns login-environment initialization, but Ghosthub's
+    /// command language is POSIX shell. Keep the command handed to fish, zsh,
+    /// or another account shell to one portable simple-command invocation.
+    private static func posixCommand(_ command: String) -> String {
+        "exec /bin/sh -c " + shellQuotedCommandArgument(command)
     }
 
     private static func runProcess(

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -31,6 +31,45 @@ struct TmuxBinaryResolverTests {
         #expect(try resolver.resolveTmuxPath().get() == "/opt/homebrew/bin/tmux")
     }
 
+    @Test("account shell initializes PATH without interpreting probe syntax")
+    func supportsNonPOSIXLoginShells() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghosthub-login-shell-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let tmux = directory.appendingPathComponent("tmux")
+        try "#!/bin/sh\nprintf 'tmux 3.6a\\n'\n".write(
+            to: tmux, atomically: true, encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: tmux.path
+        )
+
+        let shell = directory.appendingPathComponent("account-shell")
+        try """
+        #!/bin/sh
+        case "$2" in
+          "exec /bin/sh -c "*) ;;
+          *) exit 97 ;;
+        esac
+        PATH=\(shellQuotedCommandArgument(directory.path)):/usr/bin:/bin
+        export PATH
+        exec /bin/sh -c "$2"
+        """.write(to: shell, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: shell.path
+        )
+
+        let resolver = TmuxBinaryResolver(
+            loginShellProvider: { shell.path }
+        )
+
+        #expect(resolver.resolveTmuxPath() == .success(tmux.path))
+    }
+
     @Test("rejects unsupported tmux versions")
     func rejectsOldVersion() {
         let resolver = TmuxBinaryResolver(processRunner: { _, _ in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,9 @@ exact bundle path; Ghosthub does not select a different local kwt from `PATH`.
 This is a CLI boundary, not a vendored daemon or submodule. Remote hosts execute
 their own kwt from the remote login-shell `PATH`. Kwt's machine-readable CLI
 provides project identity, worktree metadata, and exact tmux session names.
+The account login shell initializes the command environment, while Ghosthub's
+own inventory and discovery commands execute under the host's POSIX `/bin/sh`;
+non-POSIX account shells such as fish are not asked to interpret those commands.
 Direct tmux discovery provides every otherwise-unbound session. A remote host
 without kwt remains a valid tmux-only host; remote inventory failures stay
 attached to that host and never replace usable local or cached inventory with a

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -75,6 +75,9 @@ owning window shuts down.
 
 Before discovery or attachment, Ghosthub resolves an absolute tmux path
 through the target host's login shell and verifies tmux 3.2 or newer.
+The login shell initializes its environment, then delegates Ghosthub's probe
+to `/bin/sh`; fish and other non-POSIX account shells never interpret the
+POSIX probe itself.
 Successful paths are cached per host; lookup and version failures remain
 retryable and are presented to the user.
 


### PR DESCRIPTION
Ghosthub currently asks the account login shell to both initialize its environment and interpret POSIX kwt/tmux probe commands. On nix-darwin machines where fish is the account shell, that prevents workspace inventory and tmux discovery from completing before the user can open a session.

This keeps the login shell as the source of the user environment while delegating Ghosthub-owned commands to `/bin/sh`. The same boundary applies over SSH so local and remote discovery do not depend on the account shell language.

Validated with the full 523-test Swift suite, 101 Python tests, 42 libghostty bootstrap tests, the essential kwt/tmux workflow suites, and `make build`.