### PR TITLE
Fix terminal reloads and make tmux theming explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ The file uses
 [Ghostty's configuration format](https://ghostty.org/docs/config/reference),
 but remains independent of Ghostty.app configuration and state. Ghosthub
 reloads the active configuration when the base file, an included file, or a
-project override changes.
+project override changes. The **Tmux Theme** setting controls how sessions
+appear in Ghosthub. Shared tmux colors remain untouched by default; an explicit
+opt-in applies the selected built-in theme to the session's existing windows
+and chrome for every attached terminal. Use **Ghosthub → Reload Configuration**
+for an explicit reload and diagnostic result.
 
 ## How the pieces fit
 

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -87,6 +87,7 @@ final class NativeTmuxSessionCoordinator {
         @Sendable (SSHHostInfo) -> Result<String, TmuxBinaryError>
     private let localKwtPathProvider: @Sendable () -> String?
     private let remoteKwtCommandPreludeProvider: @Sendable () -> String?
+    private let presentationStyleProvider: () -> TmuxPresentationStyle?
     private var handlesByKey: [NativeTmuxSessionKey: BorrowedTmuxSessionHandle] = [:]
     private var targetHostsByHandle: [UUID: TmuxHost] = [:]
     private var attachments: [UUID: NativeTmuxAttachment] = [:]
@@ -112,6 +113,8 @@ final class NativeTmuxSessionCoordinator {
                 revision: KwtBinaryLocator.bundledRemoteRevision()
             )
         },
+        presentationStyleProvider:
+        @escaping () -> TmuxPresentationStyle? = { nil },
         remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
             -> Result<String, TmuxBinaryError> = {
                 TmuxBinaryResolver().resolveTmuxPath(on: $0)
@@ -122,6 +125,7 @@ final class NativeTmuxSessionCoordinator {
         self.localKwtPathProvider = localKwtPathProvider
         self.remoteKwtCommandPreludeProvider =
             remoteKwtCommandPreludeProvider
+        self.presentationStyleProvider = presentationStyleProvider
         self.remoteTmuxPathProvider = remoteTmuxPathProvider
     }
 
@@ -294,6 +298,7 @@ final class NativeTmuxSessionCoordinator {
                 ? attachment.workingDirectory
                 : nil,
             protectedWorkspacePath: attachment.protectedWorkspacePath,
+            presentationStyle: presentationStyleProvider(),
             launchMode: attachment.launchMode
         )
         let surface = terminalCoordinator.paneSurface(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -286,6 +286,17 @@ final class WorkspaceSceneModel: ObservableObject {
                 workspaceConfiguration: boot.workspaceConfiguration,
                 terminalRuntime: terminalRuntime,
                 notificationService: boot.notificationService,
+                tmuxPresentationStyleProvider: {
+                    let preferences = SettingsStore.shared
+                        .terminalAppearancePreferences
+                    guard preferences.appliesThemeToTmuxSessions,
+                          let spec = preferences.theme.spec
+                    else { return nil }
+                    return TmuxPresentationStyle(
+                        foreground: spec.foreground.hexRGB,
+                        background: spec.background.hexRGB
+                    )
+                },
                 localHostID: boot.localHostID,
                 startServices: true
             )
@@ -308,6 +319,8 @@ final class WorkspaceSceneModel: ObservableObject {
             -> Result<String, TmuxBinaryError> = {
                 TmuxBinaryResolver().resolveTmuxPath(on: $0)
             },
+        tmuxPresentationStyleProvider:
+        @escaping () -> TmuxPresentationStyle? = { nil },
         kwtInventoryLoader: @escaping KwtInventoryLoader = { host in
             try await KwtInventoryClient().load(from: host)
         },
@@ -462,6 +475,7 @@ final class WorkspaceSceneModel: ObservableObject {
             tmuxPathProvider: {
                 tmuxPathCache.resolveTmuxPath()
             },
+            presentationStyleProvider: tmuxPresentationStyleProvider,
             remoteTmuxPathProvider: remoteTmuxPathProvider
         )
         nativeTmuxSessionCoordinatorBacking?.onStateChanged = {

--- a/Sources/Settings/SettingsDomain.swift
+++ b/Sources/Settings/SettingsDomain.swift
@@ -33,7 +33,7 @@ public enum SettingsDomain: String, CaseIterable, Identifiable, Sendable {
     public var subtitle: String {
         switch self {
         case .appearance:
-            return "App chrome, built-in terminal themes,"
+            return "App chrome, built-in tmux themes,"
                 + " font overrides, and cursor styling."
         case .terminal:
             return "Terminal interaction and ghostty.conf configuration."

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -25,6 +25,8 @@ public final class SettingsStore: ObservableObject {
             "ghosthub.settings.privacy.shareAnonymousUsageData"
         static let terminalTheme =
             "ghosthub.settings.terminalAppearance.theme"
+        static let terminalAppliesThemeToTmuxSessions =
+            "ghosthub.settings.terminalAppearance.appliesThemeToTmuxSessions"
         static let terminalUsesCustomFont =
             "ghosthub.settings.terminalAppearance.usesCustomFont"
         static let terminalFontFamily =
@@ -54,6 +56,7 @@ public final class SettingsStore: ObservableObject {
     public static let defaultTerminalAppearancePreferences =
         TerminalAppearancePreferences(
             theme: .followConfig,
+            appliesThemeToTmuxSessions: false,
             usesCustomFont: false,
             fontFamily: "Berkeley Mono",
             fontSize: 13
@@ -219,6 +222,13 @@ public final class SettingsStore: ObservableObject {
         }
         persistTerminalAppearanceDefaults()
         persistTerminalAppearancePreferences()
+    }
+
+    public func setTerminalThemeAppliesToTmuxSessions(_ enabled: Bool) {
+        updateTerminalAppearancePreferences { preferences in
+            preferences.appliesThemeToTmuxSessions = enabled
+        }
+        persistTerminalAppearanceDefaults()
     }
 
     public func setUseCustomTerminalFont(_ enabled: Bool) {
@@ -445,6 +455,10 @@ public final class SettingsStore: ObservableObject {
             forKey: DefaultsKey.terminalTheme
         )
         userDefaults.set(
+            ta.appliesThemeToTmuxSessions,
+            forKey: DefaultsKey.terminalAppliesThemeToTmuxSessions
+        )
+        userDefaults.set(
             ta.usesCustomFont,
             forKey: DefaultsKey.terminalUsesCustomFont
         )
@@ -576,6 +590,12 @@ public final class SettingsStore: ObservableObject {
         )
         .flatMap(TerminalTheme.init(rawValue:)) {
             preferences.theme = theme
+        }
+        if let appliesThemeToTmuxSessions = userDefaults.object(
+            forKey: DefaultsKey.terminalAppliesThemeToTmuxSessions
+        ) as? Bool {
+            preferences.appliesThemeToTmuxSessions =
+                appliesThemeToTmuxSessions
         }
         if let usesCustomFont = userDefaults.object(
             forKey: DefaultsKey.terminalUsesCustomFont

--- a/Sources/Settings/SettingsViewDraft.swift
+++ b/Sources/Settings/SettingsViewDraft.swift
@@ -18,6 +18,7 @@ public struct SettingsViewDraft: Equatable {
     public var selectedDomain: SettingsDomain
     public var interfaceAppearance: AppearancePreference
     public var terminalTheme: TerminalTheme
+    public var appliesTerminalThemeToTmuxSessions: Bool
     public var usesCustomTerminalFont: Bool
     public var terminalFontFamily: String
     public var terminalFontSize: Double
@@ -43,6 +44,8 @@ public struct SettingsViewDraft: Equatable {
         ) ? store.selectedDomain : .appearance
         interfaceAppearance = store.interfaceAppearance
         terminalTheme = terminalAppearance.theme
+        appliesTerminalThemeToTmuxSessions =
+            terminalAppearance.appliesThemeToTmuxSessions
         usesCustomTerminalFont = terminalAppearance.usesCustomFont
         terminalFontFamily = terminalAppearance.fontFamily
         terminalFontSize = terminalAppearance.fontSize
@@ -84,6 +87,9 @@ public struct SettingsViewDraft: Equatable {
         store.selectedDomain = selectedDomain
         store.setInterfaceAppearance(interfaceAppearance)
         store.setTerminalTheme(terminalTheme)
+        store.setTerminalThemeAppliesToTmuxSessions(
+            appliesTerminalThemeToTmuxSessions
+        )
         store.setUseCustomTerminalFont(usesCustomTerminalFont)
         store.setTerminalFontFamily(terminalFontFamily)
         store.setTerminalFontSize(terminalFontSize)

--- a/Sources/Settings/TerminalAppearance.swift
+++ b/Sources/Settings/TerminalAppearance.swift
@@ -107,17 +107,20 @@ public enum TerminalTheme: String, CaseIterable, Identifiable, Sendable {
 
 public struct TerminalAppearancePreferences: Equatable, Sendable {
     public var theme: TerminalTheme
+    public var appliesThemeToTmuxSessions: Bool
     public var usesCustomFont: Bool
     public var fontFamily: String
     public var fontSize: Double
 
     public init(
         theme: TerminalTheme,
+        appliesThemeToTmuxSessions: Bool,
         usesCustomFont: Bool,
         fontFamily: String,
         fontSize: Double
     ) {
         self.theme = theme
+        self.appliesThemeToTmuxSessions = appliesThemeToTmuxSessions
         self.usesCustomFont = usesCustomFont
         self.fontFamily = fontFamily
         self.fontSize = fontSize

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -210,12 +210,13 @@ public final class LibghosttyRuntime: ObservableObject {
             }
             clearMonitorFailure()
             diagnostics = []
-            configReloadNotice = nil
             if notifyOnSuccess {
                 configReloadNotice = LibghosttyConfigReloadNotice(
                     kind: .success,
                     message: "Terminal configuration reloaded."
                 )
+            } else if configReloadNotice?.kind == .error {
+                configReloadNotice = nil
             }
             return .applied
         } catch {

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -449,7 +449,7 @@ public final class LibghosttyRuntime: ObservableObject {
                     Task { @MainActor in
                         self.reloadActiveConfig(
                             force: true,
-                            notifyOnSuccess: true
+                            notifyOnSuccess: false
                         )
                     }
                 }

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -177,7 +177,6 @@ public struct LibghosttyConfigPipeline {
 
     font-family = Berkeley Mono
     font-size = 13
-    theme = dark:ghostty,light:ghostty-light
     background-opacity = 0.95
     scrollback-limit = 50000000
     term = xterm-256color
@@ -250,6 +249,7 @@ public struct LibghosttyConfigPipeline {
             return
         }
 
+        var updated = contents
         let defaults: [(key: String, value: String)] = [
             ("scrollback-limit", "50000000"),
             ("term", "xterm-256color"),
@@ -258,19 +258,20 @@ public struct LibghosttyConfigPipeline {
         ]
 
         let missingDefaults = defaults.filter { setting in
-            !configContainsKey(setting.key, in: contents)
+            !configContainsKey(setting.key, in: updated)
         }
-        guard !missingDefaults.isEmpty else {
+        guard updated != contents || !missingDefaults.isEmpty else {
             return
         }
 
-        var updated = contents
-        if !updated.hasSuffix("\n") {
+        if !missingDefaults.isEmpty {
+            if !updated.hasSuffix("\n") {
+                updated.append("\n")
+            }
             updated.append("\n")
-        }
-        updated.append("\n")
-        for setting in missingDefaults {
-            updated.append("\(setting.key) = \(setting.value)\n")
+            for setting in missingDefaults {
+                updated.append("\(setting.key) = \(setting.value)\n")
+            }
         }
 
         try? updated.write(

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -249,7 +249,6 @@ public struct LibghosttyConfigPipeline {
             return
         }
 
-        var updated = contents
         let defaults: [(key: String, value: String)] = [
             ("scrollback-limit", "50000000"),
             ("term", "xterm-256color"),
@@ -258,20 +257,19 @@ public struct LibghosttyConfigPipeline {
         ]
 
         let missingDefaults = defaults.filter { setting in
-            !configContainsKey(setting.key, in: updated)
+            !configContainsKey(setting.key, in: contents)
         }
-        guard updated != contents || !missingDefaults.isEmpty else {
-            return
-        }
+        guard !missingDefaults.isEmpty else { return }
 
-        if !missingDefaults.isEmpty {
-            if !updated.hasSuffix("\n") {
-                updated.append("\n")
-            }
+        // Existing config is user-owned. Never infer that a setting was
+        // generated from its value or rewrite it while backfilling defaults.
+        var updated = contents
+        if !updated.hasSuffix("\n") {
             updated.append("\n")
-            for setting in missingDefaults {
-                updated.append("\(setting.key) = \(setting.value)\n")
-            }
+        }
+        updated.append("\n")
+        for setting in missingDefaults {
+            updated.append("\(setting.key) = \(setting.value)\n")
         }
 
         try? updated.write(

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -372,17 +372,21 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         ).map(shellQuotedCommandArgument).joined(separator: " ")
         return [
             "exec 3<&0",
-            "ghosthub_existing_clients=\" $(\(listClients) 2>/dev/null "
-                + "| /usr/bin/tr '\\n' ' ') \"",
+            "ghosthub_existing_clients=\"$(\(listClients) 2>/dev/null)\"",
             "\(kwtCommand) <&3 3<&- & ghosthub_kwt_pid=$!",
             "ghosthub_kwt_client_ready=",
             "while kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; do "
                 + "for ghosthub_client_pid in $(\(listClients) 2>/dev/null); "
-                + "do case \"$ghosthub_existing_clients\" in "
-                + "*\" $ghosthub_client_pid \"*) ;; "
-                + "*) ghosthub_kwt_client_ready=1; break ;; esac; done; "
+                + "do ghosthub_client_was_existing=; "
+                + "for ghosthub_existing_client_pid in "
+                + "$ghosthub_existing_clients; do "
+                + "if [ \"$ghosthub_existing_client_pid\" = "
+                + "\"$ghosthub_client_pid\" ]; then "
+                + "ghosthub_client_was_existing=1; break; fi; done; "
+                + "if [ -z \"$ghosthub_client_was_existing\" ]; then "
+                + "ghosthub_kwt_client_ready=1; break; fi; done; "
                 + "[ -n \"$ghosthub_kwt_client_ready\" ] && break; "
-                + "/bin/sleep 0.01; done",
+                + "sleep 0.01; done",
             "if [ -n \"$ghosthub_kwt_client_ready\" ]; then "
                 + "\(presentationSetupCommand(tmuxPath: tmuxPath)); fi",
             "wait \"$ghosthub_kwt_pid\"",

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -376,18 +376,14 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 + "| /usr/bin/tr '\\n' ' ') \"",
             "\(kwtCommand) <&3 3<&- & ghosthub_kwt_pid=$!",
             "ghosthub_kwt_client_ready=",
-            "ghosthub_kwt_attempts=0",
-            "while [ \"$ghosthub_kwt_attempts\" -lt 500 ] "
-                + "&& kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; do "
+            "while kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; do "
                 + "for ghosthub_client_pid in $(\(listClients) 2>/dev/null); "
                 + "do case \"$ghosthub_existing_clients\" in "
                 + "*\" $ghosthub_client_pid \"*) ;; "
                 + "*) ghosthub_kwt_client_ready=1; break ;; esac; done; "
                 + "[ -n \"$ghosthub_kwt_client_ready\" ] && break; "
-                + "ghosthub_kwt_attempts=$((ghosthub_kwt_attempts + 1)); "
                 + "/bin/sleep 0.01; done",
-            "if [ -n \"$ghosthub_kwt_client_ready\" ] "
-                + "|| kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; then "
+            "if [ -n \"$ghosthub_kwt_client_ready\" ]; then "
                 + "\(presentationSetupCommand(tmuxPath: tmuxPath)); fi",
             "wait \"$ghosthub_kwt_pid\"",
             "ghosthub_kwt_status=$?",

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -91,6 +91,23 @@ public enum TmuxAttachmentLaunchMode: String, Codable, Equatable, Sendable {
     case create
 }
 
+/// Default colors Ghosthub applies to tmux panes when a built-in terminal
+/// theme is selected. Tmux otherwise answers OSC 10/11 queries from the first
+/// attached client, which can describe a different terminal's theme.
+public struct TmuxPresentationStyle: Equatable, Sendable {
+    public let foreground: String
+    public let background: String
+
+    public init(foreground: String, background: String) {
+        self.foreground = foreground
+        self.background = background
+    }
+
+    fileprivate var tmuxStyle: String {
+        "fg=\(foreground),bg=\(background)"
+    }
+}
+
 /// An ordinary tmux client launched inside a libghostty terminal surface.
 /// Tmux owns rendering, windows, panes, history, input, and process lifetime.
 public struct TmuxAttachmentInfo: Equatable, Sendable {
@@ -99,6 +116,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     public let socketName: String?
     public let workspacePath: String?
     public let protectedWorkspacePath: String?
+    public let presentationStyle: TmuxPresentationStyle?
     public var launchMode: TmuxAttachmentLaunchMode
 
     public init(
@@ -107,6 +125,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         socketName: String? = nil,
         workspacePath: String? = nil,
         protectedWorkspacePath: String? = nil,
+        presentationStyle: TmuxPresentationStyle? = nil,
         launchMode: TmuxAttachmentLaunchMode = .attach
     ) {
         self.sessionName = sessionName
@@ -114,6 +133,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         self.socketName = socketName
         self.workspacePath = workspacePath
         self.protectedWorkspacePath = protectedWorkspacePath
+        self.presentationStyle = presentationStyle
         self.launchMode = launchMode
     }
 
@@ -170,7 +190,6 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         switch launchMode {
         case .attach:
             if let protectedWorkspacePath {
-                commands.append(presentationSetupCommand(tmuxPath: tmuxPath))
                 guard let kwtPath, !kwtPath.isEmpty else {
                     commands.append(
                         "printf 'Ghosthub: bundled kwt is unavailable\\n' >&2"
@@ -192,7 +211,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 let protectedAttach = [
                     kwtPath, "pr", "attach", protectedWorkspacePath,
                 ].map(shellQuotedCommandArgument).joined(separator: " ")
-                commands.append("exec \(protectedAttach)")
+                commands.append(
+                    kwtAttachWithPresentationCommand(
+                        protectedAttach,
+                        tmuxPath: tmuxPath
+                    )
+                )
             } else {
                 if let workspacePath {
                     guard let kwtPath, !kwtPath.isEmpty else {
@@ -214,7 +238,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     // Let kwt create and attach with one tmux client.
                     // A detached `--start-session` phase is unsafe when the
                     // user's tmux server enables destroy-unattached.
-                    commands.append("exec \(openWorkspace)")
+                    commands.append(
+                        kwtAttachWithPresentationCommand(
+                            openWorkspace,
+                            tmuxPath: tmuxPath
+                        )
+                    )
                 } else {
                     commands.append(
                         presentationSetupCommand(tmuxPath: tmuxPath)
@@ -252,6 +281,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 presentationTarget, option, value,
             ]
         }
+        for (option, value) in windowPresentationOptions {
+            arguments += [
+                ";", "set-option", "-w", "-t",
+                presentationTarget, option, value,
+            ]
+        }
         return arguments
             .map(shellQuotedCommandArgument)
             .joined(separator: " ")
@@ -265,24 +300,100 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     }
 
     private var presentationOptions: [(String, String)] {
-        [
+        guard presentationStyle != nil else { return [] }
+        return [
             ("status-style", "reverse"),
             ("message-style", "reverse"),
             ("message-command-style", "reverse"),
         ]
     }
 
-    /// Tmux behavior remains user-owned. These session-scoped style resets
-    /// only make tmux chrome resolve through the foreground and background
+    private var windowPresentationOptions: [(String, String)] {
+        guard let presentationStyle else { return [] }
+        return [
+            ("window-style", presentationStyle.tmuxStyle),
+            ("window-active-style", presentationStyle.tmuxStyle),
+        ]
+    }
+
+    /// Tmux interaction remains user-owned. These style resets only make tmux
+    /// chrome and terminal default-color queries resolve through the colors
     /// configured by Ghosthub.
     private func presentationSetupCommand(tmuxPath: String) -> String {
-        presentationOptions.map { option, value in
+        guard presentationStyle != nil else { return ":" }
+        var commands = presentationOptions.map { option, value in
             let command = tmuxArguments(
                 tmuxPath,
                 "set-option", "-t", presentationTarget, option, value
             ).map(shellQuotedCommandArgument).joined(separator: " ")
             return "\(command) >/dev/null 2>&1 || :"
-        }.joined(separator: "; ")
+        }
+        if !windowPresentationOptions.isEmpty {
+            let listWindows = tmuxArguments(
+                tmuxPath,
+                "list-windows", "-t", presentationTarget,
+                "-F", "#{window_id}"
+            ).map(shellQuotedCommandArgument).joined(separator: " ")
+            let setWindowOptions = windowPresentationOptions.map {
+                option, value in
+                let commandPrefix = tmuxArguments(
+                    tmuxPath,
+                    "set-option", "-w", "-t"
+                ).map(shellQuotedCommandArgument).joined(separator: " ")
+                return "\(commandPrefix) \"$ghosthub_window\" "
+                    + "\(shellQuotedCommandArgument(option)) "
+                    + "\(shellQuotedCommandArgument(value)) "
+                    + ">/dev/null 2>&1 || :"
+            }.joined(separator: "; ")
+            commands.append(
+                "\(listWindows) 2>/dev/null | "
+                    + "while IFS= read -r ghosthub_window; do "
+                    + "\(setWindowOptions); done"
+            )
+        }
+        return commands.joined(separator: "; ")
+    }
+
+    /// Kwt establishes or repairs the complete session before starting its
+    /// tmux client. When Ghosthub owns presentation, run kwt as the foreground
+    /// terminal's background child just long enough to identify that client,
+    /// then style the finished session and wait on the same client process.
+    /// This preserves kwt's atomic create-and-attach path under
+    /// `destroy-unattached` while ensuring repair-created windows are included.
+    private func kwtAttachWithPresentationCommand(
+        _ kwtCommand: String,
+        tmuxPath: String
+    ) -> String {
+        guard presentationStyle != nil else { return "exec \(kwtCommand)" }
+        let listClients = tmuxArguments(
+            tmuxPath,
+            "list-clients", "-t", "=\(sessionName)",
+            "-F", "#{client_pid}"
+        ).map(shellQuotedCommandArgument).joined(separator: " ")
+        return [
+            "exec 3<&0",
+            "ghosthub_existing_clients=\" $(\(listClients) 2>/dev/null "
+                + "| /usr/bin/tr '\\n' ' ') \"",
+            "\(kwtCommand) <&3 3<&- & ghosthub_kwt_pid=$!",
+            "ghosthub_kwt_client_ready=",
+            "ghosthub_kwt_attempts=0",
+            "while [ \"$ghosthub_kwt_attempts\" -lt 500 ] "
+                + "&& kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; do "
+                + "for ghosthub_client_pid in $(\(listClients) 2>/dev/null); "
+                + "do case \"$ghosthub_existing_clients\" in "
+                + "*\" $ghosthub_client_pid \"*) ;; "
+                + "*) ghosthub_kwt_client_ready=1; break ;; esac; done; "
+                + "[ -n \"$ghosthub_kwt_client_ready\" ] && break; "
+                + "ghosthub_kwt_attempts=$((ghosthub_kwt_attempts + 1)); "
+                + "/bin/sleep 0.01; done",
+            "if [ -n \"$ghosthub_kwt_client_ready\" ] "
+                + "|| kill -0 \"$ghosthub_kwt_pid\" 2>/dev/null; then "
+                + "\(presentationSetupCommand(tmuxPath: tmuxPath)); fi",
+            "wait \"$ghosthub_kwt_pid\"",
+            "ghosthub_kwt_status=$?",
+            "exec 3<&-",
+            "exit \"$ghosthub_kwt_status\"",
+        ].joined(separator: "; ")
     }
 
     private func remoteAttachCommand(
@@ -296,9 +407,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         if let protectedWorkspacePath {
             let protectedAttach: String
             if let remoteKwtCommandPrelude {
-                protectedAttach = remoteKwtCommandPrelude
-                    + "exec \"$ghosthub_kwt_path\" 'pr' 'attach' "
+                let kwtAttach = remoteKwtCommandPrelude
+                    + "\"$ghosthub_kwt_path\" 'pr' 'attach' "
                     + shellQuotedCommandArgument(protectedWorkspacePath)
+                protectedAttach = kwtAttachWithPresentationCommand(
+                    kwtAttach,
+                    tmuxPath: tmuxPath
+                )
             } else {
                 protectedAttach =
                     "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
@@ -312,11 +427,14 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             ).map(shellQuotedCommandArgument).joined(separator: " ")
             attach = "exec \(tmuxAttach)"
         }
-        let remoteAttachBody = [
-            "unset TMUX TMUX_PANE",
-            presentationSetupCommand(tmuxPath: tmuxPath),
-            attach,
-        ].joined(separator: "; ")
+        var remoteAttachCommands = ["unset TMUX TMUX_PANE"]
+        if protectedWorkspacePath == nil {
+            remoteAttachCommands.append(
+                presentationSetupCommand(tmuxPath: tmuxPath)
+            )
+        }
+        remoteAttachCommands.append(attach)
+        let remoteAttachBody = remoteAttachCommands.joined(separator: "; ")
         let remoteAttach = useAccountLoginShell
             ? remoteAccountLoginShellCommand(remoteAttachBody)
             : remoteAttachBody
@@ -349,19 +467,27 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         }
         let remoteOpen: String
         if let remoteKwtCommandPrelude {
-            remoteOpen = remoteKwtCommandPrelude
-                + "exec \"$ghosthub_kwt_path\" 'open' "
+            let kwtOpen = remoteKwtCommandPrelude
+                + "\"$ghosthub_kwt_path\" 'open' "
                 + shellQuotedCommandArgument(workspacePath)
+            remoteOpen = kwtAttachWithPresentationCommand(
+                kwtOpen,
+                tmuxPath: tmuxPath
+            )
         } else {
             remoteOpen =
                 "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
                     + "exit 127"
         }
+        let initialBody = [
+            "unset TMUX TMUX_PANE",
+            remoteOpen,
+        ].joined(separator: "; ")
         let initialAttach = shellCommand(
             sshArguments(
                 info: info,
                 allocateTTY: true,
-                remoteCommand: remoteAccountLoginShellCommand(remoteOpen),
+                remoteCommand: remoteAccountLoginShellCommand(initialBody),
                 sshConnectionArguments: sshConnectionArguments
             )
         )

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -419,7 +419,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
                         + "exit 127"
             }
-            attach = remoteAccountLoginShellCommand(protectedAttach)
+            attach = protectedAttach
         } else {
             let tmuxAttach = tmuxArguments(
                 tmuxPath,
@@ -435,7 +435,11 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         }
         remoteAttachCommands.append(attach)
         let remoteAttachBody = remoteAttachCommands.joined(separator: "; ")
-        let remoteAttach = useAccountLoginShell
+        let requiresAccountLoginShell =
+            useAccountLoginShell
+                || protectedWorkspacePath != nil
+                || presentationStyle != nil
+        let remoteAttach = requiresAccountLoginShell
             ? remoteAccountLoginShellCommand(remoteAttachBody)
             : remoteAttachBody
         return shellCommand(

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -388,7 +388,7 @@ public struct SettingsView: View {
                 }
             }
 
-            settingsSection("Terminal Theme") {
+            settingsSection("Tmux Theme") {
                 settingRow("Theme") {
                     Picker("Theme", selection: $draft.terminalTheme) {
                         ForEach(TerminalTheme.allCases) { theme in
@@ -401,8 +401,14 @@ public struct SettingsView: View {
 
                 terminalThemePreview(theme: draft.terminalTheme)
 
+                Toggle(
+                    "Apply theme to shared tmux sessions",
+                    isOn: $draft.appliesTerminalThemeToTmuxSessions
+                )
+                .disabled(draft.terminalTheme == .followConfig)
+
                 Text(
-                    "Follow ghostty.conf keeps Ghosthub from applying any built-in terminal colors. Choosing a built-in theme writes a Ghosthub-owned overlay file that loads after ghostty.conf and any project terminal.conf override."
+                    "The selected theme controls how tmux appears in Ghosthub. The shared-session override also changes tmux window, status, and message colors when Ghosthub next attaches. Tmux shares those settings, so every attached terminal sees the change. Follow ghostty.conf leaves the configured tmux theme untouched."
                 )
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -47,7 +47,42 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(command.contains("release-work"))
         #expect(!command.contains("'-d'"))
         #expect(!command.contains("attach-session"))
+        #expect(!command.contains("status-style"))
+    }
+
+    @Test("surface launch reads the current terminal presentation style")
+    func surfaceLaunchReadsCurrentPresentationStyle() async throws {
+        let store = TmuxSurfaceStoreStub()
+        var style = TmuxPresentationStyle(
+            foreground: "#3B4851",
+            background: "#FFFFFF"
+        )
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            presentationStyleProvider: { style }
+        )
+        var isReady = false
+        coordinator.onSurfaceReady = { _ in isReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "docbank",
+            host: .local
+        )
+        style = TmuxPresentationStyle(
+            foreground: "#EEEEEE",
+            background: "#111111"
+        )
+
+        await waitUntilMainActor { isReady }
+        _ = coordinator.surface(handle: handle)
+
+        let command = try #require(
+            store.requestedConfigurations.last?.command
+        )
+        #expect(command.contains("fg=#EEEEEE,bg=#111111"))
         #expect(command.contains("status-style"))
+        #expect(!command.contains("fg=#3B4851,bg=#FFFFFF"))
     }
 
     @Test("isolated session socket participates in command routing")
@@ -58,6 +93,12 @@ struct NativeTmuxSessionCoordinatorTests {
             tmuxPathProvider: { .success("/usr/bin/tmux") },
             localKwtPathProvider: {
                 "/Applications/Ghosthub.app/Contents/Helpers/kwt"
+            },
+            presentationStyleProvider: {
+                TmuxPresentationStyle(
+                    foreground: "#3B4851",
+                    background: "#FFFFFF"
+                )
             }
         )
         var isReady = false

--- a/Tests/Settings/ConfigSectionEditorTests.swift
+++ b/Tests/Settings/ConfigSectionEditorTests.swift
@@ -9,6 +9,7 @@ struct ConfigSectionEditorTests {
     @Test func renderTerminalAppearanceOverlay_nilForConfig() {
         let prefs = TerminalAppearancePreferences(
             theme: .followConfig,
+            appliesThemeToTmuxSessions: false,
             usesCustomFont: false,
             fontFamily: "Berkeley Mono",
             fontSize: 13
@@ -23,6 +24,7 @@ struct ConfigSectionEditorTests {
     @Test func renderTerminalAppearanceOverlay_includesCustomFont() {
         let prefs = TerminalAppearancePreferences(
             theme: .followConfig,
+            appliesThemeToTmuxSessions: false,
             usesCustomFont: true,
             fontFamily: "Monaco",
             fontSize: 14.5
@@ -40,7 +42,8 @@ struct ConfigSectionEditorTests {
 
     @Test func renderTerminalAppearanceOverlay_includesThemeColors() {
         let prefs = TerminalAppearancePreferences(
-            theme: .pro,
+            theme: .clearLight,
+            appliesThemeToTmuxSessions: false,
             usesCustomFont: false,
             fontFamily: "Berkeley Mono",
             fontSize: 13
@@ -60,6 +63,7 @@ struct ConfigSectionEditorTests {
     @Test func renderTerminalAppearanceOverlay_themeAndFont() {
         let prefs = TerminalAppearancePreferences(
             theme: .homebrew,
+            appliesThemeToTmuxSessions: false,
             usesCustomFont: true,
             fontFamily: "JetBrains Mono",
             fontSize: 16

--- a/Tests/Settings/SettingsDomainTests.swift
+++ b/Tests/Settings/SettingsDomainTests.swift
@@ -8,7 +8,7 @@ struct SettingsDomainTests {
             (
                 .appearance,
                 "Appearance",
-                "App chrome, built-in terminal themes,"
+                "App chrome, built-in tmux themes,"
                     + " font overrides, and cursor styling."
             ),
             (

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -153,6 +153,10 @@ final class SettingsStoreTests {
             store.terminalAppearancePreferences
                 == SettingsStore.defaultTerminalAppearancePreferences
         )
+        #expect(
+            !store.terminalAppearancePreferences
+                .appliesThemeToTmuxSessions
+        )
         #expect(!store.worktreePreferences.hideRootCheckout)
         #expect(store.shareAnonymousUsageData)
     }
@@ -226,9 +230,9 @@ final class SettingsStoreTests {
 
         assertContainsAll(
             globalConfig,
-            "theme = dark:ghostty,light:ghostty-light",
             "font-family = Berkeley Mono"
         )
+        #expect(globalConfig.contains("theme =") == false)
         #expect(globalConfig.contains("background = #000000") == false)
         #expect(globalConfig.contains("font-family = \"Monaco\"") == false)
     }
@@ -270,6 +274,7 @@ final class SettingsStoreTests {
         store.setShowHiddenWorktreesByDefault(true)
         store.setShowPaneResourceUsage(false)
         store.setTerminalTheme(.clearDark)
+        store.setTerminalThemeAppliesToTmuxSessions(true)
         store.setUseCustomTerminalFont(true)
         store.setTerminalFontFamily("Monaco")
         store.setTerminalFontSize(15.5)
@@ -286,6 +291,10 @@ final class SettingsStoreTests {
         #expect(reloaded.worktreePreferences.showHiddenWorktreesByDefault)
         #expect(!reloaded.terminalPreferences.showPaneResourceUsage)
         #expect(reloaded.terminalAppearancePreferences.theme == .clearDark)
+        #expect(
+            reloaded.terminalAppearancePreferences
+                .appliesThemeToTmuxSessions
+        )
         #expect(reloaded.terminalAppearancePreferences.usesCustomFont)
         #expect(reloaded.terminalAppearancePreferences.fontFamily == "Monaco")
         #expect(reloaded.terminalAppearancePreferences.fontSize == 15.5)
@@ -538,7 +547,6 @@ final class SettingsStoreTests {
         try writeGlobalConfig("""
         font-family = JetBrains Mono
         font-size = 16
-        theme = dark:ghostty,light:ghostty-light
         """)
 
         let store = makeSUT()

--- a/Tests/Settings/SettingsViewDraftTests.swift
+++ b/Tests/Settings/SettingsViewDraftTests.swift
@@ -12,6 +12,7 @@ struct SettingsViewDraftTests {
         store.selectedDomain = .hosts
         store.setInterfaceAppearance(.dark)
         store.setTerminalTheme(.homebrew)
+        store.setTerminalThemeAppliesToTmuxSessions(true)
         store.setHideRootCheckout(true)
         store.setShowHiddenWorktreesByDefault(true)
         store.setShowMacOSNotifications(false)
@@ -23,12 +24,31 @@ struct SettingsViewDraftTests {
         #expect(draft.selectedDomain == .hosts)
         #expect(draft.interfaceAppearance == .dark)
         #expect(draft.terminalTheme == .homebrew)
+        #expect(draft.appliesTerminalThemeToTmuxSessions)
         #expect(draft.hideRootCheckout)
         #expect(draft.showHiddenWorktreesByDefault)
         #expect(!draft.showMacOSNotifications)
         #expect(draft.attentionSound == .glass)
         #expect(draft.sshHosts.map(\.configKey) == ["epyc"])
         #expect(draft.selectedSSHHostDraftID == draft.sshHosts.first?.id)
+    }
+
+    @Test("tmux theme opt-in persists without reloading libghostty")
+    func tmuxThemeOptInDoesNotReloadTerminalConfig() {
+        let store = makeStore()
+        var draft = SettingsViewDraft(store: store)
+        draft.terminalTheme = .pro
+        _ = draft.persist(to: store)
+        draft = SettingsViewDraft(store: store)
+        draft.appliesTerminalThemeToTmuxSessions = true
+
+        let result = draft.persist(to: store)
+
+        #expect(!result.shouldReloadTerminalConfig)
+        #expect(
+            store.terminalAppearancePreferences
+                .appliesThemeToTmuxSessions
+        )
     }
 
     @Test("persist restores worktree and agent settings")

--- a/Tests/Terminal/LibghosttyConfigPipelineTests.swift
+++ b/Tests/Terminal/LibghosttyConfigPipelineTests.swift
@@ -35,6 +35,7 @@ struct LibghosttyConfigPipelineTests {
             "shell-integration = detect",
         ], omits: [
             "shell-integration-features",
+            "theme =",
         ])
     }
 

--- a/Tests/Terminal/LibghosttyConfigPipelineTests.swift
+++ b/Tests/Terminal/LibghosttyConfigPipelineTests.swift
@@ -214,6 +214,22 @@ struct LibghosttyConfigPipelineTests {
         )
     }
 
+    @Test("loadPlan preserves user-authored theme settings")
+    func loadPlanPreservesUserTheme() throws {
+        let fixture = try ConfigPipelineFixture.create()
+
+        try fixture.writeGlobalConfig("""
+        theme = dark:ghostty,light:ghostty-light
+        """)
+
+        _ = try fixture.pipeline.loadPlan()
+
+        let contents = try fixture.readGlobalConfig()
+        #expect(contents.contains(
+            "theme = dark:ghostty,light:ghostty-light"
+        ))
+    }
+
     @Test("loadPlan preserves user-authored scrollback-limit")
     func loadPlanPreservesUserScrollbackLimit() throws {
         let fixture = try ConfigPipelineFixture.create()

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -424,6 +424,21 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         XCTAssertNil(runtime.configReloadNotice)
     }
 
+    func testSilentSuccessfulReloadPreservesExplicitSuccessNotice() throws {
+        let ctx = try makeIsolatedRuntime()
+        let explicitResult = ctx.runtime.reloadActiveConfig()
+        XCTAssertEqual(explicitResult, .applied)
+        XCTAssertEqual(ctx.runtime.configReloadNotice?.kind, .success)
+        let explicitNoticeID = ctx.runtime.configReloadNotice?.id
+
+        let silentResult = ctx.runtime.reloadActiveConfig(
+            notifyOnSuccess: false
+        )
+
+        XCTAssertEqual(silentResult, .applied)
+        XCTAssertEqual(ctx.runtime.configReloadNotice?.id, explicitNoticeID)
+    }
+
     func testMonitorUpdateFailurePublishesDegradedReload() throws {
         try skipUnlessLibghosttyReady()
         let (pipeline, tempRoot) = makeIsolatedPipeline()

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -701,7 +701,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
-    func testIncludedConfigAutomaticallyReloads() throws {
+    func testIncludedConfigAutomaticallyReloadsWithoutSuccessNotice() throws {
         try skipUnlessLibghosttyReady()
         let (pipeline, tempRoot) = makeIsolatedPipeline()
         addTeardownBlock {
@@ -730,6 +730,16 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
                 == true
         )
 
+        try "font-size = definitely-not-a-number\n".write(
+            to: included,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        waitUntil(timeout: 3) {
+            runtime.configReloadNotice?.kind == .error
+        }
+
         try "foreground = eeeeee\n".write(
             to: included,
             atomically: true,
@@ -737,8 +747,10 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
 
         waitUntil(timeout: 3) {
-            runtime.configReloadNotice?.kind == .success
+            runtime.configReloadNotice == nil
+                && runtime.diagnostics.isEmpty
         }
+        XCTAssertNil(runtime.configReloadNotice)
         XCTAssertEqual(runtime.diagnostics, [])
     }
 

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -19,8 +19,8 @@ struct TmuxAttachmentInfoTests {
         #expect(TmuxHost.local.displayName == "localhost")
     }
 
-    @Test("local attachment normalizes only tmux presentation styles")
-    func localAttachCommand() {
+    @Test("local attachment leaves tmux presentation unchanged by default")
+    func localAttachCommandLeavesTmuxPresentationUnchanged() {
         let info = TmuxAttachmentInfo(
             sessionName: "doc bank's work",
             host: .local
@@ -31,11 +31,8 @@ struct TmuxAttachmentInfoTests {
         )
 
         #expect(command.contains("unset TMUX TMUX_PANE"))
-        #expect(command.contains("set-option"))
-        #expect(command.contains("status-style"))
-        #expect(command.contains("message-style"))
-        #expect(command.contains("message-command-style"))
-        #expect(command.contains("reverse"))
+        #expect(!command.contains("set-option"))
+        #expect(!command.contains("status-style"))
         #expect(command.contains("exec"))
         #expect(command.contains("attach-session"))
         #expect(command.contains("=doc bank"))
@@ -50,12 +47,52 @@ struct TmuxAttachmentInfoTests {
     func presentationStylesUseExactSessionTarget() {
         let command = TmuxAttachmentInfo(
             sessionName: "alpha",
-            host: .local
+            host: .local,
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
 
         #expect(
-            command.components(separatedBy: "=alpha:").count - 1 == 3
+            command.components(separatedBy: "=alpha:").count - 1 == 4
         )
+    }
+
+    @Test("built-in themes set pane defaults for terminal color queries")
+    func builtInThemeSetsPaneDefaults() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "docbank",
+            host: .local,
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
+        ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
+
+        #expect(command.contains("'list-windows'"))
+        #expect(command.contains("'#{window_id}'"))
+        #expect(command.contains("\"$ghosthub_window\""))
+        #expect(command.contains("'window-style'"))
+        #expect(command.contains("'window-active-style'"))
+        #expect(command.contains("'status-style'"))
+        #expect(command.contains("'message-style'"))
+        #expect(command.contains("'message-command-style'"))
+        #expect(command.contains("'fg=#3B4851,bg=#FFFFFF'"))
+    }
+
+    @Test("follow-config leaves tmux pane defaults unchanged")
+    func followConfigLeavesPaneDefaultsUnchanged() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "docbank",
+            host: .local
+        ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
+
+        #expect(!command.contains("list-windows"))
+        #expect(!command.contains("set-option"))
+        #expect(!command.contains("status-style"))
+        #expect(!command.contains("window-style"))
+        #expect(!command.contains("window-active-style"))
     }
 
     @Test("protected attachment leads kwt to the resolved tmux")
@@ -64,7 +101,11 @@ struct TmuxAttachmentInfoTests {
             sessionName: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
-            protectedWorkspacePath: "/worktrees/pr-32"
+            protectedWorkspacePath: "/worktrees/pr-32",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(
             tmuxPath: "/opt/homebrew/bin/tmux",
             kwtPath: "/Applications/Ghosthub.app/Contents/Helpers/kwt"
@@ -77,6 +118,11 @@ struct TmuxAttachmentInfoTests {
             .components(separatedBy: "Helpers/kwt")
             .first ?? ""
         #expect(beforeKwt.contains("export PATH"))
+        let kwtPosition = command.range(of: "Helpers/kwt")?.lowerBound
+        let stylePosition = command.range(of: "window-style")?.lowerBound
+        if let kwtPosition, let stylePosition {
+            #expect(kwtPosition < stylePosition)
+        }
     }
 
     @Test("an unresolved tmux name contributes no PATH entry")
@@ -125,6 +171,34 @@ struct TmuxAttachmentInfoTests {
         #expect(!command.contains("attach-session"))
     }
 
+    @Test("existing local worktrees receive built-in theme defaults")
+    func localWorktreeReceivesThemeDefaults() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "kwt-widget-feature",
+            host: .local,
+            workspacePath: "/worktrees/widget",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
+        ).attachCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            kwtPath: "/Applications/Ghosthub.app/Contents/Helpers/kwt"
+        )
+
+        let stylePosition = command.range(of: "window-style")?.lowerBound
+        let kwtPosition = command.range(of: "Helpers/kwt")?.lowerBound
+        #expect(stylePosition != nil)
+        #expect(kwtPosition != nil)
+        if let stylePosition, let kwtPosition {
+            #expect(kwtPosition < stylePosition)
+        }
+        #expect(command.contains("ghosthub_existing_clients"))
+        #expect(command.contains(
+            "[ \"$ghosthub_kwt_attempts\" -lt 500 ]"
+        ))
+    }
+
     @Test("local attachment stops when kwt cannot start the workspace")
     func localWorktreeStartFailureStopsAttachment() throws {
         let directory = FileManager.default.temporaryDirectory
@@ -142,7 +216,7 @@ struct TmuxAttachmentInfoTests {
         """.write(to: kwt, atomically: true, encoding: .utf8)
         try """
         #!/bin/sh
-        touch "$GHOSTHUB_TMUX_MARKER"
+        printf '%s\n' "$*" >> "$GHOSTHUB_TMUX_MARKER"
         exit 0
         """.write(to: tmux, atomically: true, encoding: .utf8)
         for executable in [kwt, tmux] {
@@ -154,7 +228,11 @@ struct TmuxAttachmentInfoTests {
         let command = TmuxAttachmentInfo(
             sessionName: "kwt-widget-feature",
             host: .local,
-            workspacePath: "/worktrees/widget"
+            workspacePath: "/worktrees/widget",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(
             tmuxPath: tmux.path,
             kwtPath: kwt.path
@@ -171,7 +249,106 @@ struct TmuxAttachmentInfoTests {
         process.waitUntilExit()
 
         #expect(process.terminationStatus == 42)
-        #expect(!FileManager.default.fileExists(atPath: tmuxMarker.path))
+        let tmuxCommands = try String(
+            contentsOf: tmuxMarker,
+            encoding: .utf8
+        )
+        #expect(!tmuxCommands.contains("set-option"))
+        #expect(!tmuxCommands.contains("attach-session"))
+    }
+
+    @Test("theming waits for kwt to create and repair every window")
+    func themingFollowsKwtSessionRepair() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let kwt = directory.appendingPathComponent("kwt")
+        let tmux = directory.appendingPathComponent("tmux")
+        let log = directory.appendingPathComponent("tmux.log")
+        let clientPID = directory.appendingPathComponent("client.pid")
+        try """
+        #!/bin/sh
+        "$GHOSTHUB_TMUX" new-session
+        "$GHOSTHUB_TMUX" new-window
+        /bin/sh -c '"$GHOSTHUB_TMUX" attach-session'
+        """.write(to: kwt, atomically: true, encoding: .utf8)
+        try """
+        #!/bin/sh
+        case " $* " in
+          *" new-session "*)
+            printf 'new-session\n' >> "$GHOSTHUB_TMUX_LOG"
+            ;;
+          *" new-window "*)
+            printf 'new-window\n' >> "$GHOSTHUB_TMUX_LOG"
+            ;;
+          *" attach-session "*)
+            printf '%s\n' "$$" > "$GHOSTHUB_TMUX_CLIENT_PID"
+            trap 'rm -f "$GHOSTHUB_TMUX_CLIENT_PID"' EXIT
+            while ! grep -q '@2 window-active-style' \
+                "$GHOSTHUB_TMUX_LOG"; do
+              sleep 0.01
+            done
+            ;;
+          *" list-clients "*)
+            if [ -f "$GHOSTHUB_TMUX_CLIENT_PID" ]; then
+              cat "$GHOSTHUB_TMUX_CLIENT_PID"
+            fi
+            ;;
+          *" list-windows "*)
+            if ! grep -q new-window "$GHOSTHUB_TMUX_LOG"; then
+              printf 'early-list-windows\n' >> "$GHOSTHUB_TMUX_LOG"
+              exit 1
+            fi
+            printf '@1\n@2\n'
+            ;;
+          *" set-option "*)
+            if ! grep -q new-window "$GHOSTHUB_TMUX_LOG"; then
+              printf 'early-set-option\n' >> "$GHOSTHUB_TMUX_LOG"
+              exit 1
+            fi
+            printf 'set-option %s\n' "$*" >> "$GHOSTHUB_TMUX_LOG"
+            ;;
+        esac
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        for executable in [kwt, tmux] {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: executable.path
+            )
+        }
+
+        let command = TmuxAttachmentInfo(
+            sessionName: "kwt-widget-feature",
+            host: .local,
+            workspacePath: "/worktrees/widget",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
+        ).attachCommand(
+            tmuxPath: tmux.path,
+            kwtPath: kwt.path
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "GHOSTHUB_TMUX": tmux.path,
+            "GHOSTHUB_TMUX_LOG": log.path,
+            "GHOSTHUB_TMUX_CLIENT_PID": clientPID.path,
+        ]) { _, new in new }
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        let tmuxCommands = try String(contentsOf: log, encoding: .utf8)
+        #expect(!tmuxCommands.contains("early-"))
+        #expect(tmuxCommands.contains("@1 window-style"))
+        #expect(tmuxCommands.contains("@2 window-active-style"))
     }
 
     @Test("worktree attachment survives destroy-unattached")
@@ -216,7 +393,7 @@ struct TmuxAttachmentInfoTests {
                     "sleep 0.2; : > '$GHOSTHUB_SESSION_MARKER'"
             fi
         done
-        exec "$GHOSTHUB_TMUX" -L "$GHOSTHUB_TMUX_SOCKET" \
+        "$GHOSTHUB_TMUX" -L "$GHOSTHUB_TMUX_SOCKET" \
             -f "$GHOSTHUB_TMUX_CONFIG" new-session -A -s "$GHOSTHUB_TMUX_SESSION" \
             "sleep 0.2; : > '$GHOSTHUB_SESSION_MARKER'"
         """.write(to: kwt, atomically: true, encoding: .utf8)
@@ -226,7 +403,11 @@ struct TmuxAttachmentInfoTests {
         let command = TmuxAttachmentInfo(
             sessionName: "kwt-destroy-unattached",
             host: .local,
-            workspacePath: "/worktrees/widget"
+            workspacePath: "/worktrees/widget",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(
             tmuxPath: tmuxPath,
             kwtPath: kwt.path
@@ -257,7 +438,11 @@ struct TmuxAttachmentInfoTests {
             sessionName: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
-            protectedWorkspacePath: "/worktrees/pr-32"
+            protectedWorkspacePath: "/worktrees/pr-32",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(
             tmuxPath: "/opt/homebrew/bin/tmux",
             kwtPath: "/Applications/Ghosthub.app/Contents/Helpers/kwt"
@@ -273,7 +458,7 @@ struct TmuxAttachmentInfoTests {
         #expect(
             command.components(
                 separatedBy: "kwt-pr-0123456789abcdef"
-            ).count - 1 == 3
+            ).count - 1 == 8
         )
     }
 
@@ -296,9 +481,9 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'attach-session'"))
         #expect(command.contains("'-E'"))
         #expect(command.contains("=docbank"))
-        #expect(command.contains("status-style"))
-        #expect(command.contains("message-style"))
-        #expect(command.contains("message-command-style"))
+        #expect(!command.contains("status-style"))
+        #expect(!command.contains("message-style"))
+        #expect(!command.contains("message-command-style"))
         #expect(command.contains("[ \"$status\" -eq 255 ] || exit \"$status\""))
         #expect(!command.contains("-CC"))
         #expect(!command.contains("KexAlgorithms"))
@@ -314,7 +499,11 @@ struct TmuxAttachmentInfoTests {
                 user: "wesm", hostname: "build-box", port: nil
             )),
             socketName: "kwt-pr-0123456789abcdef",
-            protectedWorkspacePath: "/worktrees/pr-32"
+            protectedWorkspacePath: "/worktrees/pr-32",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
         ).attachCommand(
             tmuxPath: "/usr/bin/tmux",
             remoteKwtCommandPrelude:
@@ -336,6 +525,11 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("/worktrees/pr-32"))
         #expect(!command.contains("exec '\\''/usr/bin/tmux"))
         #expect(command.contains("kwt-pr-0123456789abcdef"))
+        let kwtPosition = command.range(of: "ghosthub_kwt_path")?.lowerBound
+        let stylePosition = command.range(of: "window-style")?.lowerBound
+        if let kwtPosition, let stylePosition {
+            #expect(kwtPosition < stylePosition)
+        }
     }
 
     @Test("demo SSH arguments isolate config, trust, and routing")
@@ -381,7 +575,7 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'-A'"))
         #expect(command.contains("'-E'"))
         #expect(command.contains("release-work"))
-        #expect(command.contains("status-style"))
+        #expect(!command.contains("status-style"))
         #expect(!command.contains("'-d'"))
         #expect(!command.contains("attach-session"))
         #expect(
@@ -445,6 +639,35 @@ struct TmuxAttachmentInfoTests {
                 separatedBy: "${SHELL:-/bin/sh}"
             ).count - 1 == 3
         )
+    }
+
+    @Test("existing remote worktrees receive built-in theme defaults")
+    func remoteWorktreeReceivesThemeDefaults() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "kwt-widget-feature",
+            host: .ssh(SSHHostInfo(
+                user: "wesm", hostname: "build-box", port: nil
+            )),
+            workspacePath: "/srv/widget",
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
+        ).attachCommand(
+            tmuxPath: "/usr/bin/tmux",
+            remoteKwtCommandPrelude:
+            "ghosthub_kwt_path=\"$HOME/.ghosthub/helpers/kwt/pinned/kwt\"; "
+                + "[ -x \"$ghosthub_kwt_path\" ] || exit 127; "
+        )
+
+        #expect(command.contains("list-windows"))
+        #expect(command.contains("window-style"))
+        #expect(command.contains("fg=#3B4851,bg=#FFFFFF"))
+        let kwtPosition = command.range(of: "ghosthub_kwt_path")?.lowerBound
+        let stylePosition = command.range(of: "window-style")?.lowerBound
+        if let kwtPosition, let stylePosition {
+            #expect(kwtPosition < stylePosition)
+        }
     }
 
     @Test("remote worktree switches to tmux only after transport loss")

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -195,7 +195,7 @@ struct TmuxAttachmentInfoTests {
         }
         #expect(command.contains("ghosthub_existing_clients"))
         #expect(command.contains(
-            "[ \"$ghosthub_kwt_attempts\" -lt 500 ]"
+            "while kill -0 \"$ghosthub_kwt_pid\""
         ))
     }
 

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -670,6 +670,33 @@ struct TmuxAttachmentInfoTests {
         }
     }
 
+    @Test("themed remote attachment supports non-POSIX account shells")
+    func themedRemoteAttachmentUsesPOSIXShell() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "shared-session",
+            host: .ssh(SSHHostInfo(
+                user: "wesm", hostname: "build-box", port: nil
+            )),
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            )
+        ).attachCommand(tmuxPath: "/usr/bin/tmux")
+
+        #expect(command.contains("${SHELL:-/bin/sh}"))
+        let loginShellPosition = command.range(
+            of: "${SHELL:-/bin/sh}"
+        )?.lowerBound
+        let presentationPosition = command.range(
+            of: "while IFS= read -r ghosthub_window"
+        )?.lowerBound
+        #expect(loginShellPosition != nil)
+        #expect(presentationPosition != nil)
+        if let loginShellPosition, let presentationPosition {
+            #expect(loginShellPosition < presentationPosition)
+        }
+    }
+
     @Test("remote worktree switches to tmux only after transport loss")
     func remoteWorktreeReconnectsAfterTransportLoss() throws {
         let directory = FileManager.default.temporaryDirectory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,8 +181,8 @@ scan the host for repositories.
 Terminal configuration is Ghosthub-owned and applied transactionally through
 libghostty. The runtime watches the active base, project, appearance, and
 recursive include graph with debouncing. Invalid candidates never replace the
-last valid configuration, and both automatic and explicit reloads publish a
-user-visible result.
+last valid configuration. Automatic successes are silent, automatic failures
+remain visible, and explicit reloads publish a user-visible result.
 
 ## Session Attachment
 
@@ -206,13 +206,14 @@ Ghosthub supplies keepalives and retries
 transport status 255. Tmux owns all windows, panes, history, input, rendering,
 and server-side lifetime.
 
-Ghosthub normalizes only tmux's session-scoped visual chrome before attaching:
-the status and message styles resolve through the foreground and background
-from Ghosthub's Ghostty-compatible terminal configuration, with reversed terminal
-colors highlighting the status line. This styling is best-effort and can never
-prevent attachment. Tmux still owns all interaction behavior; Ghosthub does
-not modify its prefix, key tables, mouse mode, window/pane commands, history,
-or layout.
+Ghosthub does not modify shared tmux colors by default. The explicit Tmux Theme
+override is the only presentation exception: before attachment it resets
+status and message styles to terminal defaults and supplies the selected
+built-in theme's foreground and background to existing windows in the exact
+session. This gives tmux deterministic OSC 10/11 responses, but tmux shares the
+result with every attached client. The best-effort styling can never prevent
+attachment. Tmux still owns all interaction behavior; Ghosthub does not modify
+its prefix, key tables, mouse mode, window/pane commands, history, or layout.
 
 An explicit New Tmux Session action is the sole boundary where Ghosthub
 creates a bare tmux session itself. For a user-supplied exact name, local

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -56,12 +56,15 @@ leaves the presentation open. After success it rechecks the active attachment,
 closing that exact current selection and navigating away only if it is the
 killed target.
 
-The one presentation exception is color normalization. Before attachment,
-Ghosthub resets the selected session's `status-style`, `message-style`, and
-`message-command-style` to terminal-default colors so tmux chrome follows
-Ghosthub's configured foreground and background instead of tmux's built-in
-green/black and yellow/black defaults. Reversed terminal colors highlight the
-status and message areas without introducing a second fixed palette. These
+Ghosthub does not modify shared tmux colors by default. Users may explicitly
+enable the Tmux Theme shared-session override. Before attachment, that override
+resets the exact session's `status-style`, `message-style`, and
+`message-command-style` to terminal-default colors and sets each existing
+window's default foreground and background. For kwt-backed workspaces, styling
+runs only after kwt has created or repaired the complete session and layout.
+This gives tmux a deterministic answer to OSC 10/11 color queries; otherwise
+tmux may report the first attached client's theme even when Ghosthub uses
+different colors. Tmux shares the override with every attached client. These
 best-effort style commands do not change tmux interaction: prefix and key
 tables, mouse behavior, windows, panes, history, and layout remain untouched.
 
@@ -193,6 +196,8 @@ session model and die with the app process.
 - Keep `TERM_PROGRAM=ghosthub`.
 - Do not leak launcher-terminal `EDITOR` or `VISUAL` into embedded shells.
 - Keep Ghosthub terminal config at `~/.config/ghosthub/ghostty.conf`.
+- Keep the generated base config independent of optional named-theme files;
+  built-in Appearance themes use an explicit Ghosthub-owned color overlay.
 - Keep mutable Ghosthub app state under `~/.ghosthub/`.
 - Do not read or depend on Ghostty.app global config.
 - Do not install Ghosthub split, zoom, or tab keybindings. Native tmux owns
@@ -214,9 +219,10 @@ An imported pull-request workspace is contributor-authored source, so its
 own checkout instead.
 
 Reloading is transactional. A candidate with diagnostics is rejected and the
-last valid libghostty configuration remains active. The app presents the result
-of automatic and explicit reloads; errors remain visible until dismissed or
-superseded. **Ghosthub → Reload Configuration**, Quick Launch, and
+last valid libghostty configuration remains active. Successful automatic
+reloads are silent; automatic failures remain visible until dismissed or
+superseded. Explicit reloads present their result. **Ghosthub → Reload
+Configuration**, Quick Launch, and
 <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd> all provide the explicit path.
 Options that libghostty cannot apply to existing surfaces retain their upstream
 restart or new-surface semantics.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -177,11 +177,13 @@ retained inventory cannot authorize killing a same-named replacement,
 including one created during the same timestamp second or after a rapid tmux
 server restart. An active client is detached only after the kill succeeds.
 
-Attachment may reset a small, documented set of session-scoped tmux visual
-styles so status and message chrome use Ghosthub's terminal colors. This
-presentation-only exception targets the exact selected session and does not
-authorize changes to tmux key tables, prefixes, mouse behavior, windows, panes,
-layout, history, or process state.
+Attachment does not modify tmux visual styles by default. The explicit Tmux
+Theme shared-session override may reset status/message styles and set existing
+window foreground/background defaults so tmux reports the selected colors to
+terminal-aware programs. This presentation-only exception targets the exact
+selected session, affects every attached client, and does not authorize changes
+to tmux key tables, prefixes, mouse behavior, windows, panes, layout, history,
+or process state.
 
 ### Release distribution
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -311,7 +311,11 @@ const imageAlt = {
           <p>
             The file uses{' '}<a href="https://ghostty.org/docs/config/reference">Ghostty’s
               configuration format</a>, but is isolated from Ghostty.app.
-            Ghosthub reloads the active configuration when it changes.
+            The Tmux Theme picker controls how sessions appear inside
+            Ghosthub. Shared tmux colors remain untouched by default. An
+            explicit opt-in applies a built-in theme to the session’s existing
+            windows and chrome for every attached terminal. Ghosthub reloads
+            the active configuration when it changes.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Ghosthub generated base configuration referenced theme files that are not included with libghostty. That invalid default prevented the app-owned Appearance overlay from loading, made theme settings appear ineffective, and could show a misleading error when opening a tmux session. New generated configuration is now self-contained, existing user-authored ghostty.conf files remain user-owned, and automatic successful reloads are silent; failures and explicit reload results remain visible.

Tmux introduced a separate color mismatch for shared sessions. When a pane has no explicit defaults, tmux can answer OSC 10/11 using another attached client, so an older dark SSH client could make Codex render dark panels on a light Ghosthub surface. Appearance settings now describe this accurately as Tmux Theme: the picker controls how tmux appears in Ghosthub, while a separate default-off toggle explicitly opts into applying those colors to shared session windows and chrome for every attached terminal. With the toggle off, Ghosthub leaves shared tmux presentation options untouched.

For kwt-backed workspaces, opt-in styling waits until kwt has created or repaired the complete session and layout, then applies to every resulting window before handing control to the same attached client. The handoff detects a genuinely new session client without depending on process ancestry and waits for that client or kwt exit, while retaining protected-session validation and destroy-unattached safety.

The earlier ANSI-palette workaround was removed after testing showed it was unrelated. All 42 libghostty bootstrap tests, 113 Python tests, 619 Swift Testing cases, 149 terminal smoke/XCTest cases, the app build, and formatting pass.