### PR TITLE
Add screenshot-led website guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ Ghosthub is a **worktree-centric terminal multiplexer** for macOS.
 - For Python build tooling and tests, use `uv` rather than bare `python`, `pip`, or ad hoc virtualenv state.
 - Prefer Makefile targets over raw multi-flag test commands; if a Python or test invocation is complex enough to be copied around, add a `make` target for it.
 - Use `kata` for task management (see `CLAUDE.md`).
+- Every user-facing UI change must update the website Guide in the same turn
+  and regenerate the complete website screenshot set. Publish refreshed
+  binaries to the orphan `website-assets` branch so UI changes never leave
+  ghosthub.ai with stale product views.
 - Pull request descriptions should be concise, rationale-first prose. Do not add boilerplate or navel-gazing sections like "Changes", "Tests", or "Verification"; mention validation only when it is genuinely useful reviewer context.
 - Do not poll or watch GitHub Actions through `gh`, the GitHub API, or browser automation unless the user explicitly asks you to do so.
 - **NO DATABASE MIGRATIONS** until the first production release. Update the current schema, bootstrap paths, fixtures, and tests directly.

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -64,17 +64,12 @@ def test_scratch_guard_requires_creation_after_allow_missing_check(tmp_path: Pat
     assert "disappeared or was never created" in required.stderr
 
 
-def test_stage_disables_claude_customizations_without_accepting_trust() -> None:
+def test_stage_uses_a_curated_account_free_agent_session() -> None:
     stage = (DEMO / "stage.sh").read_text()
 
-    assert "claude --safe-mode --permission-mode plan --strict-mcp-config" in stage
-    assert "--setting-sources project" not in stage
-    trust_block = stage[
-        stage.index('trust_required=""') : stage.index('if [[ -z "$claude_ready" ]]')
-    ]
-    assert "trust the files in this folder" in trust_block
-    assert "tmux send-keys" not in trust_block
-    assert "exit 1" in trust_block
+    assert 'cat > "$scratch/agent-transcript.txt"' in stage
+    assert "Ghosthub opens the same tmux client locally and remotely." in stage
+    assert '"clear; cat $(printf \'%q\' "$scratch/agent-transcript.txt")"' in stage
 
 
 def test_stage_stops_live_consumers_before_replacing_scratch_state() -> None:
@@ -96,13 +91,15 @@ def test_stage_uses_immutable_docker_image_id_without_a_shared_tag() -> None:
     assert '-p 127.0.0.1:2201:22 "$image_id"' in stage
 
 
-def test_stage_clones_only_public_main_without_local_objects() -> None:
+def test_stage_builds_ghosthub_from_synthetic_history() -> None:
     stage = (DEMO / "stage.sh").read_text()
 
-    assert "--no-local --single-branch --branch main --depth 1" in stage
-    assert "https://github.com/kenn-io/ghosthub.git" in stage
-    assert "git clone -q --local " not in stage
-    assert "GHOSTHUB_DEMO_SOURCE" not in stage
+    ghosthub_fixture = stage[
+        stage.index("make_repo ghosthub") : stage.index("make_repo agentsview")
+    ]
+    assert "Initial native workspace" in ghosthub_fixture
+    assert "Attach ordinary tmux clients" in ghosthub_fixture
+    assert "Reconnect remote sessions" in ghosthub_fixture
 
 
 def test_demo_git_ignores_url_rewrites_and_hooks(tmp_path: Path) -> None:
@@ -854,10 +851,22 @@ def make_offline_asset_tree(tmp_path: Path, *, trusted: bool) -> tuple[Path, dic
     assets.mkdir(parents=True)
     fake_bin.mkdir()
     shutil.copy2(ROOT / "website" / "scripts" / "sync-assets.sh", scripts)
-    (assets / "hero.png").write_bytes(b"legacy-placeholder-or-unverified-image")
-    if trusted:
-        digest = hashlib.sha256((assets / "hero.png").read_bytes()).hexdigest()
-        (assets / "hero.png.synced").write_text(f"{digest}  src/assets/hero.png\n")
+    asset_names = (
+        "hero.png",
+        "guide-sessions.png",
+        "guide-hosts.png",
+        "guide-worktree.png",
+        "guide-quick-launch.png",
+        "guide-terminal.png",
+    )
+    for asset_name in asset_names:
+        asset = assets / asset_name
+        asset.write_bytes(f"unverified-{asset_name}".encode())
+        if trusted:
+            digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+            (assets / f"{asset_name}.synced").write_text(
+                f"{digest}  src/assets/{asset_name}\n"
+            )
     for command in ("git", "curl"):
         path = fake_bin / command
         path.write_text("#!/usr/bin/env bash\nexit 1\n")
@@ -878,4 +887,4 @@ def test_offline_asset_reuse_requires_synced_provenance(
 
     assert result.returncode == expected_code
     if not trusted:
-        assert "missing or is a stale placeholder" in result.stderr
+        assert "is missing or stale" in result.stderr

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -858,6 +858,12 @@ def make_offline_asset_tree(tmp_path: Path, *, trusted: bool) -> tuple[Path, dic
         "guide-worktree.png",
         "guide-quick-launch.png",
         "guide-terminal.png",
+        "guide-command-ghosthub.png",
+        "guide-command-agentsview.png",
+        "guide-command-scratch.png",
+        "guide-command-export.png",
+        "guide-command-release.png",
+        "guide-command-tests.png",
     )
     for asset_name in asset_names:
         asset = assets / asset_name

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -73,6 +73,55 @@ def test_scratch_guard_requires_creation_after_allow_missing_check(tmp_path: Pat
     assert "disappeared or was never created" in required.stderr
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="demo scripts target macOS stat")
+def test_private_directory_prepare_creates_owner_only_output(tmp_path: Path) -> None:
+    output = tmp_path / "screenshots"
+    env = {
+        **os.environ,
+        "GUARD": str(DEMO / "scratch-guard.sh"),
+        "OUTPUT": str(output),
+    }
+
+    result = run_bash(
+        'source "$GUARD"; '
+        'demo_private_directory_prepare '
+        '"$OUTPUT" "screenshot output" "replace screenshots"',
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="demo scripts target macOS stat")
+@pytest.mark.parametrize("unsafe_kind", ["shared", "symlink"])
+def test_private_directory_prepare_rejects_unsafe_output(
+    tmp_path: Path, unsafe_kind: str
+) -> None:
+    output = tmp_path / "screenshots"
+    if unsafe_kind == "shared":
+        output.mkdir(mode=0o700)
+        output.chmod(0o755)
+    else:
+        target = tmp_path / "target"
+        target.mkdir(mode=0o700)
+        output.symlink_to(target, target_is_directory=True)
+    env = {
+        **os.environ,
+        "GUARD": str(DEMO / "scratch-guard.sh"),
+        "OUTPUT": str(output),
+    }
+
+    result = run_bash(
+        'source "$GUARD"; '
+        'demo_private_directory_prepare '
+        '"$OUTPUT" "screenshot output" "replace screenshots"',
+        env=env,
+    )
+
+    assert result.returncode != 0
+
+
 def test_stage_uses_a_curated_account_free_agent_session() -> None:
     stage = (DEMO / "stage.sh").read_text()
 

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -858,12 +858,7 @@ def make_offline_asset_tree(tmp_path: Path, *, trusted: bool) -> tuple[Path, dic
         "guide-worktree.png",
         "guide-quick-launch.png",
         "guide-terminal.png",
-        "guide-command-ghosthub.png",
-        "guide-command-agentsview.png",
-        "guide-command-scratch.png",
-        "guide-command-export.png",
-        "guide-command-release.png",
-        "guide-command-tests.png",
+        "guide-command-center.png",
     )
     for asset_name in asset_names:
         asset = assets / asset_name

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -889,3 +889,72 @@ def test_offline_asset_reuse_requires_synced_provenance(
     assert result.returncode == expected_code
     if not trusted:
         assert "is missing or stale" in result.stderr
+
+
+def test_fetched_asset_ref_is_authoritative_and_atomic(tmp_path: Path) -> None:
+    website = tmp_path / "website"
+    scripts = website / "scripts"
+    assets = website / "src" / "assets"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    assets.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(ROOT / "website" / "scripts" / "sync-assets.sh", scripts)
+    asset_names = (
+        "hero.png",
+        "guide-sessions.png",
+        "guide-hosts.png",
+        "guide-worktree.png",
+        "guide-quick-launch.png",
+        "guide-terminal.png",
+        "guide-command-center.png",
+    )
+    originals = {}
+    for asset_name in asset_names:
+        content = f"original-{asset_name}".encode()
+        originals[asset_name] = content
+        (assets / asset_name).write_bytes(content)
+
+    git = fake_bin / "git"
+    git.write_text(
+        "#!/usr/bin/env bash\n"
+        "case \"$1\" in\n"
+        "  fetch) exit 0 ;;\n"
+        "  cat-file)\n"
+        "    [[ \"$3\" == \"FETCH_HEAD:guide-worktree.png\" ]] && exit 1\n"
+        "    exit 0\n"
+        "    ;;\n"
+        "  show) printf 'fetched-%s' \"${2#*:}\"; exit 0 ;;\n"
+        "esac\n"
+        "exit 1\n"
+    )
+    git.chmod(0o755)
+    curl_marker = tmp_path / "curl-called"
+    curl = fake_bin / "curl"
+    curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "touch \"$CURL_MARKER\"\n"
+        "exit 0\n"
+    )
+    curl.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CURL_MARKER": str(curl_marker),
+    }
+
+    result = subprocess.run(
+        ["bash", str(scripts / "sync-assets.sh")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "fetched website-assets is incomplete" in result.stderr
+    assert not curl_marker.exists()
+    assert {
+        asset_name: (assets / asset_name).read_bytes()
+        for asset_name in asset_names
+    } == originals

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -15,6 +15,15 @@ import pytest
 
 ROOT = Path(__file__).parents[1]
 DEMO = ROOT / "website" / "demo"
+WEBSITE_ASSET_NAMES = (
+    "hero.png",
+    "guide-sessions.png",
+    "guide-hosts.png",
+    "guide-worktree.png",
+    "guide-quick-launch.png",
+    "guide-terminal.png",
+    "guide-command-center.png",
+)
 
 
 def run_bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -851,23 +860,15 @@ def make_offline_asset_tree(tmp_path: Path, *, trusted: bool) -> tuple[Path, dic
     assets.mkdir(parents=True)
     fake_bin.mkdir()
     shutil.copy2(ROOT / "website" / "scripts" / "sync-assets.sh", scripts)
-    asset_names = (
-        "hero.png",
-        "guide-sessions.png",
-        "guide-hosts.png",
-        "guide-worktree.png",
-        "guide-quick-launch.png",
-        "guide-terminal.png",
-        "guide-command-center.png",
-    )
-    for asset_name in asset_names:
+    manifest = []
+    for asset_name in WEBSITE_ASSET_NAMES:
         asset = assets / asset_name
         asset.write_bytes(f"unverified-{asset_name}".encode())
         if trusted:
             digest = hashlib.sha256(asset.read_bytes()).hexdigest()
-            (assets / f"{asset_name}.synced").write_text(
-                f"{digest}  src/assets/{asset_name}\n"
-            )
+            manifest.append(f"{digest}  src/assets/{asset_name}\n")
+    if trusted:
+        (assets / ".website-assets.synced").write_text("".join(manifest))
     for command in ("git", "curl"):
         path = fake_bin / command
         path.write_text("#!/usr/bin/env bash\nexit 1\n")
@@ -900,17 +901,8 @@ def test_fetched_asset_ref_is_authoritative_and_atomic(tmp_path: Path) -> None:
     assets.mkdir(parents=True)
     fake_bin.mkdir()
     shutil.copy2(ROOT / "website" / "scripts" / "sync-assets.sh", scripts)
-    asset_names = (
-        "hero.png",
-        "guide-sessions.png",
-        "guide-hosts.png",
-        "guide-worktree.png",
-        "guide-quick-launch.png",
-        "guide-terminal.png",
-        "guide-command-center.png",
-    )
     originals = {}
-    for asset_name in asset_names:
+    for asset_name in WEBSITE_ASSET_NAMES:
         content = f"original-{asset_name}".encode()
         originals[asset_name] = content
         (assets / asset_name).write_bytes(content)
@@ -956,5 +948,65 @@ def test_fetched_asset_ref_is_authoritative_and_atomic(tmp_path: Path) -> None:
     assert not curl_marker.exists()
     assert {
         asset_name: (assets / asset_name).read_bytes()
-        for asset_name in asset_names
+        for asset_name in WEBSITE_ASSET_NAMES
     } == originals
+
+
+def test_interrupted_asset_publication_invalidates_generation(
+    tmp_path: Path,
+) -> None:
+    website = tmp_path / "website"
+    scripts = website / "scripts"
+    assets = website / "src" / "assets"
+    fake_bin = tmp_path / "bin"
+    scripts.mkdir(parents=True)
+    assets.mkdir(parents=True)
+    fake_bin.mkdir()
+    shutil.copy2(ROOT / "website" / "scripts" / "sync-assets.sh", scripts)
+
+    manifest = []
+    for asset_name in WEBSITE_ASSET_NAMES:
+        asset = assets / asset_name
+        asset.write_bytes(f"original-{asset_name}".encode())
+        digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+        manifest.append(f"{digest}  src/assets/{asset_name}\n")
+    generation = assets / ".website-assets.synced"
+    generation.write_text("".join(manifest))
+
+    git = fake_bin / "git"
+    git.write_text(
+        "#!/usr/bin/env bash\n"
+        "case \"$1\" in\n"
+        "  fetch|cat-file) exit 0 ;;\n"
+        "  show) printf 'fetched-%s' \"${2#*:}\"; exit 0 ;;\n"
+        "esac\n"
+        "exit 1\n"
+    )
+    git.chmod(0o755)
+    move_count = tmp_path / "move-count"
+    move = fake_bin / "mv"
+    move.write_text(
+        "#!/usr/bin/env bash\n"
+        "count=$(cat \"$MOVE_COUNT\" 2>/dev/null || printf 0)\n"
+        "count=$((count + 1))\n"
+        "printf '%s' \"$count\" > \"$MOVE_COUNT\"\n"
+        "[[ \"$count\" -eq 4 ]] && exit 1\n"
+        "exec /bin/mv \"$@\"\n"
+    )
+    move.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "MOVE_COUNT": str(move_count),
+    }
+
+    result = subprocess.run(
+        ["bash", str(scripts / "sync-assets.sh")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not generation.exists()

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -5,3 +5,5 @@ dist/
 src/assets/*.png
 src/assets/*.png.placeholder
 src/assets/*.png.synced
+src/assets/.website-assets.placeholder
+src/assets/.website-assets.synced

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -2,6 +2,6 @@ node_modules/
 dist/
 .astro/
 # Synced from the orphan website-assets branch by scripts/sync-assets.sh
-src/assets/hero.png
-src/assets/hero.png.placeholder
-src/assets/hero.png.synced
+src/assets/*.png
+src/assets/*.png.placeholder
+src/assets/*.png.synced

--- a/website/README.md
+++ b/website/README.md
@@ -28,30 +28,34 @@ The target builds the site first, which hydrates the hero screenshot from the
 `website-assets` branch, then runs `vercel deploy --prod`. The repository-root
 `.vercelignore` limits the upload to the website project.
 
-## Hero screenshot
+## Product screenshots
 
-`src/assets/hero.png` is gitignored; binaries live on the orphan
-`website-assets` branch and `scripts/sync-assets.sh` materializes them
+`src/assets/*.png` is gitignored; binaries live on the orphan
+`website-assets` branch and `scripts/sync-assets.sh` materializes the required set
 (it runs automatically via `pnpm dev`, `pnpm check`, and `pnpm build`).
 The script degrades to a generated placeholder only when
 `SYNC_ASSETS_ALLOW_PLACEHOLDER` is set (CI does this while the repo is
 private); production builds fail instead of silently deploying a
-placeholder. Successfully fetched assets get a local checksum sidecar, so an
-unmarked legacy placeholder is never reused by an offline production build.
+placeholder or partial set. Successfully fetched assets get local checksum
+sidecars, so unmarked legacy placeholders are never reused by an offline
+production build.
 
-To refresh the screenshot, use the faux environment in `demo/`. It never
-shows real project or host details:
+To refresh every screenshot, use the faux environment in `demo/`. It never
+shows real project or host details, and `shoot.sh` drives the exact staged
+process through every documented UI state:
 
     cd website/demo
-    ./stage.sh && ./run.sh && ./shoot.sh
+    ./stage.sh && ./run.sh && ./shoot.sh /tmp/ghosthub-website-assets
     ./teardown.sh   # always run: stops demo processes and removes scratch state
 
 The staged app receives an explicit demo-only OpenSSH configuration and
 known-hosts file under the guarded scratch directory. Discovery and attachment
 therefore cannot inherit the developer's SSH aliases, proxies, or host trust.
 
-Crop the native titlebar (34px at 1x) since Hero.astro renders its own
-synthetic titlebar, then commit the result as `hero.png` on
-`website-assets` and push that branch. Pushing `website-assets` does not
-redeploy the site by itself: trigger a Vercel redeploy (dashboard, or any
-push to the production branch) to publish the new screenshot.
+The injected demo controller drives and captures only its exact staged
+process, so the workflow needs neither Accessibility nor Screen Recording
+permission. `shoot.sh` crops the native 34pt titlebar and writes optimized
+1600px PNGs with the exact filenames expected by the site.
+Commit those files on `website-assets` and push that branch. Pushing
+`website-assets` does not redeploy the site by itself: trigger a Vercel
+redeploy (dashboard, or any push to the production branch) to publish them.

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -117,6 +117,22 @@ static BOOL DemoContainsText(id element, NSString *text,
   return NO;
 }
 
+static BOOL DemoPalettePostcondition(NSString *kind,
+                                     NSWindow *paletteSheet) {
+  NSWindow *currentSheet = DemoRootWindow().attachedSheet;
+  BOOL paletteOpen = currentSheet == paletteSheet;
+  if ([kind isEqualToString:@"palette-open"]) {
+    return paletteOpen;
+  }
+  if ([kind isEqualToString:@"palette-closed"]) {
+    return !paletteOpen;
+  }
+  if ([kind isEqualToString:@"palette-replaced"]) {
+    return !paletteOpen && currentSheet != nil;
+  }
+  return NO;
+}
+
 static NSWindow *DemoRootWindow(void) {
   NSWindow *window = [NSApp keyWindow] ?: [NSApp mainWindow];
   while (window.sheetParent != nil) {
@@ -363,6 +379,7 @@ static void DemoCapture(NSString *path, BOOL matrix) {
   NSString *action = notification.userInfo[@"action"];
   NSString *requestID = notification.userInfo[@"requestID"];
   NSString *text = notification.userInfo[@"text"] ?: @"";
+  NSString *expectKind = notification.userInfo[@"expectKind"] ?: @"";
   BOOL submit =
       [notification.userInfo[@"submit"] isEqualToString:@"true"];
   if (action.length == 0 || requestID.length == 0) return;
@@ -381,20 +398,43 @@ static void DemoCapture(NSString *path, BOOL matrix) {
                         message:@"command palette did not accept text"];
               return;
             }
-            if (!submit) {
-              [self acknowledge:requestID
-                        success:YES
-                        message:@"command palette ready"];
-              return;
-            }
+            NSWindow *paletteSheet = DemoRootWindow().attachedSheet;
             dispatch_after(
-                dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+                dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
                 dispatch_get_main_queue(), ^{
-                  BOOL sent = DemoSendKey(@"\r", 36, 0);
-                  [self acknowledge:requestID
-                            success:sent
-                            message:sent ? @"command palette submitted"
-                                         : @"command palette lost its window"];
+                  if (!submit) {
+                    BOOL matched = DemoPalettePostcondition(
+                        expectKind, paletteSheet);
+                    [self acknowledge:requestID
+                              success:matched
+                              message:matched
+                                  ? @"command palette matched requested state"
+                                  : @"command palette did not match requested state"];
+                    return;
+                  }
+                  dispatch_after(
+                      dispatch_time(
+                          DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
+                      dispatch_get_main_queue(), ^{
+                        if (!DemoSendKey(@"\r", 36, 0)) {
+                          [self acknowledge:requestID
+                                    success:NO
+                                    message:@"command palette lost its window"];
+                          return;
+                        }
+                        dispatch_after(
+                            dispatch_time(
+                                DISPATCH_TIME_NOW, 750 * NSEC_PER_MSEC),
+                            dispatch_get_main_queue(), ^{
+                              BOOL matched = DemoPalettePostcondition(
+                                  expectKind, paletteSheet);
+                              [self acknowledge:requestID
+                                        success:matched
+                                        message:matched
+                                            ? @"command reached requested state"
+                                            : @"command did not reach requested state"];
+                            });
+                      });
                 });
           });
     } else if ([action isEqualToString:@"text"]) {

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -124,6 +124,87 @@ static CGRect DemoWindowBounds(CGWindowID windowID) {
   return bounds;
 }
 
+static CFArrayRef DemoOwnedWindowIDs(CGRect captureBounds) {
+  CFArrayRef info = CGWindowListCopyWindowInfo(
+      kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+  CFMutableArrayRef windowIDs = CFArrayCreateMutable(
+      kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+  if (info == NULL) return windowIDs;
+
+  pid_t demoPID = getpid();
+  for (CFIndex index = 0; index < CFArrayGetCount(info); index++) {
+    CFDictionaryRef entry = CFArrayGetValueAtIndex(info, index);
+    CFNumberRef owner = CFDictionaryGetValue(entry, kCGWindowOwnerPID);
+    int ownerPID = 0;
+    if (owner == NULL ||
+        !CFNumberGetValue(owner, kCFNumberIntType, &ownerPID) ||
+        ownerPID != demoPID) {
+      continue;
+    }
+
+    CFDictionaryRef rawBounds =
+        CFDictionaryGetValue(entry, kCGWindowBounds);
+    CGRect windowBounds = CGRectNull;
+    if (rawBounds == NULL ||
+        !CGRectMakeWithDictionaryRepresentation(rawBounds, &windowBounds) ||
+        CGRectIsNull(CGRectIntersection(captureBounds, windowBounds))) {
+      continue;
+    }
+
+    CFNumberRef windowID =
+        CFDictionaryGetValue(entry, kCGWindowNumber);
+    if (windowID != NULL) CFArrayAppendValue(windowIDs, windowID);
+  }
+  CFRelease(info);
+  return windowIDs;
+}
+
+typedef CGImageRef (*DemoCreateWindowImage)(
+    CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
+
+static CGImageRef DemoCreateOwnedWindowComposite(
+    CGRect captureBounds, CFArrayRef windowIDs,
+    DemoCreateWindowImage createImage) {
+  size_t width = (size_t)ceil(CGRectGetWidth(captureBounds));
+  size_t height = (size_t)ceil(CGRectGetHeight(captureBounds));
+  CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+  CGContextRef context = CGBitmapContextCreate(
+      NULL, width, height, 8, width * 4, colorSpace,
+      (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
+  CGColorSpaceRelease(colorSpace);
+  if (context == NULL) return NULL;
+
+  CGWindowImageOption imageOptions =
+      kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution;
+  for (CFIndex index = CFArrayGetCount(windowIDs); index > 0; index--) {
+    CFNumberRef rawWindowID = CFArrayGetValueAtIndex(windowIDs, index - 1);
+    CGWindowID windowID = kCGNullWindowID;
+    if (!CFNumberGetValue(
+            rawWindowID, kCGWindowIDCFNumberType, &windowID)) {
+      continue;
+    }
+    CGRect windowBounds = DemoWindowBounds(windowID);
+    if (CGRectIsNull(windowBounds)) continue;
+    CGImageRef windowImage = createImage(
+        windowBounds, kCGWindowListOptionIncludingWindow, windowID,
+        imageOptions);
+    if (windowImage == NULL) continue;
+
+    CGRect destination = CGRectMake(
+        CGRectGetMinX(windowBounds) - CGRectGetMinX(captureBounds),
+        CGRectGetHeight(captureBounds) -
+            (CGRectGetMinY(windowBounds) - CGRectGetMinY(captureBounds)) -
+            CGRectGetHeight(windowBounds),
+        CGRectGetWidth(windowBounds), CGRectGetHeight(windowBounds));
+    CGContextDrawImage(context, destination, windowImage);
+    CGImageRelease(windowImage);
+  }
+
+  CGImageRef composite = CGBitmapContextCreateImage(context);
+  CGContextRelease(context);
+  return composite;
+}
+
 static BOOL DemoCaptureWindow(NSWindow *window, NSString *path,
                               BOOL exactWindow) {
   if (window == nil) return NO;
@@ -134,17 +215,25 @@ static BOOL DemoCaptureWindow(NSWindow *window, NSString *path,
    * but the runtime retains it for binary compatibility. Resolving it here
    * lets the injected process capture only its existing on-screen demo
    * window without ScreenCaptureKit's system-wide recording permission. */
-  typedef CGImageRef (*CreateWindowImage)(
-      CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
-  CreateWindowImage createImage =
-      (CreateWindowImage)dlsym(RTLD_DEFAULT, "CGWindowListCreateImage");
+  DemoCreateWindowImage createImage =
+      (DemoCreateWindowImage)dlsym(
+          RTLD_DEFAULT, "CGWindowListCreateImage");
   if (createImage == NULL) return NO;
-  CGImageRef image = createImage(
-      bounds,
-      exactWindow ? kCGWindowListOptionIncludingWindow
-                  : kCGWindowListOptionOnScreenOnly,
-      exactWindow ? (CGWindowID)window.windowNumber : kCGNullWindowID,
-      kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution);
+  CGImageRef image = NULL;
+  CGWindowImageOption imageOptions =
+      kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution;
+  if (exactWindow) {
+    image = createImage(
+        bounds, kCGWindowListOptionIncludingWindow,
+        (CGWindowID)window.windowNumber, imageOptions);
+  } else {
+    CFArrayRef windowIDs = DemoOwnedWindowIDs(bounds);
+    if (CFArrayGetCount(windowIDs) > 0) {
+      image = DemoCreateOwnedWindowComposite(
+          bounds, windowIDs, createImage);
+    }
+    CFRelease(windowIDs);
+  }
   if (image == NULL) return NO;
 
   BOOL wrote = NO;

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -15,6 +15,8 @@ static NSString *const DemoCaptureNotification =
     @"com.ghosthub.demo.capture";
 static NSString *const DemoInputNotification =
     @"com.ghosthub.demo.input";
+static NSString *const DemoInputAcknowledgement =
+    @"com.ghosthub.demo.input.ack";
 
 @interface DemoController : NSObject
 @end
@@ -25,10 +27,10 @@ static NSString *DemoHostName(id self, SEL _cmd) {
   return @"studio.local";
 }
 
-static void DemoSendKey(NSString *characters, unsigned short keyCode,
+static BOOL DemoSendKey(NSString *characters, unsigned short keyCode,
                         NSEventModifierFlags modifiers) {
   NSWindow *window = [NSApp keyWindow] ?: [NSApp mainWindow];
-  if (window == nil) return;
+  if (window == nil) return NO;
   NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
   NSEvent *down = [NSEvent keyEventWithType:NSEventTypeKeyDown
                                    location:NSZeroPoint
@@ -52,11 +54,12 @@ static void DemoSendKey(NSString *characters, unsigned short keyCode,
                                   keyCode:keyCode];
   [NSApp sendEvent:down];
   [NSApp sendEvent:up];
+  return YES;
 }
 
-static void DemoClick(NSPoint point) {
+static BOOL DemoClick(NSPoint point) {
   NSWindow *window = DemoRootWindow();
-  if (window == nil) return;
+  if (window == nil) return NO;
   NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
   NSEvent *down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
                                      location:point
@@ -78,15 +81,16 @@ static void DemoClick(NSPoint point) {
                                    pressure:0];
   [NSApp sendEvent:down];
   [NSApp sendEvent:up];
+  return YES;
 }
 
-static void DemoInsertText(NSString *text) {
+static BOOL DemoInsertText(NSString *text) {
   id responder = [NSApp keyWindow].firstResponder;
-  if ([responder respondsToSelector:
-          @selector(insertText:replacementRange:)]) {
-    [responder insertText:text
-         replacementRange:NSMakeRange(NSNotFound, 0)];
-  }
+  if (![responder respondsToSelector:
+          @selector(insertText:replacementRange:)]) return NO;
+  [responder insertText:text
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+  return YES;
 }
 
 static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
@@ -96,6 +100,19 @@ static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
   }
   for (id child in [element accessibilityChildren] ?: @[]) {
     if (DemoPressLabel(child, label, depth + 1)) return YES;
+  }
+  return NO;
+}
+
+static BOOL DemoContainsText(id element, NSString *text,
+                             NSUInteger depth) {
+  if (element == nil || depth > 20) return NO;
+  if ([[element accessibilityLabel] isEqualToString:text] ||
+      [[[element accessibilityValue] description] isEqualToString:text]) {
+    return YES;
+  }
+  for (id child in [element accessibilityChildren] ?: @[]) {
+    if (DemoContainsText(child, text, depth + 1)) return YES;
   }
   return NO;
 }
@@ -317,6 +334,22 @@ static void DemoCapture(NSString *path, BOOL matrix) {
 
 @implementation DemoController
 
+- (void)acknowledge:(NSString *)requestID
+            success:(BOOL)success
+            message:(NSString *)message {
+  NSString *target =
+      [NSString stringWithFormat:@"%d",
+                                 [NSProcessInfo processInfo].processIdentifier];
+  [[NSDistributedNotificationCenter defaultCenter]
+      postNotificationName:DemoInputAcknowledgement
+                    object:target
+                  userInfo:@{
+                    @"requestID": requestID,
+                    @"success": @(success),
+                    @"message": message ?: @"",
+                  }];
+}
+
 - (void)capture:(NSNotification *)notification {
   NSString *path = notification.userInfo[@"path"];
   BOOL matrix = [notification.userInfo[@"mode"] isEqualToString:@"matrix"];
@@ -328,57 +361,143 @@ static void DemoCapture(NSString *path, BOOL matrix) {
 
 - (void)input:(NSNotification *)notification {
   NSString *action = notification.userInfo[@"action"];
-  if ([action isEqualToString:@"palette"]) {
-    NSString *query = notification.userInfo[@"text"] ?: @"";
-    BOOL submit =
-        [notification.userInfo[@"submit"] isEqualToString:@"true"];
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:@"ghosthubCommandPalette"
-                      object:nil];
-    dispatch_after(
-        dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
-        dispatch_get_main_queue(), ^{
-          DemoInsertText(query);
-          if (submit) {
+  NSString *requestID = notification.userInfo[@"requestID"];
+  NSString *text = notification.userInfo[@"text"] ?: @"";
+  BOOL submit =
+      [notification.userInfo[@"submit"] isEqualToString:@"true"];
+  if (action.length == 0 || requestID.length == 0) return;
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if ([action isEqualToString:@"palette"]) {
+      [[NSNotificationCenter defaultCenter]
+          postNotificationName:@"ghosthubCommandPalette"
+                        object:nil];
+      dispatch_after(
+          dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+          dispatch_get_main_queue(), ^{
+            if (!DemoInsertText(text)) {
+              [self acknowledge:requestID
+                        success:NO
+                        message:@"command palette did not accept text"];
+              return;
+            }
+            if (!submit) {
+              [self acknowledge:requestID
+                        success:YES
+                        message:@"command palette ready"];
+              return;
+            }
             dispatch_after(
                 dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
                 dispatch_get_main_queue(), ^{
-                  DemoSendKey(@"\r", 36, 0);
+                  BOOL sent = DemoSendKey(@"\r", 36, 0);
+                  [self acknowledge:requestID
+                            success:sent
+                            message:sent ? @"command palette submitted"
+                                         : @"command palette lost its window"];
                 });
-          }
-        });
-  } else if ([action isEqualToString:@"text"]) {
-    DemoInsertText(notification.userInfo[@"text"] ?: @"");
-  } else if ([action isEqualToString:@"escape"]) {
-    DemoSendKey(@"\x1b", 53, 0);
-  } else if ([action isEqualToString:@"new-window"]) {
-    DemoSendKey(@"n", 45,
-                NSEventModifierFlagCommand | NSEventModifierFlagOption);
-  } else if ([action isEqualToString:@"sidebar"]) {
-    DemoSendKey(@"b", 11, NSEventModifierFlagCommand);
-  } else if ([action isEqualToString:@"frame"]) {
+          });
+    } else if ([action isEqualToString:@"text"]) {
+      BOOL inserted = DemoInsertText(text);
+      [self acknowledge:requestID
+                success:inserted
+                message:inserted ? @"text inserted"
+                                 : @"focused control did not accept text"];
+    } else if ([action isEqualToString:@"escape"]) {
+      BOOL sent = DemoSendKey(@"\x1b", 53, 0);
+      [self acknowledge:requestID
+                success:sent
+                message:sent ? @"escape sent" : @"no active window"];
+    } else if ([action isEqualToString:@"new-window"]) {
+      NSUInteger windowCount = DemoWorkspaceWindows().count;
+      if (!DemoSendKey(
+              @"n", 45,
+              NSEventModifierFlagCommand | NSEventModifierFlagOption)) {
+        [self acknowledge:requestID
+                  success:NO
+                  message:@"no active window for new-window shortcut"];
+        return;
+      }
+      dispatch_after(
+          dispatch_time(DISPATCH_TIME_NOW, 1500 * NSEC_PER_MSEC),
+          dispatch_get_main_queue(), ^{
+            BOOL created = DemoWorkspaceWindows().count > windowCount;
+            [self acknowledge:requestID
+                      success:created
+                      message:created ? @"workspace window created"
+                                      : @"workspace window did not appear"];
+          });
+    } else if ([action isEqualToString:@"sidebar"]) {
+      NSView *content = DemoRootWindow().contentView;
+      BOOL wasVisible = DemoContainsText(content, @"Workspaces", 0);
+      BOOL sent =
+          DemoSendKey(@"b", 11, NSEventModifierFlagCommand);
+      if (!sent) {
+        [self acknowledge:requestID
+                  success:NO
+                  message:@"no active window"];
+        return;
+      }
+      dispatch_after(
+          dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+          dispatch_get_main_queue(), ^{
+            BOOL isVisible =
+                DemoContainsText(content, @"Workspaces", 0);
+            BOOL toggled = isVisible != wasVisible;
+            [self acknowledge:requestID
+                      success:toggled
+                      message:toggled ? @"sidebar visibility changed"
+                                      : @"sidebar visibility did not change"];
+          });
+    } else if ([action isEqualToString:@"frame"]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [NSApp activateIgnoringOtherApps:YES];
+      [NSApp activateIgnoringOtherApps:YES];
 #pragma clang diagnostic pop
-    NSRect frame = NSMakeRect(160, 25, 1600, 1000);
-    NSArray<NSString *> *parts =
-        [notification.userInfo[@"text"] componentsSeparatedByString:@","];
-    if (parts.count == 4) {
-      frame = NSMakeRect(parts[0].doubleValue, parts[1].doubleValue,
-                         parts[2].doubleValue, parts[3].doubleValue);
+      NSRect frame = NSMakeRect(160, 25, 1600, 1000);
+      NSArray<NSString *> *parts =
+          [text componentsSeparatedByString:@","];
+      if (text.length > 0 && parts.count != 4) {
+        [self acknowledge:requestID
+                  success:NO
+                  message:@"frame requires x,y,width,height"];
+        return;
+      }
+      if (parts.count == 4) {
+        frame = NSMakeRect(parts[0].doubleValue, parts[1].doubleValue,
+                           parts[2].doubleValue, parts[3].doubleValue);
+      }
+      NSWindow *window = DemoRootWindow();
+      if (window != nil) [window setFrame:frame display:YES];
+      [self acknowledge:requestID
+                success:window != nil
+                message:window != nil ? @"window framed"
+                                      : @"no workspace window"];
+    } else if ([action isEqualToString:@"click"]) {
+      NSArray<NSString *> *parts =
+          [text componentsSeparatedByString:@","];
+      BOOL clicked =
+          parts.count == 2 &&
+          DemoClick(NSMakePoint(parts[0].doubleValue,
+                                parts[1].doubleValue));
+      [self acknowledge:requestID
+                success:clicked
+                message:clicked ? @"click sent"
+                                : @"click requires x,y and a workspace window"];
+    } else if ([action isEqualToString:@"press"]) {
+      BOOL pressed =
+          text.length > 0 &&
+          DemoPressLabel(DemoRootWindow().contentView, text, 0);
+      [self acknowledge:requestID
+                success:pressed
+                message:pressed ? @"accessibility control pressed"
+                                : @"accessibility label not found"];
+    } else {
+      [self acknowledge:requestID
+                success:NO
+                message:@"unknown demo action"];
     }
-    [DemoRootWindow() setFrame:frame display:YES];
-  } else if ([action isEqualToString:@"click"]) {
-    NSArray<NSString *> *parts =
-        [notification.userInfo[@"text"] componentsSeparatedByString:@","];
-    if (parts.count == 2) {
-      DemoClick(NSMakePoint(parts[0].doubleValue, parts[1].doubleValue));
-    }
-  } else if ([action isEqualToString:@"press"]) {
-    DemoPressLabel(DemoRootWindow().contentView,
-                   notification.userInfo[@"text"], 0);
-  }
+  });
 }
 
 @end

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -1,15 +1,223 @@
-/* Swizzles -[NSProcessInfo hostName] so the demo app shows a generic
- * machine name in marketing screenshots instead of the real hostname.
+/* Keeps marketing capture behavior inside the isolated demo process:
+ * - swizzles the hostname so real machine details never appear;
+ * - accepts exact-PID distributed controls for documented UI states; and
+ * - captures its own composited window without Screen Recording access.
+ *
  * Built by stage.sh; loaded via DYLD_INSERT_LIBRARIES in run.sh (the app
  * copy is re-signed without the hardened runtime so the insert applies). */
-#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <ImageIO/ImageIO.h>
+#import <dlfcn.h>
 #import <objc/runtime.h>
+#import <unistd.h>
+
+static NSString *const DemoCaptureNotification =
+    @"com.ghosthub.demo.capture";
+static NSString *const DemoInputNotification =
+    @"com.ghosthub.demo.input";
+
+@interface DemoController : NSObject
+@end
+
+static NSWindow *DemoRootWindow(void);
 
 static NSString *DemoHostName(id self, SEL _cmd) {
   return @"studio.local";
 }
 
-__attribute__((constructor)) static void demo_hostname_init(void) {
+static void DemoSendKey(NSString *characters, unsigned short keyCode) {
+  NSWindow *window = [NSApp keyWindow] ?: [NSApp mainWindow];
+  if (window == nil) return;
+  NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
+  NSEvent *down = [NSEvent keyEventWithType:NSEventTypeKeyDown
+                                   location:NSZeroPoint
+                              modifierFlags:0
+                                  timestamp:now
+                               windowNumber:window.windowNumber
+                                    context:nil
+                                 characters:characters
+                charactersIgnoringModifiers:characters
+                                  isARepeat:NO
+                                    keyCode:keyCode];
+  NSEvent *up = [NSEvent keyEventWithType:NSEventTypeKeyUp
+                                 location:NSZeroPoint
+                            modifierFlags:0
+                                timestamp:now
+                             windowNumber:window.windowNumber
+                                  context:nil
+                               characters:characters
+              charactersIgnoringModifiers:characters
+                                isARepeat:NO
+                                  keyCode:keyCode];
+  [NSApp sendEvent:down];
+  [NSApp sendEvent:up];
+}
+
+static void DemoClick(NSPoint point) {
+  NSWindow *window = DemoRootWindow();
+  if (window == nil) return;
+  NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
+  NSEvent *down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                     location:point
+                                modifierFlags:0
+                                    timestamp:now
+                                 windowNumber:window.windowNumber
+                                      context:nil
+                                  eventNumber:0
+                                   clickCount:1
+                                     pressure:1];
+  NSEvent *up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                   location:point
+                              modifierFlags:0
+                                  timestamp:now
+                               windowNumber:window.windowNumber
+                                    context:nil
+                                eventNumber:0
+                                 clickCount:1
+                                   pressure:0];
+  [NSApp sendEvent:down];
+  [NSApp sendEvent:up];
+}
+
+static void DemoInsertText(NSString *text) {
+  id responder = [NSApp keyWindow].firstResponder;
+  if ([responder respondsToSelector:
+          @selector(insertText:replacementRange:)]) {
+    [responder insertText:text
+         replacementRange:NSMakeRange(NSNotFound, 0)];
+  }
+}
+
+static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
+  if (element == nil || depth > 20) return NO;
+  if ([[element accessibilityLabel] isEqualToString:label]) {
+    return [element accessibilityPerformPress];
+  }
+  for (id child in [element accessibilityChildren] ?: @[]) {
+    if (DemoPressLabel(child, label, depth + 1)) return YES;
+  }
+  return NO;
+}
+
+static NSWindow *DemoRootWindow(void) {
+  NSWindow *window = [NSApp mainWindow] ?: [NSApp keyWindow];
+  while (window.sheetParent != nil) {
+    window = window.sheetParent;
+  }
+  return window;
+}
+
+static CGRect DemoWindowBounds(CGWindowID windowID) {
+  CFArrayRef info = CGWindowListCopyWindowInfo(
+      kCGWindowListOptionIncludingWindow, windowID);
+  CGRect bounds = CGRectNull;
+  if (info != NULL && CFArrayGetCount(info) > 0) {
+    CFDictionaryRef entry = CFArrayGetValueAtIndex(info, 0);
+    CFDictionaryRef rawBounds =
+        CFDictionaryGetValue(entry, kCGWindowBounds);
+    if (rawBounds != NULL) {
+      CGRectMakeWithDictionaryRepresentation(rawBounds, &bounds);
+    }
+  }
+  if (info != NULL) CFRelease(info);
+  return bounds;
+}
+
+static void DemoCapture(NSString *path) {
+  NSWindow *window = DemoRootWindow();
+  if (window == nil) return;
+  CGRect bounds = DemoWindowBounds((CGWindowID)window.windowNumber);
+  if (CGRectIsNull(bounds)) return;
+
+  /* The macOS 26 SDK makes the legacy function unavailable to new source,
+   * but the runtime retains it for binary compatibility. Resolving it here
+   * lets the injected process capture only its existing on-screen demo
+   * window without ScreenCaptureKit's system-wide recording permission. */
+  typedef CGImageRef (*CreateWindowImage)(
+      CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
+  CreateWindowImage createImage =
+      (CreateWindowImage)dlsym(RTLD_DEFAULT, "CGWindowListCreateImage");
+  if (createImage == NULL) return;
+  CGImageRef image = createImage(
+      bounds, kCGWindowListOptionOnScreenOnly, kCGNullWindowID,
+      kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution);
+  if (image == NULL) return;
+
+  NSString *temporary = [path stringByAppendingString:@".tmp"];
+  NSURL *url = [NSURL fileURLWithPath:temporary];
+  CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
+      (__bridge CFURLRef)url, CFSTR("public.png"), 1, NULL);
+  if (destination != NULL) {
+    CGImageDestinationAddImage(destination, image, NULL);
+    if (CGImageDestinationFinalize(destination)) {
+      NSFileManager *files = [NSFileManager defaultManager];
+      [files removeItemAtPath:path error:nil];
+      [files moveItemAtPath:temporary toPath:path error:nil];
+    }
+    CFRelease(destination);
+  }
+  CGImageRelease(image);
+}
+
+@implementation DemoController
+
+- (void)capture:(NSNotification *)notification {
+  NSString *path = notification.userInfo[@"path"];
+  if (path.length == 0) return;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    DemoCapture(path);
+  });
+}
+
+- (void)input:(NSNotification *)notification {
+  NSString *action = notification.userInfo[@"action"];
+  if ([action isEqualToString:@"palette"]) {
+    NSString *query = notification.userInfo[@"text"] ?: @"";
+    BOOL submit =
+        [notification.userInfo[@"submit"] isEqualToString:@"true"];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:@"ghosthubCommandPalette"
+                      object:nil];
+    dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+        dispatch_get_main_queue(), ^{
+          DemoInsertText(query);
+          if (submit) {
+            dispatch_after(
+                dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+                dispatch_get_main_queue(), ^{
+                  DemoSendKey(@"\r", 36);
+                });
+          }
+        });
+  } else if ([action isEqualToString:@"text"]) {
+    DemoInsertText(notification.userInfo[@"text"] ?: @"");
+  } else if ([action isEqualToString:@"escape"]) {
+    DemoSendKey(@"\x1b", 53);
+  } else if ([action isEqualToString:@"frame"]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [NSApp activateIgnoringOtherApps:YES];
+#pragma clang diagnostic pop
+    [DemoRootWindow() setFrame:NSMakeRect(160, 25, 1600, 1000)
+                       display:YES];
+  } else if ([action isEqualToString:@"click"]) {
+    NSArray<NSString *> *parts =
+        [notification.userInfo[@"text"] componentsSeparatedByString:@","];
+    if (parts.count == 2) {
+      DemoClick(NSMakePoint(parts[0].doubleValue, parts[1].doubleValue));
+    }
+  } else if ([action isEqualToString:@"press"]) {
+    DemoPressLabel(DemoRootWindow().contentView,
+                   notification.userInfo[@"text"], 0);
+  }
+}
+
+@end
+
+static DemoController *controller;
+
+__attribute__((constructor)) static void demo_controller_init(void) {
   /* macOS 26 Foundation backs NSProcessInfo with _NSSwiftProcessInfo, which
    * overrides hostName; swizzle the concrete class of the shared instance. */
   Class cls = object_getClass([NSProcessInfo processInfo]);
@@ -17,4 +225,20 @@ __attribute__((constructor)) static void demo_hostname_init(void) {
   if (m != NULL) {
     method_setImplementation(m, (IMP)DemoHostName);
   }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    controller = [DemoController new];
+    NSString *target =
+        [NSString stringWithFormat:@"%d", [NSProcessInfo processInfo].processIdentifier];
+    NSDistributedNotificationCenter *notifications =
+        [NSDistributedNotificationCenter defaultCenter];
+    [notifications addObserver:controller
+                      selector:@selector(capture:)
+                          name:DemoCaptureNotification
+                        object:target];
+    [notifications addObserver:controller
+                      selector:@selector(input:)
+                          name:DemoInputNotification
+                        object:target];
+  });
 }

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -25,13 +25,14 @@ static NSString *DemoHostName(id self, SEL _cmd) {
   return @"studio.local";
 }
 
-static void DemoSendKey(NSString *characters, unsigned short keyCode) {
+static void DemoSendKey(NSString *characters, unsigned short keyCode,
+                        NSEventModifierFlags modifiers) {
   NSWindow *window = [NSApp keyWindow] ?: [NSApp mainWindow];
   if (window == nil) return;
   NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
   NSEvent *down = [NSEvent keyEventWithType:NSEventTypeKeyDown
                                    location:NSZeroPoint
-                              modifierFlags:0
+                              modifierFlags:modifiers
                                   timestamp:now
                                windowNumber:window.windowNumber
                                     context:nil
@@ -41,7 +42,7 @@ static void DemoSendKey(NSString *characters, unsigned short keyCode) {
                                     keyCode:keyCode];
   NSEvent *up = [NSEvent keyEventWithType:NSEventTypeKeyUp
                                  location:NSZeroPoint
-                            modifierFlags:0
+                            modifierFlags:modifiers
                                 timestamp:now
                              windowNumber:window.windowNumber
                                   context:nil
@@ -100,7 +101,7 @@ static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
 }
 
 static NSWindow *DemoRootWindow(void) {
-  NSWindow *window = [NSApp mainWindow] ?: [NSApp keyWindow];
+  NSWindow *window = [NSApp keyWindow] ?: [NSApp mainWindow];
   while (window.sheetParent != nil) {
     window = window.sheetParent;
   }
@@ -186,21 +187,32 @@ static void DemoCapture(NSString *path) {
             dispatch_after(
                 dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
                 dispatch_get_main_queue(), ^{
-                  DemoSendKey(@"\r", 36);
+                  DemoSendKey(@"\r", 36, 0);
                 });
           }
         });
   } else if ([action isEqualToString:@"text"]) {
     DemoInsertText(notification.userInfo[@"text"] ?: @"");
   } else if ([action isEqualToString:@"escape"]) {
-    DemoSendKey(@"\x1b", 53);
+    DemoSendKey(@"\x1b", 53, 0);
+  } else if ([action isEqualToString:@"new-window"]) {
+    DemoSendKey(@"n", 45,
+                NSEventModifierFlagCommand | NSEventModifierFlagOption);
+  } else if ([action isEqualToString:@"sidebar"]) {
+    DemoSendKey(@"b", 11, NSEventModifierFlagCommand);
   } else if ([action isEqualToString:@"frame"]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [NSApp activateIgnoringOtherApps:YES];
 #pragma clang diagnostic pop
-    [DemoRootWindow() setFrame:NSMakeRect(160, 25, 1600, 1000)
-                       display:YES];
+    NSRect frame = NSMakeRect(160, 25, 1600, 1000);
+    NSArray<NSString *> *parts =
+        [notification.userInfo[@"text"] componentsSeparatedByString:@","];
+    if (parts.count == 4) {
+      frame = NSMakeRect(parts[0].doubleValue, parts[1].doubleValue,
+                         parts[2].doubleValue, parts[3].doubleValue);
+    }
+    [DemoRootWindow() setFrame:frame display:YES];
   } else if ([action isEqualToString:@"click"]) {
     NSArray<NSString *> *parts =
         [notification.userInfo[@"text"] componentsSeparatedByString:@","];

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -124,11 +124,11 @@ static CGRect DemoWindowBounds(CGWindowID windowID) {
   return bounds;
 }
 
-static void DemoCapture(NSString *path) {
-  NSWindow *window = DemoRootWindow();
-  if (window == nil) return;
+static BOOL DemoCaptureWindow(NSWindow *window, NSString *path,
+                              BOOL exactWindow) {
+  if (window == nil) return NO;
   CGRect bounds = DemoWindowBounds((CGWindowID)window.windowNumber);
-  if (CGRectIsNull(bounds)) return;
+  if (CGRectIsNull(bounds)) return NO;
 
   /* The macOS 26 SDK makes the legacy function unavailable to new source,
    * but the runtime retains it for binary compatibility. Resolving it here
@@ -138,12 +138,16 @@ static void DemoCapture(NSString *path) {
       CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
   CreateWindowImage createImage =
       (CreateWindowImage)dlsym(RTLD_DEFAULT, "CGWindowListCreateImage");
-  if (createImage == NULL) return;
+  if (createImage == NULL) return NO;
   CGImageRef image = createImage(
-      bounds, kCGWindowListOptionOnScreenOnly, kCGNullWindowID,
+      bounds,
+      exactWindow ? kCGWindowListOptionIncludingWindow
+                  : kCGWindowListOptionOnScreenOnly,
+      exactWindow ? (CGWindowID)window.windowNumber : kCGNullWindowID,
       kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution);
-  if (image == NULL) return;
+  if (image == NULL) return NO;
 
+  BOOL wrote = NO;
   NSString *temporary = [path stringByAppendingString:@".tmp"];
   NSURL *url = [NSURL fileURLWithPath:temporary];
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
@@ -153,20 +157,83 @@ static void DemoCapture(NSString *path) {
     if (CGImageDestinationFinalize(destination)) {
       NSFileManager *files = [NSFileManager defaultManager];
       [files removeItemAtPath:path error:nil];
-      [files moveItemAtPath:temporary toPath:path error:nil];
+      wrote = [files moveItemAtPath:temporary toPath:path error:nil];
     }
     CFRelease(destination);
   }
   CGImageRelease(image);
+  return wrote;
+}
+
+static NSArray<NSWindow *> *DemoWorkspaceWindows(void) {
+  NSMutableArray<NSWindow *> *windows = [NSMutableArray array];
+  for (NSWindow *window in NSApp.windows) {
+    if (!window.isVisible || window.isSheet || window.sheetParent != nil ||
+        window.parentWindow != nil || window.level != NSNormalWindowLevel ||
+        window.contentView == nil) {
+      continue;
+    }
+    [windows addObject:window];
+  }
+  [windows sortUsingComparator:^NSComparisonResult(NSWindow *left,
+                                                    NSWindow *right) {
+    if (left.windowNumber < right.windowNumber) return NSOrderedAscending;
+    if (left.windowNumber > right.windowNumber) return NSOrderedDescending;
+    return NSOrderedSame;
+  }];
+  if (windows.count > 6) {
+    return [windows subarrayWithRange:NSMakeRange(0, 6)];
+  }
+  return windows;
+}
+
+static void DemoArrangeMatrix(NSArray<NSWindow *> *windows) {
+  if (windows.count != 6) return;
+  NSRect screen = NSScreen.mainScreen.visibleFrame;
+  CGFloat gap = 6;
+  CGFloat width = floor((screen.size.width - (2 * gap)) / 3);
+  CGFloat height = floor((screen.size.height - gap) / 2);
+  for (NSUInteger index = 0; index < windows.count; index++) {
+    NSUInteger column = index % 3;
+    NSUInteger row = index / 3;
+    CGFloat x = screen.origin.x + column * (width + gap);
+    CGFloat y = screen.origin.y + (1 - row) * (height + gap);
+    NSWindow *window = windows[index];
+    [window setFrame:NSMakeRect(x, y, width, height) display:YES];
+    [window orderFront:nil];
+  }
+}
+
+static void DemoCapture(NSString *path, BOOL matrix) {
+  if (!matrix) {
+    DemoCaptureWindow(DemoRootWindow(), path, NO);
+    return;
+  }
+
+  NSArray<NSWindow *> *windows = DemoWorkspaceWindows();
+  if (windows.count != 6) return;
+  DemoArrangeMatrix(windows);
+  dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, 1000 * NSEC_PER_MSEC),
+      dispatch_get_main_queue(), ^{
+        for (NSUInteger index = 0; index < windows.count; index++) {
+          NSString *windowPath = index == 0
+              ? path
+              : [path stringByAppendingFormat:@".%lu",
+                                                 (unsigned long)index];
+          if (!DemoCaptureWindow(windows[index], windowPath, YES)) return;
+        }
+      });
 }
 
 @implementation DemoController
 
 - (void)capture:(NSNotification *)notification {
   NSString *path = notification.userInfo[@"path"];
+  BOOL matrix = [notification.userInfo[@"mode"] isEqualToString:@"matrix"];
   if (path.length == 0) return;
   dispatch_async(dispatch_get_main_queue(), ^{
-    DemoCapture(path);
+    DemoCapture(path, matrix);
   });
 }
 

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -93,28 +93,85 @@ static BOOL DemoInsertText(NSString *text) {
   return YES;
 }
 
-static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
-  if (element == nil || depth > 20) return NO;
-  if ([[element accessibilityLabel] isEqualToString:label]) {
-    return [element accessibilityPerformPress];
+// SwiftUI's accessibility tree can contain private AppKit nodes that advertise
+// NSObject ancestry but throw for standard accessibility selectors. Keep those
+// implementation details from escaping the demo controller as an app crash.
+static NSString *DemoAccessibilityLabel(id element) {
+  @try {
+    return [element accessibilityLabel];
+  } @catch (NSException *exception) {
+    (void)exception;
+    return nil;
   }
-  for (id child in [element accessibilityChildren] ?: @[]) {
-    if (DemoPressLabel(child, label, depth + 1)) return YES;
+}
+
+static id DemoAccessibilityValue(id element) {
+  @try {
+    return [element accessibilityValue];
+  } @catch (NSException *exception) {
+    (void)exception;
+    return nil;
+  }
+}
+
+static NSArray *DemoAccessibilityChildren(id element) {
+  @try {
+    id children = [element accessibilityChildren];
+    return [children isKindOfClass:[NSArray class]] ? children : @[];
+  } @catch (NSException *exception) {
+    (void)exception;
+    return @[];
+  }
+}
+
+static BOOL DemoAccessibilityPress(id element) {
+  @try {
+    return [element accessibilityPerformPress];
+  } @catch (NSException *exception) {
+    (void)exception;
+    return NO;
+  }
+}
+
+static BOOL DemoPressLabelWalk(id element, NSString *label,
+                               NSUInteger depth, NSUInteger *budget) {
+  if (element == nil || depth > 20 || *budget == 0) return NO;
+  *budget -= 1;
+  if ([DemoAccessibilityLabel(element) isEqualToString:label]) {
+    return DemoAccessibilityPress(element);
+  }
+  for (id child in DemoAccessibilityChildren(element)) {
+    if (DemoPressLabelWalk(
+            child, label, depth + 1, budget)) return YES;
+  }
+  return NO;
+}
+
+static BOOL DemoPressLabel(id element, NSString *label, NSUInteger depth) {
+  NSUInteger budget = 4096;
+  return DemoPressLabelWalk(element, label, depth, &budget);
+}
+
+static BOOL DemoContainsTextWalk(id element, NSString *text,
+                                 NSUInteger depth, NSUInteger *budget) {
+  if (element == nil || depth > 20 || *budget == 0) return NO;
+  *budget -= 1;
+  if ([DemoAccessibilityLabel(element) isEqualToString:text] ||
+      [[DemoAccessibilityValue(element) description]
+          isEqualToString:text]) {
+    return YES;
+  }
+  for (id child in DemoAccessibilityChildren(element)) {
+    if (DemoContainsTextWalk(
+            child, text, depth + 1, budget)) return YES;
   }
   return NO;
 }
 
 static BOOL DemoContainsText(id element, NSString *text,
                              NSUInteger depth) {
-  if (element == nil || depth > 20) return NO;
-  if ([[element accessibilityLabel] isEqualToString:text] ||
-      [[[element accessibilityValue] description] isEqualToString:text]) {
-    return YES;
-  }
-  for (id child in [element accessibilityChildren] ?: @[]) {
-    if (DemoContainsText(child, text, depth + 1)) return YES;
-  }
-  return NO;
+  NSUInteger budget = 4096;
+  return DemoContainsTextWalk(element, text, depth, &budget);
 }
 
 static BOOL DemoPalettePostcondition(NSString *kind,

--- a/website/demo/capture.sh
+++ b/website/demo/capture.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 demo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scratch="${GHOSTHUB_DEMO_SCRATCH:-/tmp/ghosthub-demo}"
 out="${1:-$scratch/hero-raw.png}"
+mode="${2:-window}"
 bin="$scratch/app/Ghosthub.app/Contents/MacOS/Ghosthub"
 
 # shellcheck source=SCRIPTDIR/scratch-guard.sh
@@ -21,7 +22,15 @@ source "$demo_root/process.sh"
 demo_pid="$(demo_require_recorded_process "$scratch/app.pid" "$bin")"
 
 rm -f "$out" "$out.tmp"
-GHOSTHUB_DEMO_PID="$demo_pid" GHOSTHUB_DEMO_CAPTURE_OUT="$out" swift - <<'EOF'
+if [[ "$mode" == "matrix" ]]; then
+  for index in 1 2 3 4 5; do
+    rm -f "$out.$index" "$out.$index.tmp"
+  done
+fi
+GHOSTHUB_DEMO_PID="$demo_pid" \
+  GHOSTHUB_DEMO_CAPTURE_OUT="$out" \
+  GHOSTHUB_DEMO_CAPTURE_MODE="$mode" \
+  swift - <<'EOF'
 import Foundation
 
 let environment = ProcessInfo.processInfo.environment
@@ -31,18 +40,34 @@ else { exit(1) }
 DistributedNotificationCenter.default().post(
     name: Notification.Name("com.ghosthub.demo.capture"),
     object: pid,
-    userInfo: ["path": output]
+    userInfo: [
+        "path": output,
+        "mode": environment["GHOSTHUB_DEMO_CAPTURE_MODE"] ?? "window",
+    ]
 )
 EOF
 
-for _ in $(seq 1 50); do
-  [[ -s "$out" ]] && break
+capture_complete() {
+  [[ -s "$out" ]] || return 1
+  [[ "$mode" != "matrix" ]] && return 0
+  local index
+  for index in 1 2 3 4 5; do
+    [[ -s "$out.$index" ]] || return 1
+  done
+}
+
+for _ in $(seq 1 100); do
+  capture_complete && break
   sleep 0.1
 done
-if [[ ! -s "$out" ]]; then
+if ! capture_complete; then
   echo "error: demo process did not produce a window capture" >&2
   exit 1
 fi
 
-echo "captured demo process $demo_pid -> $out"
-sips -g pixelWidth -g pixelHeight "$out" | tail -2
+if [[ "$mode" == "matrix" ]]; then
+  echo "captured six-window demo matrix from process $demo_pid -> $out{,.1...5}"
+else
+  echo "captured demo process $demo_pid -> $out"
+  sips -g pixelWidth -g pixelHeight "$out" | tail -2
+fi

--- a/website/demo/capture.sh
+++ b/website/demo/capture.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Captures the demo Ghosthub window to a PNG (no drop shadow). Pass an output
-# path; defaults to .scratch/hero-raw.png. Requires Screen Recording
-# permission for the invoking terminal.
+# Asks the injected demo controller to capture its own composited window to a
+# PNG (no drop shadow). Pass an output path; defaults to
+# .scratch/hero-raw.png. This stays exact-PID scoped and does not require
+# Screen Recording permission for the invoking terminal.
 set -euo pipefail
 
 demo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,32 +20,29 @@ demo_scratch_guard "$scratch"
 source "$demo_root/process.sh"
 demo_pid="$(demo_require_recorded_process "$scratch/app.pid" "$bin")"
 
-window_id="$(GHOSTHUB_DEMO_PID="$demo_pid" swift - <<'EOF'
-import CoreGraphics
+rm -f "$out" "$out.tmp"
+GHOSTHUB_DEMO_PID="$demo_pid" GHOSTHUB_DEMO_CAPTURE_OUT="$out" swift - <<'EOF'
 import Foundation
 
-guard let pidText = ProcessInfo.processInfo.environment["GHOSTHUB_DEMO_PID"],
-      let demoPID = Int(pidText) else { exit(1) }
-let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
-guard let list = CGWindowListCopyWindowInfo(opts, kCGNullWindowID)
-    as? [[String: Any]] else { exit(1) }
-for entry in list {
-    guard let pid = entry[kCGWindowOwnerPID as String] as? Int,
-          pid == demoPID,
-          let layer = entry[kCGWindowLayer as String] as? Int, layer == 0,
-          let number = entry[kCGWindowNumber as String] as? Int
-    else { continue }
-    print(number)
-    break
-}
+let environment = ProcessInfo.processInfo.environment
+guard let pid = environment["GHOSTHUB_DEMO_PID"],
+      let output = environment["GHOSTHUB_DEMO_CAPTURE_OUT"]
+else { exit(1) }
+DistributedNotificationCenter.default().post(
+    name: Notification.Name("com.ghosthub.demo.capture"),
+    object: pid,
+    userInfo: ["path": output]
+)
 EOF
-)"
 
-if [[ -z "$window_id" ]]; then
-  echo "error: no on-screen Ghosthub window found (run run.sh first)" >&2
+for _ in $(seq 1 50); do
+  [[ -s "$out" ]] && break
+  sleep 0.1
+done
+if [[ ! -s "$out" ]]; then
+  echo "error: demo process did not produce a window capture" >&2
   exit 1
 fi
 
-screencapture -o -l "$window_id" "$out"
-echo "captured window $window_id -> $out"
+echo "captured demo process $demo_pid -> $out"
 sips -g pixelWidth -g pixelHeight "$out" | tail -2

--- a/website/demo/scratch-guard.sh
+++ b/website/demo/scratch-guard.sh
@@ -7,51 +7,77 @@
 # shellcheck source=SCRIPTDIR/path-guard.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/path-guard.sh"
 
-demo_scratch_guard() {
-  local scratch="$1"
-  local allow_missing="${2:-}"
-  if [[ "$scratch" != /* ]]; then
-    echo "error: demo scratch must be an absolute path; refusing $scratch" >&2
+demo_private_directory_guard() {
+  local guarded="$1"
+  local label="$2"
+  local risk="$3"
+  local allow_missing="${4:-}"
+  if [[ "$guarded" != /* ]]; then
+    echo "error: $label must be an absolute path; refusing $guarded" >&2
     return 1
   fi
   # -L before -e: -e follows symlinks and reports false for a dangling
   # one, which would let a planted symlink pass as "nothing there" and
   # have its target raced into existence later.
-  if [[ -L "$scratch" ]]; then
-    echo "error: $scratch is a symlink; refusing" >&2
+  if [[ -L "$guarded" ]]; then
+    echo "error: $guarded is a symlink; refusing" >&2
     return 1
   fi
   # Validate lexical components before resolving them. realpath alone would
   # hide a planted symlink. (/tmp is a root-owned symlink on macOS.)
   local parent
-  parent="$(dirname "$scratch")"
+  parent="$(dirname "$guarded")"
   demo_lexical_ancestry_guard \
-    "$parent" allow-sticky "scratch ancestor" || return 1
+    "$parent" allow-sticky "$label ancestor" || return 1
 
   # Also validate the physical hierarchy reached through trusted symlinks.
-  demo_directory_ancestry_guard "$parent" allow-sticky "scratch ancestor" || return 1
-  if [[ ! -e "$scratch" ]]; then
+  demo_directory_ancestry_guard \
+    "$parent" allow-sticky "$label ancestor" || return 1
+  if [[ ! -e "$guarded" ]]; then
     if [[ "$allow_missing" == "allow-missing" ]]; then
       return 0
     fi
-    echo "error: $scratch disappeared or was never created; refusing" >&2
+    echo "error: $guarded disappeared or was never created; refusing" >&2
     return 1
   fi
-  if [[ ! -d "$scratch" ]]; then
-    echo "error: $scratch is not a plain directory; refusing" >&2
+  if [[ ! -d "$guarded" ]]; then
+    echo "error: $guarded is not a plain directory; refusing" >&2
     return 1
   fi
   local owner mode
-  owner="$(stat -f %u "$scratch")"
-  mode="$(stat -f %Lp "$scratch")"
+  owner="$(stat -f %u "$guarded")"
+  mode="$(stat -f %Lp "$guarded")"
   if [[ "$owner" != "$(id -u)" ]]; then
-    echo "error: $scratch is owned by uid $owner, not uid $(id -u); refusing" >&2
+    echo "error: $guarded is owned by uid $owner, not uid $(id -u); refusing" >&2
     return 1
   fi
   if [[ "$mode" != 700 ]]; then
-    echo "error: $scratch has mode $mode, expected 700; refusing" >&2
-    echo "       (another local user may be able to modify demo binaries)" >&2
+    echo "error: $guarded has mode $mode, expected 700; refusing" >&2
+    echo "       (another local user may be able to $risk)" >&2
     return 1
   fi
-  demo_acl_write_guard "$scratch" "scratch directory" || return 1
+  demo_acl_write_guard "$guarded" "$label" || return 1
+}
+
+demo_private_directory_prepare() {
+  local guarded="$1"
+  local label="$2"
+  local risk="$3"
+  demo_private_directory_guard \
+    "$guarded" "$label" "$risk" allow-missing || return 1
+  if [[ ! -e "$guarded" ]]; then
+    if mkdir -m 700 "$guarded" 2>/dev/null; then
+      chmod -N "$guarded"
+      chmod 700 "$guarded"
+    fi
+  fi
+  # If another process won the mkdir race, validate what it created rather
+  # than accepting it. Sticky /tmp plus an owner-only directory prevents a
+  # less-privileged user from replacing the entry after this check.
+  demo_private_directory_guard "$guarded" "$label" "$risk"
+}
+
+demo_scratch_guard() {
+  demo_private_directory_guard \
+    "$1" "demo scratch" "modify demo binaries" "${2:-}"
 }

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -13,17 +13,21 @@ bin="$scratch/app/Ghosthub.app/Contents/MacOS/Ghosthub"
 source "$demo_root/scratch-guard.sh"
 demo_scratch_guard "$scratch"
 [[ -f "$scratch/.ghosthub-demo-scratch" ]] || { echo "error: run stage.sh first" >&2; exit 1; }
+demo_private_directory_prepare \
+  "$out_dir" "screenshot output" "replace screenshots"
 # shellcheck source=SCRIPTDIR/process.sh
 source "$demo_root/process.sh"
 demo_pid="$(demo_require_recorded_process "$scratch/app.pid" "$bin")"
-mkdir -p "$out_dir" "$scratch/screenshots-raw"
+mkdir -p "$scratch/screenshots-raw"
 
 demo_input() {
   local action="$1" text="${2:-}" submit="${3:-false}"
+  local expect_kind="${4:-}"
   GHOSTHUB_DEMO_PID="$demo_pid" \
     GHOSTHUB_DEMO_ACTION="$action" \
     GHOSTHUB_DEMO_TEXT="$text" \
     GHOSTHUB_DEMO_SUBMIT="$submit" \
+    GHOSTHUB_DEMO_EXPECT_KIND="$expect_kind" \
     swift - <<'EOF'
 import Foundation
 import Darwin
@@ -68,9 +72,10 @@ notifications.post(
         "action": action,
         "text": environment["GHOSTHUB_DEMO_TEXT"] ?? "",
         "submit": environment["GHOSTHUB_DEMO_SUBMIT"] ?? "false",
+        "expectKind": environment["GHOSTHUB_DEMO_EXPECT_KIND"] ?? "",
     ]
 )
-let deadline = Date(timeIntervalSinceNow: 5)
+let deadline = Date(timeIntervalSinceNow: 15)
 while acknowledgement.result == nil && Date() < deadline {
     RunLoop.current.run(
         mode: .default,
@@ -113,7 +118,16 @@ sleep 10
 
 palette() {
   local query="$1" submit="${2:-true}"
-  demo_input palette "$query" "$submit"
+  local result="${3:-selection}"
+  local expectation="palette-closed"
+  if [[ "$submit" != "true" ]]; then
+    expectation="palette-open"
+  elif [[ "$result" == "sheet" ]]; then
+    expectation="palette-replaced"
+  fi
+  if ! demo_input palette "$query" "$submit" "$expectation"; then
+    return 1
+  fi
   sleep 1.5
 }
 
@@ -124,7 +138,10 @@ dismiss_sheet() {
 
 process_capture() {
   local raw="$1" destination="$2"
-  NODE_PATH="$demo_root/../node_modules" node - "$raw" "$destination" <<'EOF'
+  local temporary
+  temporary="$(mktemp "$destination.tmp.XXXXXX")"
+  if ! NODE_PATH="$demo_root/../node_modules" \
+      node - "$raw" "$temporary" <<'EOF'
 const sharp = require("sharp");
 (async () => {
   const [raw, destination] = process.argv.slice(2);
@@ -146,6 +163,11 @@ const sharp = require("sharp");
     .toFile(destination);
 })();
 EOF
+  then
+    rm -f "$temporary"
+    return 1
+  fi
+  mv -f "$temporary" "$destination"
 }
 
 capture_state() {
@@ -158,7 +180,10 @@ capture_state() {
 
 process_matrix_capture() {
   local raw="$1" destination="$2"
-  NODE_PATH="$demo_root/../node_modules" node - "$raw" "$destination" <<'EOF'
+  local temporary
+  temporary="$(mktemp "$destination.tmp.XXXXXX")"
+  if ! NODE_PATH="$demo_root/../node_modules" \
+      node - "$raw" "$temporary" <<'EOF'
 const sharp = require("sharp");
 (async () => {
   const [raw, destination] = process.argv.slice(2);
@@ -191,7 +216,22 @@ const sharp = require("sharp");
     .toFile(destination);
 })();
 EOF
+  then
+    rm -f "$temporary"
+    return 1
+  fi
+  mv -f "$temporary" "$destination"
 }
+
+echo "==> controller: unmatched palette commands fail validation"
+unmatched_command="__ghosthub_missing_command__"
+unmatched_error="$scratch/unmatched-command.error"
+if palette "$unmatched_command" \
+    2>"$unmatched_error"; then
+  echo "error: unmatched command unexpectedly passed palette validation" >&2
+  exit 1
+fi
+demo_input escape
 
 echo "==> hero: active coding-agent worktree"
 palette "fix-reconnect-backoff"
@@ -210,7 +250,7 @@ sleep 0.5
 capture_state guide-sessions.png
 
 echo "==> guide: remote host settings"
-palette "Open Hosts Settings"
+palette "Open Hosts Settings" true sheet
 sleep 2
 capture_state guide-hosts.png
 dismiss_sheet
@@ -218,7 +258,7 @@ dismiss_sheet
 echo "==> guide: new worktree"
 palette "fix-reconnect-backoff"
 sleep 2
-palette "New Worktree in ghosthub"
+palette "New Worktree in ghosthub" true sheet
 sleep 1
 demo_input text "improve-session-search"
 sleep 1
@@ -231,7 +271,7 @@ capture_state guide-quick-launch.png
 dismiss_sheet
 
 echo "==> guide: terminal settings"
-palette "Open Terminal Settings"
+palette "Open Terminal Settings" true sheet
 sleep 2
 capture_state guide-terminal.png
 dismiss_sheet

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -26,24 +26,87 @@ demo_input() {
     GHOSTHUB_DEMO_SUBMIT="$submit" \
     swift - <<'EOF'
 import Foundation
+import Darwin
 
 let environment = ProcessInfo.processInfo.environment
 guard let pid = environment["GHOSTHUB_DEMO_PID"],
       let action = environment["GHOSTHUB_DEMO_ACTION"]
 else { exit(1) }
-DistributedNotificationCenter.default().post(
+
+final class Acknowledgement: NSObject {
+    let requestID: String
+    var result: Bool?
+    var message = ""
+
+    init(requestID: String) {
+        self.requestID = requestID
+    }
+
+    @objc func receive(_ notification: Notification) {
+        guard notification.userInfo?["requestID"] as? String == requestID else {
+            return
+        }
+        result = notification.userInfo?["success"] as? Bool ?? false
+        message = notification.userInfo?["message"] as? String ?? ""
+    }
+}
+
+let requestID = UUID().uuidString
+let acknowledgement = Acknowledgement(requestID: requestID)
+let notifications = DistributedNotificationCenter.default()
+notifications.addObserver(
+    acknowledgement,
+    selector: #selector(Acknowledgement.receive(_:)),
+    name: Notification.Name("com.ghosthub.demo.input.ack"),
+    object: pid
+)
+notifications.post(
     name: Notification.Name("com.ghosthub.demo.input"),
     object: pid,
     userInfo: [
+        "requestID": requestID,
         "action": action,
         "text": environment["GHOSTHUB_DEMO_TEXT"] ?? "",
         "submit": environment["GHOSTHUB_DEMO_SUBMIT"] ?? "false",
     ]
 )
+let deadline = Date(timeIntervalSinceNow: 5)
+while acknowledgement.result == nil && Date() < deadline {
+    RunLoop.current.run(
+        mode: .default,
+        before: Date(timeIntervalSinceNow: 0.05)
+    )
+}
+notifications.removeObserver(acknowledgement)
+guard let succeeded = acknowledgement.result else {
+    fputs("error: demo action \(action) timed out (\(requestID))\n", stderr)
+    exit(1)
+}
+guard succeeded else {
+    fputs(
+        "error: demo action \(action) failed: \(acknowledgement.message) "
+        + "(\(requestID))\n",
+        stderr
+    )
+    exit(1)
+}
 EOF
 }
 
-demo_input frame
+demo_ready=""
+ready_error="$scratch/controller-ready.error"
+for _ in $(seq 1 20); do
+  if demo_input frame 2>"$ready_error"; then
+    demo_ready=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ -z "$demo_ready" ]]; then
+  sed -n '1,5p' "$ready_error" >&2
+  echo "error: demo controller never reported a ready workspace window" >&2
+  exit 1
+fi
 # Allow both local inventory and the isolated SSH host probe to settle before
 # the first capture so the full fleet is present in every sidebar.
 sleep 10

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -93,6 +93,43 @@ capture_state() {
   sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
 }
 
+process_matrix_capture() {
+  local raw="$1" destination="$2"
+  NODE_PATH="$demo_root/../node_modules" node - "$raw" "$destination" <<'EOF'
+const sharp = require("sharp");
+(async () => {
+  const [raw, destination] = process.argv.slice(2);
+  const files = [raw, ...[1, 2, 3, 4, 5].map((index) => `${raw}.${index}`)];
+  const metadata = await Promise.all(
+    files.map((file) => sharp(file).metadata())
+  );
+  const width = metadata[0].width;
+  const height = metadata[0].height;
+  if (width === undefined || height === undefined
+      || metadata.some((item) => item.width !== width || item.height !== height)) {
+    throw new Error("matrix windows did not capture at one consistent size");
+  }
+  const gap = 6;
+  await sharp({
+    create: {
+      width: width * 3 + gap * 2,
+      height: height * 2 + gap,
+      channels: 4,
+      background: "#080b0e",
+    },
+  })
+    .composite(files.map((input, index) => ({
+      input,
+      left: (index % 3) * (width + gap),
+      top: Math.floor(index / 3) * (height + gap),
+    })))
+    .resize({ width: 1800 })
+    .png({ compressionLevel: 9 })
+    .toFile(destination);
+})();
+EOF
+}
+
 echo "==> hero: active coding-agent worktree"
 palette "fix-reconnect-backoff"
 sleep 5
@@ -136,8 +173,8 @@ sleep 2
 capture_state guide-terminal.png
 dismiss_sheet
 
-command_window() {
-  local query="$1" name="$2" create="${3:-true}" select="${4:-palette}"
+prepare_command_window() {
+  local query="$1" create="${2:-true}" select="${3:-palette}"
   if [[ "$create" == "true" ]]; then
     demo_input new-window
     sleep 2
@@ -152,15 +189,19 @@ command_window() {
   sleep 3
   demo_input sidebar
   sleep 1
-  capture_state "$name"
 }
 
 echo "==> guide: six-window tmux command center"
-command_window "fix-reconnect-backoff" guide-command-ghosthub.png false
-command_window "add-session-filters" guide-command-agentsview.png
-command_window "scratch" guide-command-scratch.png true press
-command_window "docbank-export" guide-command-export.png true press
-command_window "release-watch" guide-command-release.png true press
-command_window "test-matrix" guide-command-tests.png true press
+prepare_command_window "fix-reconnect-backoff" false
+prepare_command_window "add-session-filters"
+prepare_command_window "scratch" true press
+prepare_command_window "docbank-export" true press
+prepare_command_window "release-watch" true press
+prepare_command_window "test-matrix" true press
+matrix_raw="$scratch/screenshots-raw/guide-command-center.png"
+"$demo_root/capture.sh" "$matrix_raw" matrix
+process_matrix_capture "$matrix_raw" "$out_dir/guide-command-center.png"
+sips -g pixelWidth -g pixelHeight \
+  "$out_dir/guide-command-center.png" | tail -2
 
 echo "captured website asset set -> $out_dir"

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -136,4 +136,31 @@ sleep 2
 capture_state guide-terminal.png
 dismiss_sheet
 
+command_window() {
+  local query="$1" name="$2" create="${3:-true}" select="${4:-palette}"
+  if [[ "$create" == "true" ]]; then
+    demo_input new-window
+    sleep 2
+  fi
+  demo_input frame "160,145,1200,760"
+  sleep 1
+  if [[ "$select" == "press" ]]; then
+    demo_input press "$query"
+  else
+    palette "$query"
+  fi
+  sleep 3
+  demo_input sidebar
+  sleep 1
+  capture_state "$name"
+}
+
+echo "==> guide: six-window tmux command center"
+command_window "fix-reconnect-backoff" guide-command-ghosthub.png false
+command_window "add-session-filters" guide-command-agentsview.png
+command_window "scratch" guide-command-scratch.png true press
+command_window "docbank-export" guide-command-export.png true press
+command_window "release-watch" guide-command-release.png true press
+command_window "test-matrix" guide-command-tests.png true press
+
 echo "captured website asset set -> $out_dir"

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Drives the running demo instance to the hero state and captures it:
-# activate by pid (the real Ghosthub may be running alongside), select the
-# agent session through the command palette, redraw the git log pane at the
-# attached client size, then screenshot the window via capture.sh.
+# Drives the running isolated demo through every website screenshot state,
+# captures the exact demo process, crops native macOS chrome, and writes
+# web-ready 1600px PNGs. The real Ghosthub may run alongside it.
 set -euo pipefail
 
 demo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scratch="${GHOSTHUB_DEMO_SCRATCH:-/tmp/ghosthub-demo}"
-out="${1:-$scratch/hero-raw.png}"
+out_dir="${1:-$scratch/screenshots}"
 bin="$scratch/app/Ghosthub.app/Contents/MacOS/Ghosthub"
 
 # shellcheck source=SCRIPTDIR/scratch-guard.sh
@@ -17,30 +16,124 @@ demo_scratch_guard "$scratch"
 # shellcheck source=SCRIPTDIR/process.sh
 source "$demo_root/process.sh"
 demo_pid="$(demo_require_recorded_process "$scratch/app.pid" "$bin")"
+mkdir -p "$out_dir" "$scratch/screenshots-raw"
 
-# NSRunningApplication targets the exact process; activating "Ghosthub" by
-# name or System Events frontmost routes to the real app instead.
-GHOSTHUB_DEMO_PID="$demo_pid" swift - <<'EOF'
-import AppKit
-let pid = Int32(ProcessInfo.processInfo.environment["GHOSTHUB_DEMO_PID"]!)!
-guard let app = NSRunningApplication(processIdentifier: pid) else { exit(1) }
-app.activate(options: [.activateIgnoringOtherApps])
-Thread.sleep(forTimeInterval: 1.0)
-guard NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else {
-    FileHandle.standardError.write(Data("demo app did not become frontmost\n".utf8))
-    exit(1)
+demo_input() {
+  local action="$1" text="${2:-}" submit="${3:-false}"
+  GHOSTHUB_DEMO_PID="$demo_pid" \
+    GHOSTHUB_DEMO_ACTION="$action" \
+    GHOSTHUB_DEMO_TEXT="$text" \
+    GHOSTHUB_DEMO_SUBMIT="$submit" \
+    swift - <<'EOF'
+import Foundation
+
+let environment = ProcessInfo.processInfo.environment
+guard let pid = environment["GHOSTHUB_DEMO_PID"],
+      let action = environment["GHOSTHUB_DEMO_ACTION"]
+else { exit(1) }
+DistributedNotificationCenter.default().post(
+    name: Notification.Name("com.ghosthub.demo.input"),
+    object: pid,
+    userInfo: [
+        "action": action,
+        "text": environment["GHOSTHUB_DEMO_TEXT"] ?? "",
+        "submit": environment["GHOSTHUB_DEMO_SUBMIT"] ?? "false",
+    ]
+)
+EOF
 }
-EOF
 
-osascript <<'EOF'
-tell application "System Events"
-  keystroke "p" using {command down, shift down}
-  delay 0.8
-  keystroke "fix-reconnect"
-  delay 0.8
-  key code 36
-end tell
-EOF
+demo_input frame
+# Allow both local inventory and the isolated SSH host probe to settle before
+# the first capture so the full fleet is present in every sidebar.
+sleep 10
 
+palette() {
+  local query="$1" submit="${2:-true}"
+  demo_input palette "$query" "$submit"
+  sleep 1.5
+}
+
+dismiss_sheet() {
+  demo_input escape
+  sleep 1
+}
+
+process_capture() {
+  local raw="$1" destination="$2"
+  NODE_PATH="$demo_root/../node_modules" node - "$raw" "$destination" <<'EOF'
+const sharp = require("sharp");
+(async () => {
+  const [raw, destination] = process.argv.slice(2);
+  const image = sharp(raw);
+  const metadata = await image.metadata();
+  if (metadata.width === undefined || metadata.height === undefined) {
+    throw new Error(`could not read screenshot dimensions: ${raw}`);
+  }
+  const titlebarHeight = 34;
+  await image
+    .extract({
+      left: 0,
+      top: titlebarHeight,
+      width: metadata.width,
+      height: metadata.height - titlebarHeight,
+    })
+    .resize({ width: 1600 })
+    .png({ compressionLevel: 9 })
+    .toFile(destination);
+})();
+EOF
+}
+
+capture_state() {
+  local name="$1"
+  local raw="$scratch/screenshots-raw/$name"
+  "$demo_root/capture.sh" "$raw"
+  process_capture "$raw" "$out_dir/$name"
+  sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
+}
+
+echo "==> hero: active coding-agent worktree"
+palette "fix-reconnect-backoff"
 sleep 5
-"$demo_root/capture.sh" "$out"
+demo_input press "Expand Projects"
+sleep 0.5
+demo_input press "Expand ghosthub"
+sleep 0.5
+capture_state hero.png
+
+echo "==> guide: ordinary worktree session"
+palette "add-session-filters"
+sleep 4
+demo_input press "Expand agentsview"
+sleep 0.5
+capture_state guide-sessions.png
+
+echo "==> guide: remote host settings"
+palette "Open Hosts Settings"
+sleep 2
+capture_state guide-hosts.png
+dismiss_sheet
+
+echo "==> guide: new worktree"
+palette "fix-reconnect-backoff"
+sleep 2
+palette "New Worktree in ghosthub"
+sleep 1
+demo_input text "improve-session-search"
+sleep 1
+capture_state guide-worktree.png
+dismiss_sheet
+
+echo "==> guide: Quick Launch"
+palette "reconnect" false
+capture_state guide-quick-launch.png
+dismiss_sheet
+
+echo "==> guide: terminal settings"
+palette "Open Terminal Settings"
+sleep 2
+capture_state guide-terminal.png
+dismiss_sheet
+
+echo "captured website asset set -> $out_dir"

--- a/website/demo/stage.sh
+++ b/website/demo/stage.sh
@@ -109,7 +109,7 @@ make_worktree() {
 }
 
 echo "==> staging repos and worktrees"
-rm -rf "$scratch/repos" "$scratch/worktrees"
+rm -rf "$scratch/repos" "$scratch/worktrees" "$scratch/ghosthub-state"
 mkdir -p "$scratch"/{repos,worktrees,tmux,home,ssh,ghosthub-config,ghosthub-state}
 cp "$demo_root/home/zprofile" "$scratch/home/.zprofile"
 cp "$demo_root/home/zshrc" "$scratch/home/.zshrc"

--- a/website/demo/stage.sh
+++ b/website/demo/stage.sh
@@ -54,6 +54,10 @@ touch "$sentinel"
 source "$demo_root/process.sh"
 demo_stop_recorded_process \
   "$scratch/app.pid" "$scratch/app/Ghosthub.app/Contents/MacOS/Ghosthub"
+# The staged bundle uses this demo-only defaults domain. Clear it between
+# passes so window layout and disclosure state never depend on an earlier
+# capture while leaving every real Ghosthub preference untouched.
+defaults delete com.ghosthub.demo 2>/dev/null || true
 demo_socket="$scratch/tmux/tmux-$(id -u)/default"
 # shellcheck source=SCRIPTDIR/tmux.sh
 source "$demo_root/tmux.sh"
@@ -67,8 +71,8 @@ export TMUX_TMPDIR="$scratch/tmux"
 # enclosing server. All demo tmux traffic must stay on the demo socket.
 unset TMUX
 
-# Synthetic history and the public clone must not inherit developer Git
-# rewrites, hooks, templates, transports, or configuration.
+# Synthetic history must not inherit developer Git rewrites, hooks,
+# templates, transports, or configuration.
 # shellcheck source=SCRIPTDIR/git.sh
 source "$demo_root/git.sh"
 git_c=(
@@ -110,16 +114,30 @@ mkdir -p "$scratch"/{repos,worktrees,tmux,home,ssh,ghosthub-config,ghosthub-stat
 cp "$demo_root/home/zprofile" "$scratch/home/.zprofile"
 cp "$demo_root/home/zshrc" "$scratch/home/.zshrc"
 cp "$demo_root/ssh-config" "$scratch/ssh/config"
+cat > "$scratch/ghosthub-config/ghostty.conf" <<'EOF'
+# Isolated marketing-demo terminal configuration.
+font-family = Menlo
+font-size = 13
+background = 282c34
+foreground = abb2bf
+cursor-color = abb2bf
+selection-background = 3e4451
+selection-foreground = ffffff
+scrollback-limit = 50000000
+term = xterm-256color
+cursor-style = block
+mouse-hide-while-typing = true
+copy-on-select = clipboard
+macos-option-as-alt = true
+shell-integration = detect
+EOF
 chmod 700 "$scratch/ssh"
 chmod 600 "$scratch/ssh/config"
 
-# ghosthub is a real local clone: its pane runs a live Claude Code session
-# and synthetic stub content reads as fake. Fetch only the public main branch
-# into an independent object store so unpublished local refs and objects are
-# unavailable to the demo session.
-"${git_c[@]}" clone -q --no-local --single-branch --branch main --depth 1 \
-  https://github.com/kenn-io/ghosthub.git "$scratch/repos/ghosthub"
-
+make_repo ghosthub \
+  "Initial native workspace" \
+  "Attach ordinary tmux clients" \
+  "Reconnect remote sessions"
 make_repo agentsview \
   "Initial import" \
   "Add live session table" \
@@ -144,61 +162,76 @@ new_session() {
   demo_new_session "$scratch" "$@"
 }
 
-# Bound sessions: names must match the kwt shim's session_name values.
-# The ghosthub pane runs a real Claude Code session (plan mode: read-only)
-# against the real clone; staged transcripts read as fake. Claude needs the
-# real HOME for keychain auth, but no repository or account customization may
-# execute in the demo. Safe mode disables CLAUDE.md, hooks, skills, plugins,
-# agents, and settings from the cloned source and the user account;
-# --strict-mcp-config also rejects every implicit MCP server. Pass one shell
-# string: multi-argument commands are not portable across tmux versions.
-claude_prompt='How does native tmux attachment recover from dropped SSH'
-claude_prompt+=' connections? Trace reconnect and keepalive handling'
-claude_prompt+=' through Sources/TmuxControl and the session coordinator,'
-claude_prompt+=' and point out anything fragile.'
+# Bound sessions: names must match the kwt shim's session_name values. The
+# hero pane uses a curated agent investigation so captures never depend on an
+# account, a network service, unpublished source, or nondeterministic output.
+cat > "$scratch/agent-transcript.txt" <<'EOF'
+● Read Sources/Tmux/TmuxAttachmentInfo.swift
+● Read Sources/App/NativeTmuxSessionCoordinator.swift
+● Search reconnect | ServerAliveInterval | ConnectTimeout
+
+I traced the remote attachment path from host discovery through the ordinary
+tmux client. The important boundaries are:
+
+1. Attachment
+   Ghosthub opens the same tmux client locally and remotely. Tmux continues to
+   own windows, panes, layout, history, and process lifetime.
+
+2. Keepalive
+   SSH uses a short connection timeout plus server keepalives, so a dead link
+   exits instead of leaving the terminal surface hung indefinitely.
+
+3. Reconnect
+   Transport failures restart the SSH client with bounded backoff. A clean
+   detach remains clean and never destroys the tmux session.
+
+The coordinator owns presentation lifecycle, while the reconnecting shell owns
+transport recovery inside the still-running terminal surface. That separation
+is why closing Ghosthub detaches without becoming session authority.
+
+Fragile point
+
+The user-visible reconnect state should always come from the transport process,
+not a second Swift-side timer. Two clocks would drift and report false health.
+
+Ready to turn this into a focused regression test and implementation plan.
+EOF
+cat > "$scratch/session-transcript.txt" <<'EOF'
+$ git status --short --branch
+## add-session-filters
+ M Sources/SessionTable.swift
+ M Sources/SessionFilter.swift
+?? Tests/SessionFilterTests.swift
+
+$ swift test --filter SessionFilterTests
+Building for debugging...
+Build complete! (1.8s)
+Test Suite 'Selected tests' started
+  ✓ filters sessions by host
+  ✓ matches project and worktree names
+  ✓ keeps active agents visible
+  ✓ clears the query without changing selection
+Test Suite 'Selected tests' passed
+Executed 4 tests, with 0 failures in 0.09 seconds
+
+$ git diff --stat
+ Sources/SessionFilter.swift      | 42 +++++++++++++++++++++
+ Sources/SessionTable.swift       | 18 ++++++++-
+ Tests/SessionFilterTests.swift   | 35 +++++++++++++++++
+ 3 files changed, 94 insertions(+), 1 deletion(-)
+EOF
 new_session ghosthub--fix-reconnect-backoff \
   "$scratch/worktrees/ghosthub/fix-reconnect-backoff" \
-  "HOME=$(printf '%q' "$HOME") claude --safe-mode --permission-mode plan --strict-mcp-config $(printf '%q' "$claude_prompt")"
-
-# Never accept repository trust on the user's behalf. Even with safe mode,
-# trust is an explicit developer decision and must remain visibly manual.
-claude_ready=""
-trust_required=""
-for _ in $(seq 1 30); do
-  pane="$(tmux capture-pane -pt ghosthub--fix-reconnect-backoff)"
-  if grep -qE "esc to interrupt|tokens" <<<"$pane"; then
-    claude_ready=1
-    break
-  fi
-  if grep -q "trust the files in this folder" <<<"$pane"; then
-    trust_required=1
-    break
-  fi
-  sleep 2
-done
-if [[ -n "$trust_required" ]]; then
-  echo "error: Claude requires manual repository trust; stage.sh did not accept it" >&2
-  echo "       inspect and accept only if appropriate, then rerun stage.sh:" >&2
-  echo "       TMUX_TMPDIR=$TMUX_TMPDIR tmux attach -t" \
-    "ghosthub--fix-reconnect-backoff" >&2
-  exit 1
-fi
-if [[ -z "$claude_ready" ]]; then
-  echo "error: Claude session never started working (check the pane:" >&2
-  echo "       TMUX_TMPDIR=$TMUX_TMPDIR tmux attach -t" \
-    "ghosthub--fix-reconnect-backoff)" >&2
-  exit 1
-fi
+  "clear; cat $(printf '%q' "$scratch/agent-transcript.txt")"
 
 # The default status-right renders the pane title, which carries the real
 # hostname. Same for anything else the shell stuffs into titles.
-tmux set -g status-right '"studio.local" %H:%M %d-%b-%y'
+tmux set -g status-right '"studio.local"'
 tmux set -g set-titles off
 
 new_session agentsview--add-session-filters \
-  "$scratch/worktrees/agentsview/add-session-filters"
-tmux send-keys -t agentsview--add-session-filters \
-  "clear; git status -sb" Enter
+  "$scratch/worktrees/agentsview/add-session-filters" \
+  "clear; cat $(printf '%q' "$scratch/session-transcript.txt")"
 
 # Raw local sessions (unbound: not in any kwt inventory).
 new_session scratch "$scratch/repos/msgvault"
@@ -234,7 +267,7 @@ chmod +x "$app_copy/Contents/Helpers/kwt"
 # hostname override in run.sh) takes effect.
 codesign --force --deep -s - "$app_copy" 2>/dev/null
 
-cc -dynamiclib -framework Foundation \
+cc -dynamiclib -fobjc-arc -framework AppKit -framework ImageIO \
   -o "$scratch/libdemohost.dylib" "$demo_root/assets/demohost.m"
 
 echo "==> staging docker remote (127.0.0.1:2201)"

--- a/website/demo/stage.sh
+++ b/website/demo/stage.sh
@@ -239,6 +239,12 @@ tmux send-keys -t scratch "clear; git log --oneline -4" Enter
 new_session docbank-export "$scratch"
 tmux send-keys -t docbank-export \
   "clear; echo 'exported 4,812 threads (2.1 GiB) in 96s'; echo done." Enter
+new_session release-watch "$scratch/repos/ghosthub"
+tmux send-keys -t release-watch \
+  "clear; printf 'release v0.2.1\\n\\n  ✓ build\\n  ✓ swift tests\\n  ✓ notarization\\n  ● publish\\n'" Enter
+new_session test-matrix "$scratch/repos/agentsview"
+tmux send-keys -t test-matrix \
+  "clear; printf 'test matrix\\n\\nmacOS 26 arm64     ✓ 523 passed\\nUbuntu 24.04       ✓ 118 passed\\nSSH integration    ✓  42 passed\\n'" Enter
 
 echo "==> staging patched app copy"
 # Build the release app first (make release-app in the app repo) or point

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -20,12 +20,7 @@ assets=(
   guide-worktree.png
   guide-quick-launch.png
   guide-terminal.png
-  guide-command-ghosthub.png
-  guide-command-agentsview.png
-  guide-command-scratch.png
-  guide-command-export.png
-  guide-command-release.png
-  guide-command-tests.png
+  guide-command-center.png
 )
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -1,75 +1,114 @@
 #!/usr/bin/env bash
 # Materializes binary assets from the orphan website-assets branch into
 # src/assets/. Screenshot binaries live there so refreshes never bloat
-# main's history; hero.png is gitignored on main.
+# main's history.
 #
 # Resolution order: git fetch (local dev, CI with credentials), local
 # branch, raw.githubusercontent.com (Vercel builds have no usable .git;
-# works once the repo is public), pre-existing file. A generated
-# placeholder is a last resort and only with SYNC_ASSETS_ALLOW_PLACEHOLDER
-# set, so production can never silently deploy without the real asset.
+# works once the repo is public), pre-existing verified file. Generated
+# placeholders are a last resort and only when
+# SYNC_ASSETS_ALLOW_PLACEHOLDER is set, so production can never silently
+# deploy without the real asset set.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-# hero.png may be the directory's only file; a fresh checkout lacks it.
 mkdir -p src/assets
 
-RAW_URL="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets/hero.png"
-# Sidecars distinguish generated placeholders from successfully synced assets.
-# The synced marker includes a checksum so stale provenance cannot bless a
-# subsequently replaced file.
-MARKER="src/assets/hero.png.placeholder"
-SYNCED_MARKER="src/assets/hero.png.synced"
+assets=(
+  hero.png
+  guide-sessions.png
+  guide-hosts.png
+  guide-worktree.png
+  guide-quick-launch.png
+  guide-terminal.png
+)
+raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
+fetched_ref=""
+
+if git fetch --depth=1 origin website-assets 2>/dev/null; then
+  fetched_ref="FETCH_HEAD"
+fi
 
 record_synced_asset() {
-  shasum -a 256 src/assets/hero.png > "$SYNCED_MARKER"
+  local path="$1"
+  shasum -a 256 "$path" > "$path.synced"
 }
 
 asset_is_synced() {
-  [[ -f "$SYNCED_MARKER" ]] && shasum -a 256 -c "$SYNCED_MARKER" >/dev/null 2>&1
+  local path="$1"
+  [[ -f "$path.synced" ]] \
+    && shasum -a 256 -c "$path.synced" >/dev/null 2>&1
 }
 
-if git fetch --depth=1 origin website-assets 2>/dev/null; then
-  git show FETCH_HEAD:hero.png > src/assets/hero.png
-  rm -f "$MARKER"
-  record_synced_asset
-  echo "synced src/assets/hero.png from origin/website-assets"
-elif git rev-parse --verify --quiet website-assets >/dev/null 2>&1; then
-  git show website-assets:hero.png > src/assets/hero.png
-  rm -f "$MARKER"
-  record_synced_asset
-  echo "synced src/assets/hero.png from local website-assets"
-elif curl -fsSL --max-time 30 -o src/assets/hero.png.tmp "$RAW_URL" 2>/dev/null; then
-  mv -f src/assets/hero.png.tmp src/assets/hero.png
-  rm -f "$MARKER"
-  record_synced_asset
-  echo "synced src/assets/hero.png from raw.githubusercontent.com"
-elif [[ -f src/assets/hero.png && ! -f "$MARKER" ]] && asset_is_synced; then
-  echo "warning: could not reach website-assets; keeping existing hero.png" >&2
-elif [[ -f src/assets/hero.png && -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
-  echo "warning: could not reach website-assets; keeping placeholder" >&2
-  rm -f "$SYNCED_MARKER"
-  touch "$MARKER"
-elif [[ -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
-  echo "warning: website-assets unreachable; generating placeholder" >&2
-  node -e '
+show_asset() {
+  local ref="$1" asset="$2" destination="$3"
+  git show "$ref:$asset" > "$destination.tmp" 2>/dev/null || {
+    rm -f "$destination.tmp"
+    return 1
+  }
+  mv -f "$destination.tmp" "$destination"
+}
+
+generate_placeholder() {
+  local asset="$1" path="$2"
+  ASSET_NAME="$asset" node -e '
     const sharp = require("sharp");
+    const label = process.env.ASSET_NAME;
     const svg = Buffer.from(
       `<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="966">
          <rect width="100%" height="100%" fill="#0d1420"/>
          <text x="50%" y="50%" fill="#5f6870" font-size="28"
                font-family="monospace" text-anchor="middle">
-           hero screenshot placeholder
+           ${label} placeholder
          </text>
        </svg>`
     );
-    sharp(svg).png().toFile("src/assets/hero.png");
-  '
-  rm -f "$SYNCED_MARKER"
-  touch "$MARKER"
-else
-  echo "error: website-assets branch unreachable and src/assets/hero.png" >&2
-  echo "       is missing or is a stale placeholder. Set" >&2
-  echo "       SYNC_ASSETS_ALLOW_PLACEHOLDER=1 for a placeholder (CI/dev" >&2
-  echo "       only), or fetch the branch." >&2
-  exit 1
-fi
+    sharp(svg).png().toFile(process.argv[1]);
+  ' "$path"
+}
+
+sync_asset() {
+  local asset="$1"
+  local path="src/assets/$asset"
+  local placeholder="$path.placeholder"
+
+  if [[ -n "$fetched_ref" ]] \
+    && show_asset "$fetched_ref" "$asset" "$path"; then
+    rm -f "$placeholder"
+    record_synced_asset "$path"
+    echo "synced $path from origin/website-assets"
+  elif git rev-parse --verify --quiet website-assets >/dev/null 2>&1 \
+    && show_asset website-assets "$asset" "$path"; then
+    rm -f "$placeholder"
+    record_synced_asset "$path"
+    echo "synced $path from local website-assets"
+  elif curl -fsSL --max-time 30 \
+    -o "$path.tmp" "$raw_root/$asset" 2>/dev/null; then
+    mv -f "$path.tmp" "$path"
+    rm -f "$placeholder"
+    record_synced_asset "$path"
+    echo "synced $path from raw.githubusercontent.com"
+  elif [[ -f "$path" && ! -f "$placeholder" ]] \
+    && asset_is_synced "$path"; then
+    echo "warning: could not reach website-assets; keeping $path" >&2
+  elif [[ -f "$path" \
+    && -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
+    echo "warning: could not sync $asset; keeping placeholder" >&2
+    rm -f "$path.synced"
+    touch "$placeholder"
+  elif [[ -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
+    echo "warning: website-assets unreachable; generating $asset placeholder" >&2
+    generate_placeholder "$asset" "$path"
+    rm -f "$path.synced"
+    touch "$placeholder"
+  else
+    rm -f "$path.tmp"
+    echo "error: could not sync $asset from website-assets and $path" >&2
+    echo "       is missing or stale. Set SYNC_ASSETS_ALLOW_PLACEHOLDER=1" >&2
+    echo "       for CI/dev placeholders, or publish the complete asset set." >&2
+    exit 1
+  fi
+}
+
+for asset in "${assets[@]}"; do
+  sync_asset "$asset"
+done

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -26,16 +26,18 @@ assets=(
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""
 stage_root="$(mktemp -d "src/.asset-sync.XXXXXX")"
+generation_manifest="src/assets/.website-assets.synced"
+placeholder_manifest="src/assets/.website-assets.placeholder"
 trap 'rm -rf "$stage_root"' EXIT
 
 if git fetch --depth=1 origin website-assets 2>/dev/null; then
   fetched_ref="FETCH_HEAD"
 fi
 
-asset_is_synced() {
-  local path="$1"
-  [[ -f "$path.synced" ]] \
-    && shasum -a 256 -c "$path.synced" >/dev/null 2>&1
+cached_generation_is_synced() {
+  [[ -f "$generation_manifest" ]] \
+    && [[ ! -f "$placeholder_manifest" ]] \
+    && shasum -a 256 -c "$generation_manifest" >/dev/null 2>&1
 }
 
 git_ref_has_complete_set() {
@@ -66,12 +68,11 @@ stage_raw_assets() {
 }
 
 stage_cached_assets() {
-  local destination="$1" asset path
+  local destination="$1" asset
   mkdir "$destination"
+  cached_generation_is_synced || return 1
   for asset in "${assets[@]}"; do
-    path="src/assets/$asset"
-    asset_is_synced "$path" || return 1
-    cp "$path" "$destination/$asset"
+    cp "src/assets/$asset" "$destination/$asset"
   done
 }
 
@@ -103,19 +104,30 @@ stage_placeholders() {
 
 publish_assets() {
   local source="$1" label="$2" placeholders="${3:-}" asset path digest
+  local staged_manifest="$source/.website-assets.synced"
+  if [[ -z "$placeholders" ]]; then
+    for asset in "${assets[@]}"; do
+      digest="$(shasum -a 256 "$source/$asset" | awk '{print $1}')"
+      printf '%s  src/assets/%s\n' "$digest" "$asset" \
+        >> "$staged_manifest"
+    done
+  fi
+
+  # The manifest is the commit marker for a complete generation. Invalidate
+  # the old marker before the first replacement, then publish the new marker
+  # with one rename only after every asset has landed.
+  rm -f "$generation_manifest" "$placeholder_manifest"
   for asset in "${assets[@]}"; do
     path="src/assets/$asset"
     mv -f "$source/$asset" "$path"
-    if [[ -n "$placeholders" ]]; then
-      rm -f "$path.synced"
-      touch "$path.placeholder"
-    else
-      digest="$(shasum -a 256 "$path" | awk '{print $1}')"
-      printf '%s  %s\n' "$digest" "$path" > "$path.synced"
-      rm -f "$path.placeholder"
-    fi
     echo "synced $path from $label"
   done
+  if [[ -n "$placeholders" ]]; then
+    touch "$source/.website-assets.placeholder"
+    mv -f "$source/.website-assets.placeholder" "$placeholder_manifest"
+  else
+    mv -f "$staged_manifest" "$generation_manifest"
+  fi
 }
 
 if [[ -n "$fetched_ref" ]]; then

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -3,12 +3,13 @@
 # src/assets/. Screenshot binaries live there so refreshes never bloat
 # main's history.
 #
-# Resolution order: git fetch (local dev, CI with credentials), local
-# branch, raw.githubusercontent.com (Vercel builds have no usable .git;
-# works once the repo is public), pre-existing verified file. Generated
+# Resolution order: fetched git ref (local dev, CI with credentials), then
+# complete offline sources when fetch is unavailable: local branch,
+# raw.githubusercontent.com, or the pre-existing verified set. Generated
 # placeholders are a last resort and only when
 # SYNC_ASSETS_ALLOW_PLACEHOLDER is set, so production can never silently
-# deploy without the real asset set.
+# deploy without the real asset set. Every source is staged as a complete
+# generation before any destination file is replaced.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 mkdir -p src/assets
@@ -24,15 +25,12 @@ assets=(
 )
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""
+stage_root="$(mktemp -d "src/.asset-sync.XXXXXX")"
+trap 'rm -rf "$stage_root"' EXIT
 
 if git fetch --depth=1 origin website-assets 2>/dev/null; then
   fetched_ref="FETCH_HEAD"
 fi
-
-record_synced_asset() {
-  local path="$1"
-  shasum -a 256 "$path" > "$path.synced"
-}
 
 asset_is_synced() {
   local path="$1"
@@ -40,13 +38,41 @@ asset_is_synced() {
     && shasum -a 256 -c "$path.synced" >/dev/null 2>&1
 }
 
-show_asset() {
-  local ref="$1" asset="$2" destination="$3"
-  git show "$ref:$asset" > "$destination.tmp" 2>/dev/null || {
-    rm -f "$destination.tmp"
-    return 1
-  }
-  mv -f "$destination.tmp" "$destination"
+git_ref_has_complete_set() {
+  local ref="$1" asset
+  for asset in "${assets[@]}"; do
+    if ! git cat-file -e "$ref:$asset" 2>/dev/null; then
+      missing_asset="$asset"
+      return 1
+    fi
+  done
+}
+
+stage_git_ref() {
+  local ref="$1" destination="$2" asset
+  mkdir "$destination"
+  for asset in "${assets[@]}"; do
+    git show "$ref:$asset" > "$destination/$asset" 2>/dev/null || return 1
+  done
+}
+
+stage_raw_assets() {
+  local destination="$1" asset
+  mkdir "$destination"
+  for asset in "${assets[@]}"; do
+    curl -fsSL --max-time 30 \
+      -o "$destination/$asset" "$raw_root/$asset" 2>/dev/null || return 1
+  done
+}
+
+stage_cached_assets() {
+  local destination="$1" asset path
+  mkdir "$destination"
+  for asset in "${assets[@]}"; do
+    path="src/assets/$asset"
+    asset_is_synced "$path" || return 1
+    cp "$path" "$destination/$asset"
+  done
 }
 
 generate_placeholder() {
@@ -67,49 +93,78 @@ generate_placeholder() {
   ' "$path"
 }
 
-sync_asset() {
-  local asset="$1"
-  local path="src/assets/$asset"
-  local placeholder="$path.placeholder"
-
-  if [[ -n "$fetched_ref" ]] \
-    && show_asset "$fetched_ref" "$asset" "$path"; then
-    rm -f "$placeholder"
-    record_synced_asset "$path"
-    echo "synced $path from origin/website-assets"
-  elif git rev-parse --verify --quiet website-assets >/dev/null 2>&1 \
-    && show_asset website-assets "$asset" "$path"; then
-    rm -f "$placeholder"
-    record_synced_asset "$path"
-    echo "synced $path from local website-assets"
-  elif curl -fsSL --max-time 30 \
-    -o "$path.tmp" "$raw_root/$asset" 2>/dev/null; then
-    mv -f "$path.tmp" "$path"
-    rm -f "$placeholder"
-    record_synced_asset "$path"
-    echo "synced $path from raw.githubusercontent.com"
-  elif [[ -f "$path" && ! -f "$placeholder" ]] \
-    && asset_is_synced "$path"; then
-    echo "warning: could not reach website-assets; keeping $path" >&2
-  elif [[ -f "$path" \
-    && -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
-    echo "warning: could not sync $asset; keeping placeholder" >&2
-    rm -f "$path.synced"
-    touch "$placeholder"
-  elif [[ -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
-    echo "warning: website-assets unreachable; generating $asset placeholder" >&2
-    generate_placeholder "$asset" "$path"
-    rm -f "$path.synced"
-    touch "$placeholder"
-  else
-    rm -f "$path.tmp"
-    echo "error: could not sync $asset from website-assets and $path" >&2
-    echo "       is missing or stale. Set SYNC_ASSETS_ALLOW_PLACEHOLDER=1" >&2
-    echo "       for CI/dev placeholders, or publish the complete asset set." >&2
-    exit 1
-  fi
+stage_placeholders() {
+  local destination="$1" asset
+  mkdir "$destination"
+  for asset in "${assets[@]}"; do
+    generate_placeholder "$asset" "$destination/$asset"
+  done
 }
 
-for asset in "${assets[@]}"; do
-  sync_asset "$asset"
-done
+publish_assets() {
+  local source="$1" label="$2" placeholders="${3:-}" asset path digest
+  for asset in "${assets[@]}"; do
+    path="src/assets/$asset"
+    mv -f "$source/$asset" "$path"
+    if [[ -n "$placeholders" ]]; then
+      rm -f "$path.synced"
+      touch "$path.placeholder"
+    else
+      digest="$(shasum -a 256 "$path" | awk '{print $1}')"
+      printf '%s  %s\n' "$digest" "$path" > "$path.synced"
+      rm -f "$path.placeholder"
+    fi
+    echo "synced $path from $label"
+  done
+}
+
+if [[ -n "$fetched_ref" ]]; then
+  missing_asset=""
+  if ! git_ref_has_complete_set "$fetched_ref"; then
+    echo "error: fetched website-assets is incomplete; missing $missing_asset" >&2
+    exit 1
+  fi
+  fetched_stage="$stage_root/fetched"
+  if ! stage_git_ref "$fetched_ref" "$fetched_stage"; then
+    echo "error: could not stage the complete fetched website-assets ref" >&2
+    exit 1
+  fi
+  publish_assets "$fetched_stage" "origin/website-assets"
+  exit 0
+fi
+
+missing_asset=""
+local_stage="$stage_root/local"
+if git rev-parse --verify --quiet website-assets >/dev/null 2>&1 \
+  && git_ref_has_complete_set website-assets \
+  && stage_git_ref website-assets "$local_stage"; then
+  publish_assets "$local_stage" "local website-assets"
+  exit 0
+fi
+
+raw_stage="$stage_root/raw"
+if stage_raw_assets "$raw_stage"; then
+  publish_assets "$raw_stage" "raw.githubusercontent.com"
+  exit 0
+fi
+
+cached_stage="$stage_root/cached"
+if stage_cached_assets "$cached_stage"; then
+  echo "warning: could not reach website-assets; keeping verified asset set" >&2
+  publish_assets "$cached_stage" "verified local cache"
+  exit 0
+fi
+
+if [[ -n "${SYNC_ASSETS_ALLOW_PLACEHOLDER:-}" ]]; then
+  placeholder_stage="$stage_root/placeholders"
+  stage_placeholders "$placeholder_stage"
+  echo "warning: website-assets unreachable; generating placeholder set" >&2
+  publish_assets "$placeholder_stage" "generated placeholders" placeholder
+  exit 0
+fi
+
+echo "error: could not sync the complete website-assets set" >&2
+echo "       and the local cache is missing or stale." >&2
+echo "       Set SYNC_ASSETS_ALLOW_PLACEHOLDER=1 for CI/dev placeholders," >&2
+echo "       or publish the complete asset set." >&2
+exit 1

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -20,6 +20,12 @@ assets=(
   guide-worktree.png
   guide-quick-launch.png
   guide-terminal.png
+  guide-command-ghosthub.png
+  guide-command-agentsview.png
+  guide-command-scratch.png
+  guide-command-export.png
+  guide-command-release.png
+  guide-command-tests.png
 )
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -10,6 +10,7 @@ import { DISCORD_URL, GITHUB_URL } from '../config';
       &copy; 2026 Kenn Software LLC.
     </p>
     <nav aria-label="Footer links">
+      <a href="/guide/">Guide</a>
       <a href={GITHUB_URL}>GitHub</a>
       <a href={DISCORD_URL}>Discord</a>
     </nav>

--- a/website/src/components/GuideCTA.astro
+++ b/website/src/components/GuideCTA.astro
@@ -1,0 +1,78 @@
+<section class="guide-cta">
+  <div class="container callout">
+    <div>
+      <p class="eyebrow">Five-minute guide</p>
+      <h2>From download to a connected fleet</h2>
+      <p>
+        See how sessions, SSH hosts, worktrees, Quick Launch, and terminal
+        configuration fit together.
+      </p>
+    </div>
+    <a href="/guide/">How to use Ghosthub <span aria-hidden="true">&rarr;</span></a>
+  </div>
+</section>
+
+<style>
+  .guide-cta {
+    padding: 0 0 6rem;
+  }
+
+  .callout {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2rem;
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    background:
+      linear-gradient(
+        105deg,
+        color-mix(in srgb, var(--accent) 8%, var(--bg-raise)),
+        var(--bg-raise) 64%
+      );
+  }
+
+  .eyebrow {
+    margin: 0 0 0.45rem;
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    font-size: clamp(1.25rem, 2.6vw, 1.65rem);
+  }
+
+  p:not(.eyebrow) {
+    margin: 0.6rem 0 0;
+    color: var(--text-dim);
+  }
+
+  a {
+    flex: none;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #06222e;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding: 0.75rem 1rem;
+    transition: transform 0.15s, box-shadow 0.15s;
+  }
+
+  a:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 0 32px color-mix(in srgb, var(--accent) 25%, transparent);
+  }
+
+  @media (max-width: 700px) {
+    .callout {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/website/src/components/GuideCTA.astro
+++ b/website/src/components/GuideCTA.astro
@@ -4,8 +4,8 @@
       <p class="eyebrow">Five-minute guide</p>
       <h2>From download to a connected fleet</h2>
       <p>
-        See how sessions, automatic SSH recovery, worktrees, Quick Launch,
-        and terminal configuration fit together.
+        See how automatic SSH recovery, worktrees, Quick Launch, and
+        multi-window tmux command centers fit together.
       </p>
     </div>
     <a href="/guide/">How to use Ghosthub <span aria-hidden="true">&rarr;</span></a>

--- a/website/src/components/GuideCTA.astro
+++ b/website/src/components/GuideCTA.astro
@@ -4,8 +4,8 @@
       <p class="eyebrow">Five-minute guide</p>
       <h2>From download to a connected fleet</h2>
       <p>
-        See how sessions, SSH hosts, worktrees, Quick Launch, and terminal
-        configuration fit together.
+        See how sessions, automatic SSH recovery, worktrees, Quick Launch,
+        and terminal configuration fit together.
       </p>
     </div>
     <a href="/guide/">How to use Ghosthub <span aria-hidden="true">&rarr;</span></a>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -6,7 +6,8 @@ import AppIcon from './AppIcon.astro';
 <header>
   <div class="container bar">
     <a class="brand" href="/"><AppIcon prefix="gh-ic-hdr" /><span>Ghosthub</span></a>
-    <nav aria-label="External links">
+    <nav aria-label="Primary navigation">
+      <a class="guide" href="/guide/">Guide</a>
       <a class="repo" href={GITHUB_URL}>
         <span class="sr-only">Ghosthub on GitHub:</span>
         <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor">
@@ -144,6 +145,17 @@ import AppIcon from './AppIcon.astro';
     display: flex;
     align-items: center;
     gap: 1rem;
+  }
+
+  .guide {
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    transition: color 0.15s;
+  }
+
+  .guide:hover {
+    color: var(--text);
   }
 
   .repo {

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -2,7 +2,12 @@
 import { Image } from 'astro:assets';
 import { GITHUB_URL, RELEASES_URL } from '../config';
 import AppIcon from './AppIcon.astro';
+import ZoomableImage from './ZoomableImage.astro';
 import hero from '../assets/hero.png';
+
+const heroAlt =
+  'Ghosthub main window: sidebar with local and remote tmux sessions and kwt '
+  + 'worktrees, and an attached session running a Claude Code investigation';
 ---
 
 <section class="hero">
@@ -28,14 +33,16 @@ import hero from '../assets/hero.png';
     </p>
     <figure class="window">
       <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-      <Image
-        src={hero}
-        alt="Ghosthub main window: sidebar with local and remote tmux sessions and kwt worktrees, and an attached session running a Claude Code investigation"
-        widths={[640, 960, 1280, 1920, 2400]}
-        sizes="(max-width: 1000px) 100vw, 960px"
-        loading="eager"
-        fetchpriority="high"
-      />
+      <ZoomableImage label={heroAlt}>
+        <Image
+          src={hero}
+          alt={heroAlt}
+          widths={[640, 960, 1280, 1920, 2400]}
+          sizes="(max-width: 1000px) 100vw, 960px"
+          loading="eager"
+          fetchpriority="high"
+        />
+      </ZoomableImage>
     </figure>
   </div>
 </section>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -19,9 +19,13 @@ import hero from '../assets/hero.png';
     </p>
     <div class="actions">
       <a class="cta" data-download href={RELEASES_URL}>Download for Apple Silicon</a>
-      <a class="ghost" href={GITHUB_URL}>View on GitHub</a>
+      <a class="learn" href="/guide/">Learn how it works</a>
     </div>
-    <p class="meta"><span data-version></span>macOS 26+ &middot; Apple Silicon</p>
+    <p class="meta">
+      <span data-version></span>macOS 26+ &middot; Apple Silicon
+      {' '}<span aria-hidden="true">&middot;</span>{' '}
+      <a href={GITHUB_URL}>View on GitHub</a>
+    </p>
     <figure class="window">
       <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
       <Image
@@ -108,18 +112,19 @@ import hero from '../assets/hero.png';
     box-shadow: 0 0 44px color-mix(in srgb, var(--accent) 45%, transparent);
   }
 
-  .ghost {
+  .learn {
     font-family: var(--font-mono);
     padding: 0.8rem 1.5rem;
-    border: 1px solid var(--line);
+    border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
     border-radius: 10px;
-    color: var(--text-dim);
-    transition: color 0.15s, border-color 0.15s;
+    color: var(--accent);
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
   }
 
-  .ghost:hover {
+  .learn:hover {
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
     color: var(--text);
-    border-color: var(--text-faint);
+    border-color: var(--accent);
   }
 
   .meta {
@@ -127,6 +132,18 @@ import hero from '../assets/hero.png';
     font-size: 0.78rem;
     color: var(--text-faint);
     margin-top: 1rem;
+  }
+
+  .meta a {
+    color: var(--text-faint);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--text-faint) 55%, transparent);
+    text-underline-offset: 0.2em;
+    transition: color 0.15s;
+  }
+
+  .meta a:hover {
+    color: var(--text-dim);
   }
 
   .window {

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -13,9 +13,9 @@ import hero from '../assets/hero.png';
     </p>
     <h1>A power terminal for your agents&rsquo; tmux sessions</h1>
     <p class="sub">
-      Attach to every session in your fleet, local or over SSH, with
-      keepalives and automatic reconnect. Worktree-native from the ground
-      up.
+      A native, libghostty-powered terminal for every tmux session in your
+      fleet—local or over SSH—with keepalives and automatic reconnect.
+      Worktree-native from the ground up.
     </p>
     <div class="actions">
       <a class="cta" data-download href={RELEASES_URL}>Download for Apple Silicon</a>

--- a/website/src/components/ZoomableImage.astro
+++ b/website/src/components/ZoomableImage.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  label: string;
+}
+
+const { label } = Astro.props;
+---
+
+<button
+  class="image-zoom"
+  type="button"
+  data-lightbox-trigger
+  aria-controls="image-lightbox"
+  aria-haspopup="dialog"
+  aria-label={`Enlarge screenshot: ${label}`}
+>
+  <slot />
+</button>

--- a/website/src/layouts/SiteLayout.astro
+++ b/website/src/layouts/SiteLayout.astro
@@ -1,0 +1,52 @@
+---
+// oxlint-disable-next-line import/no-unassigned-import -- global stylesheet, no export to bind
+import '../styles/global.css';
+import Footer from '../components/Footer.astro';
+import Header from '../components/Header.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  path: string;
+}
+
+const { title, description, path } = Astro.props;
+const canonical = new URL(path, Astro.site);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href={canonical} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={new URL('/og.png', Astro.site)} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:image" content={new URL('/og.png', Astro.site)} />
+    <link
+      rel="preload"
+      href="/fonts/JetBrainsMono-Bold.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <slot />
+    </main>
+    <Footer />
+    <script>
+      // oxlint-disable-next-line import/no-unassigned-import -- side-effect module, no export
+      import '../scripts/site';
+    </script>
+  </body>
+</html>

--- a/website/src/layouts/SiteLayout.astro
+++ b/website/src/layouts/SiteLayout.astro
@@ -44,6 +44,25 @@ const canonical = new URL(path, Astro.site);
       <slot />
     </main>
     <Footer />
+    <dialog
+      id="image-lightbox"
+      class="image-lightbox"
+      data-image-lightbox
+      aria-label="Enlarged screenshot"
+    >
+      <div class="image-lightbox-frame" data-image-lightbox-frame>
+        <img data-image-lightbox-image alt="" />
+        <button
+          class="image-lightbox-close"
+          type="button"
+          data-image-lightbox-close
+          aria-label="Close enlarged screenshot"
+          autofocus
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    </dialog>
     <script>
       // oxlint-disable-next-line import/no-unassigned-import -- side-effect module, no export
       import '../scripts/site';

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -23,9 +23,16 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       <p class="eyebrow">Five-minute guide</p>
       <h1>How to use Ghosthub</h1>
       <p class="lead">
-        Ghosthub puts the tmux sessions behind your projects and coding
-        agents into one native macOS workspace. Tmux keeps owning the
-        sessions; Ghosthub makes the whole fleet easy to find and enter.
+        Ghosthub keeps the tmux sessions behind your projects and coding
+        agents connected in one native macOS workspace. If SSH drops, it
+        retries and reattaches to the same exact session automatically.
+        Tmux keeps owning the windows, panes, history, and process state.
+      </p>
+      <p class="promise" aria-label="Automatic SSH reconnect and exact-session reattach">
+        <span class="promise-icon" aria-hidden="true">↻</span>
+        <span>Automatic SSH reconnect</span>
+        <i aria-hidden="true">&middot;</i>
+        <span>Exact-session reattach</span>
       </p>
       <div class="requirements" aria-label="Requirements">
         <span>Apple Silicon</span>
@@ -253,6 +260,33 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
     margin: 1rem auto 0;
     max-width: 64ch;
     text-wrap: balance;
+  }
+
+  .promise {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.55rem;
+    max-width: calc(100% - 1rem);
+    margin: 1.4rem 0 0;
+    border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--line));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 7%, transparent);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    padding: 0.45rem 0.75rem;
+  }
+
+  .promise-icon {
+    color: var(--accent);
+    font-size: 1rem;
+  }
+
+  .promise i {
+    color: var(--text-faint);
+    font-style: normal;
   }
 
   .requirements {

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 import SiteLayout from '../layouts/SiteLayout.astro';
+import ZoomableImage from '../components/ZoomableImage.astro';
 import commandCenter from '../assets/guide-command-center.png';
 import hosts from '../assets/guide-hosts.png';
 import quickLaunch from '../assets/guide-quick-launch.png';
@@ -16,6 +17,18 @@ const description =
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
+const imageAlt = {
+  sessions:
+    'Ghosthub workspace showing local sessions, projects, worktrees, and a remote host in the sidebar',
+  hosts: 'Ghosthub Hosts settings with a configured remote GPU host',
+  worktree:
+    'Ghosthub new worktree sheet ready to create a feature branch with kwt',
+  quickLaunch: 'Ghosthub Quick Launch filtered to a reconnect worktree',
+  commandCenter:
+    'Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed',
+  terminal:
+    'Ghosthub Terminal settings showing interaction and configuration options',
+};
 ---
 
 <SiteLayout title={title} description={description} path="/guide/">
@@ -74,13 +87,15 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </div>
       <figure class="container window">
         <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-        <Image
-          src={sessions}
-          alt="Ghosthub workspace showing local sessions, projects, worktrees, and a remote host in the sidebar"
-          widths={imageWidths}
-          sizes={imageSizes}
-          loading="eager"
-        />
+        <ZoomableImage label={imageAlt.sessions}>
+          <Image
+            src={sessions}
+            alt={imageAlt.sessions}
+            widths={imageWidths}
+            sizes={imageSizes}
+            loading="eager"
+          />
+        </ZoomableImage>
       </figure>
     </li>
 
@@ -112,12 +127,14 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </div>
       <figure class="container window">
         <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-        <Image
-          src={hosts}
-          alt="Ghosthub Hosts settings with a configured remote GPU host"
-          widths={imageWidths}
-          sizes={imageSizes}
-        />
+        <ZoomableImage label={imageAlt.hosts}>
+          <Image
+            src={hosts}
+            alt={imageAlt.hosts}
+            widths={imageWidths}
+            sizes={imageSizes}
+          />
+        </ZoomableImage>
       </figure>
     </li>
 
@@ -140,12 +157,14 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </div>
       <figure class="container window">
         <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-        <Image
-          src={worktree}
-          alt="Ghosthub new worktree sheet ready to create a feature branch with kwt"
-          widths={imageWidths}
-          sizes={imageSizes}
-        />
+        <ZoomableImage label={imageAlt.worktree}>
+          <Image
+            src={worktree}
+            alt={imageAlt.worktree}
+            widths={imageWidths}
+            sizes={imageSizes}
+          />
+        </ZoomableImage>
       </figure>
     </li>
 
@@ -169,12 +188,14 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </div>
       <figure class="container window">
         <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-        <Image
-          src={quickLaunch}
-          alt="Ghosthub Quick Launch filtered to a reconnect worktree"
-          widths={imageWidths}
-          sizes={imageSizes}
-        />
+        <ZoomableImage label={imageAlt.quickLaunch}>
+          <Image
+            src={quickLaunch}
+            alt={imageAlt.quickLaunch}
+            widths={imageWidths}
+            sizes={imageSizes}
+          />
+        </ZoomableImage>
       </figure>
     </li>
 
@@ -197,12 +218,14 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
         </div>
       </div>
       <figure class="container command-matrix">
-        <Image
-          src={commandCenter}
-          alt="Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed"
-          widths={[640, 960, 1280, 1800]}
-          sizes="(max-width: 1200px) calc(100vw - 3rem), 1160px"
-        />
+        <ZoomableImage label={imageAlt.commandCenter}>
+          <Image
+            src={commandCenter}
+            alt={imageAlt.commandCenter}
+            widths={[640, 960, 1280, 1800]}
+            sizes="(max-width: 1200px) calc(100vw - 3rem), 1160px"
+          />
+        </ZoomableImage>
       </figure>
     </li>
 
@@ -225,12 +248,14 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </div>
       <figure class="container window">
         <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
-        <Image
-          src={terminal}
-          alt="Ghosthub Terminal settings showing interaction and configuration options"
-          widths={imageWidths}
-          sizes={imageSizes}
-        />
+        <ZoomableImage label={imageAlt.terminal}>
+          <Image
+            src={terminal}
+            alt={imageAlt.terminal}
+            widths={imageWidths}
+            sizes={imageSizes}
+          />
+        </ZoomableImage>
       </figure>
     </li>
   </ol>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -1,0 +1,458 @@
+---
+import { Image } from 'astro:assets';
+import SiteLayout from '../layouts/SiteLayout.astro';
+import hosts from '../assets/guide-hosts.png';
+import quickLaunch from '../assets/guide-quick-launch.png';
+import sessions from '../assets/guide-sessions.png';
+import terminal from '../assets/guide-terminal.png';
+import worktree from '../assets/guide-worktree.png';
+import { RELEASES_URL } from '../config';
+
+const title = 'How to use Ghosthub';
+const description =
+  'A visual guide to opening tmux sessions, connecting SSH hosts, creating worktrees, '
+  + 'using Quick Launch, and configuring the Ghosthub terminal.';
+
+const imageWidths = [640, 960, 1280, 1600];
+const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
+---
+
+<SiteLayout title={title} description={description} path="/guide/">
+  <section class="intro">
+    <div class="container narrow">
+      <p class="eyebrow">Five-minute guide</p>
+      <h1>How to use Ghosthub</h1>
+      <p class="lead">
+        Ghosthub puts the tmux sessions behind your projects and coding
+        agents into one native macOS workspace. Tmux keeps owning the
+        sessions; Ghosthub makes the whole fleet easy to find and enter.
+      </p>
+      <div class="requirements" aria-label="Requirements">
+        <span>Apple Silicon</span>
+        <span>macOS 26+</span>
+        <span>tmux 3.2+</span>
+      </div>
+      <a class="download" data-download href={RELEASES_URL}>Download Ghosthub</a>
+    </div>
+  </section>
+
+  <nav class="contents container" aria-label="On this page">
+    <a href="#sessions"><b>01</b> Open a session</a>
+    <a href="#hosts"><b>02</b> Add a host</a>
+    <a href="#worktrees"><b>03</b> Add worktrees</a>
+    <a href="#quick-launch"><b>04</b> Move quickly</a>
+    <a href="#terminal"><b>05</b> Make it yours</a>
+  </nav>
+
+  <ol class="steps">
+    <li id="sessions">
+      <div class="container step-copy">
+        <p class="number">01</p>
+        <div>
+          <h2>Open a tmux session</h2>
+          <p>
+            Launch Ghosthub and expand your Mac under
+            <strong>Hosts</strong>. Existing tmux sessions appear
+            automatically alongside projects and worktrees. Select one to
+            attach with an ordinary tmux client.
+          </p>
+          <p>
+            Use the <strong>+</strong> button beside a host to create a named
+            session. Closing the Ghosthub window only detaches—your work keeps
+            running in tmux.
+          </p>
+        </div>
+      </div>
+      <figure class="container window">
+        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
+        <Image
+          src={sessions}
+          alt="Ghosthub workspace showing local sessions, projects, worktrees, and a remote host in the sidebar"
+          widths={imageWidths}
+          sizes={imageSizes}
+          loading="eager"
+        />
+      </figure>
+    </li>
+
+    <li id="hosts">
+      <div class="container step-copy">
+        <p class="number">02</p>
+        <div>
+          <h2>Add an SSH host</h2>
+          <p>
+            Open <strong>Settings → Hosts</strong> and add any destination
+            accepted by your SSH configuration, such as
+            <code>devbox</code> or <code>alice@build-server</code>.
+          </p>
+          <p>
+            Remote hosts need tmux and non-interactive SSH authentication
+            backed by a key or SSH agent. Ghosthub keeps each host isolated,
+            so an unreachable machine never blocks the rest of your fleet.
+          </p>
+        </div>
+      </div>
+      <figure class="container window">
+        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
+        <Image
+          src={hosts}
+          alt="Ghosthub Hosts settings with a configured remote GPU host"
+          widths={imageWidths}
+          sizes={imageSizes}
+        />
+      </figure>
+    </li>
+
+    <li id="worktrees">
+      <div class="container step-copy">
+        <p class="number">03</p>
+        <div>
+          <h2>Add project and worktree context</h2>
+          <p>
+            Ghosthub uses <a href="https://kwt.sh">kwt</a> to map repositories
+            and worktrees to their exact tmux sessions. Run <code>kwt</code>
+            once inside a repository to register it.
+          </p>
+          <p>
+            Select a project and press <kbd>⌘⇧N</kbd> to create a branch and
+            worktree without leaving Ghosthub. Kwt remains optional if you
+            only want a local and remote tmux session switcher.
+          </p>
+        </div>
+      </div>
+      <figure class="container window">
+        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
+        <Image
+          src={worktree}
+          alt="Ghosthub new worktree sheet ready to create a feature branch with kwt"
+          widths={imageWidths}
+          sizes={imageSizes}
+        />
+      </figure>
+    </li>
+
+    <li id="quick-launch">
+      <div class="container step-copy">
+        <p class="number">04</p>
+        <div>
+          <h2>Move through the fleet without the mouse</h2>
+          <p>
+            Press <kbd>⌘⇧P</kbd> for Quick Launch. Search across hosts,
+            projects, worktrees, appearance, settings, and common actions,
+            then press Return to go.
+          </p>
+          <div class="shortcuts" aria-label="Useful keyboard shortcuts">
+            <span><kbd>⌘B</kbd> Sidebar</span>
+            <span><kbd>⌘⌥↑</kbd> Previous worktree</span>
+            <span><kbd>⌘⌥↓</kbd> Next worktree</span>
+            <span><kbd>⌘W</kbd> Detach</span>
+          </div>
+        </div>
+      </div>
+      <figure class="container window">
+        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
+        <Image
+          src={quickLaunch}
+          alt="Ghosthub Quick Launch filtered to a reconnect worktree"
+          widths={imageWidths}
+          sizes={imageSizes}
+        />
+      </figure>
+    </li>
+
+    <li id="terminal">
+      <div class="container step-copy">
+        <p class="number">05</p>
+        <div>
+          <h2>Make the terminal yours</h2>
+          <p>
+            Terminal preferences live in Ghosthub Settings. For the full
+            configuration surface, edit
+            <code>~/.config/ghosthub/ghostty.conf</code>.
+          </p>
+          <p>
+            The file uses
+            <a href="https://ghostty.org/docs/config/reference">
+              Ghostty’s configuration format
+            </a>, but is isolated from Ghostty.app. Ghosthub reloads the
+            active configuration when it changes.
+          </p>
+        </div>
+      </div>
+      <figure class="container window">
+        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
+        <Image
+          src={terminal}
+          alt="Ghosthub Terminal settings showing interaction and configuration options"
+          widths={imageWidths}
+          sizes={imageSizes}
+        />
+      </figure>
+    </li>
+  </ol>
+
+  <section class="finish">
+    <div class="container narrow">
+      <p class="eyebrow">That’s it</p>
+      <h2>Your sessions keep running</h2>
+      <p>
+        Ghosthub never replaces tmux windows, panes, history, or plugins.
+        Quit the app, change networks, or close a presentation—the sessions
+        remain where you left them.
+      </p>
+      <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
+    </div>
+  </section>
+</SiteLayout>
+
+<style>
+  .intro {
+    padding: 5rem 0 3.5rem;
+    text-align: center;
+    background:
+      radial-gradient(
+        52% 70% at 50% 0%,
+        color-mix(in srgb, var(--accent) 8%, transparent),
+        transparent
+      );
+  }
+
+  .narrow {
+    max-width: 760px;
+  }
+
+  .eyebrow,
+  .number {
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.75rem;
+  }
+
+  h1 {
+    font-size: clamp(2.3rem, 6vw, 4.2rem);
+  }
+
+  .lead {
+    color: var(--text-dim);
+    font-size: clamp(1rem, 2.2vw, 1.2rem);
+    margin: 1rem auto 0;
+    max-width: 64ch;
+    text-wrap: balance;
+  }
+
+  .requirements {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.55rem;
+    margin: 1.6rem 0;
+  }
+
+  .requirements span {
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    padding: 0.3rem 0.7rem;
+  }
+
+  .download,
+  .finish a {
+    display: inline-block;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #06222e;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding: 0.75rem 1.15rem;
+  }
+
+  .contents {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    overflow: hidden;
+    margin-bottom: 2rem;
+  }
+
+  .contents a {
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    padding: 1rem;
+    text-align: center;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .contents a + a {
+    border-left: 1px solid var(--line);
+  }
+
+  .contents a:hover {
+    background: var(--bg-raise);
+    color: var(--text);
+  }
+
+  .contents b {
+    color: var(--accent);
+    display: block;
+    font-size: 0.68rem;
+    margin-bottom: 0.2rem;
+  }
+
+  .steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .steps > li {
+    border-top: 1px solid var(--line);
+    padding: 5rem 0 6rem;
+    scroll-margin-top: 4rem;
+  }
+
+  .steps > li:nth-child(even) {
+    background: var(--bg-raise);
+  }
+
+  .step-copy {
+    display: grid;
+    grid-template-columns: 5rem minmax(0, 660px);
+    justify-content: center;
+    margin-bottom: 2.5rem;
+  }
+
+  .number {
+    margin: 0.25rem 0 0;
+  }
+
+  h2 {
+    font-size: clamp(1.55rem, 3.5vw, 2.25rem);
+  }
+
+  .step-copy p:not(.number),
+  .finish p:not(.eyebrow) {
+    color: var(--text-dim);
+  }
+
+  .step-copy p {
+    margin: 0.85rem 0 0;
+  }
+
+  .step-copy strong {
+    color: var(--text);
+  }
+
+  .step-copy a {
+    color: var(--accent);
+  }
+
+  code,
+  kbd {
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    background: color-mix(in srgb, var(--bg) 75%, transparent);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.84em;
+    padding: 0.12rem 0.34rem;
+  }
+
+  .shortcuts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem 1rem;
+    margin-top: 1.25rem;
+  }
+
+  .shortcuts span {
+    color: var(--text-dim);
+    font-size: 0.82rem;
+  }
+
+  .window {
+    max-width: 920px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    overflow: hidden;
+    background: var(--bg);
+    box-shadow: 0 28px 70px rgb(0 0 0 / 0.4);
+  }
+
+  .titlebar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.42rem 0.7rem;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .titlebar i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--line);
+  }
+
+  .window :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .finish {
+    border-top: 1px solid var(--line);
+    padding: 5rem 0 6rem;
+    text-align: center;
+  }
+
+  .finish p:not(.eyebrow) {
+    margin: 1rem auto 1.6rem;
+    max-width: 58ch;
+  }
+
+  @media (max-width: 760px) {
+    .intro {
+      padding-top: 3.5rem;
+    }
+
+    .contents {
+      grid-template-columns: 1fr;
+    }
+
+    .contents a {
+      display: flex;
+      gap: 0.65rem;
+      text-align: left;
+    }
+
+    .contents b {
+      margin: 0;
+    }
+
+    .contents a + a {
+      border-left: 0;
+      border-top: 1px solid var(--line);
+    }
+
+    .steps > li {
+      padding: 3.5rem 0 4rem;
+    }
+
+    .step-copy {
+      grid-template-columns: 1fr;
+      gap: 0.65rem;
+    }
+  }
+</style>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -1,6 +1,12 @@
 ---
 import { Image } from 'astro:assets';
 import SiteLayout from '../layouts/SiteLayout.astro';
+import commandAgentsview from '../assets/guide-command-agentsview.png';
+import commandExport from '../assets/guide-command-export.png';
+import commandGhosthub from '../assets/guide-command-ghosthub.png';
+import commandRelease from '../assets/guide-command-release.png';
+import commandScratch from '../assets/guide-command-scratch.png';
+import commandTests from '../assets/guide-command-tests.png';
 import hosts from '../assets/guide-hosts.png';
 import quickLaunch from '../assets/guide-quick-launch.png';
 import sessions from '../assets/guide-sessions.png';
@@ -10,11 +16,43 @@ import { RELEASES_URL } from '../config';
 
 const title = 'How to use Ghosthub';
 const description =
-  'A visual guide to tmux sessions, automatic SSH reconnect, worktrees, '
-  + 'Quick Launch, and configuring the Ghosthub terminal.';
+  'A visual guide to connected tmux sessions, automatic SSH reconnect, '
+  + 'worktrees, Quick Launch, multi-window command centers, and terminal configuration.';
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
+const commandWindows = [
+  {
+    name: 'fix-reconnect-backoff',
+    src: commandGhosthub,
+    alt: 'Ghosthub window attached to the fix-reconnect-backoff tmux session with its sidebar hidden',
+  },
+  {
+    name: 'add-session-filters',
+    src: commandAgentsview,
+    alt: 'Ghosthub window attached to the add-session-filters tmux session with its sidebar hidden',
+  },
+  {
+    name: 'scratch',
+    src: commandScratch,
+    alt: 'Ghosthub window attached to a scratch tmux session with its sidebar hidden',
+  },
+  {
+    name: 'docbank-export',
+    src: commandExport,
+    alt: 'Ghosthub window attached to the docbank-export tmux session with its sidebar hidden',
+  },
+  {
+    name: 'release-watch',
+    src: commandRelease,
+    alt: 'Ghosthub window attached to a release-watch tmux session with its sidebar hidden',
+  },
+  {
+    name: 'test-matrix',
+    src: commandTests,
+    alt: 'Ghosthub window attached to a test-matrix tmux session with its sidebar hidden',
+  },
+];
 ---
 
 <SiteLayout title={title} description={description} path="/guide/">
@@ -48,7 +86,8 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
     <a href="#hosts"><b>02</b> Add a host</a>
     <a href="#worktrees"><b>03</b> Add worktrees</a>
     <a href="#quick-launch"><b>04</b> Move quickly</a>
-    <a href="#terminal"><b>05</b> Make it yours</a>
+    <a href="#command-center"><b>05</b> Command center</a>
+    <a href="#terminal"><b>06</b> Make it yours</a>
   </nav>
 
   <ol class="steps">
@@ -158,7 +197,7 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
             then press Return to go.
           </p>
           <div class="shortcuts" aria-label="Useful keyboard shortcuts">
-            <span><kbd>⌘B</kbd> Sidebar</span>
+            <span><kbd>⌘B</kbd> Hide/show sidebar</span>
             <span><kbd>⌘⌥↑</kbd> Previous worktree</span>
             <span><kbd>⌘⌥↓</kbd> Next worktree</span>
             <span><kbd>⌘W</kbd> Detach</span>
@@ -176,9 +215,47 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       </figure>
     </li>
 
-    <li id="terminal">
+    <li id="command-center">
       <div class="container step-copy">
         <p class="number">05</p>
+        <div>
+          <h2>Build your tmux command center</h2>
+          <p>
+            Ghosthub is window-based today—there is no app-level tab bar.
+            Press <kbd>⌘⌥N</kbd> to open another independent workspace,
+            attach each window to a different tmux session, and arrange them
+            with the macOS window tools you already use.
+          </p>
+          <p>
+            Press <kbd>⌘B</kbd> in any window to hide its sidebar and give
+            the terminal the full frame. Press it again whenever you need
+            fleet navigation back.
+          </p>
+        </div>
+      </div>
+      <div class="container command-grid" aria-label="Six independent Ghosthub windows">
+        {
+          commandWindows.map((window) => (
+            <figure class="command-window">
+              <div class="command-titlebar">
+                <span aria-hidden="true"><i></i><i></i><i></i></span>
+                <b>{window.name}</b>
+              </div>
+              <Image
+                src={window.src}
+                alt={window.alt}
+                widths={[360, 640, 960]}
+                sizes="(max-width: 620px) calc(100vw - 3rem), (max-width: 900px) calc((100vw - 4rem) / 2), 370px"
+              />
+            </figure>
+          ))
+        }
+      </div>
+    </li>
+
+    <li id="terminal">
+      <div class="container step-copy">
+        <p class="number">06</p>
         <div>
           <h2>Make the terminal yours</h2>
           <p>
@@ -320,7 +397,7 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
 
   .contents {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(6, 1fr);
     border: 1px solid var(--line);
     border-radius: 14px;
     overflow: hidden;
@@ -475,6 +552,60 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
     height: auto;
   }
 
+  .command-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+    max-width: 1180px;
+  }
+
+  .command-window {
+    min-width: 0;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--bg);
+    box-shadow: 0 18px 42px rgb(0 0 0 / 0.35);
+  }
+
+  .command-titlebar {
+    display: grid;
+    grid-template-columns: 3.4rem 1fr 3.4rem;
+    align-items: center;
+    min-width: 0;
+    border-bottom: 1px solid var(--line);
+    padding: 0.36rem 0.55rem;
+  }
+
+  .command-titlebar > span {
+    display: flex;
+    gap: 0.3rem;
+  }
+
+  .command-titlebar i {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--line);
+  }
+
+  .command-titlebar b {
+    overflow: hidden;
+    color: var(--text-faint);
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    font-weight: 400;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .command-window :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
   .finish {
     border-top: 1px solid var(--line);
     padding: 5rem 0 6rem;
@@ -517,6 +648,16 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
     .step-copy {
       grid-template-columns: 1fr;
       gap: 0.65rem;
+    }
+
+    .command-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 520px) {
+    .command-grid {
+      grid-template-columns: 1fr;
     }
   }
 </style>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -10,8 +10,8 @@ import { RELEASES_URL } from '../config';
 
 const title = 'How to use Ghosthub';
 const description =
-  'A visual guide to opening tmux sessions, connecting SSH hosts, creating worktrees, '
-  + 'using Quick Launch, and configuring the Ghosthub terminal.';
+  'A visual guide to tmux sessions, automatic SSH reconnect, worktrees, '
+  + 'Quick Launch, and configuring the Ghosthub terminal.';
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
@@ -51,7 +51,7 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
         <div>
           <h2>Open a tmux session</h2>
           <p>
-            Launch Ghosthub and expand your Mac under
+            Launch Ghosthub and expand your Mac under{' '}
             <strong>Hosts</strong>. Existing tmux sessions appear
             automatically alongside projects and worktrees. Select one to
             attach with an ordinary tmux client.
@@ -82,7 +82,7 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
           <h2>Add an SSH host</h2>
           <p>
             Open <strong>Settings → Hosts</strong> and add any destination
-            accepted by your SSH configuration, such as
+            accepted by your SSH configuration, such as{' '}
             <code>devbox</code> or <code>alice@build-server</code>.
           </p>
           <p>
@@ -90,6 +90,15 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
             backed by a key or SSH agent. Ghosthub keeps each host isolated,
             so an unreachable machine never blocks the rest of your fleet.
           </p>
+          <aside class="reconnect">
+            <span aria-hidden="true">↻</span>
+            <p>
+              <strong>Lose your connection?</strong> Ghosthub retries SSH with
+              keepalives and bounded backoff. When connectivity returns, it
+              automatically reattaches to the same exact tmux session, with
+              the server-side process state still intact.
+            </p>
+          </aside>
         </div>
       </div>
       <figure class="container window">
@@ -167,15 +176,13 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
           <h2>Make the terminal yours</h2>
           <p>
             Terminal preferences live in Ghosthub Settings. For the full
-            configuration surface, edit
+            configuration surface, edit{' '}
             <code>~/.config/ghosthub/ghostty.conf</code>.
           </p>
           <p>
-            The file uses
-            <a href="https://ghostty.org/docs/config/reference">
-              Ghostty’s configuration format
-            </a>, but is isolated from Ghostty.app. Ghosthub reloads the
-            active configuration when it changes.
+            The file uses{' '}<a href="https://ghostty.org/docs/config/reference">Ghostty’s
+              configuration format</a>, but is isolated from Ghostty.app.
+            Ghosthub reloads the active configuration when it changes.
           </p>
         </div>
       </div>
@@ -197,8 +204,9 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
       <h2>Your sessions keep running</h2>
       <p>
         Ghosthub never replaces tmux windows, panes, history, or plugins.
-        Quit the app, change networks, or close a presentation—the sessions
-        remain where you left them.
+        Quit the app or close a presentation and the sessions remain where
+        you left them. Lose the network and Ghosthub automatically reconnects
+        and reattaches when it returns.
       </p>
       <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
     </div>
@@ -352,6 +360,28 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
 
   .step-copy strong {
     color: var(--text);
+  }
+
+  .reconnect {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.8rem;
+    margin-top: 1.4rem;
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--line));
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+    padding: 1rem;
+  }
+
+  .reconnect > span {
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 1.25rem;
+    line-height: 1.25;
+  }
+
+  .reconnect p {
+    margin: 0;
   }
 
   .step-copy a {

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -28,11 +28,11 @@ const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
         retries and reattaches to the same exact session automatically.
         Tmux keeps owning the windows, panes, history, and process state.
       </p>
-      <p class="promise" aria-label="Automatic SSH reconnect and exact-session reattach">
+      <p class="promise" aria-label="Automatic SSH reconnect plus tmux reattach">
         <span class="promise-icon" aria-hidden="true">↻</span>
         <span>Automatic SSH reconnect</span>
-        <i aria-hidden="true">&middot;</i>
-        <span>Exact-session reattach</span>
+        <i aria-hidden="true">+</i>
+        <span>tmux reattach</span>
       </p>
       <div class="requirements" aria-label="Requirements">
         <span>Apple Silicon</span>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -1,12 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 import SiteLayout from '../layouts/SiteLayout.astro';
-import commandAgentsview from '../assets/guide-command-agentsview.png';
-import commandExport from '../assets/guide-command-export.png';
-import commandGhosthub from '../assets/guide-command-ghosthub.png';
-import commandRelease from '../assets/guide-command-release.png';
-import commandScratch from '../assets/guide-command-scratch.png';
-import commandTests from '../assets/guide-command-tests.png';
+import commandCenter from '../assets/guide-command-center.png';
 import hosts from '../assets/guide-hosts.png';
 import quickLaunch from '../assets/guide-quick-launch.png';
 import sessions from '../assets/guide-sessions.png';
@@ -21,38 +16,6 @@ const description =
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
-const commandWindows = [
-  {
-    name: 'fix-reconnect-backoff',
-    src: commandGhosthub,
-    alt: 'Ghosthub window attached to the fix-reconnect-backoff tmux session with its sidebar hidden',
-  },
-  {
-    name: 'add-session-filters',
-    src: commandAgentsview,
-    alt: 'Ghosthub window attached to the add-session-filters tmux session with its sidebar hidden',
-  },
-  {
-    name: 'scratch',
-    src: commandScratch,
-    alt: 'Ghosthub window attached to a scratch tmux session with its sidebar hidden',
-  },
-  {
-    name: 'docbank-export',
-    src: commandExport,
-    alt: 'Ghosthub window attached to the docbank-export tmux session with its sidebar hidden',
-  },
-  {
-    name: 'release-watch',
-    src: commandRelease,
-    alt: 'Ghosthub window attached to a release-watch tmux session with its sidebar hidden',
-  },
-  {
-    name: 'test-matrix',
-    src: commandTests,
-    alt: 'Ghosthub window attached to a test-matrix tmux session with its sidebar hidden',
-  },
-];
 ---
 
 <SiteLayout title={title} description={description} path="/guide/">
@@ -233,24 +196,14 @@ const commandWindows = [
           </p>
         </div>
       </div>
-      <div class="container command-grid" aria-label="Six independent Ghosthub windows">
-        {
-          commandWindows.map((window) => (
-            <figure class="command-window">
-              <div class="command-titlebar">
-                <span aria-hidden="true"><i></i><i></i><i></i></span>
-                <b>{window.name}</b>
-              </div>
-              <Image
-                src={window.src}
-                alt={window.alt}
-                widths={[360, 640, 960]}
-                sizes="(max-width: 620px) calc(100vw - 3rem), (max-width: 900px) calc((100vw - 4rem) / 2), 370px"
-              />
-            </figure>
-          ))
-        }
-      </div>
+      <figure class="container command-matrix">
+        <Image
+          src={commandCenter}
+          alt="Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed"
+          widths={[640, 960, 1280, 1800]}
+          sizes="(max-width: 1200px) calc(100vw - 3rem), 1160px"
+        />
+      </figure>
     </li>
 
     <li id="terminal">
@@ -552,55 +505,16 @@ const commandWindows = [
     height: auto;
   }
 
-  .command-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
+  .command-matrix {
     max-width: 1180px;
-  }
-
-  .command-window {
-    min-width: 0;
     border: 1px solid var(--line);
-    border-radius: 10px;
+    border-radius: 12px;
     overflow: hidden;
     background: var(--bg);
-    box-shadow: 0 18px 42px rgb(0 0 0 / 0.35);
+    box-shadow: 0 28px 70px rgb(0 0 0 / 0.45);
   }
 
-  .command-titlebar {
-    display: grid;
-    grid-template-columns: 3.4rem 1fr 3.4rem;
-    align-items: center;
-    min-width: 0;
-    border-bottom: 1px solid var(--line);
-    padding: 0.36rem 0.55rem;
-  }
-
-  .command-titlebar > span {
-    display: flex;
-    gap: 0.3rem;
-  }
-
-  .command-titlebar i {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--line);
-  }
-
-  .command-titlebar b {
-    overflow: hidden;
-    color: var(--text-faint);
-    font-family: var(--font-mono);
-    font-size: 0.56rem;
-    font-weight: 400;
-    text-align: center;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .command-window :global(img) {
+  .command-matrix :global(img) {
     display: block;
     width: 100%;
     height: auto;
@@ -650,14 +564,5 @@ const commandWindows = [
       gap: 0.65rem;
     }
 
-    .command-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
-
-  @media (max-width: 520px) {
-    .command-grid {
-      grid-template-columns: 1fr;
-    }
   }
 </style>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -203,7 +203,7 @@ const imageAlt = {
       <div class="container step-copy">
         <p class="number">05</p>
         <div>
-          <h2>Build your tmux command center</h2>
+          <h2>Build your command center</h2>
           <p>
             Ghosthub is window-based today—there is no app-level tab bar.
             Press <kbd>⌘⌥N</kbd> to open another independent workspace,

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,10 +1,8 @@
 ---
-// oxlint-disable-next-line import/no-unassigned-import -- global stylesheet, no export to bind
-import '../styles/global.css';
 import Features from '../components/Features.astro';
-import Footer from '../components/Footer.astro';
-import Header from '../components/Header.astro';
+import GuideCTA from '../components/GuideCTA.astro';
 import Hero from '../components/Hero.astro';
+import SiteLayout from '../layouts/SiteLayout.astro';
 
 const title = "Ghosthub: a power terminal for your agents' tmux sessions";
 const description =
@@ -12,40 +10,8 @@ const description =
   + 'local and remote. Worktree-native, built on libghostty.';
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="canonical" href={Astro.site} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={Astro.site} />
-    <meta property="og:image" content={new URL('/og.png', Astro.site)} />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:image" content={new URL('/og.png', Astro.site)} />
-    <link
-      rel="preload"
-      href="/fonts/JetBrainsMono-Bold.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-  </head>
-  <body>
-    <Header />
-    <main>
-      <Hero />
-      <Features />
-    </main>
-    <Footer />
-    <script>
-      // oxlint-disable-next-line import/no-unassigned-import -- side-effect module, no export
-      import '../scripts/site';
-    </script>
-  </body>
-</html>
+<SiteLayout title={title} description={description} path="/">
+  <Hero />
+  <Features />
+  <GuideCTA />
+</SiteLayout>

--- a/website/src/scripts/site.ts
+++ b/website/src/scripts/site.ts
@@ -64,5 +64,55 @@ function ignoreNetworkFailure(err: unknown): void {
   console.warn('github api unavailable, using static fallbacks', err);
 }
 
+function largestImageSource(image: HTMLImageElement): string {
+  const candidates = image.srcset
+    .split(',')
+    .map((candidate) => candidate.trim().split(/\s+/)[0])
+    .filter((candidate): candidate is string => candidate !== undefined);
+  return candidates.at(-1) ?? image.currentSrc ?? image.src;
+}
+
+function setupImageLightbox(): void {
+  const dialog = document.querySelector('[data-image-lightbox]');
+  const frame = document.querySelector('[data-image-lightbox-frame]');
+  const lightboxImage = document.querySelector('[data-image-lightbox-image]');
+  const close = document.querySelector('[data-image-lightbox-close]');
+  if (
+    !(dialog instanceof HTMLDialogElement)
+    || !(frame instanceof HTMLDivElement)
+    || !(lightboxImage instanceof HTMLImageElement)
+    || !(close instanceof HTMLButtonElement)
+  ) {
+    return;
+  }
+
+  let opener: HTMLButtonElement | null = null;
+  for (const trigger of document.querySelectorAll('[data-lightbox-trigger]')) {
+    if (!(trigger instanceof HTMLButtonElement)) continue;
+    const image = trigger.querySelector('img');
+    if (!(image instanceof HTMLImageElement)) continue;
+    trigger.addEventListener('click', () => {
+      opener = trigger;
+      lightboxImage.src = largestImageSource(image);
+      lightboxImage.alt = image.alt;
+      document.body.classList.add('lightbox-open');
+      dialog.showModal();
+    });
+  }
+
+  close.addEventListener('click', () => dialog.close());
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog || event.target === frame) dialog.close();
+  });
+  dialog.addEventListener('close', () => {
+    document.body.classList.remove('lightbox-open');
+    lightboxImage.removeAttribute('src');
+    lightboxImage.alt = '';
+    opener?.focus();
+    opener = null;
+  });
+}
+
+setupImageLightbox();
 renderRepoFacts().catch(ignoreNetworkFailure);
 renderDownload().catch(ignoreNetworkFailure);

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -41,6 +41,10 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+body.lightbox-open {
+  overflow: hidden;
+}
+
 h1,
 h2,
 h3 {
@@ -81,4 +85,122 @@ a {
   clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
+}
+
+.image-zoom {
+  position: relative;
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: zoom-in;
+  font: inherit;
+  text-align: inherit;
+}
+
+.image-zoom::after {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  border-radius: 6px;
+  background: rgb(8 11 14 / 0.82);
+  color: var(--text-dim);
+  content: 'Zoom';
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.image-zoom:hover::after,
+.image-zoom:focus-visible::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.image-zoom:focus-visible {
+  outline-offset: -3px;
+}
+
+.image-lightbox {
+  max-width: none;
+  max-height: none;
+  margin: auto;
+  padding: 0;
+  overflow: visible;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.image-lightbox::backdrop {
+  background: rgb(3 5 7 / 0.9);
+  backdrop-filter: blur(10px);
+}
+
+.image-lightbox-frame {
+  display: grid;
+  width: calc(100vw - 2rem);
+  height: calc(100dvh - 2rem);
+  place-items: center;
+}
+
+.image-lightbox img {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 30px 100px rgb(0 0 0 / 0.7);
+  object-fit: contain;
+}
+
+.image-lightbox-close {
+  position: fixed;
+  top: max(1rem, env(safe-area-inset-top));
+  right: max(1rem, env(safe-area-inset-right));
+  display: grid;
+  width: 2.6rem;
+  height: 2.6rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 0.2);
+  border-radius: 50%;
+  background: rgb(10 12 14 / 0.88);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+}
+
+.image-lightbox-close span {
+  font-size: 1.75rem;
+  font-weight: 300;
+  line-height: 1;
+}
+
+.image-lightbox-close:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .image-lightbox[open] {
+    animation: lightbox-in 0.18s ease-out;
+  }
+
+  @keyframes lightbox-in {
+    from {
+      opacity: 0;
+      transform: scale(0.985);
+    }
+  }
 }


### PR DESCRIPTION
Prospective users need a short path from discovering Ghosthub to understanding why its tmux-native model matters. The current homepage does not explain automatic SSH reconnect and exact tmux reattach clearly enough, and it leaves the multi-window workflow, keyboard navigation, and libghostty foundation largely implicit.

This adds a five-minute visual guide and gives it a clear homepage CTA, with a reproducible six-window command-center view that reflects the shipped window model without implying tabs. Screenshots come from an isolated, controlled Ghosthub environment, remain on the orphan website-assets branch, and open in accessible lightboxes so dense terminal details are readable. The new contributor rule keeps future UI changes from leaving the public guide stale.

Validation included a complete controlled screenshot regeneration and visual review, 101 Python tests, Astro diagnostics, lint, 11 website tests, and a production website build.