### PR TITLE
Make refresh cancellation test deterministic

### DIFF
--- a/Tests/App/WorkspaceResourceSamplingCoordinatorTests.swift
+++ b/Tests/App/WorkspaceResourceSamplingCoordinatorTests.swift
@@ -12,7 +12,8 @@ struct ResourceSamplingCoordinatorTests {
 
         let recorder = ctx.recorder
         ctx.coordinator.scheduleRefresh(after: 0.2)
-        try? await Task.sleep(for: .milliseconds(50))
+        // Replace the pending task before yielding so scheduler load cannot
+        // let the first refresh fire before the cancellation under test.
         ctx.coordinator.scheduleRefresh(after: 0.01)
 
         await waitUntil {


### PR DESCRIPTION
The refresh-cancellation test yields for 50 milliseconds before replacing a 200-millisecond task. On a loaded hosted runner, that suspension can resume after the first refresh has legitimately fired, so scheduler latency produces a false production failure and blocks releases.

This replaces the pending refresh synchronously before the test yields, preserving the existing wait past the original deadline to verify that only the replacement runs. Production sampling behavior remains unchanged.

The focused test passed 50 consecutive process-level runs, and the exact serialized Swift Testing CI lane passed all 555 tests across 92 suites.