### PR TITLE
Prepare the website guide for 0.4.0

### DIFF
--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -281,8 +281,8 @@ def test_demo_session_ignores_launcher_shell_configuration(
     tmux = bin_dir / "tmux"
     tmux.write_text(
         "#!/usr/bin/env bash\n"
-        "printf 'CALL\\n' >> \"$CAPTURE\"\n"
-        "printf '%s\\n' \"$@\" >> \"$CAPTURE\"\n"
+        "printf 'CALL\\0' >> \"$CAPTURE\"\n"
+        "printf '%s\\0' \"$@\" >> \"$CAPTURE\"\n"
     )
     tmux.chmod(0o755)
     scratch = tmp_path / "scratch"
@@ -303,13 +303,18 @@ def test_demo_session_ignores_launcher_shell_configuration(
     )
 
     assert result.returncode == 0, result.stderr
-    calls = [call.splitlines() for call in capture.read_text().split("CALL\n")[1:]]
-    new_session, send_keys = calls
+    captured = capture.read_bytes().split(b"\0")
+    assert captured[0] == b"CALL"
+    assert captured[-1] == b""
+    new_session = [argument.decode() for argument in captured[1:-1]]
     assert f"HOME={scratch}/home" in new_session
     assert f"ZDOTDIR={scratch}/home" in new_session
     assert "SHELL=/bin/zsh" in new_session
-    assert new_session[-1] == "/bin/zsh -l"
-    assert send_keys == ["send-keys", "-t", "demo", "printf demo-ready", "Enter"]
+    assert new_session[-3:] == [
+        "/bin/zsh",
+        "-lc",
+        "printf demo-ready\nexec /bin/zsh -l",
+    ]
     if launcher_zdotdir:
         assert launcher_zdotdir not in new_session
     if launcher_shell != "/bin/zsh":

--- a/website/demo/bin/kwt
+++ b/website/demo/bin/kwt
@@ -70,9 +70,72 @@ list_json() {
   echo "]"
 }
 
+branches_json() {
+  local project
+  project="$(basename "$PWD")"
+  case "$project" in
+    ghosthub)
+      cat <<'EOF'
+[
+  {"name": "feature/session-search",
+   "source": "feature/session-search", "is_remote": false},
+  {"name": "feature/sidebar-groups",
+   "source": "origin/feature/sidebar-groups", "is_remote": true},
+  {"name": "release/0.4.0",
+   "source": "origin/release/0.4.0", "is_remote": true}
+]
+EOF
+      ;;
+    agentsview)
+      cat <<'EOF'
+[
+  {"name": "feature/live-filters",
+   "source": "feature/live-filters", "is_remote": false},
+  {"name": "feature/session-groups",
+   "source": "origin/feature/session-groups", "is_remote": true}
+]
+EOF
+      ;;
+    msgvault)
+      cat <<'EOF'
+[
+  {"name": "feature/export-progress",
+   "source": "origin/feature/export-progress", "is_remote": true}
+]
+EOF
+      ;;
+    *)
+      echo "[]"
+      ;;
+  esac
+}
+
+open_worktree() {
+  local path="${2:-}" relative project branch session
+  case "$path" in
+    "$scratch/worktrees/"*)
+      relative="${path#"$scratch/worktrees/"}"
+      project="${relative%%/*}"
+      branch="${relative#*/}"
+      ;;
+    "$scratch/repos/"*)
+      project="$(basename "$path")"
+      branch="main"
+      ;;
+    *)
+      echo "faux kwt: unknown demo worktree: $path" >&2
+      exit 64
+      ;;
+  esac
+  session="$project--${branch//\//-}"
+  exec tmux new-session -A -s "$session" -c "$path"
+}
+
 case "${1:-}" in
   projects) projects_json ;;
   list) list_json ;;
+  branches) branches_json ;;
+  open) open_worktree "$@" ;;
   *)
     echo "faux kwt: unsupported command: ${1:-<none>}" >&2
     exit 64

