### PR TITLE
Show native tabs in website screenshots

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -54,8 +54,8 @@ therefore cannot inherit the developer's SSH aliases, proxies, or host trust.
 
 The injected demo controller drives and captures only its exact staged
 process, so the workflow needs neither Accessibility nor Screen Recording
-permission. `shoot.sh` crops the native 34pt titlebar and writes optimized
-1600px PNGs with the exact filenames expected by the site.
+permission. `shoot.sh` preserves native window and tab chrome and writes
+optimized 1600px PNGs with the exact filenames expected by the site.
 Commit those files on `website-assets` and push that branch. Pushing
 `website-assets` does not redeploy the site by itself: trigger a Vercel
 redeploy (dashboard, or any push to the production branch) to publish them.

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -565,6 +565,44 @@ static void DemoCapture(NSString *path, BOOL matrix) {
                         message:message];
             });
       });
+    } else if ([action isEqualToString:@"new-tab"]) {
+      NSWindow *rootWindow = DemoRootWindow();
+      NSUInteger tabCount = rootWindow.tabGroup.windows.count;
+      NSMenuItem *newTab = DemoMenuItemForShortcut(
+          @"New Tab", @"t", NSEventModifierFlagCommand);
+      if (newTab == nil) {
+        [self acknowledge:requestID
+                  success:NO
+                  message:@"New Tab is not bound to Cmd-T"];
+        return;
+      }
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (![NSApp sendAction:newTab.action
+                            to:newTab.target
+                          from:newTab]) {
+          [self acknowledge:requestID
+                    success:NO
+                    message:@"New Tab menu action was not handled"];
+          return;
+        }
+        dispatch_after(
+            dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC),
+            dispatch_get_main_queue(), ^{
+              NSUInteger currentCount =
+                  DemoRootWindow().tabGroup.windows.count;
+              BOOL created = currentCount > tabCount;
+              NSString *message = created
+                  ? @"workspace tab created"
+                  : [NSString stringWithFormat:
+                      @"workspace tab did not appear "
+                       "(before=%lu, after=%lu)",
+                      (unsigned long)tabCount,
+                      (unsigned long)currentCount];
+              [self acknowledge:requestID
+                        success:created
+                        message:message];
+            });
+      });
     } else if ([action isEqualToString:@"sidebar"]) {
       NSView *content = DemoRootWindow().contentView;
       BOOL wasVisible = DemoContainsText(content, @"Workspaces", 0);

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -171,51 +171,6 @@ capture_state() {
   sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
 }
 
-process_matrix_capture() {
-  local raw="$1" destination="$2"
-  local temporary
-  temporary="$(mktemp "$destination.tmp.XXXXXX")"
-  if ! NODE_PATH="$demo_root/../node_modules" \
-      node - "$raw" "$temporary" <<'EOF'
-const sharp = require("sharp");
-(async () => {
-  const [raw, destination] = process.argv.slice(2);
-  const files = [raw, ...[1, 2, 3, 4, 5].map((index) => `${raw}.${index}`)];
-  const metadata = await Promise.all(
-    files.map((file) => sharp(file).metadata())
-  );
-  const width = metadata[0].width;
-  const height = metadata[0].height;
-  if (width === undefined || height === undefined
-      || metadata.some((item) => item.width !== width || item.height !== height)) {
-    throw new Error("matrix windows did not capture at one consistent size");
-  }
-  const gap = 6;
-  await sharp({
-    create: {
-      width: width * 3 + gap * 2,
-      height: height * 2 + gap,
-      channels: 4,
-      background: "#080b0e",
-    },
-  })
-    .composite(files.map((input, index) => ({
-      input,
-      left: (index % 3) * (width + gap),
-      top: Math.floor(index / 3) * (height + gap),
-    })))
-    .resize({ width: 1800 })
-    .png({ compressionLevel: 9 })
-    .toFile(destination);
-})();
-EOF
-  then
-    rm -f "$temporary"
-    return 1
-  fi
-  mv -f "$temporary" "$destination"
-}
-
 echo "==> controller: unmatched palette commands fail validation"
 unmatched_command="__ghosthub_missing_command__"
 unmatched_error="$scratch/unmatched-command.error"
@@ -269,13 +224,13 @@ sleep 2
 capture_state guide-terminal.png
 dismiss_sheet
 
-prepare_command_window() {
+prepare_command_tab() {
   local query="$1" create="${2:-true}" select="${3:-palette}"
   if [[ "$create" == "true" ]]; then
-    demo_input new-window
+    demo_input new-tab
     sleep 2
   fi
-  demo_input frame "160,145,1200,760"
+  demo_input frame "110,145,1500,820"
   sleep 1
   if [[ "$select" == "press" ]]; then
     demo_input press "$query"
@@ -287,17 +242,13 @@ prepare_command_window() {
   sleep 1
 }
 
-echo "==> guide: six-window tmux command center"
-prepare_command_window "fix-reconnect-backoff" false
-prepare_command_window "add-session-filters"
-prepare_command_window "scratch" true press
-prepare_command_window "docbank-export" true press
-prepare_command_window "release-watch" true press
-prepare_command_window "test-matrix" true press
-matrix_raw="$scratch/screenshots-raw/guide-command-center.png"
-"$demo_root/capture.sh" "$matrix_raw" matrix
-process_matrix_capture "$matrix_raw" "$out_dir/guide-command-center.png"
-sips -g pixelWidth -g pixelHeight \
-  "$out_dir/guide-command-center.png" | tail -2
+echo "==> guide: six-tab tmux command center"
+prepare_command_tab "fix-reconnect-backoff" false
+prepare_command_tab "add-session-filters"
+prepare_command_tab "scratch" true press
+prepare_command_tab "docbank-export" true press
+prepare_command_tab "release-watch" true press
+prepare_command_tab "test-matrix" true press
+capture_state guide-command-center.png
 
 echo "captured website asset set -> $out_dir"

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -25,7 +25,7 @@ const imageAlt = {
     'Ghosthub new worktree sheet ready to create a feature branch with kwt',
   quickLaunch: 'Ghosthub Quick Launch filtered to a reconnect worktree',
   commandCenter:
-    'Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed',
+    'Six native Ghosthub workspace tabs, each attached to a different tmux session',
   terminal:
     'Ghosthub Terminal settings showing interaction and configuration options',
 };
@@ -223,13 +223,13 @@ const imageAlt = {
           </p>
         </div>
       </div>
-      <figure class="container command-matrix">
+      <figure class="container window">
         <ZoomableImage label={imageAlt.commandCenter}>
           <Image
             src={commandCenter}
             alt={imageAlt.commandCenter}
-            widths={[640, 960, 1280, 1800]}
-            sizes="(max-width: 1200px) calc(100vw - 3rem), 1160px"
+            widths={imageWidths}
+            sizes={imageSizes}
           />
         </ZoomableImage>
       </figure>
@@ -515,21 +515,6 @@ const imageAlt = {
   }
 
   .window :global(img) {
-    display: block;
-    width: 100%;
-    height: auto;
-  }
-
-  .command-matrix {
-    max-width: 1180px;
-    border: 1px solid var(--line);
-    border-radius: 12px;
-    overflow: hidden;
-    background: var(--bg);
-    box-shadow: 0 28px 70px rgb(0 0 0 / 0.45);
-  }
-
-  .command-matrix :global(img) {
     display: block;
     width: 100%;
     height: auto;


### PR DESCRIPTION
Ghosthub 0.3.0 teaches native workspace tabs, but the command-center screenshot still shows the previous six-window-only workflow. That visual mismatch makes the new Cmd-T model easy to miss even though the guide copy is already correct.

This makes the isolated demo drive the real New Tab menu command and presents six tmux sessions as native AppKit tabs in one window. The complete screenshot generation was published on the website-assets branch at 5dee02a and visually reviewed before the site was built against it.

Astro diagnostics, lint, all 11 website tests, the production site build, ShellCheck, Objective-C syntax validation, and all 108 Python tests pass.