### PR TITLE
Show native title bars in website screenshots

### DIFF
--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Drives the running isolated demo through every website screenshot state,
-# captures the exact demo process, crops native macOS chrome, and writes
-# web-ready 1600px PNGs. The real Ghosthub may run alongside it.
+# captures the exact demo process with native macOS chrome, and writes web-ready
+# 1600px PNGs. The real Ghosthub may run alongside it.
 set -euo pipefail
 
 demo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -150,14 +150,7 @@ const sharp = require("sharp");
   if (metadata.width === undefined || metadata.height === undefined) {
     throw new Error(`could not read screenshot dimensions: ${raw}`);
   }
-  const titlebarHeight = 34;
   await image
-    .extract({
-      left: 0,
-      top: titlebarHeight,
-      width: metadata.width,
-      height: metadata.height - titlebarHeight,
-    })
     .resize({ width: 1600 })
     .png({ compressionLevel: 9 })
     .toFile(destination);

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -32,7 +32,6 @@ const heroAlt =
       <a href={GITHUB_URL}>View on GitHub</a>
     </p>
     <figure class="window">
-      <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
       <ZoomableImage label={heroAlt}>
         <Image
           src={hero}
@@ -163,23 +162,6 @@ const heroAlt =
     box-shadow:
       0 40px 90px rgb(0 0 0 / 0.55),
       0 0 80px color-mix(in srgb, var(--accent) 6%, transparent);
-  }
-
-  /* Sized to read at the same scale as the screenshot below (1600px
-     capture shown at 960px, ~0.6x), not at native macOS chrome size. */
-  .titlebar {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.42rem 0.7rem;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .titlebar i {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--line);
   }
 
   .window :global(img) {

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -86,7 +86,6 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
         <ZoomableImage label={imageAlt.sessions}>
           <Image
             src={sessions}
@@ -126,7 +125,6 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
         <ZoomableImage label={imageAlt.hosts}>
           <Image
             src={hosts}
@@ -156,7 +154,6 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
         <ZoomableImage label={imageAlt.worktree}>
           <Image
             src={worktree}
@@ -187,7 +184,6 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
         <ZoomableImage label={imageAlt.quickLaunch}>
           <Image
             src={quickLaunch}
@@ -247,7 +243,6 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <div class="titlebar" aria-hidden="true"><i></i><i></i><i></i></div>
         <ZoomableImage label={imageAlt.terminal}>
           <Image
             src={terminal}
@@ -507,21 +502,6 @@ const imageAlt = {
     overflow: hidden;
     background: var(--bg);
     box-shadow: 0 28px 70px rgb(0 0 0 / 0.4);
-  }
-
-  .titlebar {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.42rem 0.7rem;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .titlebar i {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--line);
   }
 
   .window :global(img) {


### PR DESCRIPTION
The homepage and guide currently place title-bar-cropped product images beneath synthetic chrome, leaving a blank strip where Ghosthub’s session title, host identity, and toolbar controls should be. That makes six screenshots look less accurate than the command-center image, which already preserves real native window chrome.

This keeps the real macOS/Ghosthub title bar in each affected capture and removes the duplicate decorative frame from the site. The command-center asset remains byte-for-byte unchanged. The six refreshed binaries are already published on the `website-assets` orphan branch at `6f455b8`.

Validation included direct visual review of the regenerated captures, Astro diagnostics, lint, all 11 website tests, and a production website build against the refreshed orphan assets.