### PR TITLE
Add experimental native Windows hosts through psmux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,12 @@ Ghosthub is a **worktree-centric terminal multiplexer** for macOS.
 - Use `kata` for task management (see `CLAUDE.md`).
 - User-facing workflow changes must update the website Guide when they affect
   documented behavior. Regenerate and publish the website screenshot set only
-  when a change materially alters visuals shown in those screenshots; copy,
+  at feature acceptance and when opening a pull request, and only when the
+  accepted change materially alters visuals shown in those screenshots; copy,
   accessibility, and non-visual behavior changes do not require new captures.
+  Do not capture or publish screenshots while a feature is still in
+  development. Publish required refreshed binaries to the orphan
+  `website-assets` branch so ghosthub.ai does not ship stale product views.
 - Pull request descriptions should be concise, rationale-first prose. Do not add boilerplate or navel-gazing sections like "Changes", "Tests", or "Verification"; mention validation only when it is genuinely useful reviewer context.
 - Do not poll or watch GitHub Actions through `gh`, the GitHub API, or browser automation unless the user explicitly asks you to do so.
 - **NO DATABASE MIGRATIONS** until the first production release. Update the current schema, bootstrap paths, fixtures, and tests directly.

--- a/Sources/App/ConfiguredHostOverlay.swift
+++ b/Sources/App/ConfiguredHostOverlay.swift
@@ -37,7 +37,8 @@ enum ConfiguredHostOverlay {
             }
             if let existing {
                 consumedHostIDs.insert(existing.id)
-                if existing.sshDestination != configured.sshDestination {
+                if existing.sshDestination != configured.sshDestination
+                    || existing.platform != configured.platform {
                     invalidatedHostIDs.insert(existing.id)
                 }
             }

--- a/Sources/App/KwtBinaryLocator.swift
+++ b/Sources/App/KwtBinaryLocator.swift
@@ -5,6 +5,24 @@ enum KwtBinaryLocator {
     private static let remoteRevisionKey =
         "GhosthubRemoteKwtSourceRevision"
 
+    enum WindowsArchitecture: String, Equatable, Sendable {
+        case amd64
+        case arm64
+
+        init?(remoteValue: String) {
+            switch remoteValue
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() {
+            case "x64", "amd64", "x86_64":
+                self = .amd64
+            case "arm64", "aarch64":
+                self = .arm64
+            default:
+                return nil
+            }
+        }
+    }
+
     static func bundledPath(
         bundle: Bundle = .main,
         fileManager: FileManager = .default
@@ -69,6 +87,17 @@ enum KwtBinaryLocator {
         }
         return "ghosthub_kwt_path=\"\(path)\"; "
             + "[ -x \"$ghosthub_kwt_path\" ] || exit 127; "
+    }
+
+    static func windowsBundledPath(
+        architecture: WindowsArchitecture,
+        bundleURL: URL = Bundle.main.bundleURL
+    ) -> String {
+        bundleURL
+            .appendingPathComponent("Contents/Resources/KwtRemote")
+            .appendingPathComponent("windows-\(architecture.rawValue)")
+            .appendingPathComponent("kwt")
+            .path
     }
 
     private static func validRevision(_ value: String?) -> String? {

--- a/Sources/App/KwtBinaryLocator.swift
+++ b/Sources/App/KwtBinaryLocator.swift
@@ -89,6 +89,17 @@ enum KwtBinaryLocator {
             + "[ -x \"$ghosthub_kwt_path\" ] || exit 127; "
     }
 
+    static func windowsRemoteManagedRelativePath(
+        revision: String?
+    ) -> String? {
+        guard let revision = validRevision(revision) else {
+            return nil
+        }
+        return #".ghosthub\helpers\kwt\"#
+            + revision
+            + #"\kwt.exe"#
+    }
+
     static func windowsBundledPath(
         architecture: WindowsArchitecture,
         bundleURL: URL = Bundle.main.bundleURL

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -143,6 +143,7 @@ struct KwtInventoryClient: Sendable {
             run(
                 host: host,
                 command: Self.projectsCommand(
+                    platform: platform(for: host),
                     binaryPrelude: binaryPrelude(for: host)
                 )
             ),
@@ -159,6 +160,7 @@ struct KwtInventoryClient: Sendable {
                         host: host,
                         command: Self.worktreesCommand(
                             projectPath: project.path,
+                            platform: platform(for: host),
                             binaryPrelude: binaryPrelude(for: host)
                         )
                     )
@@ -209,6 +211,15 @@ struct KwtInventoryClient: Sendable {
         }
     }
 
+    private func platform(
+        for host: TmuxHost
+    ) -> SSHHostInfo.Platform {
+        switch host {
+        case .local: .posix
+        case let .ssh(info): info.platform
+        }
+    }
+
     private func run(
         host: TmuxHost,
         command: String
@@ -248,17 +259,34 @@ struct KwtInventoryClient: Sendable {
         }
     }
 
-    private static func projectsCommand(binaryPrelude: String) -> String {
-        binaryPrelude
+    private static func projectsCommand(
+        platform: SSHHostInfo.Platform,
+        binaryPrelude: String
+    ) -> String {
+        if platform == .windows {
+            return KwtPowerShellCommand.run(
+                arguments: ["projects", "--json"],
+                marker: "GHOSTHUB_KWT_JSON"
+            )
+        }
+        return binaryPrelude
             + "printf 'GHOSTHUB_KWT_JSON\\n'; "
             + "exec \"$ghosthub_kwt_path\" projects --json"
     }
 
     private static func worktreesCommand(
         projectPath: String,
+        platform: SSHHostInfo.Platform,
         binaryPrelude: String
     ) -> String {
-        binaryPrelude
+        if platform == .windows {
+            return KwtPowerShellCommand.run(
+                arguments: ["list", "--json"],
+                workingDirectory: projectPath,
+                marker: "GHOSTHUB_KWT_JSON"
+            )
+        }
+        return binaryPrelude
             + "cd -- \(shellQuotedCommandArgument(projectPath)) || exit $?; "
             + "printf 'GHOSTHUB_KWT_JSON\\n'; "
             + "exec \"$ghosthub_kwt_path\" list --json"

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -139,12 +139,17 @@ struct KwtInventoryClient: Sendable {
         case .local: "this Mac"
         case let .ssh(info): info.displayName
         }
+        let windowsKwtRelativePath =
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: remoteBinaryRevision
+            )
         let projects: [KwtProjectRecord] = try decode(
             run(
                 host: host,
                 command: Self.projectsCommand(
                     platform: platform(for: host),
-                    binaryPrelude: binaryPrelude(for: host)
+                    binaryPrelude: binaryPrelude(for: host),
+                    windowsKwtRelativePath: windowsKwtRelativePath
                 )
             ),
             hostLabel: hostLabel
@@ -161,7 +166,8 @@ struct KwtInventoryClient: Sendable {
                         command: Self.worktreesCommand(
                             projectPath: project.path,
                             platform: platform(for: host),
-                            binaryPrelude: binaryPrelude(for: host)
+                            binaryPrelude: binaryPrelude(for: host),
+                            windowsKwtRelativePath: windowsKwtRelativePath
                         )
                     )
                     do {
@@ -265,12 +271,14 @@ struct KwtInventoryClient: Sendable {
 
     private static func projectsCommand(
         platform: SSHHostInfo.Platform,
-        binaryPrelude: String
+        binaryPrelude: String,
+        windowsKwtRelativePath: String?
     ) -> String {
         if platform == .windows {
             return KwtPowerShellCommand.run(
                 arguments: ["projects", "--json"],
-                marker: "GHOSTHUB_KWT_JSON"
+                marker: "GHOSTHUB_KWT_JSON",
+                managedRelativePath: windowsKwtRelativePath
             )
         }
         return binaryPrelude
@@ -281,13 +289,15 @@ struct KwtInventoryClient: Sendable {
     private static func worktreesCommand(
         projectPath: String,
         platform: SSHHostInfo.Platform,
-        binaryPrelude: String
+        binaryPrelude: String,
+        windowsKwtRelativePath: String?
     ) -> String {
         if platform == .windows {
             return KwtPowerShellCommand.run(
                 arguments: ["list", "--json"],
                 workingDirectory: projectPath,
-                marker: "GHOSTHUB_KWT_JSON"
+                marker: "GHOSTHUB_KWT_JSON",
+                managedRelativePath: windowsKwtRelativePath
             )
         }
         return binaryPrelude

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -98,7 +98,7 @@ struct KwtInventoryClient: Sendable {
         _ host: SSHHostInfo, _ command: String
     ) -> (status: Int32, stdout: String)
 
-    private static let jsonMarker = "GHOSTHUB_KWT_JSON"
+    private static let jsonMarker = "GHOSTHUB_KWT_JSON\n"
     private let localRunner: LocalRunner
     private let remoteRunner: RemoteRunner
     private let loginShellProvider: @Sendable () -> String
@@ -242,14 +242,17 @@ struct KwtInventoryClient: Sendable {
                 status: result.status
             )
         }
-        let lines = result.stdout.split(whereSeparator: \.isNewline)
-        guard let markerIndex = lines.lastIndex(where: {
-            $0 == Self.jsonMarker
-        }) else {
+        let normalizedOutput = result.stdout.replacingOccurrences(
+            of: "\r\n",
+            with: "\n"
+        )
+        guard let markerRange = normalizedOutput.range(
+            of: Self.jsonMarker,
+            options: .backwards
+        ) else {
             throw KwtInventoryError.malformedOutput(host: hostLabel)
         }
-        let json = lines[lines.index(after: markerIndex)...]
-            .joined(separator: "\n")
+        let json = normalizedOutput[markerRange.upperBound...]
         do {
             return try JSONDecoder().decode(
                 Value.self,

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -98,7 +98,7 @@ struct KwtInventoryClient: Sendable {
         _ host: SSHHostInfo, _ command: String
     ) -> (status: Int32, stdout: String)
 
-    private static let jsonMarker = "GHOSTHUB_KWT_JSON\n"
+    private static let jsonMarker = "GHOSTHUB_KWT_JSON"
     private let localRunner: LocalRunner
     private let remoteRunner: RemoteRunner
     private let loginShellProvider: @Sendable () -> String
@@ -242,13 +242,14 @@ struct KwtInventoryClient: Sendable {
                 status: result.status
             )
         }
-        guard let markerRange = result.stdout.range(
-            of: Self.jsonMarker,
-            options: .backwards
-        ) else {
+        let lines = result.stdout.split(whereSeparator: \.isNewline)
+        guard let markerIndex = lines.lastIndex(where: {
+            $0 == Self.jsonMarker
+        }) else {
             throw KwtInventoryError.malformedOutput(host: hostLabel)
         }
-        let json = result.stdout[markerRange.upperBound...]
+        let json = lines[lines.index(after: markerIndex)...]
+            .joined(separator: "\n")
         do {
             return try JSONDecoder().decode(
                 Value.self,

--- a/Sources/App/KwtPowerShellCommand.swift
+++ b/Sources/App/KwtPowerShellCommand.swift
@@ -1,24 +1,33 @@
 import GhosthubTmux
 
 enum KwtPowerShellCommand {
-    static var resolutionPrelude: String {
-        powerShellKwtResolutionPrelude()
+    static func resolutionPrelude(
+        managedRelativePath: String?
+    ) -> String {
+        powerShellKwtResolutionPrelude(
+            managedRelativePath: managedRelativePath
+        )
     }
 
-    static var availabilityPrelude: String {
-        powerShellKwtAvailabilityPrelude()
+    static func availabilityPrelude(
+        managedRelativePath: String?
+    ) -> String {
+        powerShellKwtAvailabilityPrelude(
+            managedRelativePath: managedRelativePath
+        )
     }
 
     static func run(
         arguments: [String],
         workingDirectory: String? = nil,
-        marker: String? = nil
+        marker: String? = nil,
+        managedRelativePath: String?
     ) -> String {
         var lines = [
             "$ErrorActionPreference = 'Stop'",
             "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
             "$OutputEncoding = [Console]::OutputEncoding",
-            resolutionPrelude,
+            resolutionPrelude(managedRelativePath: managedRelativePath),
         ]
         if let workingDirectory {
             lines.append(

--- a/Sources/App/KwtPowerShellCommand.swift
+++ b/Sources/App/KwtPowerShellCommand.swift
@@ -1,0 +1,44 @@
+import GhosthubTmux
+
+enum KwtPowerShellCommand {
+    static var resolutionPrelude: String {
+        powerShellKwtResolutionPrelude()
+    }
+
+    static var availabilityPrelude: String {
+        powerShellKwtAvailabilityPrelude()
+    }
+
+    static func run(
+        arguments: [String],
+        workingDirectory: String? = nil,
+        marker: String? = nil
+    ) -> String {
+        var lines = [
+            "$ErrorActionPreference = 'Stop'",
+            "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+            "$OutputEncoding = [Console]::OutputEncoding",
+            resolutionPrelude,
+        ]
+        if let workingDirectory {
+            lines.append(
+                "Set-Location -LiteralPath "
+                    + powerShellQuotedCommandArgument(workingDirectory)
+            )
+        }
+        if let marker {
+            lines.append(
+                "Write-Output "
+                    + powerShellQuotedCommandArgument(marker)
+            )
+        }
+        lines.append(
+            "& $ghosthubKwt "
+                + arguments
+                .map(powerShellQuotedCommandArgument)
+                .joined(separator: " ")
+        )
+        lines.append("exit $LASTEXITCODE")
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/App/KwtPowerShellCommand.swift
+++ b/Sources/App/KwtPowerShellCommand.swift
@@ -23,19 +23,19 @@ enum KwtPowerShellCommand {
         if let workingDirectory {
             lines.append(
                 "Set-Location -LiteralPath "
-                    + powerShellQuotedCommandArgument(workingDirectory)
+                    + powerShellEncodedArgument(workingDirectory)
             )
         }
         if let marker {
             lines.append(
                 "Write-Output "
-                    + powerShellQuotedCommandArgument(marker)
+                    + powerShellEncodedArgument(marker)
             )
         }
         lines.append(
             "& $ghosthubKwt "
                 + arguments
-                .map(powerShellQuotedCommandArgument)
+                .map(powerShellEncodedArgument)
                 .joined(separator: " ")
         )
         lines.append("exit $LASTEXITCODE")

--- a/Sources/App/KwtPullRequestClient.swift
+++ b/Sources/App/KwtPullRequestClient.swift
@@ -99,7 +99,11 @@ struct KwtPullRequestClient: Sendable {
             Self.listCommand(
                 projectIdentity: projectIdentity,
                 platform: platform(for: host),
-                binaryPrelude: binaryPrelude(for: host)
+                binaryPrelude: binaryPrelude(for: host),
+                windowsKwtRelativePath:
+                KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                    revision: remoteBinaryRevision
+                )
             ),
             on: host
         )
@@ -116,7 +120,11 @@ struct KwtPullRequestClient: Sendable {
                 id: id,
                 projectIdentity: projectIdentity,
                 platform: platform(for: host),
-                binaryPrelude: binaryPrelude(for: host)
+                binaryPrelude: binaryPrelude(for: host),
+                windowsKwtRelativePath:
+                KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                    revision: remoteBinaryRevision
+                )
             ),
             on: host
         )
@@ -228,7 +236,8 @@ struct KwtPullRequestClient: Sendable {
     static func listCommand(
         projectIdentity: String,
         platform: SSHHostInfo.Platform = .posix,
-        binaryPrelude: String
+        binaryPrelude: String,
+        windowsKwtRelativePath: String? = nil
     ) -> String {
         if platform == .windows {
             return KwtPowerShellCommand.run(
@@ -236,7 +245,8 @@ struct KwtPullRequestClient: Sendable {
                     "pr", "list", "--project", projectIdentity,
                     "--state", "open", "--json",
                 ],
-                marker: "GHOSTHUB_KWT_PR_JSON"
+                marker: "GHOSTHUB_KWT_PR_JSON",
+                managedRelativePath: windowsKwtRelativePath
             )
         }
         return commandPrelude(binaryPrelude: binaryPrelude)
@@ -249,7 +259,8 @@ struct KwtPullRequestClient: Sendable {
         id: String,
         projectIdentity: String,
         platform: SSHHostInfo.Platform = .posix,
-        binaryPrelude: String
+        binaryPrelude: String,
+        windowsKwtRelativePath: String? = nil
     ) -> String {
         if platform == .windows {
             return KwtPowerShellCommand.run(
@@ -257,7 +268,8 @@ struct KwtPullRequestClient: Sendable {
                     "pr", "import", id, "--project", projectIdentity,
                     "--json",
                 ],
-                marker: "GHOSTHUB_KWT_PR_JSON"
+                marker: "GHOSTHUB_KWT_PR_JSON",
+                managedRelativePath: windowsKwtRelativePath
             )
         }
         return commandPrelude(binaryPrelude: binaryPrelude)

--- a/Sources/App/KwtPullRequestClient.swift
+++ b/Sources/App/KwtPullRequestClient.swift
@@ -55,7 +55,7 @@ struct KwtPullRequestClient: Sendable {
         _ host: SSHHostInfo, _ command: String
     ) -> (status: Int32, stdout: String)
 
-    private static let jsonMarker = "GHOSTHUB_KWT_PR_JSON\n"
+    private static let jsonMarker = "GHOSTHUB_KWT_PR_JSON"
     private let localRunner: LocalRunner
     private let remoteRunner: RemoteRunner
     private let loginShellProvider: @Sendable () -> String
@@ -184,10 +184,10 @@ struct KwtPullRequestClient: Sendable {
         _ result: (status: Int32, stdout: String),
         hostLabel: String
     ) throws -> Value {
-        guard let markerRange = result.stdout.range(
-            of: jsonMarker,
-            options: .backwards
-        ) else {
+        let lines = result.stdout.split(whereSeparator: \.isNewline)
+        guard let markerIndex = lines.lastIndex(where: {
+            $0 == jsonMarker
+        }) else {
             if result.status != 0 {
                 throw KwtPullRequestError.commandFailed(
                     host: hostLabel,
@@ -199,7 +199,9 @@ struct KwtPullRequestClient: Sendable {
             }
             throw KwtPullRequestError.malformedOutput(host: hostLabel)
         }
-        let data = Data(result.stdout[markerRange.upperBound...].utf8)
+        let payload = lines[lines.index(after: markerIndex)...]
+            .joined(separator: "\n")
+        let data = Data(payload.utf8)
         guard result.status == 0 else {
             let envelope = try? JSONDecoder().decode(
                 ErrorEnvelope.self,

--- a/Sources/App/KwtPullRequestClient.swift
+++ b/Sources/App/KwtPullRequestClient.swift
@@ -55,7 +55,7 @@ struct KwtPullRequestClient: Sendable {
         _ host: SSHHostInfo, _ command: String
     ) -> (status: Int32, stdout: String)
 
-    private static let jsonMarker = "GHOSTHUB_KWT_PR_JSON"
+    private static let jsonMarker = "GHOSTHUB_KWT_PR_JSON\n"
     private let localRunner: LocalRunner
     private let remoteRunner: RemoteRunner
     private let loginShellProvider: @Sendable () -> String
@@ -184,10 +184,14 @@ struct KwtPullRequestClient: Sendable {
         _ result: (status: Int32, stdout: String),
         hostLabel: String
     ) throws -> Value {
-        let lines = result.stdout.split(whereSeparator: \.isNewline)
-        guard let markerIndex = lines.lastIndex(where: {
-            $0 == jsonMarker
-        }) else {
+        let normalizedOutput = result.stdout.replacingOccurrences(
+            of: "\r\n",
+            with: "\n"
+        )
+        guard let markerRange = normalizedOutput.range(
+            of: jsonMarker,
+            options: .backwards
+        ) else {
             if result.status != 0 {
                 throw KwtPullRequestError.commandFailed(
                     host: hostLabel,
@@ -199,8 +203,7 @@ struct KwtPullRequestClient: Sendable {
             }
             throw KwtPullRequestError.malformedOutput(host: hostLabel)
         }
-        let payload = lines[lines.index(after: markerIndex)...]
-            .joined(separator: "\n")
+        let payload = normalizedOutput[markerRange.upperBound...]
         let data = Data(payload.utf8)
         guard result.status == 0 else {
             let envelope = try? JSONDecoder().decode(

--- a/Sources/App/KwtPullRequestClient.swift
+++ b/Sources/App/KwtPullRequestClient.swift
@@ -98,6 +98,7 @@ struct KwtPullRequestClient: Sendable {
         let response: ListResponse = try await execute(
             Self.listCommand(
                 projectIdentity: projectIdentity,
+                platform: platform(for: host),
                 binaryPrelude: binaryPrelude(for: host)
             ),
             on: host
@@ -114,6 +115,7 @@ struct KwtPullRequestClient: Sendable {
             Self.importCommand(
                 id: id,
                 projectIdentity: projectIdentity,
+                platform: platform(for: host),
                 binaryPrelude: binaryPrelude(for: host)
             ),
             on: host
@@ -169,6 +171,15 @@ struct KwtPullRequestClient: Sendable {
         }
     }
 
+    private func platform(
+        for host: TmuxHost
+    ) -> SSHHostInfo.Platform {
+        switch host {
+        case .local: .posix
+        case let .ssh(info): info.platform
+        }
+    }
+
     private static func decode<Value: Decodable>(
         _ result: (status: Int32, stdout: String),
         hostLabel: String
@@ -211,9 +222,19 @@ struct KwtPullRequestClient: Sendable {
 
     static func listCommand(
         projectIdentity: String,
+        platform: SSHHostInfo.Platform = .posix,
         binaryPrelude: String
     ) -> String {
-        commandPrelude(binaryPrelude: binaryPrelude)
+        if platform == .windows {
+            return KwtPowerShellCommand.run(
+                arguments: [
+                    "pr", "list", "--project", projectIdentity,
+                    "--state", "open", "--json",
+                ],
+                marker: "GHOSTHUB_KWT_PR_JSON"
+            )
+        }
+        return commandPrelude(binaryPrelude: binaryPrelude)
             + "exec \"$ghosthub_kwt_path\" pr list --project "
             + shellQuotedCommandArgument(projectIdentity)
             + " --state open --json"
@@ -222,9 +243,19 @@ struct KwtPullRequestClient: Sendable {
     static func importCommand(
         id: String,
         projectIdentity: String,
+        platform: SSHHostInfo.Platform = .posix,
         binaryPrelude: String
     ) -> String {
-        commandPrelude(binaryPrelude: binaryPrelude)
+        if platform == .windows {
+            return KwtPowerShellCommand.run(
+                arguments: [
+                    "pr", "import", id, "--project", projectIdentity,
+                    "--json",
+                ],
+                marker: "GHOSTHUB_KWT_PR_JSON"
+            )
+        }
+        return commandPrelude(binaryPrelude: binaryPrelude)
             + "exec \"$ghosthub_kwt_path\" pr import "
             + shellQuotedCommandArgument(id)
             + " --project "

--- a/Sources/App/KwtWindowsInstaller.swift
+++ b/Sources/App/KwtWindowsInstaller.swift
@@ -158,7 +158,7 @@ struct KwtWindowsInstaller: Sendable {
         $ErrorActionPreference = 'Stop'
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $OutputEncoding = [Console]::OutputEncoding
-        $ghosthubUpload = Join-Path $env:USERPROFILE \(powerShellQuotedCommandArgument(uploadName))
+        $ghosthubUpload = Join-Path $env:USERPROFILE \(powerShellEncodedArgument(uploadName))
         $ghosthubDirectory = Join-Path $env:USERPROFILE '.ghosthub\\bin'
         $ghosthubDestination = Join-Path $ghosthubDirectory 'kwt.exe'
         $ghosthubStaging = Join-Path $ghosthubDirectory ('kwt-stage-' + [System.Guid]::NewGuid().ToString('N') + '.exe')

--- a/Sources/App/KwtWindowsInstaller.swift
+++ b/Sources/App/KwtWindowsInstaller.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import GhosthubSettings
 import GhosthubTmux
@@ -6,6 +7,7 @@ enum KwtWindowsInstallError: Error, Equatable, LocalizedError {
     case invalidDestination
     case architectureProbeFailed(status: Int32)
     case unsupportedArchitecture(String)
+    case bundleIncomplete
     case bundledHelperMissing(String)
     case transferFailed(status: Int32)
     case activationFailed(status: Int32)
@@ -19,6 +21,8 @@ enum KwtWindowsInstallError: Error, Equatable, LocalizedError {
             return "Could not determine the Windows architecture over SSH (status \(status))."
         case let .unsupportedArchitecture(value):
             return "The Windows architecture \(value) is not supported. Ghosthub currently bundles AMD64 and ARM64 kwt."
+        case .bundleIncomplete:
+            return "This Ghosthub build does not identify a pinned Windows kwt helper."
         case let .bundledHelperMissing(path):
             return "The bundled Windows kwt helper is missing at \(path)."
         case let .transferFailed(status):
@@ -46,6 +50,7 @@ struct KwtWindowsInstaller: Sendable {
     private static let installedMarker = "GHOSTHUB_KWT_INSTALLED"
 
     private let bundleURL: URL
+    private let revision: String?
     private let isReadableFile: @Sendable (String) -> Bool
     private let remoteRunner: RemoteRunner
     private let transferRunner: TransferRunner
@@ -53,6 +58,7 @@ struct KwtWindowsInstaller: Sendable {
 
     init(
         bundleURL: URL = Bundle.main.bundleURL,
+        revision: String? = KwtBinaryLocator.bundledRemoteRevision(),
         isReadableFile: @escaping @Sendable (String) -> Bool = {
             FileManager.default.isReadableFile(atPath: $0)
         },
@@ -63,6 +69,7 @@ struct KwtWindowsInstaller: Sendable {
         }
     ) {
         self.bundleURL = bundleURL
+        self.revision = revision
         self.isReadableFile = isReadableFile
         self.remoteRunner = remoteRunner ?? { host, command in
             TmuxBinaryResolver.runRemoteLoginShell(
@@ -77,6 +84,14 @@ struct KwtWindowsInstaller: Sendable {
 
     func install(on configuredHost: SSHHost) async
         -> Result<Void, KwtWindowsInstallError> {
+        guard let revision,
+              let managedRelativePath =
+              KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                  revision: revision
+              )
+        else {
+            return .failure(.bundleIncomplete)
+        }
         guard let parsed = TmuxHostResolver.parseSSHDestination(
             configuredHost.sshDestination
         ) else {
@@ -115,6 +130,14 @@ struct KwtWindowsInstaller: Sendable {
         guard isReadableFile(localPath) else {
             return .failure(.bundledHelperMissing(localPath))
         }
+        guard let helperData = try? Data(
+            contentsOf: URL(fileURLWithPath: localPath)
+        ) else {
+            return .failure(.bundledHelperMissing(localPath))
+        }
+        let digest = SHA256.hash(data: helperData)
+            .map { String(format: "%02x", $0) }
+            .joined()
 
         let uploadName = uploadNameProvider()
         let transferRunner = transferRunner
@@ -128,7 +151,12 @@ struct KwtWindowsInstaller: Sendable {
         let activationResult = await Task.detached {
             remoteRunner(
                 host,
-                Self.activationCommand(uploadName: uploadName)
+                Self.activationCommand(
+                    uploadName: uploadName,
+                    managedRelativePath: managedRelativePath,
+                    revision: revision,
+                    digest: digest
+                )
             )
         }.value
         guard activationResult.status == 0 else {
@@ -152,15 +180,21 @@ struct KwtWindowsInstaller: Sendable {
     """
 
     private static func activationCommand(
-        uploadName: String
+        uploadName: String,
+        managedRelativePath: String,
+        revision: String,
+        digest: String
     ) -> String {
-        """
+        let expectedVersion = "kwt version \(revision)"
+        return """
         $ErrorActionPreference = 'Stop'
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $OutputEncoding = [Console]::OutputEncoding
         $ghosthubUpload = Join-Path $env:USERPROFILE \(powerShellEncodedArgument(uploadName))
-        $ghosthubDirectory = Join-Path $env:USERPROFILE '.ghosthub\\bin'
-        $ghosthubDestination = Join-Path $ghosthubDirectory 'kwt.exe'
+        $ghosthubDestination = Join-Path $env:USERPROFILE \(
+            powerShellEncodedArgument(managedRelativePath)
+        )
+        $ghosthubDirectory = Split-Path -Parent $ghosthubDestination
         $ghosthubStaging = Join-Path $ghosthubDirectory ('kwt-stage-' + [System.Guid]::NewGuid().ToString('N') + '.exe')
         $ghosthubBackup = Join-Path $ghosthubDirectory ('kwt-backup-' + [System.Guid]::NewGuid().ToString('N') + '.exe')
         $ghosthubHadPrevious = $false
@@ -168,9 +202,19 @@ struct KwtWindowsInstaller: Sendable {
         try {
             New-Item -ItemType Directory -Force -Path $ghosthubDirectory | Out-Null
             Move-Item -LiteralPath $ghosthubUpload -Destination $ghosthubStaging
-            & $ghosthubStaging '--version' *> $null
-            if ($LASTEXITCODE -ne 0) {
-                exit $LASTEXITCODE
+            $ghosthubDigest = (Get-FileHash -LiteralPath $ghosthubStaging -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($ghosthubDigest -cne \(powerShellEncodedArgument(digest))) {
+                exit 65
+            }
+            $ghosthubVersionOutput = @(& $ghosthubStaging 'version')
+            $ghosthubVersionStatus = $LASTEXITCODE
+            if ($ghosthubVersionStatus -ne 0) {
+                exit $ghosthubVersionStatus
+            }
+            if (($ghosthubVersionOutput.Count -eq 0) -or ([string]$ghosthubVersionOutput[0] -cne \(
+                powerShellEncodedArgument(expectedVersion)
+            ))) {
+                exit 66
             }
             if (Test-Path -LiteralPath $ghosthubDestination -PathType Leaf) {
                 $ghosthubHadPrevious = $true
@@ -179,9 +223,15 @@ struct KwtWindowsInstaller: Sendable {
                 [System.IO.File]::Move($ghosthubStaging, $ghosthubDestination)
             }
             $ghosthubReplacementComplete = $true
-            & $ghosthubDestination '--version' *> $null
-            if ($LASTEXITCODE -ne 0) {
-                $ghosthubVerificationStatus = $LASTEXITCODE
+            $ghosthubInstalledVersionOutput = @(& $ghosthubDestination 'version')
+            $ghosthubVerificationStatus = $LASTEXITCODE
+            $ghosthubInstalledVersionMatches = ($ghosthubInstalledVersionOutput.Count -gt 0) -and ([string]$ghosthubInstalledVersionOutput[0] -ceq \(
+                powerShellEncodedArgument(expectedVersion)
+            ))
+            if (($ghosthubVerificationStatus -ne 0) -or (-not $ghosthubInstalledVersionMatches)) {
+                if ($ghosthubVerificationStatus -eq 0) {
+                    $ghosthubVerificationStatus = 66
+                }
                 if ($ghosthubHadPrevious -and (Test-Path -LiteralPath $ghosthubBackup -PathType Leaf)) {
                     [System.IO.File]::Replace($ghosthubBackup, $ghosthubDestination, $null, $true)
                 } else {
@@ -211,12 +261,20 @@ struct KwtWindowsInstaller: Sendable {
         in output: String,
         marker: String
     ) -> String? {
-        output
-            .split(whereSeparator: \.isNewline)
-            .lazy
-            .map(String.init)
-            .first { $0.hasPrefix(marker) }
-            .map { String($0.dropFirst(marker.count)) }
+        let normalizedOutput = output.replacingOccurrences(
+            of: "\r\n",
+            with: "\n"
+        )
+        guard let markerRange = normalizedOutput.range(
+            of: marker,
+            options: .backwards
+        ) else {
+            return nil
+        }
+        let value = normalizedOutput[markerRange.upperBound...]
+            .prefix(while: { !$0.isNewline })
+            .trimmingCharacters(in: .whitespaces)
+        return value.isEmpty ? nil : value
     }
 
     private static func transfer(

--- a/Sources/App/KwtWindowsInstaller.swift
+++ b/Sources/App/KwtWindowsInstaller.swift
@@ -1,0 +1,219 @@
+import Foundation
+import GhosthubSettings
+import GhosthubTmux
+
+enum KwtWindowsInstallError: Error, Equatable, LocalizedError {
+    case invalidDestination
+    case architectureProbeFailed(status: Int32)
+    case unsupportedArchitecture(String)
+    case bundledHelperMissing(String)
+    case transferFailed(status: Int32)
+    case activationFailed(status: Int32)
+    case activationUnconfirmed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDestination:
+            return "Enter a valid Windows SSH destination."
+        case let .architectureProbeFailed(status):
+            return "Could not determine the Windows architecture over SSH (status \(status))."
+        case let .unsupportedArchitecture(value):
+            return "The Windows architecture \(value) is not supported. Ghosthub currently bundles AMD64 and ARM64 kwt."
+        case let .bundledHelperMissing(path):
+            return "The bundled Windows kwt helper is missing at \(path)."
+        case let .transferFailed(status):
+            return "Could not upload the bundled Windows kwt helper (status \(status))."
+        case let .activationFailed(status):
+            return "The uploaded Windows kwt helper could not be installed (status \(status))."
+        case .activationUnconfirmed:
+            return "Windows did not confirm the bundled kwt installation."
+        }
+    }
+}
+
+struct KwtWindowsInstaller: Sendable {
+    typealias RemoteRunner = @Sendable (
+        _ host: SSHHostInfo,
+        _ command: String
+    ) -> (status: Int32, stdout: String)
+    typealias TransferRunner = @Sendable (
+        _ host: SSHHostInfo,
+        _ localPath: String,
+        _ remoteName: String
+    ) -> Int32
+
+    private static let architectureMarker = "GHOSTHUB_WINDOWS_ARCH="
+    private static let installedMarker = "GHOSTHUB_KWT_INSTALLED"
+
+    private let bundleURL: URL
+    private let isReadableFile: @Sendable (String) -> Bool
+    private let remoteRunner: RemoteRunner
+    private let transferRunner: TransferRunner
+    private let uploadNameProvider: @Sendable () -> String
+
+    init(
+        bundleURL: URL = Bundle.main.bundleURL,
+        isReadableFile: @escaping @Sendable (String) -> Bool = {
+            FileManager.default.isReadableFile(atPath: $0)
+        },
+        remoteRunner: RemoteRunner? = nil,
+        transferRunner: TransferRunner? = nil,
+        uploadNameProvider: @escaping @Sendable () -> String = {
+            "ghosthub-kwt-\(UUID().uuidString).exe"
+        }
+    ) {
+        self.bundleURL = bundleURL
+        self.isReadableFile = isReadableFile
+        self.remoteRunner = remoteRunner ?? { host, command in
+            TmuxBinaryResolver.runRemoteLoginShell(
+                host: host,
+                command: command,
+                timeout: 30
+            )
+        }
+        self.transferRunner = transferRunner ?? Self.transfer
+        self.uploadNameProvider = uploadNameProvider
+    }
+
+    func install(on configuredHost: SSHHost) async
+        -> Result<Void, KwtWindowsInstallError> {
+        guard let parsed = TmuxHostResolver.parseSSHDestination(
+            configuredHost.sshDestination
+        ) else {
+            return .failure(.invalidDestination)
+        }
+        let host = SSHHostInfo(
+            user: parsed.user,
+            hostname: parsed.hostname,
+            port: parsed.port,
+            platform: .windows
+        )
+        let remoteRunner = remoteRunner
+        let architectureResult = await Task.detached {
+            remoteRunner(host, Self.architectureCommand)
+        }.value
+        guard architectureResult.status == 0 else {
+            return .failure(.architectureProbeFailed(
+                status: architectureResult.status
+            ))
+        }
+        guard let rawArchitecture = Self.markedValue(
+            in: architectureResult.stdout,
+            marker: Self.architectureMarker
+        ) else {
+            return .failure(.unsupportedArchitecture("unknown"))
+        }
+        guard let architecture = KwtBinaryLocator.WindowsArchitecture(
+            remoteValue: rawArchitecture
+        ) else {
+            return .failure(.unsupportedArchitecture(rawArchitecture))
+        }
+        let localPath = KwtBinaryLocator.windowsBundledPath(
+            architecture: architecture,
+            bundleURL: bundleURL
+        )
+        guard isReadableFile(localPath) else {
+            return .failure(.bundledHelperMissing(localPath))
+        }
+
+        let uploadName = uploadNameProvider()
+        let transferRunner = transferRunner
+        let transferStatus = await Task.detached {
+            transferRunner(host, localPath, uploadName)
+        }.value
+        guard transferStatus == 0 else {
+            return .failure(.transferFailed(status: transferStatus))
+        }
+
+        let activationResult = await Task.detached {
+            remoteRunner(
+                host,
+                Self.activationCommand(uploadName: uploadName)
+            )
+        }.value
+        guard activationResult.status == 0 else {
+            return .failure(.activationFailed(
+                status: activationResult.status
+            ))
+        }
+        guard activationResult.stdout.contains(Self.installedMarker) else {
+            return .failure(.activationUnconfirmed)
+        }
+        return .success(())
+    }
+
+    private static let architectureCommand = """
+    $ErrorActionPreference = 'Stop'
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $OutputEncoding = [Console]::OutputEncoding
+    Write-Output ('\(
+        architectureMarker
+    )' + [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString())
+    """
+
+    private static func activationCommand(
+        uploadName: String
+    ) -> String {
+        """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $OutputEncoding = [Console]::OutputEncoding
+        $ghosthubUpload = Join-Path $env:USERPROFILE \(powerShellQuotedCommandArgument(uploadName))
+        $ghosthubDirectory = Join-Path $env:USERPROFILE '.ghosthub\\bin'
+        $ghosthubDestination = Join-Path $ghosthubDirectory 'kwt.exe'
+        try {
+            New-Item -ItemType Directory -Force -Path $ghosthubDirectory | Out-Null
+            Move-Item -LiteralPath $ghosthubUpload -Destination $ghosthubDestination -Force
+            & $ghosthubDestination '--version' *> $null
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+            Write-Output '\(installedMarker)'
+        } finally {
+            Remove-Item -LiteralPath $ghosthubUpload -Force -ErrorAction SilentlyContinue
+        }
+        """
+    }
+
+    private static func markedValue(
+        in output: String,
+        marker: String
+    ) -> String? {
+        output
+            .split(whereSeparator: \.isNewline)
+            .lazy
+            .map(String.init)
+            .first { $0.hasPrefix(marker) }
+            .map { String($0.dropFirst(marker.count)) }
+    }
+
+    private static func transfer(
+        host: SSHHostInfo,
+        localPath: String,
+        remoteName: String
+    ) -> Int32 {
+        var arguments = [
+            "-q",
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=15",
+        ]
+        arguments.append(contentsOf: tmuxSSHConnectionArguments())
+        if let port = host.port, port != 22 {
+            arguments += ["-P", String(port)]
+        }
+        let hostname = host.hostname.contains(":")
+            ? "[\(host.hostname)]"
+            : host.hostname
+        let destination = host.user.map { "\($0)@\(hostname)" } ?? hostname
+        arguments += [
+            "--",
+            localPath,
+            "\(destination):\(remoteName)",
+        ]
+        return TmuxBinaryResolver.runProcess(
+            executable: "/usr/bin/scp",
+            arguments: arguments,
+            timeout: 120
+        ).status
+    }
+}

--- a/Sources/App/KwtWindowsInstaller.swift
+++ b/Sources/App/KwtWindowsInstaller.swift
@@ -161,16 +161,48 @@ struct KwtWindowsInstaller: Sendable {
         $ghosthubUpload = Join-Path $env:USERPROFILE \(powerShellQuotedCommandArgument(uploadName))
         $ghosthubDirectory = Join-Path $env:USERPROFILE '.ghosthub\\bin'
         $ghosthubDestination = Join-Path $ghosthubDirectory 'kwt.exe'
+        $ghosthubStaging = Join-Path $ghosthubDirectory ('kwt-stage-' + [System.Guid]::NewGuid().ToString('N') + '.exe')
+        $ghosthubBackup = Join-Path $ghosthubDirectory ('kwt-backup-' + [System.Guid]::NewGuid().ToString('N') + '.exe')
+        $ghosthubHadPrevious = $false
+        $ghosthubReplacementComplete = $false
         try {
             New-Item -ItemType Directory -Force -Path $ghosthubDirectory | Out-Null
-            Move-Item -LiteralPath $ghosthubUpload -Destination $ghosthubDestination -Force
-            & $ghosthubDestination '--version' *> $null
+            Move-Item -LiteralPath $ghosthubUpload -Destination $ghosthubStaging
+            & $ghosthubStaging '--version' *> $null
             if ($LASTEXITCODE -ne 0) {
                 exit $LASTEXITCODE
             }
+            if (Test-Path -LiteralPath $ghosthubDestination -PathType Leaf) {
+                $ghosthubHadPrevious = $true
+                [System.IO.File]::Replace($ghosthubStaging, $ghosthubDestination, $ghosthubBackup, $true)
+            } else {
+                [System.IO.File]::Move($ghosthubStaging, $ghosthubDestination)
+            }
+            $ghosthubReplacementComplete = $true
+            & $ghosthubDestination '--version' *> $null
+            if ($LASTEXITCODE -ne 0) {
+                $ghosthubVerificationStatus = $LASTEXITCODE
+                if ($ghosthubHadPrevious -and (Test-Path -LiteralPath $ghosthubBackup -PathType Leaf)) {
+                    [System.IO.File]::Replace($ghosthubBackup, $ghosthubDestination, $null, $true)
+                } else {
+                    Remove-Item -LiteralPath $ghosthubDestination -Force -ErrorAction SilentlyContinue
+                }
+                exit $ghosthubVerificationStatus
+            }
+            Remove-Item -LiteralPath $ghosthubBackup -Force -ErrorAction SilentlyContinue
             Write-Output '\(installedMarker)'
+        } catch {
+            if ($ghosthubReplacementComplete) {
+                if ($ghosthubHadPrevious -and (Test-Path -LiteralPath $ghosthubBackup -PathType Leaf)) {
+                    [System.IO.File]::Replace($ghosthubBackup, $ghosthubDestination, $null, $true)
+                } else {
+                    Remove-Item -LiteralPath $ghosthubDestination -Force -ErrorAction SilentlyContinue
+                }
+            }
+            throw
         } finally {
             Remove-Item -LiteralPath $ghosthubUpload -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $ghosthubStaging -Force -ErrorAction SilentlyContinue
         }
         """
     }

--- a/Sources/App/KwtWorktreeClient.swift
+++ b/Sources/App/KwtWorktreeClient.swift
@@ -76,17 +76,23 @@ struct KwtWorktreeClient: Sendable {
         on host: TmuxHost
     ) async throws {
         let binaryPrelude: String
+        let windowsKwtRelativePath: String?
         let platform: SSHHostInfo.Platform
         switch host {
         case .local:
             binaryPrelude = KwtBinaryLocator.commandPrelude(
                 exactPath: localBinaryPath
             )
+            windowsKwtRelativePath = nil
             platform = .posix
         case let .ssh(info):
             binaryPrelude = KwtBinaryLocator.remoteCommandPrelude(
                 revision: remoteBinaryRevision
             )
+            windowsKwtRelativePath =
+                KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                    revision: remoteBinaryRevision
+                )
             platform = info.platform
         }
         let command = Self.command(
@@ -94,7 +100,8 @@ struct KwtWorktreeClient: Sendable {
             createsBranch: request.createsBranch,
             projectPath: projectPath,
             platform: platform,
-            binaryPrelude: binaryPrelude
+            binaryPrelude: binaryPrelude,
+            windowsKwtRelativePath: windowsKwtRelativePath
         )
         let localRunner = localRunner
         let remoteRunner = remoteRunner
@@ -120,7 +127,8 @@ struct KwtWorktreeClient: Sendable {
         createsBranch: Bool,
         projectPath: String,
         platform: SSHHostInfo.Platform = .posix,
-        binaryPrelude: String
+        binaryPrelude: String,
+        windowsKwtRelativePath: String? = nil
     ) -> String {
         if platform == .windows {
             var arguments = ["add"]
@@ -130,7 +138,8 @@ struct KwtWorktreeClient: Sendable {
             arguments += [branchName, "--no-launch"]
             return KwtPowerShellCommand.run(
                 arguments: arguments,
-                workingDirectory: projectPath
+                workingDirectory: projectPath,
+                managedRelativePath: windowsKwtRelativePath
             )
         }
         let branchFlag = createsBranch ? " --branch" : ""

--- a/Sources/App/KwtWorktreeClient.swift
+++ b/Sources/App/KwtWorktreeClient.swift
@@ -76,20 +76,24 @@ struct KwtWorktreeClient: Sendable {
         on host: TmuxHost
     ) async throws {
         let binaryPrelude: String
+        let platform: SSHHostInfo.Platform
         switch host {
         case .local:
             binaryPrelude = KwtBinaryLocator.commandPrelude(
                 exactPath: localBinaryPath
             )
-        case .ssh:
+            platform = .posix
+        case let .ssh(info):
             binaryPrelude = KwtBinaryLocator.remoteCommandPrelude(
                 revision: remoteBinaryRevision
             )
+            platform = info.platform
         }
         let command = Self.command(
             branchName: request.branchName,
             createsBranch: request.createsBranch,
             projectPath: projectPath,
+            platform: platform,
             binaryPrelude: binaryPrelude
         )
         let localRunner = localRunner
@@ -115,8 +119,20 @@ struct KwtWorktreeClient: Sendable {
         branchName: String,
         createsBranch: Bool,
         projectPath: String,
+        platform: SSHHostInfo.Platform = .posix,
         binaryPrelude: String
     ) -> String {
+        if platform == .windows {
+            var arguments = ["add"]
+            if createsBranch {
+                arguments.append("--branch")
+            }
+            arguments += [branchName, "--no-launch"]
+            return KwtPowerShellCommand.run(
+                arguments: arguments,
+                workingDirectory: projectPath
+            )
+        }
         let branchFlag = createsBranch ? " --branch" : ""
         return binaryPrelude
             + "cd -- \(shellQuotedCommandArgument(projectPath)) || exit $?; "

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -68,6 +68,7 @@ private struct NativeTmuxAttachment {
     var tmuxPath: String
     var kwtPath: String?
     var remoteKwtCommandPrelude: String?
+    var windowsKwtRelativePath: String?
     var socketName: String?
     var protectedWorkspacePath: String?
     var launchMode: TmuxAttachmentLaunchMode
@@ -87,6 +88,7 @@ final class NativeTmuxSessionCoordinator {
         @Sendable (SSHHostInfo) -> Result<String, TmuxBinaryError>
     private let localKwtPathProvider: @Sendable () -> String?
     private let remoteKwtCommandPreludeProvider: @Sendable () -> String?
+    private let windowsKwtRelativePathProvider: @Sendable () -> String?
     private let presentationStyleProvider: () -> TmuxPresentationStyle?
     private var handlesByKey: [NativeTmuxSessionKey: BorrowedTmuxSessionHandle] = [:]
     private var targetHostsByHandle: [UUID: TmuxHost] = [:]
@@ -113,6 +115,12 @@ final class NativeTmuxSessionCoordinator {
                 revision: KwtBinaryLocator.bundledRemoteRevision()
             )
         },
+        windowsKwtRelativePathProvider:
+        @escaping @Sendable () -> String? = {
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: KwtBinaryLocator.bundledRemoteRevision()
+            )
+        },
         presentationStyleProvider:
         @escaping () -> TmuxPresentationStyle? = { nil },
         remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
@@ -125,6 +133,8 @@ final class NativeTmuxSessionCoordinator {
         self.localKwtPathProvider = localKwtPathProvider
         self.remoteKwtCommandPreludeProvider =
             remoteKwtCommandPreludeProvider
+        self.windowsKwtRelativePathProvider =
+            windowsKwtRelativePathProvider
         self.presentationStyleProvider = presentationStyleProvider
         self.remoteTmuxPathProvider = remoteTmuxPathProvider
     }
@@ -229,6 +239,9 @@ final class NativeTmuxSessionCoordinator {
                 remoteKwtCommandPrelude: host.isRemote
                     ? remoteKwtCommandPreludeProvider()
                     : nil,
+                windowsKwtRelativePath: host.isRemote
+                    ? windowsKwtRelativePathProvider()
+                    : nil,
                 socketName: socketName,
                 protectedWorkspacePath: protectedWorkspacePath,
                 launchMode: launchMode,
@@ -310,6 +323,8 @@ final class NativeTmuxSessionCoordinator {
                     kwtPath: attachment.kwtPath,
                     remoteKwtCommandPrelude:
                     attachment.remoteKwtCommandPrelude,
+                    windowsKwtRelativePath:
+                    attachment.windowsKwtRelativePath,
                     workingDirectory: attachment.workingDirectory
                 )
             )

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -230,7 +230,7 @@ struct TmuxBinaryResolver: Sendable {
             if ($LASTEXITCODE -ne 0) {
                 exit $LASTEXITCODE
             }
-            & $ghosthubMux 'list-sessions' '-F' \(powerShellQuotedCommandArgument(discoveryFormat))
+            & $ghosthubMux 'list-sessions' '-F' \(powerShellEncodedArgument(discoveryFormat))
             $ghosthubMuxStatus = $LASTEXITCODE
             if (($ghosthubMuxStatus -eq 0) -or ($ghosthubMuxStatus -eq 1)) {
                 exit 0
@@ -308,7 +308,7 @@ struct TmuxBinaryResolver: Sendable {
         }
         let prefix = discoveryPrefix + "\t"
         let sessions = result.stdout
-            .split(separator: "\n", omittingEmptySubsequences: true)
+            .split(whereSeparator: \.isNewline)
             .compactMap { rawLine -> DiscoveredTmuxSession? in
                 let line = String(rawLine)
                 guard line.hasPrefix(prefix) else { return nil }

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -149,7 +149,10 @@ struct TmuxBinaryResolver: Sendable {
     }
 
     func resolveTmuxPath(on host: SSHHostInfo) -> Result<String, TmuxBinaryError> {
-        let result = remoteProcessRunner(host, Self.probeCommand)
+        let result = remoteProcessRunner(
+            host,
+            Self.probeCommand(for: host.platform)
+        )
         if result.status == 255 {
             return .failure(.sshConnectionFailed(host: host.displayName))
         }
@@ -167,7 +170,10 @@ struct TmuxBinaryResolver: Sendable {
     func discoverSessions(
         on host: SSHHostInfo
     ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
-        let result = remoteProcessRunner(host, Self.discoveryCommand)
+        let result = remoteProcessRunner(
+            host,
+            Self.discoveryCommand(for: host.platform)
+        )
         if result.status == 255 {
             return .failure(.sshConnectionFailed(host: host.displayName))
         }
@@ -194,6 +200,53 @@ struct TmuxBinaryResolver: Sendable {
         + "[ \"$ghosthub_tmux_status\" -eq 0 ]"
         + " || [ \"$ghosthub_tmux_status\" -eq 1 ]"
 
+    private static func probeCommand(
+        for platform: SSHHostInfo.Platform
+    ) -> String {
+        switch platform {
+        case .posix:
+            probeCommand
+        case .windows:
+            windowsProbePrelude + """
+
+            Write-Output $ghosthubMux
+            & $ghosthubMux '-V'
+            exit $LASTEXITCODE
+            """
+        }
+    }
+
+    private static func discoveryCommand(
+        for platform: SSHHostInfo.Platform
+    ) -> String {
+        switch platform {
+        case .posix:
+            discoveryCommand
+        case .windows:
+            windowsProbePrelude + """
+
+            Write-Output $ghosthubMux
+            & $ghosthubMux '-V'
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+            & $ghosthubMux 'list-sessions' '-F' \(powerShellQuotedCommandArgument(discoveryFormat))
+            $ghosthubMuxStatus = $LASTEXITCODE
+            if (($ghosthubMuxStatus -eq 0) -or ($ghosthubMuxStatus -eq 1)) {
+                exit 0
+            }
+            exit $ghosthubMuxStatus
+            """
+        }
+    }
+
+    private static let windowsProbePrelude = """
+    $ErrorActionPreference = 'Stop'
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $OutputEncoding = [Console]::OutputEncoding
+    $ghosthubMux = (Get-Command tmux.exe -CommandType Application -ErrorAction Stop).Source
+    """
+
     private static func parseProbe(
         _ result: (status: Int32, stdout: String),
         shell: String
@@ -215,7 +268,7 @@ struct TmuxBinaryResolver: Sendable {
         }
         let lines = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
         guard let pathIndex = lines.indices.first(where: {
-            lines[$0].hasPrefix("/")
+            isAbsoluteExecutablePath(lines[$0])
                 && lines.indices.contains($0 + 1)
                 && lines[$0 + 1].hasPrefix("tmux ")
         })
@@ -230,6 +283,17 @@ struct TmuxBinaryResolver: Sendable {
             return .failure(.unsupportedVersion(found: version))
         }
         return .success(path)
+    }
+
+    private static func isAbsoluteExecutablePath(_ value: String) -> Bool {
+        if value.hasPrefix("/") || value.hasPrefix("\\\\") {
+            return true
+        }
+        guard value.count >= 3 else { return false }
+        let characters = Array(value)
+        return characters[0].isLetter
+            && characters[1] == ":"
+            && (characters[2] == "\\" || characters[2] == "/")
     }
 
     private static func parseDiscovery(

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -377,15 +377,26 @@ struct TmuxBinaryResolver: Sendable {
             arguments.append(contentsOf: ["-p", String(port)])
         }
         let target = host.user.map { "\($0)@\(host.hostname)" } ?? host.hostname
-        let accountShellCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
-            + shellQuotedCommandArgument(posixCommand(command))
-        let loginCommand = posixCommand(accountShellCommand)
-        arguments.append(contentsOf: ["--", target, loginCommand])
+        arguments.append(contentsOf: [
+            "--", target, remoteLoginCommand(host: host, command: command),
+        ])
         return runProcess(
             executable: "/usr/bin/ssh",
             arguments: arguments,
             timeout: timeout
         )
+    }
+
+    static func remoteLoginCommand(
+        host: SSHHostInfo,
+        command: String
+    ) -> String {
+        if host.platform == .windows {
+            return powerShellEncodedCommand(command)
+        }
+        let accountShellCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
+            + shellQuotedCommandArgument(posixCommand(command))
+        return posixCommand(accountShellCommand)
     }
 
     /// The account shell owns login-environment initialization, but Ghosthub's

--- a/Sources/App/TmuxHostResolver.swift
+++ b/Sources/App/TmuxHostResolver.swift
@@ -9,7 +9,16 @@ enum TmuxHostResolver {
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !destination.isEmpty
         else { return nil }
-        return parseSSHDestination(destination).map(TmuxHost.ssh)
+        return parseSSHDestination(destination).map { info in
+            TmuxHost.ssh(
+                SSHHostInfo(
+                    user: info.user,
+                    hostname: info.hostname,
+                    port: info.port,
+                    platform: host.platform == .windows ? .windows : .posix
+                )
+            )
+        }
     }
 
     static func parseSSHDestination(_ destination: String) -> SSHHostInfo? {

--- a/Sources/App/TmuxSessionKiller.swift
+++ b/Sources/App/TmuxSessionKiller.swift
@@ -96,7 +96,8 @@ struct TmuxSessionKiller: Sendable {
             tmuxPath: tmuxPath,
             sessionName: selection.name,
             socketName: selection.socketName,
-            expectedIdentity: expectedIdentity
+            expectedIdentity: expectedIdentity,
+            platform: Self.platform(for: host)
         )
         let runner = runner
         let result = await Task.detached(priority: .userInitiated) {
@@ -125,7 +126,8 @@ struct TmuxSessionKiller: Sendable {
         let command = Self.identityCommand(
             tmuxPath: tmuxPath,
             sessionName: selection.name,
-            socketName: selection.socketName
+            socketName: selection.socketName,
+            platform: Self.platform(for: host)
         )
         let runner = runner
         let result = await Task.detached(priority: .userInitiated) {
@@ -146,7 +148,8 @@ struct TmuxSessionKiller: Sendable {
         tmuxPath: String,
         sessionName: String,
         socketName: String?,
-        expectedIdentity: TmuxSessionIdentity
+        expectedIdentity: TmuxSessionIdentity,
+        platform: SSHHostInfo.Platform = .posix
     ) -> String {
         let target = "=\(sessionName):"
         var arguments = [tmuxPath]
@@ -165,6 +168,13 @@ struct TmuxSessionKiller: Sendable {
             "display-message -p "
                 + shellQuotedCommandArgument(identityMismatchMarker),
         ])
+        if platform == .windows {
+            arguments[arguments.count - 2] =
+                "kill-session -t \(expectedIdentity.sessionID)"
+            arguments[arguments.count - 1] =
+                "display-message -p \(identityMismatchMarker)"
+            return powerShellCommand(arguments)
+        }
         return arguments
             .map(shellQuotedCommandArgument)
             .joined(separator: " ")
@@ -173,7 +183,8 @@ struct TmuxSessionKiller: Sendable {
     private static func identityCommand(
         tmuxPath: String,
         sessionName: String,
-        socketName: String?
+        socketName: String?,
+        platform: SSHHostInfo.Platform
     ) -> String {
         var arguments = [tmuxPath]
         if let socketName {
@@ -186,9 +197,33 @@ struct TmuxSessionKiller: Sendable {
             "=\(sessionName):",
             identityMarker + "#{pid}\t#{session_id}\t#{session_created}",
         ])
+        if platform == .windows {
+            return powerShellCommand(arguments)
+        }
         return arguments
             .map(shellQuotedCommandArgument)
             .joined(separator: " ")
+    }
+
+    private static func powerShellCommand(_ arguments: [String]) -> String {
+        """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $OutputEncoding = [Console]::OutputEncoding
+        & \(arguments.map(powerShellQuotedCommandArgument).joined(separator: " "))
+        exit $LASTEXITCODE
+        """
+    }
+
+    private static func platform(
+        for host: TmuxHost
+    ) -> SSHHostInfo.Platform {
+        switch host {
+        case .local:
+            .posix
+        case let .ssh(info):
+            info.platform
+        }
     }
 
     static func isSessionCreatedAt(_ value: String) -> Bool {

--- a/Sources/App/TmuxSessionKiller.swift
+++ b/Sources/App/TmuxSessionKiller.swift
@@ -210,7 +210,7 @@ struct TmuxSessionKiller: Sendable {
         $ErrorActionPreference = 'Stop'
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $OutputEncoding = [Console]::OutputEncoding
-        & \(arguments.map(powerShellQuotedCommandArgument).joined(separator: " "))
+        & \(arguments.map(powerShellEncodedArgument).joined(separator: " "))
         exit $LASTEXITCODE
         """
     }
@@ -248,7 +248,7 @@ struct TmuxSessionKiller: Sendable {
         _ output: String
     ) -> TmuxSessionIdentity? {
         let markedLine = output
-            .split(separator: "\n", omittingEmptySubsequences: true)
+            .split(whereSeparator: \.isNewline)
             .reversed()
             .map(String.init)
             .first { $0.hasPrefix(identityMarker) }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1403,72 +1403,109 @@ final class WorkspaceSceneModel: ObservableObject {
         HostProbeSummary,
         HostProbeError
     > {
-        guard let sshHost = TmuxHostResolver.parseSSHDestination(
+        guard let parsedSSHHost = TmuxHostResolver.parseSSHDestination(
             host.sshDestination
         ) else {
             return .failure(.message("Enter a valid SSH destination."))
         }
+        let sshHost = SSHHostInfo(
+            user: parsedSSHHost.user,
+            hostname: parsedSSHHost.hostname,
+            port: parsedSSHHost.port,
+            platform: host.platform == .windows ? .windows : .posix
+        )
         let sshHostProbeRunner = sshHostProbeRunner
         let kwtPrelude = KwtBinaryLocator.remoteCommandPrelude(
             revision: KwtBinaryLocator.bundledRemoteRevision()
         )
-        let reachedMarker = "GHOSTHUB_REMOTE_PROBE_REACHED"
-        return await Task.detached {
-            let result = sshHostProbeRunner(
-                sshHost,
-                "printf '\(reachedMarker)\\n'; "
-                    + "if command -v tmux >/dev/null; then "
+        let probeCommand: String
+        if host.platform == .windows {
+            probeCommand = """
+            $ErrorActionPreference = 'Stop'
+            [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+            $OutputEncoding = [Console]::OutputEncoding
+            Write-Output 'GHOSTHUB_SSH_REACHED'
+            $ghosthubMuxCommand = Get-Command tmux.exe -CommandType Application -ErrorAction SilentlyContinue
+            if ($null -eq $ghosthubMuxCommand) {
+                Write-Output 'GHOSTHUB_TMUX_UNAVAILABLE'
+                exit 127
+            }
+            Write-Output 'GHOSTHUB_TMUX_AVAILABLE'
+            $ghosthubMux = $ghosthubMuxCommand.Source
+            & $ghosthubMux '-V' *> $null
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+            \(KwtPowerShellCommand.availabilityPrelude)
+            if ($ghosthubKwtAvailable) {
+                Write-Output 'GHOSTHUB_KWT_AVAILABLE'
+            } else {
+                Write-Output 'GHOSTHUB_KWT_UNAVAILABLE'
+            }
+            """
+        } else {
+            probeCommand =
+                "printf 'GHOSTHUB_SSH_REACHED\\n'; "
+                    + "ghosthub_tmux_path=$(command -v tmux) || { "
+                    + "printf 'GHOSTHUB_TMUX_UNAVAILABLE\\n'; exit 127; }; "
                     + "printf 'GHOSTHUB_TMUX_AVAILABLE\\n'; "
-                    + "else printf 'GHOSTHUB_TMUX_UNAVAILABLE\\n'; fi; "
+                    + "\"$ghosthub_tmux_path\" -V >/dev/null || exit $?; "
                     + "if ( \(kwtPrelude): ); then "
                     + "printf 'GHOSTHUB_KWT_AVAILABLE\\n'; "
                     + "else printf 'GHOSTHUB_KWT_UNAVAILABLE\\n'; fi"
+        }
+        return await Task.detached {
+            let result = sshHostProbeRunner(
+                sshHost,
+                probeCommand
             )
-            let reachable = result.stdout.contains(reachedMarker)
-            let probeSucceeded = result.status == 0 && reachable
+            let sshReached = result.stdout.contains(
+                "GHOSTHUB_SSH_REACHED"
+            )
             let tmuxAvailable = result.stdout.contains(
                 "GHOSTHUB_TMUX_AVAILABLE"
             )
             let kwtAvailable = result.stdout.contains(
                 "GHOSTHUB_KWT_AVAILABLE"
             )
-            var diagnostics: [RemoteHostDiagnostic] = []
-            if !reachable, result.status == 255 {
-                diagnostics.append(RemoteHostDiagnostic(
+            let diagnostics: [RemoteHostDiagnostic]
+            if !sshReached {
+                diagnostics = [RemoteHostDiagnostic(
                     code: .sshConnectionFailed,
                     severity: .error,
-                    summary: "SSH connection failed.",
+                    summary: "SSH could not be reached.",
                     recoverySuggestion:
-                    "Verify the SSH address, key authorization, and network, "
-                        + "then test the connection again."
-                ))
-            } else if !reachable {
-                diagnostics.append(RemoteHostDiagnostic(
+                    "Run `ssh \(host.sshDestination)` in Terminal once to "
+                        + "accept the host key, then verify key-based "
+                        + "authentication works without a prompt."
+                )]
+            } else if !tmuxAvailable {
+                diagnostics = [RemoteHostDiagnostic(
+                    code: .missingTmux,
+                    severity: .error,
+                    summary: host.platform == .windows
+                        ? "psmux is not available."
+                        : "tmux is not available.",
+                    recoverySuggestion: host.platform == .windows
+                        ? "Install psmux and ensure its tmux.exe alias is on "
+                        + "PATH for this SSH account, then test again."
+                        : "Install tmux on this host, then test again."
+                )]
+            } else if result.status != 0 {
+                diagnostics = [RemoteHostDiagnostic(
                     code: .probeFailure,
                     severity: .error,
-                    summary: "Remote verification did not reach the host"
-                        + " (status \(result.status)).",
+                    summary: host.platform == .windows
+                        ? "psmux did not respond successfully."
+                        : "tmux did not respond successfully.",
                     recoverySuggestion:
-                    "Verify the SSH address, network, and local SSH process, "
-                        + "then test the connection again."
-                ))
-            } else if !probeSucceeded {
-                diagnostics.append(RemoteHostDiagnostic(
-                    code: .probeFailure,
-                    severity: .error,
-                    summary: "Remote verification failed"
-                        + " (status \(result.status)).",
-                    recoverySuggestion:
-                    "Check the remote account’s login-shell startup files "
-                        + "and test the connection again."
-                ))
+                    "Run the tmux version command on the host and resolve "
+                        + "the reported error, then test again."
+                )]
+            } else if !kwtAvailable {
+                diagnostics = [.missingKwtCapability]
             } else {
-                if !tmuxAvailable {
-                    diagnostics.append(.missingTmuxCapability)
-                }
-                if !kwtAvailable {
-                    diagnostics.append(.missingKwtCapability)
-                }
+                diagnostics = []
             }
             return .success(HostProbeSummary(
                 host: HostSummary(
@@ -1479,12 +1516,12 @@ final class WorkspaceSceneModel: ObservableObject {
                     platform: host.platform,
                     sshDestination: host.sshDestination,
                     preferredTransport: .ssh,
-                    lastKnownReachable: reachable,
-                    lastSeenAt: reachable ? Date() : nil,
+                    lastKnownReachable: sshReached,
+                    lastSeenAt: sshReached ? Date() : nil,
                     remoteDiagnostics: diagnostics,
-                    decodedConnectionState: probeSucceeded
-                        ? .online
-                        : (reachable ? .degraded : .offline)
+                    decodedConnectionState: !sshReached
+                        ? .offline
+                        : result.status == 0 ? .online : .degraded
                 )
             ))
         }.value

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1418,6 +1418,10 @@ final class WorkspaceSceneModel: ObservableObject {
         let kwtPrelude = KwtBinaryLocator.remoteCommandPrelude(
             revision: KwtBinaryLocator.bundledRemoteRevision()
         )
+        let windowsKwtRelativePath =
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: KwtBinaryLocator.bundledRemoteRevision()
+            )
         let probeCommand: String
         if host.platform == .windows {
             probeCommand = """
@@ -1436,7 +1440,9 @@ final class WorkspaceSceneModel: ObservableObject {
             if ($LASTEXITCODE -ne 0) {
                 exit $LASTEXITCODE
             }
-            \(KwtPowerShellCommand.availabilityPrelude)
+            \(KwtPowerShellCommand.availabilityPrelude(
+                managedRelativePath: windowsKwtRelativePath
+            ))
             if ($ghosthubKwtAvailable) {
                 Write-Output 'GHOSTHUB_KWT_AVAILABLE'
             } else {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1540,6 +1540,19 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    func installWindowsKwt(
+        on host: SSHHost
+    ) async -> Result<Void, HostProbeError> {
+        switch await KwtWindowsInstaller().install(on: host) {
+        case .success:
+            refreshHosts()
+            refreshKwtInventory()
+            return .success(())
+        case let .failure(error):
+            return .failure(.message(error.localizedDescription))
+        }
+    }
+
     func registerRemoteProject(
         _ projectPath: String,
         on host: SSHHost

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -613,6 +613,18 @@ struct WorkspaceWindow: View {
                                             on: host
                                         )
                                 },
+                                installWindowsKwt: {
+                                    host in
+                                    switch await KwtWindowsInstaller()
+                                        .install(on: host) {
+                                    case .success:
+                                        return .success(())
+                                    case let .failure(error):
+                                        return .failure(.message(
+                                            error.localizedDescription
+                                        ))
+                                    }
+                                },
                                 reloadTerminalConfig: {
                                     sceneModel.reloadTerminalConfig()
                                 }

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -615,15 +615,10 @@ struct WorkspaceWindow: View {
                                 },
                                 installWindowsKwt: {
                                     host in
-                                    switch await KwtWindowsInstaller()
-                                        .install(on: host) {
-                                    case .success:
-                                        return .success(())
-                                    case let .failure(error):
-                                        return .failure(.message(
-                                            error.localizedDescription
-                                        ))
-                                    }
+                                    await sceneModel
+                                        .installWindowsKwt(
+                                            on: host
+                                        )
                                 },
                                 reloadTerminalConfig: {
                                     sceneModel.reloadTerminalConfig()

--- a/Sources/Settings/HostProbeResult.swift
+++ b/Sources/Settings/HostProbeResult.swift
@@ -91,6 +91,8 @@ private extension HostPlatform {
             return "macOS"
         case .linux:
             return "Linux"
+        case .windows:
+            return "Windows"
         }
     }
 }

--- a/Sources/Settings/TailscalePeer.swift
+++ b/Sources/Settings/TailscalePeer.swift
@@ -33,6 +33,8 @@ public struct TailscalePeer: Identifiable, Equatable, Sendable {
             return .macOS
         case "linux":
             return .linux
+        case "windows":
+            return .windows
         default:
             return .linux
         }
@@ -40,7 +42,7 @@ public struct TailscalePeer: Identifiable, Equatable, Sendable {
 
     public var isSSHCapable: Bool {
         let lower = os.lowercased()
-        return lower == "linux" || lower == "macos"
+        return lower == "linux" || lower == "macos" || lower == "windows"
     }
 }
 

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -205,6 +205,28 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 workingDirectory: workingDirectory
             )
         case let .ssh(info):
+            if info.platform == .windows {
+                if launchMode == .create {
+                    return remoteCreateThenAttachCommand(
+                        info: info,
+                        tmuxPath: tmuxPath,
+                        workingDirectory: workingDirectory,
+                        sshConnectionArguments: sshConnectionArguments
+                    )
+                }
+                if protectedWorkspacePath == nil, workspacePath != nil {
+                    return windowsRemoteWorkspaceAttachCommand(
+                        info: info,
+                        tmuxPath: tmuxPath,
+                        sshConnectionArguments: sshConnectionArguments
+                    )
+                }
+                return windowsRemoteAttachCommand(
+                    info: info,
+                    tmuxPath: tmuxPath,
+                    sshConnectionArguments: sshConnectionArguments
+                )
+            }
             if launchMode == .create {
                 return remoteCreateThenAttachCommand(
                     info: info,
@@ -578,6 +600,68 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 remoteCommand: remoteAccountLoginShellCommand(remoteProbe),
                 sshConnectionArguments: sshConnectionArguments
             )
+        )
+        return shellCommand([
+            "/bin/sh", "-c", Self.remoteWorkspaceAttachScript,
+            "ghosthub-ssh-kwt-attach",
+            initialAttach, sessionProbe, reconnectAttach,
+        ])
+    }
+
+    private func windowsRemoteWorkspaceAttachCommand(
+        info: SSHHostInfo,
+        tmuxPath: String,
+        sshConnectionArguments: [String]
+    ) -> String {
+        guard let workspacePath else {
+            return windowsRemoteAttachCommand(
+                info: info,
+                tmuxPath: tmuxPath,
+                sshConnectionArguments: sshConnectionArguments
+            )
+        }
+        let initialScript = """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $OutputEncoding = [Console]::OutputEncoding
+        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
+        \(powerShellKwtResolutionPrelude())
+        & $ghosthubKwt 'open' \(powerShellQuotedCommandArgument(workspacePath))
+        exit $LASTEXITCODE
+        """
+        let initialAttach = shellCommand(
+            sshArguments(
+                info: info,
+                allocateTTY: true,
+                remoteCommand: powerShellEncodedCommand(initialScript),
+                sshConnectionArguments: sshConnectionArguments
+            )
+        )
+        let probeScript = """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
+        \(windowsMuxCommand(
+            tmuxPath: tmuxPath,
+            arguments: ["has-session", "-t", "=\(sessionName)"]
+        )) *> $null
+        exit $LASTEXITCODE
+        """
+        let sessionProbe = shellCommand(
+            [
+                "/bin/sh", "-c", Self.sshReconnectScript,
+                "ghosthub-ssh-kwt-probe",
+            ] + sshArguments(
+                info: info,
+                allocateTTY: false,
+                remoteCommand: powerShellEncodedCommand(probeScript),
+                sshConnectionArguments: sshConnectionArguments
+            )
+        )
+        let reconnectAttach = windowsRemoteAttachCommand(
+            info: info,
+            tmuxPath: tmuxPath,
+            sshConnectionArguments: sshConnectionArguments
         )
         return shellCommand([
             "/bin/sh", "-c", Self.remoteWorkspaceAttachScript,

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -28,6 +28,47 @@ public func shellQuotedCommandArgument(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
 }
 
+public func powerShellQuotedCommandArgument(_ value: String) -> String {
+    "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+}
+
+public func powerShellEncodedCommand(_ command: String) -> String {
+    let data = command.data(using: .utf16LittleEndian) ?? Data()
+    return [
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        data.base64EncodedString(),
+    ].joined(separator: " ")
+}
+
+public let ghosthubManagedWindowsKwtRelativePath =
+    #".ghosthub\bin\kwt.exe"#
+
+public func powerShellKwtResolutionPrelude() -> String {
+    """
+    $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
+        powerShellQuotedCommandArgument(ghosthubManagedWindowsKwtRelativePath)
+    )
+    if (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) {
+        $ghosthubKwt = $ghosthubManagedKwt
+    } else {
+        $ghosthubKwt = (Get-Command kwt.exe -CommandType Application -ErrorAction Stop).Source
+    }
+    """
+}
+
+public func powerShellKwtAvailabilityPrelude() -> String {
+    """
+    $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
+        powerShellQuotedCommandArgument(ghosthubManagedWindowsKwtRelativePath)
+    )
+    $ghosthubKwtAvailable = (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) -or ($null -ne (Get-Command kwt.exe -CommandType Application -ErrorAction SilentlyContinue))
+    """
+}
+
 /// Initializes the remote account's login environment, then delegates
 /// Ghosthub-owned POSIX command text to `/bin/sh`. The outer simple command is
 /// accepted by POSIX shells and non-POSIX account shells such as fish.
@@ -48,14 +89,26 @@ public enum ConnectionState: Codable, Equatable, Sendable {
 }
 
 public struct SSHHostInfo: Codable, Hashable, Sendable {
+    public enum Platform: String, Codable, Hashable, Sendable {
+        case posix
+        case windows
+    }
+
     public let user: String?
     public let hostname: String
     public let port: Int?
+    public let platform: Platform
 
-    public init(user: String?, hostname: String, port: Int?) {
+    public init(
+        user: String?,
+        hostname: String,
+        port: Int?,
+        platform: Platform = .posix
+    ) {
         self.user = user
         self.hostname = hostname
         self.port = port
+        self.platform = platform
     }
 
     public var displayName: String {
@@ -403,6 +456,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         sshConnectionArguments: [String],
         useAccountLoginShell: Bool = false
     ) -> String {
+        if info.platform == .windows {
+            return windowsRemoteAttachCommand(
+                info: info,
+                tmuxPath: tmuxPath,
+                sshConnectionArguments: sshConnectionArguments
+            )
+        }
         let attach: String
         if let protectedWorkspacePath {
             let protectedAttach: String
@@ -526,17 +586,71 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         ])
     }
 
+    private func windowsRemoteAttachCommand(
+        info: SSHHostInfo,
+        tmuxPath: String,
+        sshConnectionArguments: [String]
+    ) -> String {
+        let attach: String
+        if let protectedWorkspacePath {
+            attach = """
+            \(powerShellKwtResolutionPrelude())
+            & $ghosthubKwt 'pr' 'attach' \(powerShellQuotedCommandArgument(protectedWorkspacePath))
+            """
+        } else {
+            attach = windowsMuxCommand(
+                tmuxPath: tmuxPath,
+                arguments: [
+                    "attach-session", "-E", "-t", "=\(sessionName)",
+                ]
+            )
+        }
+        let script = """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
+        \(attach)
+        exit $LASTEXITCODE
+        """
+        let remoteCommand = powerShellEncodedCommand(script)
+        return shellCommand(
+            [
+                "/bin/sh", "-c", Self.sshReconnectScript,
+                "ghosthub-ssh-psmux",
+            ] + sshArguments(
+                info: info,
+                allocateTTY: true,
+                remoteCommand: remoteCommand,
+                sshConnectionArguments: sshConnectionArguments
+            )
+        )
+    }
+
     private func remoteCreateThenAttachCommand(
         info: SSHHostInfo,
         tmuxPath: String,
         workingDirectory: String?,
         sshConnectionArguments: [String]
     ) -> String {
-        let remoteCreate = "unset TMUX TMUX_PANE; "
-            + createIfAbsentCommand(
+        let remoteCreate: String
+        if info.platform == .windows {
+            let script = """
+            $ErrorActionPreference = 'Stop'
+            [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+            Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
+            \(windowsCreateIfAbsentScript(
                 tmuxPath: tmuxPath,
                 workingDirectory: workingDirectory
-            )
+            ))
+            """
+            remoteCreate = powerShellEncodedCommand(script)
+        } else {
+            remoteCreate = "unset TMUX TMUX_PANE; "
+                + createIfAbsentCommand(
+                    tmuxPath: tmuxPath,
+                    workingDirectory: workingDirectory
+                )
+        }
         let createOnce = shellCommand(
             sshArguments(
                 info: info,
@@ -575,6 +689,39 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             + "\(createSession) || \(hasSession)"
     }
 
+    private func windowsCreateIfAbsentScript(
+        tmuxPath: String,
+        workingDirectory: String?
+    ) -> String {
+        let target = "=\(sessionName)"
+        let hasSession = windowsMuxCommand(
+            tmuxPath: tmuxPath,
+            arguments: ["has-session", "-t", target]
+        )
+        var createArguments = [
+            "new-session", "-d", "-E", "-s", sessionName,
+        ]
+        if let workingDirectory {
+            createArguments += ["-c", workingDirectory]
+        }
+        let createSession = windowsMuxCommand(
+            tmuxPath: tmuxPath,
+            arguments: createArguments
+        ) + " '-e' ('PATH=' + $env:PATH)"
+        return """
+        & { \(hasSession) } *> $null
+        if ($LASTEXITCODE -ne 0) {
+            \(createSession)
+            $ghosthubCreateStatus = $LASTEXITCODE
+            if ($ghosthubCreateStatus -ne 0) {
+                & { \(hasSession) } *> $null
+                exit $LASTEXITCODE
+            }
+        }
+        exit 0
+        """
+    }
+
     private func tmuxArguments(
         _ tmuxPath: String,
         _ arguments: String...
@@ -584,6 +731,20 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             result.append(contentsOf: ["-L", socketName])
         }
         return result + arguments
+    }
+
+    private func windowsMuxCommand(
+        tmuxPath: String,
+        arguments: [String]
+    ) -> String {
+        var values = [tmuxPath]
+        if let socketName, !socketName.isEmpty {
+            values += ["-L", socketName]
+        }
+        values += arguments
+        return "& " + values
+            .map(powerShellQuotedCommandArgument)
+            .joined(separator: " ")
     }
 
     private func sshArguments(

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -48,28 +48,33 @@ public func powerShellEncodedCommand(_ command: String) -> String {
     ].joined(separator: " ")
 }
 
-public let ghosthubManagedWindowsKwtRelativePath =
-    #".ghosthub\bin\kwt.exe"#
-
-public func powerShellKwtResolutionPrelude() -> String {
-    """
-    $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
-        powerShellEncodedArgument(ghosthubManagedWindowsKwtRelativePath)
+public func powerShellKwtResolutionPrelude(
+    managedRelativePath: String?
+) -> String {
+    guard let managedRelativePath else {
+        return "throw 'Ghosthub managed kwt is unavailable'"
+    }
+    return """
+    $ghosthubKwt = Join-Path $env:USERPROFILE \(
+        powerShellEncodedArgument(managedRelativePath)
     )
-    if (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) {
-        $ghosthubKwt = $ghosthubManagedKwt
-    } else {
-        $ghosthubKwt = (Get-Command kwt.exe -CommandType Application -ErrorAction Stop).Source
+    if (-not (Test-Path -LiteralPath $ghosthubKwt -PathType Leaf)) {
+        throw 'Ghosthub managed kwt is unavailable'
     }
     """
 }
 
-public func powerShellKwtAvailabilityPrelude() -> String {
-    """
+public func powerShellKwtAvailabilityPrelude(
+    managedRelativePath: String?
+) -> String {
+    guard let managedRelativePath else {
+        return "$ghosthubKwtAvailable = $false"
+    }
+    return """
     $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
-        powerShellEncodedArgument(ghosthubManagedWindowsKwtRelativePath)
+        powerShellEncodedArgument(managedRelativePath)
     )
-    $ghosthubKwtAvailable = (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) -or ($null -ne (Get-Command kwt.exe -CommandType Application -ErrorAction SilentlyContinue))
+    $ghosthubKwtAvailable = Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf
     """
 }
 
@@ -198,6 +203,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         tmuxPath: String = "tmux",
         kwtPath: String? = nil,
         remoteKwtCommandPrelude: String? = nil,
+        windowsKwtRelativePath: String? = nil,
         workingDirectory: String? = nil,
         sshConnectionArguments: [String] = tmuxSSHConnectionArguments()
     ) -> String {
@@ -222,12 +228,14 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     return windowsRemoteWorkspaceAttachCommand(
                         info: info,
                         tmuxPath: tmuxPath,
+                        windowsKwtRelativePath: windowsKwtRelativePath,
                         sshConnectionArguments: sshConnectionArguments
                     )
                 }
                 return windowsRemoteAttachCommand(
                     info: info,
                     tmuxPath: tmuxPath,
+                    windowsKwtRelativePath: windowsKwtRelativePath,
                     sshConnectionArguments: sshConnectionArguments
                 )
             }
@@ -615,12 +623,14 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     private func windowsRemoteWorkspaceAttachCommand(
         info: SSHHostInfo,
         tmuxPath: String,
+        windowsKwtRelativePath: String?,
         sshConnectionArguments: [String]
     ) -> String {
         guard let workspacePath else {
             return windowsRemoteAttachCommand(
                 info: info,
                 tmuxPath: tmuxPath,
+                windowsKwtRelativePath: windowsKwtRelativePath,
                 sshConnectionArguments: sshConnectionArguments
             )
         }
@@ -629,7 +639,9 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $OutputEncoding = [Console]::OutputEncoding
         Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
-        \(powerShellKwtResolutionPrelude())
+        \(powerShellKwtResolutionPrelude(
+            managedRelativePath: windowsKwtRelativePath
+        ))
         & $ghosthubKwt 'open' \(powerShellEncodedArgument(workspacePath))
         exit $LASTEXITCODE
         """
@@ -665,6 +677,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         let reconnectAttach = windowsRemoteAttachCommand(
             info: info,
             tmuxPath: tmuxPath,
+            windowsKwtRelativePath: windowsKwtRelativePath,
             sshConnectionArguments: sshConnectionArguments
         )
         return shellCommand([
@@ -677,12 +690,15 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     private func windowsRemoteAttachCommand(
         info: SSHHostInfo,
         tmuxPath: String,
+        windowsKwtRelativePath: String? = nil,
         sshConnectionArguments: [String]
     ) -> String {
         let attach: String
         if let protectedWorkspacePath {
             attach = """
-            \(powerShellKwtResolutionPrelude())
+            \(powerShellKwtResolutionPrelude(
+                managedRelativePath: windowsKwtRelativePath
+            ))
             & $ghosthubKwt 'pr' 'attach' \(powerShellEncodedArgument(protectedWorkspacePath))
             """
         } else {

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -28,8 +28,12 @@ public func shellQuotedCommandArgument(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
 }
 
-public func powerShellQuotedCommandArgument(_ value: String) -> String {
-    "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+/// Keeps caller-controlled text out of PowerShell source. The generated
+/// expression contains only a Base64 alphabet in an ASCII-delimited literal.
+public func powerShellEncodedArgument(_ value: String) -> String {
+    let encoded = Data(value.utf8).base64EncodedString()
+    return "([System.Text.Encoding]::UTF8.GetString("
+        + "[System.Convert]::FromBase64String('\(encoded)')))"
 }
 
 public func powerShellEncodedCommand(_ command: String) -> String {
@@ -50,7 +54,7 @@ public let ghosthubManagedWindowsKwtRelativePath =
 public func powerShellKwtResolutionPrelude() -> String {
     """
     $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
-        powerShellQuotedCommandArgument(ghosthubManagedWindowsKwtRelativePath)
+        powerShellEncodedArgument(ghosthubManagedWindowsKwtRelativePath)
     )
     if (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) {
         $ghosthubKwt = $ghosthubManagedKwt
@@ -63,7 +67,7 @@ public func powerShellKwtResolutionPrelude() -> String {
 public func powerShellKwtAvailabilityPrelude() -> String {
     """
     $ghosthubManagedKwt = Join-Path $env:USERPROFILE \(
-        powerShellQuotedCommandArgument(ghosthubManagedWindowsKwtRelativePath)
+        powerShellEncodedArgument(ghosthubManagedWindowsKwtRelativePath)
     )
     $ghosthubKwtAvailable = (Test-Path -LiteralPath $ghosthubManagedKwt -PathType Leaf) -or ($null -ne (Get-Command kwt.exe -CommandType Application -ErrorAction SilentlyContinue))
     """
@@ -626,7 +630,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         $OutputEncoding = [Console]::OutputEncoding
         Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
         \(powerShellKwtResolutionPrelude())
-        & $ghosthubKwt 'open' \(powerShellQuotedCommandArgument(workspacePath))
+        & $ghosthubKwt 'open' \(powerShellEncodedArgument(workspacePath))
         exit $LASTEXITCODE
         """
         let initialAttach = shellCommand(
@@ -679,7 +683,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         if let protectedWorkspacePath {
             attach = """
             \(powerShellKwtResolutionPrelude())
-            & $ghosthubKwt 'pr' 'attach' \(powerShellQuotedCommandArgument(protectedWorkspacePath))
+            & $ghosthubKwt 'pr' 'attach' \(powerShellEncodedArgument(protectedWorkspacePath))
             """
         } else {
             attach = windowsMuxCommand(
@@ -827,7 +831,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         }
         values += arguments
         return "& " + values
-            .map(powerShellQuotedCommandArgument)
+            .map(powerShellEncodedArgument)
             .joined(separator: " ")
     }
 

--- a/Sources/UI/CommandPaletteModel.swift
+++ b/Sources/UI/CommandPaletteModel.swift
@@ -345,7 +345,7 @@ public enum CommandPaletteModel {
         in snapshot: WorkspaceSnapshot
     ) -> [WorkspaceCommandItem] {
         snapshot.hosts.flatMap { host in
-            [
+            var commands = [
                 WorkspaceCommandItem(
                     id: "new-tmux-session-\(host.id.uuidString)",
                     title: "New tmux session on \(host.name)",
@@ -356,7 +356,9 @@ public enum CommandPaletteModel {
                     ],
                     action: .newTmuxSession(host.id)
                 ),
-                WorkspaceCommandItem(
+            ]
+            if host.canRegisterProjects {
+                commands.append(WorkspaceCommandItem(
                     id: "add-project-\(host.id.uuidString)",
                     title: "Add Project on \(host.name)",
                     subtitle: "Register an existing checkout with kwt.",
@@ -365,8 +367,9 @@ public enum CommandPaletteModel {
                         host.name, host.sshDestination ?? "",
                     ],
                     action: .addProject(host.id)
-                ),
-            ]
+                ))
+            }
+            return commands
         }
     }
 

--- a/Sources/UI/HostsSettingsView.swift
+++ b/Sources/UI/HostsSettingsView.swift
@@ -62,6 +62,7 @@ public struct HostsSettingsView: View {
     @Binding var tailscaleError: String?
     @Binding var isLoadingTailscale: Bool
     @Binding var isTailscaleSheetPresented: Bool
+    @Binding var isInstallingWindowsKwt: Bool
     let probeSSHHost:
         (SSHHost) async -> Result<
             HostProbeSummary,
@@ -72,6 +73,8 @@ public struct HostsSettingsView: View {
     let registerRemoteProject:
         (SSHHost, String) async -> Result<String, HostProbeError>
     let loadTailscalePeers: () async -> TailscalePeerLoadResult
+    let installWindowsKwt:
+        (SSHHost) async -> Result<Void, HostProbeError>
 
     public init(
         sshHosts: Binding<[SSHHostDraft]>,
@@ -85,6 +88,7 @@ public struct HostsSettingsView: View {
         tailscaleError: Binding<String?>,
         isLoadingTailscale: Binding<Bool>,
         isTailscaleSheetPresented: Binding<Bool>,
+        isInstallingWindowsKwt: Binding<Bool>,
         probeSSHHost: @escaping (SSHHost) async -> Result<
             HostProbeSummary,
             HostProbeError
@@ -96,7 +100,11 @@ public struct HostsSettingsView: View {
             SSHHost,
             String
         ) async -> Result<String, HostProbeError>,
-        loadTailscalePeers: @escaping () async -> TailscalePeerLoadResult
+        loadTailscalePeers: @escaping () async -> TailscalePeerLoadResult,
+        installWindowsKwt: @escaping (SSHHost) async -> Result<
+            Void,
+            HostProbeError
+        >
     ) {
         _sshHosts = sshHosts
         _selectedSSHHostDraftID = selectedSSHHostDraftID
@@ -109,10 +117,12 @@ public struct HostsSettingsView: View {
         _tailscaleError = tailscaleError
         _isLoadingTailscale = isLoadingTailscale
         _isTailscaleSheetPresented = isTailscaleSheetPresented
+        _isInstallingWindowsKwt = isInstallingWindowsKwt
         self.probeSSHHost = probeSSHHost
         self.installRemoteKwt = installRemoteKwt
         self.registerRemoteProject = registerRemoteProject
         self.loadTailscalePeers = loadTailscalePeers
+        self.installWindowsKwt = installWindowsKwt
     }
 
     public var body: some View {
@@ -238,6 +248,8 @@ public struct HostsSettingsView: View {
                             Picker("Platform", selection: binding.platform) {
                                 Text("Linux").tag(HostPlatform.linux)
                                 Text("macOS").tag(HostPlatform.macOS)
+                                Text("Windows (psmux)")
+                                    .tag(HostPlatform.windows)
                             }
                             .labelsHidden()
                         }
@@ -321,6 +333,19 @@ public struct HostsSettingsView: View {
                             }
                         }
 
+                        if draft.platform == .windows {
+                            Text(
+                                "Installs Ghosthub’s unsigned experimental"
+                                    + " AMD64 or ARM64 kwt.exe for this user."
+                            )
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(
+                                horizontal: false,
+                                vertical: true
+                            )
+                        }
+
                         if let hostProbeResult {
                             Text(hostProbeResult.subtitle)
                                 .font(.system(size: 12, weight: .semibold))
@@ -389,7 +414,7 @@ public struct HostsSettingsView: View {
                         }
                     }
 
-                    if isRemoteKwtReady {
+                    if isRemoteKwtReady, draft.platform != .windows {
                         settingsSection("Projects") {
                             Text(
                                 "Register an existing Git checkout explicitly."
@@ -663,8 +688,11 @@ public struct HostsSettingsView: View {
     }
 
     private var remoteKwtButtonTitle: String {
-        if isInstallingRemoteKwt {
+        if isInstallingRemoteKwt || isInstallingWindowsKwt {
             return "Installing\u{2026}"
+        }
+        if selectedSSHHostDraft?.platform == .windows {
+            return "Install Bundled kwt"
         }
         let isMissing = hostProbeResult?.diagnostics.contains {
             $0.code == .missingKwt
@@ -677,6 +705,7 @@ public struct HostsSettingsView: View {
     private var isHostActionInProgress: Bool {
         isProbingSSHHost
             || isInstallingRemoteKwt
+            || isInstallingWindowsKwt
             || isRegisteringRemoteProject
     }
 
@@ -698,6 +727,20 @@ public struct HostsSettingsView: View {
     }
 
     private func installKwt(on draft: SSHHostDraft) async {
+        if draft.platform == .windows {
+            clearSSHHostProbeFeedback()
+            isInstallingWindowsKwt = true
+            defer { isInstallingWindowsKwt = false }
+
+            switch await installWindowsKwt(draft.sshHost) {
+            case .success:
+                await probeHost(draft)
+            case let .failure(error):
+                hostProbeErrorMessage = error.displayMessage
+            }
+            return
+        }
+
         let target = HostOperationTarget(draft)
         hostProbeErrorMessage = nil
         remoteKwtInstallMessage = nil

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -23,6 +23,10 @@ public struct SettingsActions {
             _, _ in
             .failure(.message("Remote project registration is unavailable."))
         }
+    var installWindowsKwt:
+        (SSHHost) async -> Result<Void, HostProbeError> = { _ in
+            .failure(.message("Windows kwt installation is unavailable."))
+        }
     var reloadTerminalConfig: () -> Void = {}
 
     public init(
@@ -47,6 +51,12 @@ public struct SettingsActions {
         ) async -> Result<String, HostProbeError> = { _, _ in
             .failure(.message("Remote project registration is unavailable."))
         },
+        installWindowsKwt: @escaping (SSHHost) async -> Result<
+            Void,
+            HostProbeError
+        > = { _ in
+            .failure(.message("Windows kwt installation is unavailable."))
+        },
         reloadTerminalConfig: @escaping () -> Void = {}
     ) {
         self.refreshHosts = refreshHosts
@@ -54,6 +64,7 @@ public struct SettingsActions {
         self.loadTailscalePeers = loadTailscalePeers
         self.installRemoteKwt = installRemoteKwt
         self.registerRemoteProject = registerRemoteProject
+        self.installWindowsKwt = installWindowsKwt
         self.reloadTerminalConfig = reloadTerminalConfig
     }
 }
@@ -79,6 +90,7 @@ public struct SettingsView: View {
     @State private var tailscaleError: String?
     @State private var isLoadingTailscale = false
     @State private var isTailscaleSheetPresented = false
+    @State private var isInstallingWindowsKwt = false
     public init(
         store: SettingsStore,
         actions: SettingsActions = SettingsActions(),
@@ -236,10 +248,12 @@ public struct SettingsView: View {
             tailscaleError: $tailscaleError,
             isLoadingTailscale: $isLoadingTailscale,
             isTailscaleSheetPresented: $isTailscaleSheetPresented,
+            isInstallingWindowsKwt: $isInstallingWindowsKwt,
             probeSSHHost: actions.probeSSHHost,
             installRemoteKwt: actions.installRemoteKwt,
             registerRemoteProject: actions.registerRemoteProject,
-            loadTailscalePeers: actions.loadTailscalePeers
+            loadTailscalePeers: actions.loadTailscalePeers,
+            installWindowsKwt: actions.installWindowsKwt
         )
     }
 

--- a/Sources/UI/TailscalePeerPickerSheet.swift
+++ b/Sources/UI/TailscalePeerPickerSheet.swift
@@ -18,7 +18,7 @@ struct TailscalePeerPickerSheet: View {
             Text(
                 "Select hosts to add as SSH connections."
                     + " Only SSH-capable hosts (Linux and"
-                    + " macOS) are shown."
+                    + " macOS, and Windows) are shown."
             )
             .font(.subheadline)
             .foregroundStyle(.secondary)

--- a/Sources/UI/WorkspaceEntityPresentation.swift
+++ b/Sources/UI/WorkspaceEntityPresentation.swift
@@ -107,6 +107,8 @@ extension HostPlatform {
             return "macOS"
         case .linux:
             return "Linux"
+        case .windows:
+            return "Windows"
         }
     }
 }

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -199,8 +199,10 @@ struct WorkspaceSidebarView: View {
             Button("New tmux session…") {
                 onNewTmuxSession(section.host)
             }
-            Button("Add Project…") {
-                onAddProject(section.host)
+            if section.host.canRegisterProjects {
+                Button("Add Project…") {
+                    onAddProject(section.host)
+                }
             }
         }
     }
@@ -340,20 +342,9 @@ struct WorkspaceSidebarView: View {
             }
             NativePopupMenuButton(
                 groups: [
-                    [
-                        NativePopupMenuAction("New tmux session…") {
-                            guard let host = preferredNewSessionHost else {
-                                return
-                            }
-                            onNewTmuxSession(host)
-                        },
-                        NativePopupMenuAction("Add Project…") {
-                            guard let host = preferredNewSessionHost else {
-                                return
-                            }
-                            onAddProject(host)
-                        },
-                    ],
+                    preferredNewSessionHost.map {
+                        hostActionMenuItems(for: $0)
+                    } ?? [],
                     [
                         NativePopupMenuAction(
                             "New worktree…",
@@ -725,14 +716,7 @@ struct WorkspaceSidebarView: View {
             if let actionHost {
                 NativePopupMenuButton(
                     groups: [
-                        [
-                            NativePopupMenuAction("New tmux session…") {
-                                onNewTmuxSession(actionHost)
-                            },
-                            NativePopupMenuAction("Add Project…") {
-                                onAddProject(actionHost)
-                            },
-                        ],
+                        hostActionMenuItems(for: actionHost),
                     ]
                 ) {
                     Image(systemName: "plus")
@@ -750,6 +734,24 @@ struct WorkspaceSidebarView: View {
                 .accessibilityIdentifier("host-actions")
             }
         }
+    }
+
+    private func hostActionMenuItems(
+        for host: HostSummary
+    ) -> [NativePopupMenuAction] {
+        var actions = [
+            NativePopupMenuAction("New tmux session…") {
+                onNewTmuxSession(host)
+            },
+        ]
+        if host.canRegisterProjects {
+            actions.append(
+                NativePopupMenuAction("Add Project…") {
+                    onAddProject(host)
+                }
+            )
+        }
+        return actions
     }
 
     private func projectHierarchyRow(

--- a/Sources/Workspace/HostModels.swift
+++ b/Sources/Workspace/HostModels.swift
@@ -455,6 +455,10 @@ public struct HostSummary: Identifiable, Equatable, Sendable {
         remoteDiagnostics.first
     }
 
+    public var canRegisterProjects: Bool {
+        platform != .windows
+    }
+
     public var canCreateWorktree: Bool {
         if kind == .remote, connectionState == .offline {
             return false

--- a/Sources/Workspace/HostModels.swift
+++ b/Sources/Workspace/HostModels.swift
@@ -26,6 +26,7 @@ public enum HostTransport: String, Codable, Equatable, Sendable {
 public enum HostPlatform: String, Equatable, Sendable {
     case macOS
     case linux
+    case windows
 }
 
 extension HostPlatform: Codable {
@@ -35,6 +36,7 @@ extension HostPlatform: Codable {
         switch raw {
         case "macos", "macOS": self = .macOS
         case "linux": self = .linux
+        case "windows": self = .windows
         default:
             throw DecodingError.dataCorrupted(
                 .init(
@@ -52,6 +54,7 @@ extension HostPlatform: Codable {
         switch self {
         case .macOS: try container.encode("macos")
         case .linux: try container.encode("linux")
+        case .windows: try container.encode("windows")
         }
     }
 }
@@ -70,6 +73,9 @@ extension HostPlatform {
         if lower.hasPrefix("macos")
             || lower.hasPrefix("darwin") {
             return .macOS
+        }
+        if lower.hasPrefix("windows") {
+            return .windows
         }
         return .linux
     }

--- a/Tests/App/ConfiguredHostOverlayTests.swift
+++ b/Tests/App/ConfiguredHostOverlayTests.swift
@@ -117,6 +117,62 @@ struct ConfiguredHostOverlayTests {
         #expect(result.sessions.isEmpty)
     }
 
+    @Test(
+        "changing host platform clears inventory",
+        arguments: [
+            (from: HostPlatform.linux, to: HostPlatform.windows),
+            (from: HostPlatform.windows, to: HostPlatform.linux),
+        ]
+    )
+    func changingPlatformClearsInventory(
+        from: HostPlatform,
+        to: HostPlatform
+    ) {
+        let host = HostSummary.fixture(
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: from,
+            sshDestination: "builder",
+            tmuxSessions: [
+                .init(name: "old-session", managed: false, windows: []),
+            ]
+        )
+        let project = ProjectSummary.fixture(hostID: host.id)
+        let worktree = WorktreeSummary.fixture(
+            hostID: host.id,
+            projectID: project.id
+        )
+        let session = TerminalSessionSummary(
+            id: UUID(),
+            hostID: host.id,
+            worktreeID: worktree.id,
+            isAlive: true
+        )
+        let source = WorkspaceSnapshot.fixture(
+            hosts: [host],
+            projects: [project],
+            worktrees: [worktree],
+            sessions: [session]
+        )
+
+        let result = ConfiguredHostOverlay.apply([
+            SSHHost(
+                configKey: "builder",
+                name: "Builder",
+                platform: to,
+                sshDestination: "builder"
+            ),
+        ], to: source)
+
+        #expect(result.hosts[0].id == host.id)
+        #expect(result.hosts[0].platform == to)
+        #expect(result.hosts[0].tmuxSessions.isEmpty)
+        #expect(result.projects.isEmpty)
+        #expect(result.worktrees.isEmpty)
+        #expect(result.sessions.isEmpty)
+    }
+
     @Test("duplicate destinations receive distinct host identities")
     func duplicateDestinationsReceiveDistinctIDs() {
         let existing = HostSummary.fixture(

--- a/Tests/App/KwtBinaryLocatorTests.swift
+++ b/Tests/App/KwtBinaryLocatorTests.swift
@@ -63,4 +63,23 @@ struct KwtBinaryLocatorTests {
             )
         )
     }
+
+    @Test("Windows managed helper path is revision-pinned")
+    func windowsManagedHelperPath() {
+        let revision = String(repeating: "f", count: 40)
+
+        #expect(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: revision
+            )
+                == #".ghosthub\helpers\kwt\"#
+                + revision
+                + #"\kwt.exe"#
+        )
+        #expect(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: "unpinned"
+            ) == nil
+        )
+    }
 }

--- a/Tests/App/KwtBinaryLocatorTests.swift
+++ b/Tests/App/KwtBinaryLocatorTests.swift
@@ -40,4 +40,27 @@ struct KwtBinaryLocatorTests {
                 .contains("managed kwt is unavailable")
         )
     }
+
+    @Test(
+        "Windows helper paths preserve the remote architecture",
+        arguments: [
+            KwtBinaryLocator.WindowsArchitecture.amd64,
+            KwtBinaryLocator.WindowsArchitecture.arm64,
+        ]
+    )
+    func windowsHelperPath(
+        architecture: KwtBinaryLocator.WindowsArchitecture
+    ) {
+        let path = KwtBinaryLocator.windowsBundledPath(
+            architecture: architecture,
+            bundleURL: URL(fileURLWithPath: "/Applications/Ghosthub.app")
+        )
+
+        #expect(
+            path.hasSuffix(
+                "/Contents/Resources/KwtRemote/windows-"
+                    + "\(architecture.rawValue)/kwt"
+            )
+        )
+    }
 }

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -78,6 +78,12 @@ struct KwtInventoryClientTests {
 
     @Test("Windows inventory invokes native kwt through PowerShell")
     func windowsRemoteInventory() async throws {
+        let revision = String(repeating: "b", count: 40)
+        let managedPath = try #require(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: revision
+            )
+        )
         let ssh = SSHHostInfo(
             user: "wesm",
             hostname: "arm-builder",
@@ -87,7 +93,10 @@ struct KwtInventoryClientTests {
         let client = KwtInventoryClient(
             remoteRunner: { host, command in
                 #expect(host == ssh)
-                #expect(command.contains("Get-Command kwt.exe"))
+                #expect(command.contains(
+                    powerShellEncodedArgument(managedPath)
+                ))
+                #expect(!command.contains("Get-Command kwt.exe"))
                 #expect(command.contains(
                     ["projects", "--json"]
                         .map(powerShellEncodedArgument)
@@ -103,7 +112,8 @@ struct KwtInventoryClientTests {
                     "PowerShell banner without newline"
                         + "GHOSTHUB_KWT_JSON\r\n[]\r\n"
                 )
-            }
+            },
+            remoteBinaryRevision: revision
         )
 
         let inventory = try await client.load(from: .ssh(ssh))

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -76,6 +76,32 @@ struct KwtInventoryClientTests {
         #expect(inventory.projects.isEmpty)
     }
 
+    @Test("Windows inventory invokes native kwt through PowerShell")
+    func windowsRemoteInventory() async throws {
+        let ssh = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let client = KwtInventoryClient(
+            remoteRunner: { host, command in
+                #expect(host == ssh)
+                #expect(command.contains("Get-Command kwt.exe"))
+                #expect(command.contains("'projects' '--json'"))
+                #expect(command.contains(
+                    "Write-Output 'GHOSTHUB_KWT_JSON'"
+                ))
+                #expect(!command.contains("command -v"))
+                return (0, "GHOSTHUB_KWT_JSON\n[]")
+            }
+        )
+
+        let inventory = try await client.load(from: .ssh(ssh))
+
+        #expect(inventory.projects.isEmpty)
+    }
+
     @Test("real zsh login shell loads the current kwt inventory")
     func loadsCurrentInventoryThroughZsh() async throws {
         guard ProcessInfo.processInfo.environment[

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -88,12 +88,17 @@ struct KwtInventoryClientTests {
             remoteRunner: { host, command in
                 #expect(host == ssh)
                 #expect(command.contains("Get-Command kwt.exe"))
-                #expect(command.contains("'projects' '--json'"))
                 #expect(command.contains(
-                    "Write-Output 'GHOSTHUB_KWT_JSON'"
+                    ["projects", "--json"]
+                        .map(powerShellEncodedArgument)
+                        .joined(separator: " ")
+                ))
+                #expect(command.contains(
+                    "Write-Output "
+                        + powerShellEncodedArgument("GHOSTHUB_KWT_JSON")
                 ))
                 #expect(!command.contains("command -v"))
-                return (0, "GHOSTHUB_KWT_JSON\n[]")
+                return (0, "GHOSTHUB_KWT_JSON\r\n[]\r\n")
             }
         )
 

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -98,7 +98,11 @@ struct KwtInventoryClientTests {
                         + powerShellEncodedArgument("GHOSTHUB_KWT_JSON")
                 ))
                 #expect(!command.contains("command -v"))
-                return (0, "GHOSTHUB_KWT_JSON\r\n[]\r\n")
+                return (
+                    0,
+                    "PowerShell banner without newline"
+                        + "GHOSTHUB_KWT_JSON\r\n[]\r\n"
+                )
             }
         )
 

--- a/Tests/App/KwtPullRequestClientTests.swift
+++ b/Tests/App/KwtPullRequestClientTests.swift
@@ -82,6 +82,39 @@ struct KwtPullRequestClientTests {
         #expect(result.pullRequest.isImported)
     }
 
+    @Test("Windows listing uses the native kwt PowerShell contract")
+    func windowsRemoteListing() async throws {
+        let recorder = PullRequestCommandRecorder()
+        let ssh = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let client = KwtPullRequestClient(
+            remoteRunner: { host, command in
+                recorder.record(host: host, command: command)
+                return (0, Self.listResponse)
+            }
+        )
+
+        let candidates = try await client.list(
+            projectIdentity: "github.com/kenn-io/ghosthub",
+            on: .ssh(ssh)
+        )
+
+        #expect(recorder.host == ssh)
+        #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
+        #expect(recorder.command?.contains(
+            "'pr' 'list' '--project' 'github.com/kenn-io/ghosthub'"
+        ) == true)
+        #expect(recorder.command?.contains(
+            "Write-Output 'GHOSTHUB_KWT_PR_JSON'"
+        ) == true)
+        #expect(recorder.command?.contains("command -v") == false)
+        #expect(candidates.map(\.number) == [32])
+    }
+
     @Test(
         "successful imports require an isolated tmux socket",
         arguments: [false, true]

--- a/Tests/App/KwtPullRequestClientTests.swift
+++ b/Tests/App/KwtPullRequestClientTests.swift
@@ -94,7 +94,13 @@ struct KwtPullRequestClientTests {
         let client = KwtPullRequestClient(
             remoteRunner: { host, command in
                 recorder.record(host: host, command: command)
-                return (0, Self.listResponse)
+                return (
+                    0,
+                    Self.listResponse.replacingOccurrences(
+                        of: "\n",
+                        with: "\r\n"
+                    )
+                )
             }
         )
 
@@ -106,10 +112,13 @@ struct KwtPullRequestClientTests {
         #expect(recorder.host == ssh)
         #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
         #expect(recorder.command?.contains(
-            "'pr' 'list' '--project' 'github.com/kenn-io/ghosthub'"
+            ["pr", "list", "--project", "github.com/kenn-io/ghosthub"]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ) == true)
         #expect(recorder.command?.contains(
-            "Write-Output 'GHOSTHUB_KWT_PR_JSON'"
+            "Write-Output "
+                + powerShellEncodedArgument("GHOSTHUB_KWT_PR_JSON")
         ) == true)
         #expect(recorder.command?.contains("command -v") == false)
         #expect(candidates.map(\.number) == [32])

--- a/Tests/App/KwtPullRequestClientTests.swift
+++ b/Tests/App/KwtPullRequestClientTests.swift
@@ -85,6 +85,12 @@ struct KwtPullRequestClientTests {
     @Test("Windows listing uses the native kwt PowerShell contract")
     func windowsRemoteListing() async throws {
         let recorder = PullRequestCommandRecorder()
+        let revision = String(repeating: "d", count: 40)
+        let managedPath = try #require(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: revision
+            )
+        )
         let ssh = SSHHostInfo(
             user: "wesm",
             hostname: "arm-builder",
@@ -106,7 +112,8 @@ struct KwtPullRequestClientTests {
                             with: "\r\n"
                         )
                 )
-            }
+            },
+            remoteBinaryRevision: revision
         )
 
         let candidates = try await client.list(
@@ -115,7 +122,10 @@ struct KwtPullRequestClientTests {
         )
 
         #expect(recorder.host == ssh)
-        #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
+        #expect(recorder.command?.contains(
+            powerShellEncodedArgument(managedPath)
+        ) == true)
+        #expect(recorder.command?.contains("Get-Command kwt.exe") == false)
         #expect(recorder.command?.contains(
             ["pr", "list", "--project", "github.com/kenn-io/ghosthub"]
                 .map(powerShellEncodedArgument)

--- a/Tests/App/KwtPullRequestClientTests.swift
+++ b/Tests/App/KwtPullRequestClientTests.swift
@@ -96,10 +96,15 @@ struct KwtPullRequestClientTests {
                 recorder.record(host: host, command: command)
                 return (
                     0,
-                    Self.listResponse.replacingOccurrences(
-                        of: "\n",
-                        with: "\r\n"
-                    )
+                    Self.listResponse
+                        .replacingOccurrences(
+                            of: "login banner\nGHOSTHUB_KWT_PR_JSON",
+                            with: "login bannerGHOSTHUB_KWT_PR_JSON"
+                        )
+                        .replacingOccurrences(
+                            of: "\n",
+                            with: "\r\n"
+                        )
                 )
             }
         )

--- a/Tests/App/KwtWindowsInstallerTests.swift
+++ b/Tests/App/KwtWindowsInstallerTests.swift
@@ -36,6 +36,19 @@ struct KwtWindowsInstallerTests {
                 #expect(command.contains(#".ghosthub\bin"#))
                 #expect(command.contains("'ghosthub-upload.exe'"))
                 #expect(command.contains("'kwt.exe'"))
+                #expect(command.contains("[System.IO.File]::Replace"))
+                #expect(command.contains("$ghosthubBackup"))
+                let stagedVerification = command.range(
+                    of: "& $ghosthubStaging '--version'"
+                )?.lowerBound
+                let replacement = command.range(
+                    of: "[System.IO.File]::Replace("
+                )?.lowerBound
+                #expect(stagedVerification != nil)
+                #expect(replacement != nil)
+                if let stagedVerification, let replacement {
+                    #expect(stagedVerification < replacement)
+                }
                 return (
                     status: 0,
                     stdout: "GHOSTHUB_KWT_INSTALLED\n"

--- a/Tests/App/KwtWindowsInstallerTests.swift
+++ b/Tests/App/KwtWindowsInstallerTests.swift
@@ -8,6 +8,12 @@ import Testing
 struct KwtWindowsInstallerTests {
     @Test("installs the matching bundled helper at the managed path")
     func installsArm64Helper() async throws {
+        let revision = String(repeating: "a", count: 40)
+        let managedPath = try #require(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: revision
+            )
+        )
         let bundleURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "Ghosthub-\(UUID().uuidString).app",
@@ -25,31 +31,50 @@ struct KwtWindowsInstallerTests {
 
         let installer = KwtWindowsInstaller(
             bundleURL: bundleURL,
+            revision: revision,
             remoteRunner: { host, command in
                 #expect(host.platform == .windows)
                 if command.contains("OSArchitecture") {
                     return (
                         status: 0,
-                        stdout: "GHOSTHUB_WINDOWS_ARCH=Arm64\n"
+                        stdout:
+                        "banner without newline"
+                            + "GHOSTHUB_WINDOWS_ARCH=Arm64\r\n"
                     )
                 }
-                #expect(command.contains(#".ghosthub\bin"#))
+                #expect(command.contains(
+                    powerShellEncodedArgument(managedPath)
+                ))
                 #expect(command.contains(
                     powerShellEncodedArgument("ghosthub-upload.exe")
                 ))
-                #expect(command.contains("'kwt.exe'"))
+                #expect(command.contains("Get-FileHash"))
+                #expect(command.contains("-Algorithm SHA256"))
+                #expect(command.contains("$ghosthubDigest -cne "))
+                #expect(command.contains(
+                    powerShellEncodedArgument(
+                        "kwt version \(revision)"
+                    )
+                ))
                 #expect(command.contains("[System.IO.File]::Replace"))
                 #expect(command.contains("$ghosthubBackup"))
                 let stagedVerification = command.range(
-                    of: "& $ghosthubStaging '--version'"
+                    of: "& $ghosthubStaging 'version'"
+                )?.lowerBound
+                let digestVerification = command.range(
+                    of: "Get-FileHash"
                 )?.lowerBound
                 let replacement = command.range(
                     of: "[System.IO.File]::Replace("
                 )?.lowerBound
                 #expect(stagedVerification != nil)
+                #expect(digestVerification != nil)
                 #expect(replacement != nil)
-                if let stagedVerification, let replacement {
+                if let stagedVerification,
+                   let digestVerification,
+                   let replacement {
                     #expect(stagedVerification < replacement)
+                    #expect(digestVerification < replacement)
                 }
                 return (
                     status: 0,
@@ -78,6 +103,7 @@ struct KwtWindowsInstallerTests {
     @Test("rejects a Windows architecture without a bundled target")
     func rejectsUnsupportedArchitecture() async {
         let installer = KwtWindowsInstaller(
+            revision: String(repeating: "b", count: 40),
             remoteRunner: { _, _ in
                 (
                     status: 0,

--- a/Tests/App/KwtWindowsInstallerTests.swift
+++ b/Tests/App/KwtWindowsInstallerTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import GhosthubSettings
+import GhosthubTmux
+import Testing
+@testable import GhosthubApp
+
+@Suite("Windows kwt installation")
+struct KwtWindowsInstallerTests {
+    @Test("installs the matching bundled helper at the managed path")
+    func installsArm64Helper() async throws {
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "Ghosthub-\(UUID().uuidString).app",
+                isDirectory: true
+            )
+        let helperURL = bundleURL.appendingPathComponent(
+            "Contents/Resources/KwtRemote/windows-arm64/kwt"
+        )
+        try FileManager.default.createDirectory(
+            at: helperURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("kwt".utf8).write(to: helperURL)
+        defer { try? FileManager.default.removeItem(at: bundleURL) }
+
+        let installer = KwtWindowsInstaller(
+            bundleURL: bundleURL,
+            remoteRunner: { host, command in
+                #expect(host.platform == .windows)
+                if command.contains("OSArchitecture") {
+                    return (
+                        status: 0,
+                        stdout: "GHOSTHUB_WINDOWS_ARCH=Arm64\n"
+                    )
+                }
+                #expect(command.contains(#".ghosthub\bin"#))
+                #expect(command.contains("'ghosthub-upload.exe'"))
+                #expect(command.contains("'kwt.exe'"))
+                return (
+                    status: 0,
+                    stdout: "GHOSTHUB_KWT_INSTALLED\n"
+                )
+            },
+            transferRunner: { host, localPath, remoteName in
+                #expect(host.hostname == "arm-builder")
+                #expect(localPath == helperURL.path)
+                #expect(remoteName == "ghosthub-upload.exe")
+                return 0
+            },
+            uploadNameProvider: { "ghosthub-upload.exe" }
+        )
+
+        let result = await installer.install(on: SSHHost(
+            configKey: "arm-builder",
+            name: "ARM Builder",
+            platform: .windows,
+            sshDestination: "wesm@arm-builder"
+        ))
+
+        try result.get()
+    }
+
+    @Test("rejects a Windows architecture without a bundled target")
+    func rejectsUnsupportedArchitecture() async {
+        let installer = KwtWindowsInstaller(
+            remoteRunner: { _, _ in
+                (
+                    status: 0,
+                    stdout: "GHOSTHUB_WINDOWS_ARCH=RISCV64\n"
+                )
+            },
+            transferRunner: { _, _, _ in
+                Issue.record("unsupported architecture must not upload")
+                return 0
+            }
+        )
+
+        let result = await installer.install(on: SSHHost(
+            configKey: "future-builder",
+            name: "Future Builder",
+            platform: .windows,
+            sshDestination: "future-builder"
+        ))
+
+        guard case let .failure(error) = result else {
+            Issue.record("expected unsupported architecture failure")
+            return
+        }
+        #expect(error == .unsupportedArchitecture("RISCV64"))
+    }
+}

--- a/Tests/App/KwtWindowsInstallerTests.swift
+++ b/Tests/App/KwtWindowsInstallerTests.swift
@@ -34,7 +34,9 @@ struct KwtWindowsInstallerTests {
                     )
                 }
                 #expect(command.contains(#".ghosthub\bin"#))
-                #expect(command.contains("'ghosthub-upload.exe'"))
+                #expect(command.contains(
+                    powerShellEncodedArgument("ghosthub-upload.exe")
+                ))
                 #expect(command.contains("'kwt.exe'"))
                 #expect(command.contains("[System.IO.File]::Replace"))
                 #expect(command.contains("$ghosthubBackup"))

--- a/Tests/App/KwtWorktreeClientTests.swift
+++ b/Tests/App/KwtWorktreeClientTests.swift
@@ -79,9 +79,11 @@ struct KwtWorktreeClientTests {
         #expect(recorder.command?.contains("--branch") == false)
     }
 
-    @Test("Windows creation quotes paths and branch names for PowerShell")
+    @Test("Windows creation encodes paths and hostile branch names")
     func windowsRemoteCreation() async throws {
         let recorder = CommandRecorder()
+        let projectPath = #"C:\code\ghost hub"#
+        let branchName = #"x’;iex("attacker-command");#‘&|$()"#
         let ssh = SSHHostInfo(
             user: "wesm",
             hostname: "arm-builder",
@@ -98,21 +100,28 @@ struct KwtWorktreeClientTests {
         try await client.create(
             request: WorktreeCreateRequest(
                 projectID: UUID(),
-                branchName: "wesm's-fix",
+                branchName: branchName,
                 createsBranch: true
             ),
-            projectPath: #"C:\code\ghost hub"#,
+            projectPath: projectPath,
             on: .ssh(ssh)
         )
 
         #expect(recorder.host == ssh)
         #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
         #expect(recorder.command?.contains(
-            #"Set-Location -LiteralPath 'C:\code\ghost hub'"#
+            "Set-Location -LiteralPath "
+                + powerShellEncodedArgument(projectPath)
         ) == true)
         #expect(recorder.command?.contains(
-            #"& $ghosthubKwt 'add' '--branch' 'wesm''s-fix' '--no-launch'"#
+            ["add", "--branch", branchName, "--no-launch"]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ) == true)
+        #expect(recorder.command?.contains(branchName) == false)
+        #expect(recorder.command?.contains("iex(") == false)
+        #expect(recorder.command?.contains("’") == false)
+        #expect(recorder.command?.contains("‘") == false)
         #expect(recorder.command?.contains("command -v") == false)
     }
 

--- a/Tests/App/KwtWorktreeClientTests.swift
+++ b/Tests/App/KwtWorktreeClientTests.swift
@@ -84,6 +84,12 @@ struct KwtWorktreeClientTests {
         let recorder = CommandRecorder()
         let projectPath = #"C:\code\ghost hub"#
         let branchName = #"x’;iex("attacker-command");#‘&|$()"#
+        let revision = String(repeating: "e", count: 40)
+        let managedPath = try #require(
+            KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                revision: revision
+            )
+        )
         let ssh = SSHHostInfo(
             user: "wesm",
             hostname: "arm-builder",
@@ -94,7 +100,8 @@ struct KwtWorktreeClientTests {
             remoteRunner: { host, command in
                 recorder.record(host: host, command: command)
                 return (0, "")
-            }
+            },
+            remoteBinaryRevision: revision
         )
 
         try await client.create(
@@ -108,7 +115,10 @@ struct KwtWorktreeClientTests {
         )
 
         #expect(recorder.host == ssh)
-        #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
+        #expect(recorder.command?.contains(
+            powerShellEncodedArgument(managedPath)
+        ) == true)
+        #expect(recorder.command?.contains("Get-Command kwt.exe") == false)
         #expect(recorder.command?.contains(
             "Set-Location -LiteralPath "
                 + powerShellEncodedArgument(projectPath)

--- a/Tests/App/KwtWorktreeClientTests.swift
+++ b/Tests/App/KwtWorktreeClientTests.swift
@@ -79,6 +79,43 @@ struct KwtWorktreeClientTests {
         #expect(recorder.command?.contains("--branch") == false)
     }
 
+    @Test("Windows creation quotes paths and branch names for PowerShell")
+    func windowsRemoteCreation() async throws {
+        let recorder = CommandRecorder()
+        let ssh = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let client = KwtWorktreeClient(
+            remoteRunner: { host, command in
+                recorder.record(host: host, command: command)
+                return (0, "")
+            }
+        )
+
+        try await client.create(
+            request: WorktreeCreateRequest(
+                projectID: UUID(),
+                branchName: "wesm's-fix",
+                createsBranch: true
+            ),
+            projectPath: #"C:\code\ghost hub"#,
+            on: .ssh(ssh)
+        )
+
+        #expect(recorder.host == ssh)
+        #expect(recorder.command?.contains("Get-Command kwt.exe") == true)
+        #expect(recorder.command?.contains(
+            #"Set-Location -LiteralPath 'C:\code\ghost hub'"#
+        ) == true)
+        #expect(recorder.command?.contains(
+            #"& $ghosthubKwt 'add' '--branch' 'wesm''s-fix' '--no-launch'"#
+        ) == true)
+        #expect(recorder.command?.contains("command -v") == false)
+    }
+
     @Test("a nonzero kwt exit is reported")
     func reportsFailure() async {
         let client = KwtWorktreeClient(

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -278,15 +278,16 @@ struct TmuxBinaryResolverTests {
                 #expect(received == host)
                 #expect(command.contains("Get-Command tmux.exe"))
                 #expect(command.contains("'list-sessions' '-F'"))
-                #expect(command.contains("#{session_name}"))
+                #expect(!command.contains("#{session_name}"))
+                #expect(command.contains(
+                    "[System.Convert]::FromBase64String"
+                ))
                 return (
                     status: 0,
-                    stdout: """
-                    C:\\Tools\\psmux\\tmux.exe
-                    tmux 3.3.7
-                    GHOSTHUB_TMUX_SESSION\t2\t202\t$7\t1783344091\t\twindows-work
-
-                    """
+                    stdout: "C:\\Tools\\psmux\\tmux.exe\r\n"
+                        + "tmux 3.3.7\r\n"
+                        + "GHOSTHUB_TMUX_SESSION\t2\t202\t$7"
+                        + "\t1783344091\t\twindows-work\r\n"
                 )
             }
         )

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -146,6 +146,31 @@ struct TmuxBinaryResolverTests {
         )
     }
 
+    @Test("Windows remote commands bypass POSIX login shells")
+    func encodesWindowsRemoteCommand() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let command = "Write-Output 'windows-ready'"
+
+        let remoteCommand = TmuxBinaryResolver.remoteLoginCommand(
+            host: host,
+            command: command
+        )
+
+        #expect(remoteCommand.hasPrefix(
+            "powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand "
+        ))
+        #expect(!remoteCommand.contains("${SHELL"))
+        #expect(!remoteCommand.contains("/bin/sh"))
+        let encoded = try #require(remoteCommand.split(separator: " ").last)
+        let data = try #require(Data(base64Encoded: String(encoded)))
+        #expect(String(data: data, encoding: .utf16LittleEndian) == command)
+    }
+
     @Test("discovers every local tmux session without control-mode attachment")
     func discoversLocalSessions() throws {
         let resolver = TmuxBinaryResolver(processRunner: { _, command in

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -117,6 +117,35 @@ struct TmuxBinaryResolverTests {
         #expect(resolver.discoverSessions(on: host) == .failure(expected))
     }
 
+    @Test("Windows resolution discovers the psmux tmux alias")
+    func resolvesWindowsPsmuxPath() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: 2222,
+            platform: .windows
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { received, command in
+                #expect(received == host)
+                #expect(command.contains("Get-Command tmux.exe"))
+                #expect(command.contains("[Console]::OutputEncoding"))
+                #expect(!command.contains("command -v"))
+                return (
+                    status: 0,
+                    stdout:
+                    #"C:\Users\wesm\scoop\apps\psmux\current\tmux.exe"#
+                        + "\ntmux 3.3.7\n"
+                )
+            }
+        )
+
+        #expect(
+            try resolver.resolveTmuxPath(on: host).get()
+                == #"C:\Users\wesm\scoop\apps\psmux\current\tmux.exe"#
+        )
+    }
+
     @Test("discovers every local tmux session without control-mode attachment")
     func discoversLocalSessions() throws {
         let resolver = TmuxBinaryResolver(processRunner: { _, command in
@@ -207,6 +236,45 @@ struct TmuxBinaryResolverTests {
                     name: "remote-work", windowCount: 3,
                     serverPID: "202",
                     sessionID: "$7", createdAt: "99", managed: false
+                )]
+        )
+    }
+
+    @Test("Windows discovery uses psmux formatted session output")
+    func discoversWindowsPsmuxSessions() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { received, command in
+                #expect(received == host)
+                #expect(command.contains("Get-Command tmux.exe"))
+                #expect(command.contains("'list-sessions' '-F'"))
+                #expect(command.contains("#{session_name}"))
+                return (
+                    status: 0,
+                    stdout: """
+                    C:\\Tools\\psmux\\tmux.exe
+                    tmux 3.3.7
+                    GHOSTHUB_TMUX_SESSION\t2\t202\t$7\t1783344091\t\twindows-work
+
+                    """
+                )
+            }
+        )
+
+        #expect(
+            try resolver.discoverSessions(on: host).get()
+                == [DiscoveredTmuxSession(
+                    name: "windows-work",
+                    windowCount: 2,
+                    serverPID: "202",
+                    sessionID: "$7",
+                    createdAt: "1783344091",
+                    managed: false
                 )]
         )
     }

--- a/Tests/App/TmuxHostResolverTests.swift
+++ b/Tests/App/TmuxHostResolverTests.swift
@@ -32,6 +32,25 @@ struct TmuxHostResolverTests {
         #expect(TmuxHostResolver.resolve(.fixture(kind: .remote)) == nil)
     }
 
+    @Test("Windows hosts preserve their native command platform")
+    func windowsRemoteHost() {
+        let host = HostSummary.fixture(
+            kind: .remote,
+            platform: .windows,
+            sshDestination: "wesm@arm-builder"
+        )
+
+        #expect(
+            TmuxHostResolver.resolve(host)
+                == .ssh(SSHHostInfo(
+                    user: "wesm",
+                    hostname: "arm-builder",
+                    port: nil,
+                    platform: .windows
+                ))
+        )
+    }
+
     @Test("raw IPv6 destinations use the default SSH port")
     func rawIPv6Destination() {
         #expect(

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -149,6 +149,66 @@ struct TmuxSessionKillerTests {
         )
     }
 
+    @Test("Windows identity and kill use PowerShell and psmux quoting")
+    func windowsIdentityAndKillCommands() async throws {
+        let commands = LockedValue<[String]>([])
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let killer = TmuxSessionKiller(
+            pathResolver: { _ in
+                .success(#"C:\Program Files\psmux\tmux.exe"#)
+            },
+            runner: { _, command in
+                commands.withLock { $0.append(command) }
+                if command.contains("'display-message'") {
+                    return (
+                        0,
+                        "GHOSTHUB_TMUX_SESSION_IDENTITY\t"
+                            + "31415\t$42\t1785182057\n"
+                    )
+                }
+                return (0, "")
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "review's session",
+            socketName: "kwt-pr-windows"
+        )
+
+        let identity = try await killer.sessionIdentity(
+            selection,
+            on: .ssh(host)
+        )
+        try await killer.kill(
+            selection,
+            expectedIdentity: identity,
+            on: .ssh(host)
+        )
+
+        let recorded = try #require(
+            commands.load().count == 2 ? commands.load() : nil
+        )
+        #expect(recorded.allSatisfy { $0.contains(
+            "[Console]::OutputEncoding"
+        ) })
+        #expect(recorded[0].contains(
+            #"& 'C:\Program Files\psmux\tmux.exe' '-L' 'kwt-pr-windows' 'display-message' '-p' '-t' '=review''s session:'"#
+        ))
+        #expect(recorded[1].contains("'if-shell' '-F'"))
+        #expect(recorded[1].contains(
+            "'-t' '=review''s session:'"
+        ))
+        #expect(recorded[1].contains(
+            "'kill-session -t $42'"
+        ))
+        #expect(!recorded.joined().contains(#"'\''"#))
+    }
+
     @Test("kill failure preserves host, session, and status")
     func commandFailure() async {
         let host = SSHHostInfo(

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -164,11 +164,13 @@ struct TmuxSessionKillerTests {
             },
             runner: { _, command in
                 commands.withLock { $0.append(command) }
-                if command.contains("'display-message'") {
+                if command.contains(
+                    powerShellEncodedArgument("display-message")
+                ) {
                     return (
                         0,
                         "GHOSTHUB_TMUX_SESSION_IDENTITY\t"
-                            + "31415\t$42\t1785182057\n"
+                            + "31415\t$42\t1785182057\r\n"
                     )
                 }
                 return (0, "")
@@ -197,16 +199,33 @@ struct TmuxSessionKillerTests {
             "[Console]::OutputEncoding"
         ) })
         #expect(recorded[0].contains(
-            #"& 'C:\Program Files\psmux\tmux.exe' '-L' 'kwt-pr-windows' 'display-message' '-p' '-t' '=review''s session:'"#
+            "& "
+                + [
+                    #"C:\Program Files\psmux\tmux.exe"#,
+                    "-L",
+                    "kwt-pr-windows",
+                    "display-message",
+                    "-p",
+                    "-t",
+                    "=review's session:",
+                ]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ))
-        #expect(recorded[1].contains("'if-shell' '-F'"))
         #expect(recorded[1].contains(
-            "'-t' '=review''s session:'"
+            ["if-shell", "-F"]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ))
         #expect(recorded[1].contains(
-            "'kill-session -t $42'"
+            ["-t", "=review's session:"]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ))
-        #expect(!recorded.joined().contains(#"'\''"#))
+        #expect(recorded[1].contains(
+            powerShellEncodedArgument("kill-session -t $42")
+        ))
+        #expect(!recorded.joined().contains("review's session"))
     }
 
     @Test("kill failure preserves host, session, and status")

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1956,11 +1956,20 @@ struct WorkspaceTmuxDiscoveryTests {
                 #expect(host.platform == .windows)
                 #expect(command.contains("Get-Command tmux.exe"))
                 #expect(command.contains("GHOSTHUB_KWT_AVAILABLE"))
-                #expect(command.contains(
-                    powerShellEncodedArgument(
-                        ghosthubManagedWindowsKwtRelativePath
-                    )
-                ))
+                if let managedPath =
+                    KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                        revision:
+                        KwtBinaryLocator.bundledRemoteRevision()
+                    ) {
+                    #expect(command.contains(
+                        powerShellEncodedArgument(managedPath)
+                    ))
+                } else {
+                    #expect(command.contains(
+                        "$ghosthubKwtAvailable = $false"
+                    ))
+                }
+                #expect(!command.contains("Get-Command kwt.exe"))
                 #expect(!command.contains("command -v"))
                 return (
                     status: 0,

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1716,13 +1716,15 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             sshHostProbeRunner: { _, command in
                 #expect(command.contains("command -v tmux"))
-                #expect(command.contains("GHOSTHUB_REMOTE_PROBE_REACHED"))
+                #expect(command.contains("GHOSTHUB_SSH_REACHED"))
                 return (
                     status: 0,
-                    stdout:
-                    "GHOSTHUB_REMOTE_PROBE_REACHED\n"
-                        + "GHOSTHUB_TMUX_AVAILABLE\n"
-                        + "GHOSTHUB_KWT_UNAVAILABLE\n"
+                    stdout: """
+                    GHOSTHUB_SSH_REACHED
+                    GHOSTHUB_TMUX_AVAILABLE
+                    GHOSTHUB_KWT_UNAVAILABLE
+
+                    """
                 )
             }
         )
@@ -1756,9 +1758,9 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             sshHostProbeRunner: { _, _ in
                 (
-                    status: 0,
+                    status: 127,
                     stdout:
-                    "GHOSTHUB_REMOTE_PROBE_REACHED\n"
+                    "GHOSTHUB_SSH_REACHED\n"
                         + "GHOSTHUB_TMUX_UNAVAILABLE\n"
                         + "GHOSTHUB_KWT_UNAVAILABLE\n"
                 )
@@ -1773,15 +1775,12 @@ struct WorkspaceTmuxDiscoveryTests {
         ))
         let summary = try result.get()
 
-        #expect(summary.connectionState == .online)
+        #expect(summary.connectionState == .degraded)
         #expect(summary.host.lastKnownReachable)
-        #expect(summary.diagnostics.map(\.code) == [
-            .missingTmux,
-            .missingKwt,
-        ])
+        #expect(summary.diagnostics.map(\.code) == [.missingTmux])
         #expect(
             summary.diagnostics.first?.summary
-                == "tmux is not installed."
+                == "tmux is not available."
         )
         await model.shutdown()
     }
@@ -1813,7 +1812,7 @@ struct WorkspaceTmuxDiscoveryTests {
         ])
         #expect(
             summary.diagnostics.first?.summary
-                == "SSH connection failed."
+                == "SSH could not be reached."
         )
         await model.shutdown()
     }
@@ -1831,7 +1830,9 @@ struct WorkspaceTmuxDiscoveryTests {
             sshHostProbeRunner: { _, _ in
                 (
                     status: status,
-                    stdout: "GHOSTHUB_REMOTE_PROBE_REACHED\n"
+                    stdout:
+                    "GHOSTHUB_SSH_REACHED\n"
+                        + "GHOSTHUB_TMUX_AVAILABLE\n"
                 )
             }
         )
@@ -1850,7 +1851,7 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(summary.diagnostics.map(\.code) == [.probeFailure])
         #expect(
             summary.diagnostics.first?.summary
-                == "Remote verification failed (status \(status))."
+                == "tmux did not respond successfully."
         )
         await model.shutdown()
     }
@@ -1878,10 +1879,10 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(summary.connectionState == .offline)
         #expect(!summary.host.lastKnownReachable)
         #expect(summary.host.lastSeenAt == nil)
-        #expect(summary.diagnostics.map(\.code) == [.probeFailure])
+        #expect(summary.diagnostics.map(\.code) == [.sshConnectionFailed])
         #expect(
             summary.diagnostics.first?.summary
-                == "Remote verification did not reach the host (status -124)."
+                == "SSH could not be reached."
         )
         await model.shutdown()
     }
@@ -1941,6 +1942,81 @@ struct WorkspaceTmuxDiscoveryTests {
             ))
         )
         #expect(registrationCalls.count == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("connection probe uses native PowerShell for Windows hosts")
+    func connectionProbeUsesWindowsPowerShell() async throws {
+        let environment = try setupStandardEnvironment()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            sshHostProbeRunner: { host, command in
+                #expect(host.platform == .windows)
+                #expect(command.contains("Get-Command tmux.exe"))
+                #expect(command.contains("GHOSTHUB_KWT_AVAILABLE"))
+                #expect(command.contains(#".ghosthub\bin\kwt.exe"#))
+                #expect(!command.contains("command -v"))
+                return (
+                    status: 0,
+                    stdout: """
+                    GHOSTHUB_SSH_REACHED
+                    GHOSTHUB_TMUX_AVAILABLE
+                    GHOSTHUB_KWT_AVAILABLE
+
+                    """
+                )
+            }
+        )
+
+        let result = await model.probeSSHHost(SSHHost(
+            configKey: "arm-builder",
+            name: "ARM Builder",
+            platform: .windows,
+            sshDestination: "wesm@arm-builder"
+        ))
+        let summary = try result.get()
+
+        #expect(summary.connectionState == .online)
+        #expect(summary.platform == .windows)
+        #expect(summary.diagnostics.isEmpty)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("connection probe distinguishes missing psmux from SSH failure")
+    func connectionProbeReportsMissingPsmux() async throws {
+        let environment = try setupStandardEnvironment()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            sshHostProbeRunner: { _, _ in
+                (
+                    status: 127,
+                    stdout: """
+                    GHOSTHUB_SSH_REACHED
+                    GHOSTHUB_TMUX_UNAVAILABLE
+
+                    """
+                )
+            }
+        )
+
+        let result = await model.probeSSHHost(SSHHost(
+            configKey: "arm-builder",
+            name: "ARM Builder",
+            platform: .windows,
+            sshDestination: "wesm@arm-builder"
+        ))
+        let summary = try result.get()
+        let diagnostic = try #require(summary.diagnostics.first)
+
+        #expect(summary.connectionState == .degraded)
+        #expect(summary.host.lastKnownReachable)
+        #expect(diagnostic.code == .missingTmux)
+        #expect(diagnostic.summary == "psmux is not available.")
+        #expect(diagnostic.recoverySuggestion.contains("tmux.exe alias"))
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1956,7 +1956,11 @@ struct WorkspaceTmuxDiscoveryTests {
                 #expect(host.platform == .windows)
                 #expect(command.contains("Get-Command tmux.exe"))
                 #expect(command.contains("GHOSTHUB_KWT_AVAILABLE"))
-                #expect(command.contains(#".ghosthub\bin\kwt.exe"#))
+                #expect(command.contains(
+                    powerShellEncodedArgument(
+                        ghosthubManagedWindowsKwtRelativePath
+                    )
+                ))
                 #expect(!command.contains("command -v"))
                 return (
                     status: 0,

--- a/Tests/Settings/TailscalePeerTests.swift
+++ b/Tests/Settings/TailscalePeerTests.swift
@@ -33,14 +33,16 @@ struct TailscalePeerTests {
     func mapsSupportedPlatforms() {
         #expect(peer(os: "macOS").platform == .macOS)
         #expect(peer(os: "linux").platform == .linux)
+        #expect(peer(os: "windows").platform == .windows)
         #expect(peer(os: "ios").platform == .linux)
     }
 
-    @Test("marks only linux and macOS peers as SSH capable")
+    @Test("marks desktop peers as SSH capable")
     func sshCapability() {
         #expect(peer(os: "linux").isSSHCapable)
         #expect(peer(os: "macOS").isSSHCapable)
-        #expect(!peer(os: "windows").isSSHCapable)
+        #expect(peer(os: "windows").isSSHCapable)
+        #expect(!peer(os: "ios").isSSHCapable)
     }
 
     private func peer(os: String) -> TailscalePeer {

--- a/Tests/Settings/TailscaleStatusParserTests.swift
+++ b/Tests/Settings/TailscaleStatusParserTests.swift
@@ -90,7 +90,8 @@ struct TailscaleStatusParserTests {
         let data = Data(json.utf8)
         let peers = try TailscaleStatusParser
             .peers(from: data).get()
-        #expect(peers.isEmpty)
+        #expect(peers.map(\.hostName) == ["windows-pc"])
+        #expect(peers.first?.platform == .windows)
     }
 
     @Test("sorts online peers before offline")

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -491,6 +491,33 @@ struct TmuxAttachmentInfoTests {
         #expect(!command.contains("unbind-key"))
     }
 
+    @Test("Windows attachment leaves psmux presentation user-owned")
+    func windowsRemoteAttachCommand() throws {
+        let command = TmuxAttachmentInfo(
+            sessionName: "doc bank's work",
+            host: .ssh(SSHHostInfo(
+                user: "wesm",
+                hostname: "arm-builder",
+                port: 2222,
+                platform: .windows
+            ))
+        ).attachCommand(
+            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#
+        )
+
+        #expect(command.contains("'/usr/bin/ssh' '-tt'"))
+        #expect(command.contains("'wesm@arm-builder'"))
+        #expect(command.contains("-EncodedCommand"))
+        #expect(command.contains("ghosthub-ssh-psmux"))
+        #expect(!command.contains("command -v"))
+
+        let script = try Self.decodedPowerShellScript(from: command)
+        #expect(script.contains("""
+        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
+        & 'C:\\Program Files\\psmux\\tmux.exe' 'attach-session' '-E' '-t' '=doc bank''s work'
+        """))
+    }
+
     @Test("isolated remote attachment targets the returned tmux socket")
     func isolatedRemoteAttachCommand() {
         let command = TmuxAttachmentInfo(
@@ -810,6 +837,40 @@ struct TmuxAttachmentInfoTests {
         ))
     }
 
+    @Test("Windows named creation runs once before psmux attachment")
+    func windowsRemoteCreationIsOneShot() throws {
+        let command = TmuxAttachmentInfo(
+            sessionName: "release-work",
+            host: .ssh(SSHHostInfo(
+                user: "wesm",
+                hostname: "arm-builder",
+                port: nil,
+                platform: .windows
+            )),
+            launchMode: .create
+        ).attachCommand(
+            tmuxPath: #"C:\Tools\psmux\tmux.exe"#,
+            workingDirectory: #"C:\code\release work"#
+        )
+
+        #expect(command.contains("'-T'"))
+        #expect(command.contains("'-tt'"))
+        #expect(
+            command.components(separatedBy: "-EncodedCommand").count == 3
+        )
+        let decoded = try Self.decodedPowerShellScripts(from: command)
+        let scripts = try #require(decoded.count == 2 ? decoded : nil)
+        #expect(scripts[0].contains(
+            #"& 'C:\Tools\psmux\tmux.exe' 'has-session' '-t' '=release-work'"#
+        ))
+        #expect(scripts[0].contains(
+            #"'new-session' '-d' '-E' '-s' 'release-work' '-c' 'C:\code\release work' '-e' ('PATH=' + $env:PATH)"#
+        ))
+        #expect(scripts[1].contains(
+            #"'attach-session' '-E' '-t' '=release-work'"#
+        ))
+    }
+
     @Test("attach retries never rerun the completed create phase")
     func reconnectDoesNotRepeatCreation() throws {
         let directory = FileManager.default.temporaryDirectory
@@ -956,5 +1017,28 @@ struct TmuxAttachmentInfoTests {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TmuxHost.self, from: data)
         #expect(original == decoded)
+    }
+
+    private static func decodedPowerShellScript(
+        from command: String
+    ) throws -> String {
+        try #require(decodedPowerShellScripts(from: command).first)
+    }
+
+    private static func decodedPowerShellScripts(
+        from command: String
+    ) throws -> [String] {
+        let marker = "-EncodedCommand "
+        return try command
+            .components(separatedBy: marker)
+            .dropFirst()
+            .map { suffix in
+                let encoded = try #require(suffix.split(separator: "'").first)
+                let data = try #require(Data(base64Encoded: String(encoded)))
+                return try #require(String(
+                    data: data,
+                    encoding: .utf16LittleEndian
+                ))
+            }
     }
 }

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -502,7 +502,9 @@ struct TmuxAttachmentInfoTests {
                 platform: .windows
             ))
         ).attachCommand(
-            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#
+            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#,
+            windowsKwtRelativePath:
+            #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
         )
 
         #expect(command.contains("'/usr/bin/ssh' '-tt'"))
@@ -560,13 +562,21 @@ struct TmuxAttachmentInfoTests {
             )),
             workspacePath: #"C:\code\release work"#
         ).attachCommand(
-            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#
+            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#,
+            windowsKwtRelativePath:
+            #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
         )
 
         #expect(command.contains("ghosthub-ssh-kwt-attach"))
         #expect(command.contains("ghosthub-ssh-kwt-probe"))
         let decoded = try Self.decodedPowerShellScripts(from: command)
         let scripts = try #require(decoded.count == 3 ? decoded : nil)
+        #expect(scripts[0].contains(
+            powerShellEncodedArgument(
+                #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
+            )
+        ))
+        #expect(!scripts[0].contains("Get-Command kwt.exe"))
         #expect(scripts[0].contains(
             "& $ghosthubKwt 'open' "
                 + powerShellEncodedArgument(#"C:\code\release work"#)

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -518,6 +518,37 @@ struct TmuxAttachmentInfoTests {
         """))
     }
 
+    @Test("Windows worktrees open through kwt before psmux reconnect")
+    func windowsRemoteWorkspaceAttachCommand() throws {
+        let command = TmuxAttachmentInfo(
+            sessionName: "release work",
+            host: .ssh(SSHHostInfo(
+                user: "wesm",
+                hostname: "arm-builder",
+                port: nil,
+                platform: .windows
+            )),
+            workspacePath: #"C:\code\release work"#
+        ).attachCommand(
+            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#
+        )
+
+        #expect(command.contains("ghosthub-ssh-kwt-attach"))
+        #expect(command.contains("ghosthub-ssh-kwt-probe"))
+        let decoded = try Self.decodedPowerShellScripts(from: command)
+        let scripts = try #require(decoded.count == 3 ? decoded : nil)
+        #expect(scripts[0].contains(
+            #"& $ghosthubKwt 'open' 'C:\code\release work'"#
+        ))
+        #expect(scripts[1].contains(
+            #"& 'C:\Program Files\psmux\tmux.exe' 'has-session' '-t' '=release work'"#
+        ))
+        #expect(scripts[2].contains(
+            #"& 'C:\Program Files\psmux\tmux.exe' 'attach-session' '-E' '-t' '=release work'"#
+        ))
+        #expect(!scripts.joined().contains("exec /bin/sh"))
+    }
+
     @Test("isolated remote attachment targets the returned tmux socket")
     func isolatedRemoteAttachCommand() {
         let command = TmuxAttachmentInfo(

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -512,10 +512,40 @@ struct TmuxAttachmentInfoTests {
         #expect(!command.contains("command -v"))
 
         let script = try Self.decodedPowerShellScript(from: command)
-        #expect(script.contains("""
-        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
-        & 'C:\\Program Files\\psmux\\tmux.exe' 'attach-session' '-E' '-t' '=doc bank''s work'
-        """))
+        #expect(script.contains(
+            "& " + [
+                #"C:\Program Files\psmux\tmux.exe"#,
+                "attach-session",
+                "-E",
+                "-t",
+                "=doc bank's work",
+            ]
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
+        ))
+    }
+
+    @Test("Windows attachment keeps hostile values out of PowerShell source")
+    func windowsRemoteAttachEncodesHostileSessionName() throws {
+        let sessionName = #"x’;iex("attacker-command");#‘&|$()"#
+        let command = TmuxAttachmentInfo(
+            sessionName: sessionName,
+            host: .ssh(SSHHostInfo(
+                user: "wesm",
+                hostname: "arm-builder",
+                port: nil,
+                platform: .windows
+            ))
+        ).attachCommand(tmuxPath: #"C:\Tools\psmux\tmux.exe"#)
+
+        let script = try Self.decodedPowerShellScript(from: command)
+        #expect(script.contains(
+            powerShellEncodedArgument("=\(sessionName)")
+        ))
+        #expect(!script.contains(sessionName))
+        #expect(!script.contains("iex("))
+        #expect(!script.contains("’"))
+        #expect(!script.contains("‘"))
     }
 
     @Test("Windows worktrees open through kwt before psmux reconnect")
@@ -538,13 +568,29 @@ struct TmuxAttachmentInfoTests {
         let decoded = try Self.decodedPowerShellScripts(from: command)
         let scripts = try #require(decoded.count == 3 ? decoded : nil)
         #expect(scripts[0].contains(
-            #"& $ghosthubKwt 'open' 'C:\code\release work'"#
+            "& $ghosthubKwt 'open' "
+                + powerShellEncodedArgument(#"C:\code\release work"#)
         ))
         #expect(scripts[1].contains(
-            #"& 'C:\Program Files\psmux\tmux.exe' 'has-session' '-t' '=release work'"#
+            "& " + [
+                #"C:\Program Files\psmux\tmux.exe"#,
+                "has-session",
+                "-t",
+                "=release work",
+            ]
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
         ))
         #expect(scripts[2].contains(
-            #"& 'C:\Program Files\psmux\tmux.exe' 'attach-session' '-E' '-t' '=release work'"#
+            "& " + [
+                #"C:\Program Files\psmux\tmux.exe"#,
+                "attach-session",
+                "-E",
+                "-t",
+                "=release work",
+            ]
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
         ))
         #expect(!scripts.joined().contains("exec /bin/sh"))
     }
@@ -892,13 +938,33 @@ struct TmuxAttachmentInfoTests {
         let decoded = try Self.decodedPowerShellScripts(from: command)
         let scripts = try #require(decoded.count == 2 ? decoded : nil)
         #expect(scripts[0].contains(
-            #"& 'C:\Tools\psmux\tmux.exe' 'has-session' '-t' '=release-work'"#
+            "& " + [
+                #"C:\Tools\psmux\tmux.exe"#,
+                "has-session",
+                "-t",
+                "=release-work",
+            ]
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
         ))
         #expect(scripts[0].contains(
-            #"'new-session' '-d' '-E' '-s' 'release-work' '-c' 'C:\code\release work' '-e' ('PATH=' + $env:PATH)"#
+            [
+                "new-session",
+                "-d",
+                "-E",
+                "-s",
+                "release-work",
+                "-c",
+                #"C:\code\release work"#,
+            ]
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
+            + " '-e' ('PATH=' + $env:PATH)"
         ))
         #expect(scripts[1].contains(
-            #"'attach-session' '-E' '-t' '=release-work'"#
+            ["attach-session", "-E", "-t", "=release-work"]
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
         ))
     }
 

--- a/Tests/UI/CommandPaletteModelTests.swift
+++ b/Tests/UI/CommandPaletteModelTests.swift
@@ -514,6 +514,31 @@ struct CommandPaletteModelTests {
         )
     }
 
+    @Test("Windows hosts do not offer POSIX project registration")
+    func windowsHostsHideAddProject() {
+        let host = HostSummary.fixture(
+            name: "ARM Builder",
+            kind: .remote,
+            platform: .windows,
+            sshDestination: "wesm@arm-builder"
+        )
+        let commands = makeCommandPaletteCommands(
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            selection: WorkspaceSelection(selectedHostID: host.id)
+        )
+
+        commands.expectCommandContains(
+            title: "New tmux session on ARM Builder"
+        )
+        commands.expectCommandNotContains(
+            title: "Add Project on ARM Builder"
+        )
+    }
+
     @Test("import PR command hidden without GitHub-linked projects")
     func importPRCommandHiddenWithoutGitHubLink() {
         let host = HostSummary.fixture(

--- a/Tests/test_assemble_app_bundle.py
+++ b/Tests/test_assemble_app_bundle.py
@@ -59,6 +59,8 @@ def make_release_inputs(
         "darwin-arm64",
         "linux-amd64",
         "linux-arm64",
+        "windows-amd64",
+        "windows-arm64",
     ):
         make_executable(kwt_variants_dir / target / "kwt")
     licenses_dir = tmp_path / "Licenses"
@@ -199,6 +201,8 @@ def test_assemble_app_bundle_stages_icon_and_binary(tmp_path):
         "darwin-arm64",
         "linux-amd64",
         "linux-arm64",
+        "windows-amd64",
+        "windows-arm64",
     ):
         helper = remote_helpers / target / "kwt"
         assert helper.is_file()

--- a/Tests/test_build_pinned_kwt.py
+++ b/Tests/test_build_pinned_kwt.py
@@ -53,6 +53,20 @@ def bootstrap_fixture(tmp_path: Path) -> tuple[Path, str, str, Path]:
     fake_go.write_text(
         """#!/bin/sh
 set -eu
+if [ "$#" -eq 2 ] && [ "$1" = "env" ]; then
+  case "$2" in
+    GOOS) printf 'darwin\\n' ;;
+    GOARCH) printf 'arm64\\n' ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+if [ "$#" -eq 3 ] && [ "$1" = "version" ] && [ "$2" = "-m" ]; then
+  printf '%s: go1.test\\n' "$3"
+  printf '\\tbuild\\tGOOS=darwin\\n'
+  printf '\\tbuild\\tGOARCH=arm64\\n'
+  exit 0
+fi
 output=
 revision=
 while [ "$#" -gt 0 ]; do

--- a/Tests/test_validate_kwt_variants.py
+++ b/Tests/test_validate_kwt_variants.py
@@ -20,13 +20,19 @@ def test_variant_validation_accepts_exact_target_and_revision(
     binary_format, cpu = TARGETS[target]
     if binary_format == "mach-o":
         header = b"\xcf\xfa\xed\xfe" + struct.pack("<I", cpu)
-    else:
+    elif binary_format == "elf":
         header = (
             b"\x7fELF"
             + bytes([2, 1])
             + bytes(12)
             + struct.pack("<H", cpu)
         )
+    else:
+        header = bytearray(128)
+        header[:2] = b"MZ"
+        struct.pack_into("<I", header, 0x3C, 64)
+        header[64:68] = b"PE\0\0"
+        struct.pack_into("<H", header, 68, cpu)
     helper = tmp_path / "kwt"
     helper.write_bytes(header + bytes(32) + revision.encode())
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,13 +111,17 @@ unique staged file. Neither local nor remote operations select an unrelated
 kwt from `PATH`. This is a CLI boundary, not a vendored daemon or submodule.
 Kwt's machine-readable CLI provides project identity, worktree metadata, and
 exact tmux session names.
-On a host with no existing kwt registry, the user adds one absolute repository
-path at a time through **Add Project**. Ghosthub delegates registration to
-`kwt projects add --json`, then refreshes ordinary kwt inventory; it does not
-search the host's filesystem or write kwt's configuration itself.
-The account login shell initializes the command environment, while Ghosthub's
-own inventory and discovery commands execute under the host's POSIX `/bin/sh`;
-non-POSIX account shells such as fish are not asked to interpret those commands.
+On a macOS or Linux host with no existing kwt registry, the user adds one
+absolute repository path at a time through **Add Project**. Ghosthub delegates
+registration to `kwt projects add --json`, then refreshes ordinary kwt
+inventory; it does not search the host's filesystem or write kwt's
+configuration itself. Windows hosts do not expose project registration until
+that command boundary supports native Windows paths.
+On macOS and Linux, the account login shell initializes the command
+environment, while Ghosthub's own inventory and discovery commands execute
+under the host's POSIX `/bin/sh`; non-POSIX account shells such as fish are not
+asked to interpret those commands. Windows commands execute through encoded
+noninteractive PowerShell.
 Direct tmux discovery provides every otherwise-unbound session. A remote host
 without kwt remains a valid tmux-only host; remote inventory failures stay
 attached to that host and never replace usable local or cached inventory with a
@@ -182,9 +186,10 @@ there is no repository-intake interstitial and no first-launch modal.
 When both inventories are empty, Ghosthub explains that kwt owns project
 registration and tmux owns sessions. Ghosthub does not edit kwt's config file
 or present its retired Middleman-backed Add Repository flow. The **+** menu on
-each host exposes **Add Project**, which passes one explicit absolute checkout
-path to kwt's supported noninteractive registration command. Ghosthub does not
-scan the host for repositories.
+macOS and Linux hosts exposes **Add Project**, which passes one explicit
+absolute checkout path to kwt's supported noninteractive registration command.
+Windows hosts omit that action. Ghosthub does not scan the host for
+repositories.
 
 ## Source Layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,11 +156,12 @@ restore its own revision; reinstalling one revision also retains
 
 Native Windows installation uses a separate PowerShell boundary. The explicit
 **Install Bundled kwt** action probes the remote process architecture, uploads
-the matching PE helper over OpenSSH, verifies it at a managed staging path, and
-atomically installs it at `%USERPROFILE%\.ghosthub\bin\kwt.exe` without
-replacing a system `kwt.exe`. A failed activation restores the prior managed
-helper. The Windows helpers remain unsigned experimental payloads until the
-release pipeline adds an approved Authenticode/DigiCert signing step.
+the matching PE helper over OpenSSH, verifies its SHA-256 and exact pinned
+version at a managed staging path, and atomically installs it at
+`%USERPROFILE%\.ghosthub\helpers\kwt\<revision>\kwt.exe` without replacing or
+resolving a system `kwt.exe`. A failed activation restores the prior helper at
+that revision. The Windows helpers remain unsigned experimental payloads until
+the release pipeline adds an approved Authenticode/DigiCert signing step.
 
 ### Experimental native Windows hosts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,10 +152,11 @@ restore its own revision; reinstalling one revision also retains
 
 Native Windows installation uses a separate PowerShell boundary. The explicit
 **Install Bundled kwt** action probes the remote process architecture, uploads
-the matching PE helper over OpenSSH, verifies that it runs, and installs it at
-`%USERPROFILE%\.ghosthub\bin\kwt.exe` without replacing a system `kwt.exe`.
-The Windows helpers remain unsigned experimental payloads until the release
-pipeline adds an approved Authenticode/DigiCert signing step.
+the matching PE helper over OpenSSH, verifies it at a managed staging path, and
+atomically installs it at `%USERPROFILE%\.ghosthub\bin\kwt.exe` without
+replacing a system `kwt.exe`. A failed activation restores the prior managed
+helper. The Windows helpers remain unsigned experimental payloads until the
+release pipeline adds an approved Authenticode/DigiCert signing step.
 
 ### Experimental native Windows hosts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,13 +97,13 @@ twice.
 ### External State
 
 Ghosthub bundles revision-pinned kwt CLI builds for local project and worktree
-operations and for `darwin/{amd64,arm64}` and `linux/{amd64,arm64}` remote
-hosts. The local helper is signed as app code and invoked by its exact bundle
+operations and for `darwin/{amd64,arm64}`, `linux/{amd64,arm64}`, and
+`windows/{amd64,arm64}` remote hosts. The local helper is signed as app code and invoked by its exact bundle
 path. Remote helpers are sealed resources in the signed app. After the user
 chooses **Install kwt Worktree Helper** for a host, Ghosthub selects the matching
 `uname` target, uploads it, verifies its SHA-256 on the host, and atomically
 installs it under `~/.ghosthub/helpers/kwt/<revision>/kwt`. Packaging verifies
-the four binaries' formats, architectures, and embedded revision; installation
+the six binaries' formats, architectures, and embedded revision; installation
 also requires the uploaded helper's `version` output to report that revision
 before promotion. Every remote kwt operation invokes that exact revisioned
 path; failed upload or installation attempts also best-effort remove their
@@ -149,6 +149,28 @@ actions and never replace a host's system kwt. Versioned directories retain
 older pinned helpers, so installing an older Ghosthub build can select and
 restore its own revision; reinstalling one revision also retains
 `kwt.previous`.
+
+Native Windows installation uses a separate PowerShell boundary. The explicit
+**Install Bundled kwt** action probes the remote process architecture, uploads
+the matching PE helper over OpenSSH, verifies that it runs, and installs it at
+`%USERPROFILE%\.ghosthub\bin\kwt.exe` without replacing a system `kwt.exe`.
+The Windows helpers remain unsigned experimental payloads until the release
+pipeline adds an approved Authenticode/DigiCert signing step.
+
+### Experimental native Windows hosts
+
+A configured Windows host uses OpenSSH, Windows PowerShell 5.1 or newer, and
+psmux's `tmux.exe` compatibility alias. Ghosthub probes and discovers psmux
+through encoded, noninteractive PowerShell commands, then creates and attaches
+to sessions using the same exact-target and attach-only reconnect model as
+POSIX tmux hosts. Windows 11 build 22523 or newer is the initial interactive
+target because its ConPTY path supports ordinary OpenSSH TTY allocation.
+
+When Ghosthub creates a native Windows session, it passes the SSH account
+process's `PATH` through psmux's session-environment argument so the initial
+PowerShell and later panes resolve the same user-installed tools as a direct
+SSH shell. It retains psmux's native status-bar styling and does not rewrite
+the environment of an existing session or running pane.
 
 ## Startup and Onboarding
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,8 +17,9 @@ arm64.
 Ghosthub uploads a variant only after the user chooses Install or Update,
 verifies its SHA-256 remotely, and invokes the exact revisioned path under
 `~/.ghosthub/helpers/kwt/`; it never replaces or resolves a system `kwt`.
-Experimental Windows installation instead uses PowerShell to place the
-matching PE helper at `%USERPROFILE%\.ghosthub\bin\kwt.exe`. These Windows
+Experimental Windows installation follows the same pinning contract through
+PowerShell, placing the matching PE helper at
+`%USERPROFILE%\.ghosthub\helpers\kwt\<revision>\kwt.exe`. These Windows
 payloads remain unsigned until an approved Authenticode/DigiCert signing step
 is added, so they are not enterprise-ready release artifacts.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,11 +11,16 @@ The application bundles an ordinary `kwt` CLI helper at
 local project inventory and worktree operations. It does not resolve a local
 `kwt` from `PATH`, including when the bundle is damaged or incomplete: the
 local operation fails instead of drifting to another installation. Remote
-hosts use one of four pinned, CGO-disabled variants sealed under
-`Contents/Resources/KwtRemote`: Darwin and Linux, each for amd64 and arm64.
+hosts use one of six pinned, CGO-disabled variants sealed under
+`Contents/Resources/KwtRemote`: Darwin, Linux, and Windows, each for amd64 and
+arm64.
 Ghosthub uploads a variant only after the user chooses Install or Update,
 verifies its SHA-256 remotely, and invokes the exact revisioned path under
 `~/.ghosthub/helpers/kwt/`; it never replaces or resolves a system `kwt`.
+Experimental Windows installation instead uses PowerShell to place the
+matching PE helper at `%USERPROFILE%\.ghosthub\bin\kwt.exe`. These Windows
+payloads remain unsigned until an approved Authenticode/DigiCert signing step
+is added, so they are not enterprise-ready release artifacts.
 
 `make run-app` follows the same rule. Its `bootstrap-kwt` dependency builds and
 caches `KWT_REF` under `.build`, then stages that exact helper into the debug
@@ -23,7 +28,7 @@ app. A developer can override the repository, revision, source directory, or
 binary path deliberately, but the default never embeds the system kwt.
 `bootstrap-kwt-variants` cross-compiles the complete remote matrix from the
 same pin. Before either debug or release packaging, every variant is checked
-for its expected Mach-O/ELF architecture and embedded pinned revision.
+for its expected Mach-O/ELF/PE architecture and embedded pinned revision.
 
 Every packaged app also carries Ghosthub's AGPL-3.0 license and all notices in
 the repository's `LICENSES` directory under `Contents/Resources/Licenses`.
@@ -204,13 +209,14 @@ gh workflow run release.yml \
 
 The manual path imports the signing certificate into an ephemeral keychain,
 builds the pinned local kwt helper, verifies that it is an Apple Silicon
-Mach-O, cross-compiles the Darwin/Linux amd64/arm64 remote matrix,
+Mach-O, cross-compiles the Darwin/Linux/Windows amd64/arm64 remote matrix,
 builds release-optimized libghostty and Ghosthub, re-signs Sparkle's nested
 helpers and framework with Ghosthub's Developer ID identity, signs the local
 kwt helper and both Darwin remote kwt variants with hardened runtime and secure
 timestamps, then signs the enclosing app and DMG, submits it to Apple, staples
 and validates the ticket, and uploads a seven-day candidate artifact. Linux
-remote variants remain unsigned ELF resources. The candidate does not consume
+and experimental Windows remote variants remain unsigned ELF/PE resources.
+The candidate does not consume
 the production Sparkle private key, generate an appcast, create a tag, or
 create a GitHub release. Both checksum files name the DMG by basename, so they
 remain valid after download.
@@ -294,8 +300,8 @@ make release-app \
 
 `KWT_BINARY_PATH` changes only the local helper. Remote variants remain pinned
 to `KWT_REF`; use `KWT_VARIANTS_DIR` only when deliberately supplying a
-complete four-target matrix. An explicit variants directory is treated as
-prebuilt input: packaging verifies all four binary formats, target
+complete six-target matrix. An explicit variants directory is treated as
+prebuilt input: packaging verifies all six binary formats, target
 architectures, and embedded `KWT_REF`, and never rebuilds or modifies that
 directory. The default variants directory continues to be built from the
 pinned kwt source. Installation additionally runs the uploaded helper and

--- a/docs/release.md
+++ b/docs/release.md
@@ -240,8 +240,9 @@ locally built. Verify at minimum:
 - A configured SSH host discovers and attaches tmux without managed kwt.
 - Install kwt Worktree Helper selects the correct target, enables remote project
   inventory, and leaves any system `kwt` untouched.
-- On a fresh host, Add Project registers an absolute existing checkout through
-  managed kwt and makes its worktrees available without a filesystem scan.
+- On a fresh macOS or Linux host, Add Project registers an absolute existing
+  checkout through managed kwt and makes its worktrees available without a
+  filesystem scan.
 - **Check for Updates…** opens Sparkle's native UI without a configuration or
   signature error. A complete end-to-end installation requires a later release
   than the first version that embeds Sparkle.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -185,8 +185,10 @@ endpoint changed while Add Project was open. No filesystem scan occurs.
 
 On experimental Windows hosts, an explicit Install Bundled kwt action probes
 the process architecture, uploads the matching pinned AMD64 or ARM64 helper,
-and activates it at `%USERPROFILE%\.ghosthub\bin\kwt.exe`. Inventory prefers
-that per-user managed helper and otherwise resolves `kwt.exe` from `PATH`.
+verifies its SHA-256 and exact revision, and activates it at
+`%USERPROFILE%\.ghosthub\helpers\kwt\<revision>\kwt.exe`. Inventory and
+workspace operations use only that exact per-user helper and never resolve
+`kwt.exe` from `PATH`.
 Project registration is not yet supported on Windows, so its Add Project
 actions are hidden. Discovery never installs or updates remote software
 implicitly.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -97,13 +97,14 @@ remote host, only an SSH transport loss can hand a kwt-opened session to
 Ghosthub's attach-only reconnect loop. Ghosthub first retries SSH to probe the
 exact session: confirmed presence advances to ordinary attachment, while
 confirmed absence reruns `kwt open` because the failed SSH connection may never
-have executed it. The open, probe, and attach-only phases all run through the
-account login shell so settings such as `TMUX_TMPDIR` resolve the same tmux
-server. Confirmed absence retries use bounded exponential backoff. Unbound
-discovered sessions remain attach-only. Ghosthub does not expose rename, split,
-resize, window, or pane operations. Kill Session is exposed separately from
-presentation only for a session known to be running and always requires
-confirmation.
+have executed it. On POSIX hosts, the open, probe, and attach-only phases all
+run through the account login shell so settings such as `TMUX_TMPDIR` resolve
+the same tmux server. On Windows, those phases use encoded PowerShell commands
+within the same OpenSSH account environment. Confirmed absence retries use
+bounded exponential backoff. Unbound discovered sessions remain attach-only.
+Ghosthub does not expose rename, split, resize, window, or pane operations.
+Kill Session is exposed separately from presentation only for a session known
+to be running and always requires confirmation.
 
 Native Windows creation also supplies the SSH account's process `PATH` through
 psmux's `new-session -e` contract. Psmux otherwise starts detached panes

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -176,18 +176,20 @@ of a login-shell or tmux failure. Remote hosts where Ghosthub's managed kwt is
 absent remain available for direct tmux discovery and attachment. Inventory
 never uploads the helper. The user grants permission with **Install kwt
 Worktree Helper** in Host Settings, after which inventory and protected
-attachment execute its exact revisioned path. A fresh helper has an empty
-project registry: **Add Project** in the host's **+** menu passes one
-user-supplied absolute checkout path to kwt's noninteractive registration
-command, then refreshes inventory. Immediately before registration, Ghosthub
-re-resolves the host ID and rejects the operation if its endpoint changed
-while Add Project was open. No filesystem scan occurs.
+attachment execute its exact revisioned path. On macOS and Linux, a fresh
+helper has an empty project registry: **Add Project** in the host's **+** menu
+passes one user-supplied absolute checkout path to kwt's noninteractive
+registration command, then refreshes inventory. Immediately before
+registration, Ghosthub re-resolves the host ID and rejects the operation if its
+endpoint changed while Add Project was open. No filesystem scan occurs.
 
 On experimental Windows hosts, an explicit Install Bundled kwt action probes
 the process architecture, uploads the matching pinned AMD64 or ARM64 helper,
 and activates it at `%USERPROFILE%\.ghosthub\bin\kwt.exe`. Inventory prefers
 that per-user managed helper and otherwise resolves `kwt.exe` from `PATH`.
-Discovery never installs or updates remote software implicitly.
+Project registration is not yet supported on Windows, so its Add Project
+actions are hidden. Discovery never installs or updates remote software
+implicitly.
 
 Kwt session names are removed from the generic session group and rendered
 under their project/worktree. Every remaining tmux session is shown in the

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -27,7 +27,10 @@ detach-only presentation lifecycle as every other session.
 ## Native Tmux Attachment
 
 Ghosthub invokes `tmux attach-session -E -t =<name>` for a local session. A
-remote session uses the same tmux command through OpenSSH. There is no
+remote POSIX session uses the same tmux command through OpenSSH. An
+experimental native Windows host invokes psmux's `tmux.exe` compatibility
+alias through an encoded Windows PowerShell command and the same exact session
+target. There is no
 `tmux -CC`, pane capture, history replay, silent rendering child, Swift pane
 map, split-tree projection, or Ghosthub tab bar. Tmux owns:
 
@@ -67,6 +70,9 @@ tmux may report the first attached client's theme even when Ghosthub uses
 different colors. Tmux shares the override with every attached client. These
 best-effort style commands do not change tmux interaction: prefix and key
 tables, mouse behavior, windows, panes, history, and layout remain untouched.
+Native Windows attachment leaves psmux's status and message styles user-owned;
+psmux does not preserve tmux's session-scoped rendering for these style resets
+and may apply `reverse` across the client rather than only its status line.
 
 Explicit local creation uses one atomic `new-session -A` create-or-attach
 client invocation. This closes the detached-session race when the user's tmux
@@ -99,6 +105,13 @@ resize, window, or pane operations. Kill Session is exposed separately from
 presentation only for a session known to be running and always requires
 confirmation.
 
+Native Windows creation also supplies the SSH account's process `PATH` through
+psmux's `new-session -e` contract. Psmux otherwise starts detached panes
+without the user-level path entries visible to Windows OpenSSH, which prevents
+tools installed under locations such as `.local\bin`, WinGet links, or the npm
+prefix from resolving. This applies only while creating a session; attachment
+does not modify an existing session or running pane.
+
 The requested session appears optimistically so transient SSH or discovery
 latency cannot remove the user's only way back to it. Direct `list-sessions`
 reconciliation begins only after the terminal runtime accepts the creation
@@ -109,11 +122,12 @@ and all later retries are demoted to attach-only. Pending probes are scoped to
 the resolved host endpoint and cancelled when that endpoint changes or the
 owning window shuts down.
 
-Before discovery or attachment, Ghosthub resolves an absolute tmux path
-through the target host's login shell and verifies tmux 3.2 or newer.
-The login shell initializes its environment, then delegates Ghosthub's probe
-to `/bin/sh`; fish and other non-POSIX account shells never interpret the
-POSIX probe itself.
+Before discovery or attachment, Ghosthub resolves an absolute tmux-compatible
+binary path and verifies the reported tmux protocol version is 3.2 or newer.
+On POSIX hosts the login shell initializes its environment, then delegates
+Ghosthub's probe to `/bin/sh`; fish and other non-POSIX account shells never
+interpret the POSIX probe itself. On Windows, Ghosthub starts noninteractive
+Windows PowerShell and resolves `tmux.exe` with `Get-Command`.
 Successful paths are cached per host; lookup and version failures remain
 retryable and are presented to the user.
 
@@ -128,6 +142,11 @@ verification emits a marker only after the remote command begins. Status 255
 and local wrapper failures such as an unconfirmed timeout leave the host
 offline; a nonzero login-shell or probe-command status is reachable and
 degraded only when that marker proves the remote account executed the probe.
+
+The initial psmux path allocates an ordinary SSH PTY and targets Windows 11
+build 22523 or newer. Older ConPTY builds preserve keyboard input but consume
+psmux mouse-reporting sequences; supporting them would require the separate
+psmux `ssh -T` wrapper and is not part of this experiment.
 
 Tmux remains alive on the remote host while the network is unavailable. After
 connectivity returns, the client reattaches to the same exact session and tmux
@@ -162,6 +181,12 @@ user-supplied absolute checkout path to kwt's noninteractive registration
 command, then refreshes inventory. Immediately before registration, Ghosthub
 re-resolves the host ID and rejects the operation if its endpoint changed
 while Add Project was open. No filesystem scan occurs.
+
+On experimental Windows hosts, an explicit Install Bundled kwt action probes
+the process architecture, uploads the matching pinned AMD64 or ARM64 helper,
+and activates it at `%USERPROFILE%\.ghosthub\bin\kwt.exe`. Inventory prefers
+that per-user managed helper and otherwise resolves `kwt.exe` from `PATH`.
+Discovery never installs or updates remote software implicitly.
 
 Kwt session names are removed from the generic session group and rendered
 under their project/worktree. Every remaining tmux session is shown in the

--- a/tools/assemble_app_bundle.py
+++ b/tools/assemble_app_bundle.py
@@ -80,6 +80,8 @@ def assemble_app_bundle(
         "darwin-arm64",
         "linux-amd64",
         "linux-arm64",
+        "windows-amd64",
+        "windows-arm64",
     )
     remote_helpers = {
         target: kwt_variants_dir / target / "kwt"

--- a/tools/build_pinned_kwt_variants.sh
+++ b/tools/build_pinned_kwt_variants.sh
@@ -17,7 +17,9 @@ for target in \
   darwin-amd64 \
   darwin-arm64 \
   linux-amd64 \
-  linux-arm64
+  linux-arm64 \
+  windows-amd64 \
+  windows-arm64
 do
   goos="${target%-*}"
   goarch="${target#*-}"

--- a/tools/validate_kwt_variants.py
+++ b/tools/validate_kwt_variants.py
@@ -14,6 +14,8 @@ TARGETS = {
     "darwin-arm64": ("mach-o", 0x0100000C),
     "linux-amd64": ("elf", 62),
     "linux-arm64": ("elf", 183),
+    "windows-amd64": ("pe", 0x8664),
+    "windows-arm64": ("pe", 0xAA64),
 }
 
 
@@ -41,7 +43,7 @@ def validate_variant(path: Path, target: str, revision: str) -> None:
         if len(contents) < 8 or contents[:4] != b"\xcf\xfa\xed\xfe":
             raise ValueError(f"{path} is not a 64-bit little-endian Mach-O")
         actual_cpu = struct.unpack_from("<I", contents, 4)[0]
-    else:
+    elif binary_format == "elf":
         if (
             len(contents) < 20
             or contents[:4] != b"\x7fELF"
@@ -50,6 +52,16 @@ def validate_variant(path: Path, target: str, revision: str) -> None:
         ):
             raise ValueError(f"{path} is not a 64-bit little-endian ELF")
         actual_cpu = struct.unpack_from("<H", contents, 18)[0]
+    else:
+        if len(contents) < 64 or contents[:2] != b"MZ":
+            raise ValueError(f"{path} is not a PE executable")
+        pe_offset = struct.unpack_from("<I", contents, 0x3C)[0]
+        if (
+            pe_offset + 6 > len(contents)
+            or contents[pe_offset : pe_offset + 4] != b"PE\0\0"
+        ):
+            raise ValueError(f"{path} is not a PE executable")
+        actual_cpu = struct.unpack_from("<H", contents, pe_offset + 4)[0]
 
     if actual_cpu != expected_cpu:
         raise ValueError(f"{path} does not match target {target}")

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -150,12 +150,14 @@ const imageAlt = {
             first when your policy prompts for trust. Ghosthub then copies its
             pinned build for the host’s OS and CPU, verifies it, and keeps it
             under <code>~/.ghosthub/</code>.
-            On a fresh host, open the <strong>+</strong> menu beside it, choose
-            <strong>Add Project</strong>, and enter each existing checkout’s
-            absolute path. Ghosthub delegates registration to kwt and refreshes
-            inventory without scanning the machine. If the host’s SSH address
-            changes while Add Project is open, close the sheet and try again
-            against the updated host. Ghosthub marks the machine reachable only
+            On a fresh macOS or Linux host, open the <strong>+</strong> menu
+            beside it, choose <strong>Add Project</strong>, and enter each
+            existing checkout’s absolute path. Ghosthub delegates registration
+            to kwt and refreshes inventory without scanning the machine.
+            Project registration is not yet available for Windows hosts. If the
+            host’s SSH address changes while Add Project is open, close the
+            sheet and try again against the updated host. Ghosthub marks the
+            machine reachable only
             when the remote verification command actually begins; SSH failures
             and unconfirmed local timeouts remain offline, while a confirmed
             remote command failure is shown as degraded. Tmux-only hosts do not
@@ -192,11 +194,12 @@ const imageAlt = {
         <div>
           <h2>Add project and worktree context</h2>
           <p>
-            Open the <strong>+</strong> menu beside a local or remote host,
-            choose <strong>Add Project</strong>, and enter the absolute path to
-            an existing checkout. Ghosthub registers that repository through
-            its bundled or managed <a href="https://kwt.sh">kwt</a> helper
-            without scanning the machine.
+            Open the <strong>+</strong> menu beside your local Mac or a remote
+            macOS or Linux host, choose <strong>Add Project</strong>, and enter
+            the absolute path to an existing checkout. Ghosthub registers that
+            repository through its bundled or managed{' '}
+            <a href="https://kwt.sh">kwt</a> helper without scanning the machine.
+            Windows project registration is not yet supported.
           </p>
           <p>
             Pull-request import requires the{' '}

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -130,6 +130,17 @@ const imageAlt = {
             so an unreachable machine never blocks the rest of your fleet.
           </p>
           <p>
+            Native Windows support is experimental. Choose{' '}
+            <strong>Windows (psmux)</strong> for a Windows OpenSSH host with
+            PowerShell and <a href="https://github.com/marlocarlo/psmux">psmux</a>{' '}
+            installed, including its <code>tmux.exe</code> alias. After
+            testing the connection, <strong>Install Bundled kwt</strong>{' '}
+            uploads Ghosthub’s matching AMD64 or ARM64 helper for that user.
+            The Windows helper is currently unsigned, so this path is intended
+            for development machines and power users until Authenticode
+            signing is available.
+          </p>
+          <p>
             To add project and worktree context without installing{' '}
             <a href="https://kwt.sh">kwt, a Git worktree manager</a>,
             system-wide, test the connection and choose{' '}


### PR DESCRIPTION
Ghosthub’s SSH model currently assumes a POSIX remote, excluding native Windows development machines even when OpenSSH and psmux provide the same durable tmux ownership model. This adds an explicitly experimental Windows platform that runs remote operations through encoded PowerShell, discovers and attaches psmux sessions, preserves the SSH account PATH only when creating sessions, and leaves psmux’s own presentation styling intact.

Windows kwt helpers are now built for AMD64 and ARM64 as part of the pinned remote matrix and installed only through an explicit per-user action. They remain unsigned, so the UI and Guide position this for development machines and power users until an Authenticode signing path exists. Native Windows Add Project is intentionally not exposed; already registered kwt inventory and session workflows are supported.

Validated against a real ARM64 Windows host over Tailscale with OpenSSH and psmux 3.3.7, including helper installation, CLI PATH resolution, session discovery and attachment, and status-bar styling. The full Swift and Python suites, terminal regression checks, formatting, app build, and website checks pass; the complete website screenshot set was regenerated and published.