### PR TITLE
Keep the repository landing page focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,9 @@ test, and documentation-only changes are omitted.
 
 ## [0.1.0] - 2026-07-22
 
-- Initial public release with native libghostty terminal surfaces, local and
-  SSH tmux session discovery, automatic reconnect, and kwt-backed project and
-  worktree navigation.
+- Initial development release with native libghostty terminal surfaces, local
+  and SSH tmux session discovery, automatic reconnect, and kwt-backed project
+  and worktree navigation.
 
 [Unreleased]: https://github.com/kenn-io/ghosthub/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/kenn-io/ghosthub/compare/v0.2.1...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+Notable user-facing changes to Ghosthub are recorded here. Internal build,
+test, and documentation-only changes are omitted.
+
+## [Unreleased]
+
+## [0.3.0] - 2026-07-28
+
+### Added
+
+- Native macOS workspace tabs with `⌘T`, alongside independent windows with
+  `⌘N`.
+- Pull-request discovery and worktree import through kwt.
+- Managed kwt helpers for Darwin and Linux on amd64 and arm64 remote hosts,
+  installed only after explicit permission.
+- **Add Project** for registering one local or remote checkout without
+  filesystem scanning or a system kwt installation.
+- Confirmed **Kill Session** actions in session menus and the Command Palette.
+- Privacy-bounded anonymous daily activity telemetry with a Settings opt-out.
+
+### Changed
+
+- Worktrees remain available when their canonical tmux session is not running;
+  opening one creates or repairs the session before attachment.
+- Remote-host onboarding now includes connection verification, actionable
+  error details, empty-host guidance, and clearer host grouping.
+- Tool discovery supports non-POSIX account shells such as fish.
+
+## [0.2.1] - 2026-07-23
+
+### Added
+
+- Automatic terminal configuration reloads and an explicit
+  **Reload Configuration** command with diagnostics.
+
+### Changed
+
+- Restored native paste behavior inside tmux-backed terminals.
+- Tmux status and message areas now follow Ghosthub terminal colors.
+- Improved project action discoverability, window sizing, and detach/quit
+  behavior.
+
+## [0.2.0] - 2026-07-23
+
+### Added
+
+- Signed automatic updates and a native **Check for Updates…** flow powered by
+  Sparkle.
+
+## [0.1.1] - 2026-07-22
+
+### Changed
+
+- Remote inventory failures now degrade per host without blocking usable local
+  or cached sessions.
+- Improved compact window sizing and application license metadata.
+
+## [0.1.0] - 2026-07-22
+
+- Initial public release with native libghostty terminal surfaces, local and
+  SSH tmux session discovery, automatic reconnect, and kwt-backed project and
+  worktree navigation.
+
+[Unreleased]: https://github.com/kenn-io/ghosthub/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/kenn-io/ghosthub/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/kenn-io/ghosthub/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/kenn-io/ghosthub/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/kenn-io/ghosthub/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/kenn-io/ghosthub/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 <h1 align="center">Ghosthub</h1>
 
 <p align="center">
-  <strong>A power terminal for your agents' tmux sessions.</strong>
+  <strong>A native terminal for your fleet of tmux sessions.</strong>
   <br>
-  Attach to every session in your fleet, local or over SSH, with keepalives,
-  automatic reconnect, and worktree-aware navigation.
+  Find and enter the sessions behind your projects and coding agents,
+  on your Mac or over SSH.
 </p>
 
 <p align="center">
@@ -26,6 +26,10 @@
   ·
   <a href="https://github.com/kenn-io/ghosthub/releases"><strong>Download</strong></a>
   ·
+  <a href="https://ghosthub.io/guide/"><strong>Guide</strong></a>
+  ·
+  <a href="CHANGELOG.md"><strong>Changelog</strong></a>
+  ·
   <a href="https://discord.gg/nEB7VaAnU9"><strong>Discord</strong></a>
 </p>
 
@@ -37,38 +41,32 @@
   >
 </p>
 
-Ghosthub gives developers one fast, native place to find and enter the terminal
-sessions behind their projects and coding agents. It discovers the tmux
-sessions you already have, keeps remote clients connected through ordinary
-network interruptions, and makes switching between hosts, projects, and
-worktrees feel immediate.
+Ghosthub discovers the tmux sessions you already have and organizes them by
+host, project, and worktree. Tmux continues to own windows, panes, layout,
+history, and process lifetime; Ghosthub provides the native macOS interface,
+terminal presentation, and SSH reconnect supervision.
 
