### PR TITLE
Serialize pasteboard terminal smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,13 @@ jobs:
         run: >-
           swift test --skip-build --disable-swift-testing
           --filter GhosthubTerminalSmokeTests
-          --skip 'RemoteClipboardPolicy|ReceivesPasteOnCmdV'
+          --skip 'Clipboard|Paste'
           --parallel --num-workers 2
 
       - name: Run pasteboard terminal smoke tests
         run: >-
           swift test --skip-build --disable-swift-testing
-          --filter 'RemoteClipboardPolicy|ReceivesPasteOnCmdV' --no-parallel
+          --filter 'Clipboard|Paste' --no-parallel
 
       - name: Run remaining XCTest suites
         # Keep deadline-sensitive monitor and lifecycle tests serialized.


### PR DESCRIPTION
Main CI failed because the two-worker terminal smoke lane included several tests that mutate `NSPasteboard.general`. The existing serialized lane matched only part of that group, so the bracketed-paste test could read contents replaced by another worker and report a false product regression.

This routes the established `Clipboard`/`Paste` test family through the no-parallel lane while keeping independent terminal tests parallel. The exact CI split passed locally: 69 tests in the two-worker lane and all eight pasteboard-related tests in the serialized lane, including the previously failing bracketed-paste case.