### PR TITLE
Sign remote Darwin helpers for notarization

### DIFF
--- a/Tests/test_release_workflow.py
+++ b/Tests/test_release_workflow.py
@@ -122,15 +122,21 @@ def test_release_signs_nested_code_before_the_app_and_validates_notarization():
     assert 'xattr -cr "$RELEASE_APP_PATH" || true' not in text
     sparkle_sign = text.index("Codesigning Sparkle component")
     helper_sign = text.index("Codesigning kwt helper")
+    remote_helper_sign = text.index("Codesigning remote kwt helper")
     app_sign = text.index("Codesigning app bundle")
-    assert sparkle_sign < helper_sign < app_sign
+    assert sparkle_sign < helper_sign < remote_helper_sign < app_sign
     assert "Versions/B/Autoupdate" in text
     assert "XPCServices/Downloader.xpc" in text
     assert "XPCServices/Installer.xpc" in text
     assert "Versions/B/Updater.app" in text
+    assert "for target in darwin-amd64 darwin-arm64" in text
     assert "--preserve-metadata=identifier,entitlements" in text
     assert "entitlements,requirements" not in text
     assert 'codesign --verify --strict --verbose=2 "$KWT_HELPER_PATH"' in text
+    assert (
+        'codesign --verify --strict --verbose=2 "$REMOTE_KWT_HELPER_PATH"'
+        in text
+    )
     assert 'xcrun stapler validate "$RELEASE_DMG_PATH"' in text
     assert "spctl --assess --type open" in text
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -205,12 +205,14 @@ The manual path imports the signing certificate into an ephemeral keychain,
 builds the pinned local kwt helper, verifies that it is an Apple Silicon
 Mach-O, cross-compiles the Darwin/Linux amd64/arm64 remote matrix,
 builds release-optimized libghostty and Ghosthub, re-signs Sparkle's nested
-helpers and framework with Ghosthub's Developer ID identity, signs kwt and the
-enclosing app, signs the DMG, submits it to Apple, staples and validates the
-ticket, and uploads a seven-day candidate artifact. It does not consume the
-production Sparkle private key, generate an appcast, create a tag, or create a
-GitHub release. Both checksum files name the DMG by basename, so they remain
-valid after download.
+helpers and framework with Ghosthub's Developer ID identity, signs the local
+kwt helper and both Darwin remote kwt variants with hardened runtime and secure
+timestamps, then signs the enclosing app and DMG, submits it to Apple, staples
+and validates the ticket, and uploads a seven-day candidate artifact. Linux
+remote variants remain unsigned ELF resources. The candidate does not consume
+the production Sparkle private key, generate an appcast, create a tag, or
+create a GitHub release. Both checksum files name the DMG by basename, so they
+remain valid after download.
 
 Download the candidate and verify either checksum from the directory that
 contains the three artifact files:
@@ -336,10 +338,12 @@ load it from the protected 1Password export as described by the operations
 runbook.
 
 Outputs live in `dist/release/`. `tools/build_release_dmg.sh` signs Sparkle's
-nested executables and services from the inside out, then kwt, then the
-containing app; do not replace that release order with recursive
-`codesign --deep` signing. Sparkle remains under `Contents/Frameworks`, and
-SwiftPM resource bundles remain under `Contents/Resources`; placing
+nested executables and services from the inside out, then the local kwt helper
+and Darwin remote kwt resources, then the containing app; do not replace that
+release order with recursive `codesign --deep` signing. Mach-O helpers require
+their own Developer ID signatures even when staged as non-executable resources;
+the Linux ELF variants do not. Sparkle remains under `Contents/Frameworks`,
+and SwiftPM resource bundles remain under `Contents/Resources`; placing
 compatibility symlinks at the `.app` root creates unsealed content that strict
 code-signing rejects. Ghosthub's AGPL license and every third-party notice in
 `LICENSES` are staged during the same assembly step.

--- a/tools/build_release_dmg.sh
+++ b/tools/build_release_dmg.sh
@@ -90,6 +90,19 @@ if [[ -n "$APPLE_SIGNING_IDENTITY" ]]; then
     "$KWT_HELPER_PATH"
   codesign --verify --strict --verbose=2 "$KWT_HELPER_PATH"
 
+  for target in darwin-amd64 darwin-arm64; do
+    REMOTE_KWT_HELPER_PATH="$RELEASE_APP_PATH/Contents/Resources/KwtRemote/$target/kwt"
+    printf 'Codesigning remote kwt helper (%s): %s\n' \
+      "$target" "$REMOTE_KWT_HELPER_PATH"
+    codesign \
+      --force \
+      --options runtime \
+      --timestamp \
+      --sign "$APPLE_SIGNING_IDENTITY" \
+      "$REMOTE_KWT_HELPER_PATH"
+    codesign --verify --strict --verbose=2 "$REMOTE_KWT_HELPER_PATH"
+  done
+
   printf 'Codesigning app bundle: %s\n' "$RELEASE_APP_PATH"
   codesign \
     --force \


### PR DESCRIPTION
Apple rejected the v0.3.0 DMG because notarization treats the Darwin kwt variants as Mach-O code even though Ghosthub stages them as mode-0644 remote resources. The enclosing app signature does not supply the individual Developer ID signature, secure timestamp, or hardened runtime each payload requires. This signs and strictly verifies both Darwin architectures before the app while leaving Linux ELF variants unsigned. The actual x86_64 and arm64 payloads passed local hardened-runtime signing probes; ShellCheck, all 113 Python tests, the focused release test, and `make build` pass.