-There is no proprietary session format and nothing to migrate. Tmux continues
-to own windows, panes, layout, history, and process lifetime. Ghosthub is the
-macOS interface that makes the whole fleet easy to navigate.
+There is no proprietary session format, background daemon, or migration.
 
 ## Highlights
 
-- **Every tmux session in one sidebar.** See local sessions, remote sessions,
-  and worktree sessions together—even when they were created outside Ghosthub.
-- **SSH that handles real life.** Keepalives and automatic reconnect let a
-  remote tmux session survive Wi-Fi changes, sleep, and airplane mode.
-- **Worktree-native navigation with
-  [kwt](https://kwt.sh).** Kwt is a cross-platform Git
-  worktree manager written in Go for tmux-backed development. Its projects and
-  worktrees appear alongside ordinary tmux sessions, with exact
-  workspace-to-session mapping.
-- **Native tmux behavior.** Use the tmux window, pane, keybinding, history, and
-  plugin setup you already trust. Closing Ghosthub detaches; it does not kill
-  the session.
-- **Powered by libghostty.** GPU-accelerated terminal rendering and the library's
-  configuration format, with an isolated Ghosthub-owned config.
-- **Built for macOS.** A lightweight SwiftUI/AppKit application—no Electron
-  and no background daemon.
+- **One fleet sidebar.** Navigate local sessions, remote sessions, projects,
+  and worktrees—even when their tmux sessions were created outside Ghosthub.
+- **Resilient SSH.** Keepalives and automatic reconnect preserve remote
+  presentations through ordinary network interruptions.
+- **Worktree and pull-request workflows.** The bundled
+  [kwt](https://kwt.sh) helper supplies project identity, worktrees, and exact
+  tmux session names without requiring a system kwt installation.
+- **Native tmux lifecycle.** Closing a presentation detaches. Ending a session
+  requires the explicit, confirmed **Kill Session** action.
+- **Native workspaces.** Open independent windows or macOS tabs, and search
+  sessions and common actions from the Command Palette.
+- **Fast terminal rendering.** Ghosthub embeds libghostty with an isolated,
+  Ghostty-compatible configuration—no Electron and no Ghostty.app dependency.
 
 ## Install
 
-Ghosthub currently requires:
+Ghosthub requires:
 
 - an Apple Silicon Mac
 - macOS 26 (Tahoe) or newer
@@ -76,74 +74,64 @@ Ghosthub currently requires:
 
 1. Download the latest notarized
    [Ghosthub DMG](https://github.com/kenn-io/ghosthub/releases).
-2. Open the DMG and drag **Ghosthub** to **Applications**.
-3. Launch Ghosthub. Future releases are delivered through the built-in
-   automatic updater.
+2. Drag **Ghosthub** to **Applications** and launch it.
+3. Install tmux locally if needed:
 
-Install tmux on the local Mac with Homebrew if needed:
+   ```sh
+   brew install tmux
+   ```
 
-```sh
-brew install tmux
-```
+Remote hosts need tmux and non-interactive SSH authentication backed by a key
+or SSH agent. Password-only hosts cannot populate the sidebar.
 
-Remote hosts need tmux 3.2 or newer and non-interactive SSH authentication
-backed by a key or SSH agent. Ghosthub discovers remote inventory with
-`BatchMode=yes`, so password-only hosts cannot populate the sidebar. Installing
-[kwt](https://kwt.sh) remotely is optional unless you want that host's projects
-and worktrees in the sidebar.
+## Quick start
 
-## Five-minute guide
+### Open or create a session
 
-### 1. Open a session
+Expand your Mac in the sidebar and select an existing tmux session. Use the
+host's **+** menu to create a named session. Closing its Ghosthub window or tab
+only detaches; use the session action menu when you explicitly want to kill it.
 
-Launch Ghosthub and expand **Local**. Existing tmux sessions appear
-automatically. Click any session to attach with a normal tmux client.
+### Add an SSH host
 
-Use the **+** button beside a host to create a named tmux session when you want
-a new one. Closing its Ghosthub presentation only detaches from tmux, so the
-work keeps running.
+Open **Settings → Hosts**, add an SSH address such as `devbox`,
+`alice@build-server`, or `server.example.com:2222`, and choose
+**Test Connection**. If your OpenSSH policy prompts for a new host key, verify
+the host once with system `ssh` first.
 
-### 2. Add an SSH host
+Tmux-only hosts need no other setup. For project and worktree context, choose
+**Install kwt Worktree Helper** in Host Settings. Ghosthub copies the pinned
+helper for that host's operating system and CPU; it does not install or replace
+a system kwt.
 
-Open **Settings** with <kbd>⌘</kbd><kbd>,</kbd>, choose **Hosts**, and press
-**+**. Enter any destination accepted by your SSH configuration, such as:
+### Add projects and worktrees
 
-```text
-devbox
-alice@build-server
-server.example.com:2222
-```
+Open the **+** menu beside a local or remote host, choose **Add Project**, and
+enter the absolute path to an existing checkout. Ghosthub registers that one
+repository through its bundled or managed kwt helper and does not scan the
+machine.
 
-Use **Test Connection**, then close Settings. The host's tmux sessions will
-appear in the sidebar. A temporarily unreachable host stays isolated; it does
-not block local sessions or the rest of your fleet.
+Select a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a
+worktree from a branch or pull request. Selecting a listed worktree creates or
+repairs its canonical tmux session when needed, then attaches an ordinary tmux
+client.
 
-### 3. Add project and worktree context with kwt
+## Navigation
 
-[Kwt](https://kwt.sh) is a cross-platform Git worktree manager
-written in Go for tmux-backed development and coding-agent workflows. The same
-CLI runs on macOS and Linux, so it can supply workspace context on both the
-local Mac and remote hosts while Ghosthub remains a native Swift macOS app.
-Ghosthub ships with a pinned kwt helper for reliable local integration. To
-register repositories or manage them from the command line, install the kwt
-CLI:
+Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> to open the **Command Palette** and
+search across hosts, projects, worktrees, sessions, settings, and actions.
 
-```sh
-go install go.kenn.io/kwt/cmd/kwt@latest
-```
+| Shortcut | Action |
+| --- | --- |
+| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> | Open Command Palette |
+| <kbd>⌘</kbd><kbd>T</kbd> | Open a new workspace tab |
+| <kbd>⌘</kbd><kbd>N</kbd> | Open a new workspace window |
+| <kbd>⌘</kbd><kbd>B</kbd> | Show or hide the sidebar |
+| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> | Create a worktree |
+| <kbd>⌘</kbd><kbd>W</kbd> | Detach the current presentation |
+| <kbd>⌘</kbd><kbd>,</kbd> | Open Settings |
 
-Run `kwt` once from a repository to register it:
-
-```sh
-cd ~/code/my-project
-kwt
-```
-
-The project and its worktrees will appear under that host in Ghosthub. Select
-a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a new
-worktree, or use **Quick Launch** to jump there without reaching for the mouse.
-
-### 4. Make the terminal yours
+## Terminal configuration
 
 Ghosthub reads its own configuration at:
 
@@ -153,63 +141,36 @@ Ghosthub reads its own configuration at:
 
 The file uses
 [Ghostty's configuration format](https://ghostty.org/docs/config/reference),
-but remains separate from Ghostty.app so the two applications can evolve
-independently. Appearance, keyboard, worktree, agent, and host preferences are
-also available in **Settings**. Ghosthub automatically reloads the active
-configuration when the base file, a project override, or a recursively included
-file changes. Use **Ghosthub → Reload Configuration** when you want an explicit
-reload and diagnostic result.
-
-## Useful shortcuts
-
-| Shortcut | Action |
-| --- | --- |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> | Open Quick Launch |
-| <kbd>⌘</kbd><kbd>B</kbd> | Show or hide the sidebar |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> | Create a worktree in the selected project |
-| <kbd>⌘</kbd><kbd>⇧</kbd><kbd>,</kbd> | Reload terminal configuration |
-| <kbd>⌘</kbd><kbd>,</kbd> | Open Settings |
-| <kbd>⌘</kbd><kbd>W</kbd> | Detach the current presentation |
+but remains independent of Ghostty.app configuration and state. Ghosthub
+reloads the active configuration when the base file, an included file, or a
+project override changes.
 
 ## How the pieces fit
 
-**Tmux owns the session.** Ghosthub never rebuilds or replaces tmux windows,
-panes, history, or process management.
+**Tmux owns terminal sessions.** It remains authoritative for windows, panes,
+layout, history, keybindings, plugins, and process lifetime.
 
-**[Kwt](https://kwt.sh) owns worktree identity.** It tells
-Ghosthub which projects and worktrees exist and the exact tmux session
-associated with each workspace. Kwt is optional if you only want Ghosthub as a
-local and remote tmux session switcher.
+**[Kwt](https://kwt.sh) owns worktree identity.** It reports projects,
+worktrees, and their exact tmux session names. Kwt is optional when you only
+want a local and remote tmux session switcher.
 
-**Ghosthub owns the experience.** It discovers sessions, organizes the fleet,
-presents native terminal clients, and supervises SSH keepalive and reconnect.
+**Ghosthub owns presentation.** It discovers the fleet, presents native
+terminal clients, organizes workspaces, and supervises SSH reconnect.
 
 ## Anonymous usage data
 
-Packaged Ghosthub releases send one anonymous `application active` event to
-PostHog at most once per UTC day. This gives the project a daily active
-installation count without collecting repository, worktree, host, session,
-path, command, or terminal data.
-
-Each event uses a random installation UUID stored in
-`~/.ghosthub/telemetry.json`. It includes only:
-
-- `application: "ghosthub"`
-- `source: "native_app"`
-- the Ghosthub version and build number
-- `$process_person_profile: false`
-- `$geoip_disable: true`
-
-Disable reporting in **Settings → Privacy** by turning off **Share anonymous
-usage data**. You can also launch Ghosthub with
-`GHOSTHUB_TELEMETRY_ENABLED=0` or `TELEMETRY_ENABLED=0`. Debug builds and test
-runs never configure the production telemetry client.
+Packaged releases send at most one anonymous daily activity event, enabled by
+default, containing only a random installation ID and the Ghosthub version and
+build number. Repository, worktree, host, session, path, command, and terminal
+data are not collected. Disable reporting in **Settings → Privacy**. The full
+contract is documented in the
+[architecture](docs/architecture.md#anonymous-usage-telemetry) and
+[threat model](docs/threat-model.md).
 
 ## Build from source
 
-The packaged app is the easiest way to use Ghosthub. Contributors who want to
-build it need macOS 26, Xcode 26, Zig, uv, and the Metal Toolchain. Start with
-the [development quick start](docs/quickstart.md), then see
+Contributors need macOS 26, Xcode 26, Zig, uv, Go, and the Metal Toolchain.
+Start with the [development quick start](docs/quickstart.md), then read
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Architecture, security boundaries, terminal behavior, and release operations

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ enter the absolute path to an existing checkout. Ghosthub registers that one
 repository through its bundled or managed kwt helper and does not scan the
 machine.
 
+Pull-request import requires the
+[GitHub CLI (`gh`)](https://cli.github.com/) on the host containing the project:
+your Mac for a local project or the SSH machine for a remote one. Install it
+there and run `gh auth login` on that same host before importing.
+
 Select a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a Git
 worktree or import a GitHub pull request. Selecting a listed worktree creates
 or repairs its canonical tmux session when needed, then attaches an ordinary

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Ghosthub</h1>
 
 <p align="center">
-  <strong>A native terminal for your fleet of tmux sessions.</strong>
+  <strong>A power terminal for your fleet of tmux sessions.</strong>
   <br>
   Find and enter the sessions behind your projects and coding agents,
   on your Mac or over SSH.
@@ -54,9 +54,9 @@ There is no proprietary session format, background daemon, or migration.
   and worktrees—even when their tmux sessions were created outside Ghosthub.
 - **Resilient SSH.** Keepalives and automatic reconnect preserve remote
   presentations through ordinary network interruptions.
-- **Worktree and pull-request workflows.** The bundled
-  [kwt](https://kwt.sh) helper supplies project identity, worktrees, and exact
-  tmux session names without requiring a system kwt installation.
+- **Built-in worktree and pull-request workflows.** Add projects, create Git
+  worktrees, and import GitHub pull requests through the bundled
+  [kwt](https://kwt.sh) helper—no system kwt installation required.
 - **Native tmux lifecycle.** Closing a presentation detaches. Ending a session
   requires the explicit, confirmed **Kill Session** action.
 - **Native workspaces.** Open independent windows or macOS tabs, and search
@@ -111,10 +111,10 @@ enter the absolute path to an existing checkout. Ghosthub registers that one
 repository through its bundled or managed kwt helper and does not scan the
 machine.
 
-Select a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a
-worktree from a branch or pull request. Selecting a listed worktree creates or
-repairs its canonical tmux session when needed, then attaches an ordinary tmux
-client.
+Select a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a Git
+worktree or import a GitHub pull request. Selecting a listed worktree creates
+or repairs its canonical tmux session when needed, then attaches an ordinary
+tmux client.
 
 ## Navigation
 

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -14,8 +14,8 @@ const features: Feature[] = [
   },
   {
     title: 'Worktree-first',
-    body: 'Projects and worktrees in the sidebar. Create a worktree and drop into its session '
-      + 'without leaving the keyboard.',
+    body: 'Add projects, create Git worktrees, and import GitHub pull requests without leaving '
+      + 'Ghosthub, then drop straight into their tmux sessions.',
     icon: 'M9 6v14a6 6 0 0 0 6 6h4 M9 6a3 3 0 1 0 0-1 '
       + 'M23 26a3 3 0 1 0 0 1 M23 9h-6 M23 9a3 3 0 1 0 0-1',
   },

--- a/website/src/components/GuideCTA.astro
+++ b/website/src/components/GuideCTA.astro
@@ -4,7 +4,7 @@
       <p class="eyebrow">Five-minute guide</p>
       <h2>From download to a connected fleet</h2>
       <p>
-        See how automatic SSH recovery, worktrees, Quick Launch, and
+        See how automatic SSH recovery, worktrees, the Command Palette, and
         multi-window tmux command centers fit together.
       </p>
     </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -16,11 +16,11 @@ const heroAlt =
       <AppIcon prefix="gh-ic-hero" />
       <span class="wordmark">Ghosthub</span>
     </p>
-    <h1>A power terminal for your agents&rsquo; tmux sessions</h1>
+    <h1>A power terminal for your fleet of tmux sessions</h1>
     <p class="sub">
-      A native, libghostty-powered terminal for every tmux session in your
-      fleet—local or over SSH—with keepalives and automatic reconnect.
-      Worktree-native from the ground up.
+      A native, libghostty-powered home for the tmux sessions behind your
+      projects and coding agents—local or over SSH—with keepalives, automatic
+      reconnect, and built-in worktree workflows.
     </p>
     <div class="actions">
       <a class="cta" data-download href={RELEASES_URL}>Download for Apple Silicon</a>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -188,6 +188,13 @@ const imageAlt = {
             without scanning the machine.
           </p>
           <p>
+            Pull-request import requires the{' '}
+            <a href="https://cli.github.com/">GitHub CLI (<code>gh</code>)</a>{' '}
+            on the host containing the project: your Mac for a local project
+            or the SSH machine for a remote one. Install it there and run{' '}
+            <code>gh auth login</code> on that same host before importing.
+          </p>
+          <p>
             Select a project and press <kbd>⌘⇧N</kbd>. Use
             <strong>Branch</strong> to create a Git worktree, or
             <strong>Pull Request</strong> to find and import an open GitHub

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -5,7 +5,7 @@ import ZoomableImage from '../components/ZoomableImage.astro';
 import commandCenter from '../assets/guide-command-center.png';
 import hosts from '../assets/guide-hosts.png';
 import nativeTabs from '../assets/guide-native-tabs.png';
-import quickLaunch from '../assets/guide-quick-launch.png';
+import commandPalette from '../assets/guide-quick-launch.png';
 import sessions from '../assets/guide-sessions.png';
 import terminal from '../assets/guide-terminal.png';
 import worktree from '../assets/guide-worktree.png';
@@ -14,7 +14,7 @@ import { RELEASES_URL } from '../config';
 const title = 'How to use Ghosthub';
 const description =
   'A visual guide to connected tmux sessions, automatic SSH reconnect, '
-  + 'worktrees, Quick Launch, native tabs and windows, and terminal configuration.';
+  + 'worktrees, the Command Palette, native tabs and windows, and terminal configuration.';
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
@@ -23,8 +23,8 @@ const imageAlt = {
     'Ghosthub workspace showing local sessions, projects, worktrees, and a remote host in the sidebar',
   hosts: 'Ghosthub Hosts settings with a configured remote GPU host',
   worktree:
-    'Ghosthub new worktree sheet ready to create a feature branch with kwt',
-  quickLaunch: 'Ghosthub Quick Launch filtered to a reconnect worktree',
+    'Ghosthub new worktree sheet ready to create a feature branch or import a pull request',
+  commandPalette: 'Ghosthub Command Palette filtered to a reconnect worktree',
   commandCenter:
     'Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed',
   nativeTabs:
@@ -64,7 +64,7 @@ const imageAlt = {
     <a href="#sessions"><b>01</b> Open a session</a>
     <a href="#hosts"><b>02</b> Add a host</a>
     <a href="#worktrees"><b>03</b> Add worktrees</a>
-    <a href="#quick-launch"><b>04</b> Move quickly</a>
+    <a href="#command-palette"><b>04</b> Move quickly</a>
     <a href="#command-center"><b>05</b> Command center</a>
     <a href="#terminal"><b>06</b> Make it yours</a>
   </nav>
@@ -181,16 +181,21 @@ const imageAlt = {
         <div>
           <h2>Add project and worktree context</h2>
           <p>
-            Ghosthub uses <a href="https://kwt.sh">kwt</a> to map repositories
-            and worktrees to their exact tmux sessions. Run <code>kwt</code>
-            once inside a repository to register it.
+            Open the <strong>+</strong> menu beside a local or remote host,
+            choose <strong>Add Project</strong>, and enter the absolute path to
+            an existing checkout. Ghosthub registers that repository through
+            its bundled or managed <a href="https://kwt.sh">kwt</a> helper
+            without scanning the machine.
           </p>
           <p>
-            Select a project and press <kbd>⌘⇧N</kbd> to create a branch and
-            worktree without leaving Ghosthub. Kwt remains optional if you
-            only want a local and remote tmux session switcher.
-            Selecting a listed worktree starts its configured kwt session
-            when that session is not already running.
+            Select a project and press <kbd>⌘⇧N</kbd>. Use
+            <strong>Branch</strong> to create a Git worktree, or
+            <strong>Pull Request</strong> to find and import an open GitHub
+            pull request. You do not need to install or run kwt separately.
+            Selecting a listed worktree creates or repairs its canonical tmux
+            session when needed, then attaches an ordinary tmux client.
+            Kwt remains optional if you only want a local and remote tmux
+            session switcher.
           </p>
         </div>
       </div>
@@ -206,13 +211,13 @@ const imageAlt = {
       </figure>
     </li>
 
-    <li id="quick-launch">
+    <li id="command-palette">
       <div class="container step-copy">
         <p class="number">04</p>
         <div>
           <h2>Move through the fleet without the mouse</h2>
           <p>
-            Press <kbd>⌘⇧P</kbd> for Quick Launch. Search across hosts,
+            Press <kbd>⌘⇧P</kbd> for the Command Palette. Search across hosts,
             projects, worktrees, appearance, settings, and common actions,
             then press Return to go.
           </p>
@@ -225,10 +230,10 @@ const imageAlt = {
         </div>
       </div>
       <figure class="container window">
-        <ZoomableImage label={imageAlt.quickLaunch}>
+        <ZoomableImage label={imageAlt.commandPalette}>
           <Image
-            src={quickLaunch}
-            alt={imageAlt.quickLaunch}
+            src={commandPalette}
+            alt={imageAlt.commandPalette}
             widths={imageWidths}
             sizes={imageSizes}
           />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,10 +4,11 @@ import GuideCTA from '../components/GuideCTA.astro';
 import Hero from '../components/Hero.astro';
 import SiteLayout from '../layouts/SiteLayout.astro';
 
-const title = "Ghosthub: a power terminal for your agents' tmux sessions";
+const title = 'Ghosthub: a power terminal for your fleet of tmux sessions';
 const description =
-  "Ghosthub is a free and open source macOS power terminal for your agents' tmux sessions, "
-  + 'local and remote. Worktree-native, built on libghostty.';
+  'Ghosthub is a free and open source macOS power terminal for the tmux sessions '
+  + 'behind your projects and coding agents, local or over SSH. Worktree-native, '
+  + 'built on libghostty.';
 ---
 
 <SiteLayout title={title} description={description} path="/">


### PR DESCRIPTION
The README had become a second user guide while still directing users toward a system kwt installation that Ghosthub no longer requires. That obscures the actual first-use path and omits prominent shipped behavior such as native tabs, managed remote helpers, Add Project, the Command Palette, pull-request worktrees, and explicit session termination. This keeps the landing page concise and current, points detailed usage to the website Guide, and adds a release-level changelog derived from the published tag ranges rather than internal commit churn. `make docs-build` and repository hooks pass; screenshots are unchanged because this is copy-only documentation work.