### PR TITLE
Preserve both command-center layouts

### DIFF
--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -23,6 +23,7 @@ WEBSITE_ASSET_NAMES = (
     "guide-quick-launch.png",
     "guide-terminal.png",
     "guide-command-center.png",
+    "guide-native-tabs.png",
 )
 
 

--- a/website/README.md
+++ b/website/README.md
@@ -54,8 +54,9 @@ therefore cannot inherit the developer's SSH aliases, proxies, or host trust.
 
 The injected demo controller drives and captures only its exact staged
 process, so the workflow needs neither Accessibility nor Screen Recording
-permission. `shoot.sh` preserves native window and tab chrome and writes
-optimized 1600px PNGs with the exact filenames expected by the site.
+permission. `shoot.sh` preserves native window and tab chrome, including both
+the three-by-two command center and native tab group, and writes optimized PNGs
+with the exact filenames expected by the site.
 Commit those files on `website-assets` and push that branch. Pushing
 `website-assets` does not redeploy the site by itself: trigger a Vercel
 redeploy (dashboard, or any push to the production branch) to publish them.

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -382,9 +382,6 @@ static NSArray<NSWindow *> *DemoWorkspaceWindows(void) {
     if (left.windowNumber > right.windowNumber) return NSOrderedDescending;
     return NSOrderedSame;
   }];
-  if (windows.count > 6) {
-    return [windows subarrayWithRange:NSMakeRange(0, 6)];
-  }
   return windows;
 }
 

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -171,6 +171,51 @@ capture_state() {
   sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
 }
 
+process_matrix_capture() {
+  local raw="$1" destination="$2"
+  local temporary
+  temporary="$(mktemp "$destination.tmp.XXXXXX")"
+  if ! NODE_PATH="$demo_root/../node_modules" \
+      node - "$raw" "$temporary" <<'EOF'
+const sharp = require("sharp");
+(async () => {
+  const [raw, destination] = process.argv.slice(2);
+  const files = [raw, ...[1, 2, 3, 4, 5].map((index) => `${raw}.${index}`)];
+  const metadata = await Promise.all(
+    files.map((file) => sharp(file).metadata())
+  );
+  const width = metadata[0].width;
+  const height = metadata[0].height;
+  if (width === undefined || height === undefined
+      || metadata.some((item) => item.width !== width || item.height !== height)) {
+    throw new Error("matrix windows did not capture at one consistent size");
+  }
+  const gap = 6;
+  await sharp({
+    create: {
+      width: width * 3 + gap * 2,
+      height: height * 2 + gap,
+      channels: 4,
+      background: "#080b0e",
+    },
+  })
+    .composite(files.map((input, index) => ({
+      input,
+      left: (index % 3) * (width + gap),
+      top: Math.floor(index / 3) * (height + gap),
+    })))
+    .resize({ width: 1800 })
+    .png({ compressionLevel: 9 })
+    .toFile(destination);
+})();
+EOF
+  then
+    rm -f "$temporary"
+    return 1
+  fi
+  mv -f "$temporary" "$destination"
+}
+
 echo "==> controller: unmatched palette commands fail validation"
 unmatched_command="__ghosthub_missing_command__"
 unmatched_error="$scratch/unmatched-command.error"
@@ -224,6 +269,37 @@ sleep 2
 capture_state guide-terminal.png
 dismiss_sheet
 