--- a/website/demo/shell.sh
+++ b/website/demo/shell.sh
@@ -10,15 +10,15 @@ demo_new_session() {
     return 1
   fi
 
-  local pane_command="/bin/zsh -l"
+  local -a pane_command=(/bin/zsh -l)
   if (( $# == 1 )); then
     local startup
     startup="$1"$'\n''exec /bin/zsh -l'
-    pane_command="/bin/zsh -lc $(printf '%q' "$startup")"
+    pane_command=(/bin/zsh -lc "$startup")
   fi
   tmux new-session -d -x 210 -y 55 -s "$name" -c "$dir" \
     -e HOME="$scratch/home" \
     -e ZDOTDIR="$scratch/home" \
     -e SHELL=/bin/zsh \
-    "$pane_command"
+    "${pane_command[@]}"
 }

--- a/website/demo/shell.sh
+++ b/website/demo/shell.sh
@@ -10,12 +10,15 @@ demo_new_session() {
     return 1
   fi
 
+  local pane_command="/bin/zsh -l"
+  if (( $# == 1 )); then
+    local startup
+    startup="$1"$'\n''exec /bin/zsh -l'
+    pane_command="/bin/zsh -lc $(printf '%q' "$startup")"
+  fi
   tmux new-session -d -x 210 -y 55 -s "$name" -c "$dir" \
     -e HOME="$scratch/home" \
     -e ZDOTDIR="$scratch/home" \
     -e SHELL=/bin/zsh \
-    "/bin/zsh -l"
-  if (( $# == 1 )); then
-    tmux send-keys -t "$name" "$1" Enter
-  fi
+    "$pane_command"
 }

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -248,13 +248,11 @@ sleep 2
 capture_state guide-hosts.png
 dismiss_sheet
 
-echo "==> guide: new worktree"
+echo "==> guide: existing branch picker"
 palette "fix-reconnect-backoff"
 sleep 2
 palette "New Worktree in ghosthub" true sheet
-sleep 1
-demo_input text "improve-session-search"
-sleep 1
+sleep 2
 capture_state guide-worktree.png
 dismiss_sheet
 
@@ -263,8 +261,8 @@ palette "reconnect" false
 capture_state guide-quick-launch.png
 dismiss_sheet
 
-echo "==> guide: terminal settings"
-palette "Open Terminal Settings" true sheet
+echo "==> guide: appearance settings"
+palette "Open Appearance Settings" true sheet
 sleep 2
 capture_state guide-terminal.png
 dismiss_sheet

--- a/website/demo/stage.sh
+++ b/website/demo/stage.sh
@@ -234,17 +234,14 @@ new_session agentsview--add-session-filters \
   "clear; cat $(printf '%q' "$scratch/session-transcript.txt")"
 
 # Raw local sessions (unbound: not in any kwt inventory).
-new_session scratch "$scratch/repos/msgvault"
-tmux send-keys -t scratch "clear; git log --oneline -4" Enter
-new_session docbank-export "$scratch"
-tmux send-keys -t docbank-export \
-  "clear; echo 'exported 4,812 threads (2.1 GiB) in 96s'; echo done." Enter
-new_session release-watch "$scratch/repos/ghosthub"
-tmux send-keys -t release-watch \
-  "clear; printf 'release v0.2.1\\n\\n  ✓ build\\n  ✓ swift tests\\n  ✓ notarization\\n  ● publish\\n'" Enter
-new_session test-matrix "$scratch/repos/agentsview"
-tmux send-keys -t test-matrix \
-  "clear; printf 'test matrix\\n\\nmacOS 26 arm64     ✓ 523 passed\\nUbuntu 24.04       ✓ 118 passed\\nSSH integration    ✓  42 passed\\n'" Enter
+new_session scratch "$scratch/repos/msgvault" \
+  "clear; git log --oneline -4"
+new_session docbank-export "$scratch" \
+  "clear; echo 'exported 4,812 threads (2.1 GiB) in 96s'; echo done."
+new_session release-watch "$scratch/repos/ghosthub" \
+  "clear; printf 'release v0.4.0\\n\\n  ✓ build\\n  ✓ swift tests\\n  ✓ notarization\\n  ● publish\\n'"
+new_session test-matrix "$scratch/repos/agentsview" \
+  "clear; printf 'test matrix\\n\\nmacOS 26 arm64     ✓ 680 passed\\nUbuntu 24.04       ✓ 149 passed\\nSSH integration    ✓  42 passed\\n'"
 
 echo "==> staging patched app copy"
 # Build the release app first (make release-app in the app repo) or point

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -161,19 +161,23 @@ import AppIcon from './AppIcon.astro';
   .repo {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
+    gap: 0.5rem;
     font-family: var(--font-mono);
-    font-size: 0.8rem;
     color: var(--text-dim);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 0.3rem 0.7rem;
-    transition: color 0.15s, border-color 0.15s;
+    border-radius: 6px;
+    padding: 0.2rem 0.25rem;
+    transition: color 0.15s, background-color 0.15s;
   }
 
   .repo:hover {
     color: var(--text);
-    border-color: var(--text-faint);
+    background: var(--surface);
+  }
+
+  .repo > svg {
+    width: 20px;
+    height: 20px;
+    flex: 0 0 auto;
   }
 
   .repo-meta {
@@ -183,10 +187,14 @@ import AppIcon from './AppIcon.astro';
     line-height: 1.2;
   }
 
+  .repo-name {
+    font-size: 0.72rem;
+  }
+
   .facts {
     display: flex;
-    gap: 0.6rem;
-    font-size: 0.68rem;
+    gap: 0.5rem;
+    font-size: 0.64rem;
     color: var(--text-faint);
   }
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -23,14 +23,14 @@ const imageAlt = {
     'Ghosthub workspace showing local sessions, projects, worktrees, and a remote host in the sidebar',
   hosts: 'Ghosthub Hosts settings with a configured remote GPU host',
   worktree:
-    'Ghosthub new worktree sheet ready to create a feature branch or import a pull request',
+    'Ghosthub new worktree sheet listing available local and remote branches',
   commandPalette: 'Ghosthub Command Palette filtered to a reconnect worktree',
   commandCenter:
     'Six real Ghosthub windows arranged in a tight three-by-two matrix, each attached to a different tmux session with its sidebar collapsed',
   nativeTabs:
     'Six native Ghosthub workspace tabs, each attached to a different tmux session',
   terminal:
-    'Ghosthub Terminal settings showing interaction and configuration options',
+    'Ghosthub Appearance settings showing the theme for new tmux sessions',
 };
 ---
 
@@ -88,8 +88,10 @@ const imageAlt = {
           </p>
           <p>
             Closing the Ghosthub window only detaches—your work keeps running
-            in tmux. To end a session Ghosthub knows is running, hover its row,
-            open the action menu, and choose <strong>Kill Session…</strong>.
+            in tmux. To end a standalone session Ghosthub knows is running,
+            hover its row and click the subtle <strong>×</strong>. A
+            worktree-backed session keeps <strong>Kill Session…</strong> in
+            its action menu, beside the separate worktree-removal control.
             Ghosthub confirms the host and exact tmux instance before
             terminating its windows, panes, and processes. It cancels the
             action if that host’s connection changes or if the session
@@ -211,14 +213,21 @@ const imageAlt = {
           <p>
             Select a project and press <kbd>⌘⇧N</kbd>. Use
             <strong>Branch</strong> to search local and remote branches that
-            are not already checked out. Pick one to create its worktree and
-            tracking branch, or type a new branch name. Use
+            are not already checked out. Pick one to create its worktree,
+            including a local tracking branch when the source is remote, or
+            type a new branch name. Use
             <strong>Pull Request</strong> to find and import an open GitHub
             pull request. You do not need to install or run kwt separately.
             Selecting a listed worktree creates or repairs its canonical tmux
             session when needed, then attaches an ordinary tmux client.
             Kwt remains optional if you only want a local and remote tmux
             session switcher.
+          </p>
+          <p>
+            To remove a non-primary worktree, hover its sidebar row and click
+            the <strong>×</strong>. After confirmation, Ghosthub terminates
+            that worktree’s live tmux session if necessary and asks kwt to
+            remove the checkout. The Git branch is kept.
           </p>
         </div>
       </div>
@@ -330,9 +339,10 @@ const imageAlt = {
             The Tmux Theme picker supplies colors for new sessions created by
             Ghosthub. Existing sessions keep their own appearance by default;
             Ghosthub does not place a local palette over them. An explicit
-            opt-in applies the selected colors to the session’s existing
-            windows and chrome for every attached terminal. Ghosthub reloads
-            terminal configuration when it changes.
+            <strong>Apply theme to shared tmux sessions</strong> opt-in applies
+            the selected colors to the session’s existing windows and chrome
+            for every attached terminal. Ghosthub reloads terminal
+            configuration when it changes.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Ghosthub 0.4.0 changes the everyday worktree and tmux lifecycle, but the Guide still described the old standalone-session overflow action and omitted confirmed worktree removal. Its isolated screenshot helper also could not exercise the merged kwt branch inventory and exact-path open contracts, which allowed stale or visibly failed product captures.

This brings the Guide to the accepted behavior and makes future screenshot generations representative: existing local and remote branches are visible as distinct sources, session and worktree removal controls are explained, and the shared-session theme boundary is explicit. Demo panes now invoke zsh directly with isolated startup state, so screenshot staging remains deterministic even when tmux is configured to use fish or another incompatible default shell.

The website header now presents GitHub repository metadata as the same compact two-line source card used by AgentsView. Release, star, and fork facts already load from GitHub once the repository is public; while Ghosthub remains private, the card degrades cleanly to the repository identity instead of an oversized outlined pill.

The complete eight-image generation has already been published separately to the orphan website-assets branch at 832541d so the site can consume it without adding binaries to main. The release app build, complete isolated screenshot run and original-resolution image review, all 120 Python tests, and the website type-check, lint, 11 tests, and production build pass.