+prepare_command_window() {
+  local query="$1" create="${2:-true}" select="${3:-palette}"
+  if [[ "$create" == "true" ]]; then
+    demo_input new-window
+    sleep 2
+  fi
+  demo_input frame "160,145,1200,760"
+  sleep 1
+  if [[ "$select" == "press" ]]; then
+    demo_input press "$query"
+  else
+    palette "$query"
+  fi
+  sleep 3
+  demo_input sidebar
+  sleep 1
+}
+
+echo "==> guide: six-window tmux command center"
+prepare_command_window "fix-reconnect-backoff" false
+prepare_command_window "add-session-filters"
+prepare_command_window "scratch" true press
+prepare_command_window "docbank-export" true press
+prepare_command_window "release-watch" true press
+prepare_command_window "test-matrix" true press
+matrix_raw="$scratch/screenshots-raw/guide-command-center.png"
+"$demo_root/capture.sh" "$matrix_raw" matrix
+process_matrix_capture "$matrix_raw" "$out_dir/guide-command-center.png"
+sips -g pixelWidth -g pixelHeight \
+  "$out_dir/guide-command-center.png" | tail -2
+
 prepare_command_tab() {
   local query="$1" create="${2:-true}" select="${3:-palette}"
   if [[ "$create" == "true" ]]; then
@@ -242,13 +318,15 @@ prepare_command_tab() {
   sleep 1
 }
 
-echo "==> guide: six-tab tmux command center"
+echo "==> guide: six-tab tmux workspace"
+demo_input new-window
+sleep 2
 prepare_command_tab "fix-reconnect-backoff" false
 prepare_command_tab "add-session-filters"
 prepare_command_tab "scratch" true press
 prepare_command_tab "docbank-export" true press
 prepare_command_tab "release-watch" true press
 prepare_command_tab "test-matrix" true press
-capture_state guide-command-center.png
+capture_state guide-native-tabs.png
 
 echo "captured website asset set -> $out_dir"

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -22,6 +22,7 @@ assets=(
   guide-quick-launch.png
   guide-terminal.png
   guide-command-center.png
+  guide-native-tabs.png
 )
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -4,6 +4,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 import ZoomableImage from '../components/ZoomableImage.astro';
 import commandCenter from '../assets/guide-command-center.png';
 import hosts from '../assets/guide-hosts.png';
+import nativeTabs from '../assets/guide-native-tabs.png';
 import quickLaunch from '../assets/guide-quick-launch.png';
 import sessions from '../assets/guide-sessions.png';
 import terminal from '../assets/guide-terminal.png';
@@ -25,6 +26,8 @@ const imageAlt = {
     'Ghosthub new worktree sheet ready to create a feature branch with kwt',
   quickLaunch: 'Ghosthub Quick Launch filtered to a reconnect worktree',
   commandCenter:
+    'Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed',
+  nativeTabs:
     'Six native Ghosthub workspace tabs, each attached to a different tmux session',
   terminal:
     'Ghosthub Terminal settings showing interaction and configuration options',
@@ -223,11 +226,21 @@ const imageAlt = {
           </p>
         </div>
       </div>
-      <figure class="container window">
+      <figure class="container command-matrix">
         <ZoomableImage label={imageAlt.commandCenter}>
           <Image
             src={commandCenter}
             alt={imageAlt.commandCenter}
+            widths={[640, 960, 1280, 1800]}
+            sizes="(max-width: 1200px) calc(100vw - 3rem), 1160px"
+          />
+        </ZoomableImage>
+      </figure>
+      <figure class="container window">
+        <ZoomableImage label={imageAlt.nativeTabs}>
+          <Image
+            src={nativeTabs}
+            alt={imageAlt.nativeTabs}
             widths={imageWidths}
             sizes={imageSizes}
           />
@@ -515,6 +528,21 @@ const imageAlt = {
   }
 
   .window :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .command-matrix {
+    max-width: 1180px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--bg);
+    box-shadow: 0 28px 70px rgb(0 0 0 / 0.45);
+  }
+
+  .command-matrix :global(img) {
     display: block;
     width: 100%;
     height: auto;


### PR DESCRIPTION
Native workspace tabs add a useful presentation mode, but they should not replace the established three-by-two independent-window command center. The previous screenshot refresh reused the same asset path and destroyed that composition, making the guide lose a distinct workflow users still rely on.

This restores the original matrix at its stable public path and gives the native tab group a separate required asset. Future controlled regenerations now produce both layouts, so updating one cannot overwrite the other. The asset branch contains the exact prior matrix binary at its original checksum.

All 108 Python tests, Astro diagnostics, lint, all 11 website tests, the production site build, ShellCheck, and Objective-C syntax validation pass. Both published images were reviewed at original resolution. Two complete demo reruns were attempted, but the injected controller timed out on different early distributed-notification actions before reaching either command-center capture; teardown completed after both, and no retry hardening was added for that nondeterministic harness behavior.