### PR TITLE
Honor OpenSSH authentication and connection sharing

### DIFF
--- a/Sources/App/KwtRemoteInstaller.swift
+++ b/Sources/App/KwtRemoteInstaller.swift
@@ -320,7 +320,7 @@ struct KwtRemoteInstaller: Sendable {
         source: URL,
         destination: String
     ) -> (status: Int32, output: String) {
-        let result = TmuxBinaryResolver.runProcess(
+        let result = TmuxBinaryResolver.runProcessInLoginShell(
             executable: "/usr/bin/scp",
             arguments: uploadArguments(
                 host: host,

--- a/Sources/App/KwtWindowsInstaller.swift
+++ b/Sources/App/KwtWindowsInstaller.swift
@@ -300,7 +300,7 @@ struct KwtWindowsInstaller: Sendable {
             localPath,
             "\(destination):\(remoteName)",
         ]
-        return TmuxBinaryResolver.runProcess(
+        return TmuxBinaryResolver.runProcessInLoginShell(
             executable: "/usr/bin/scp",
             arguments: arguments,
             timeout: 120

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -136,7 +136,10 @@ struct TmuxBinaryResolver: Sendable {
         }
         self.remoteProcessRunner = remoteProcessRunner ?? { host, command in
             Self.runRemoteLoginShell(
-                host: host, command: command, timeout: processTimeout
+                host: host,
+                command: command,
+                timeout: processTimeout,
+                accountShell: loginShellProvider()
             )
         }
         self.loginShellProvider = loginShellProvider
@@ -357,19 +360,40 @@ struct TmuxBinaryResolver: Sendable {
     static func runLoginShell(
         shell: String,
         command: String,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        captureStandardError: Bool = false
     ) -> (status: Int32, stdout: String) {
         runProcess(
             executable: shell,
-            arguments: ["-lc", posixCommand(command)],
-            timeout: timeout
+            arguments: ["-lc", accountShellCommand(command)],
+            timeout: timeout,
+            captureStandardError: captureStandardError
+        )
+    }
+
+    static func runProcessInLoginShell(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval,
+        captureStandardError: Bool = false,
+        accountShell: String = loginShell()
+    ) -> (status: Int32, stdout: String) {
+        let command = ([executable] + arguments)
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        return runLoginShell(
+            shell: accountShell,
+            command: command,
+            timeout: timeout,
+            captureStandardError: captureStandardError
         )
     }
 
     static func runRemoteLoginShell(
         host: SSHHostInfo,
         command: String,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        accountShell: String = loginShell()
     ) -> (status: Int32, stdout: String) {
         var arguments = ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]
         arguments.append(contentsOf: tmuxSSHConnectionArguments())
@@ -380,10 +404,11 @@ struct TmuxBinaryResolver: Sendable {
         arguments.append(contentsOf: [
             "--", target, remoteLoginCommand(host: host, command: command),
         ])
-        return runProcess(
+        return runProcessInLoginShell(
             executable: "/usr/bin/ssh",
             arguments: arguments,
-            timeout: timeout
+            timeout: timeout,
+            accountShell: accountShell
         )
     }
 
@@ -394,9 +419,7 @@ struct TmuxBinaryResolver: Sendable {
         if host.platform == .windows {
             return powerShellEncodedCommand(command)
         }
-        let accountShellCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
-            + shellQuotedCommandArgument(posixCommand(command))
-        return posixCommand(accountShellCommand)
+        return accountLoginShellCommand(command)
     }
 
     /// The account shell owns login-environment initialization, but Ghosthub's

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2133,9 +2133,8 @@ final class WorkspaceSceneModel: ObservableObject {
                     severity: .error,
                     summary: "SSH could not be reached.",
                     recoverySuggestion:
-                    "Run `ssh \(host.sshDestination)` in Terminal once to "
-                        + "accept the host key, then verify key-based "
-                        + "authentication works without a prompt."
+                    "Confirm the host key is trusted and key-based "
+                        + "authentication is available from your login shell."
                 )]
             } else if !tmuxAvailable {
                 diagnostics = [RemoteHostDiagnostic(

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -3,29 +3,43 @@ import Foundation
 public func tmuxSSHConnectionArguments(
     environment: [String: String] = ProcessInfo.processInfo.environment
 ) -> [String] {
-    var arguments = [
+    // The screenshot app is ad-hoc signed and runs against guarded scratch
+    // state. Keep its SSH isolation explicit without changing normal clients.
+    guard let scratch = environment["GHOSTHUB_DEMO_SCRATCH"],
+          let directory = environment["GHOSTHUB_DEMO_SSH_DIR"],
+          scratch.hasPrefix("/"), directory == "\(scratch)/ssh"
+    else { return [] }
+
+    return [
+        "-F", "\(directory)/config",
+        "-o", "UserKnownHostsFile=\(directory)/known_hosts",
+        "-o", "GlobalKnownHostsFile=/dev/null",
+        "-o", "StrictHostKeyChecking=yes",
+        "-o", "ProxyCommand=none",
+        "-o", "ProxyJump=none",
         "-o", "ControlMaster=no",
         "-o", "ControlPath=none",
     ]
-    // The screenshot app is ad-hoc signed and runs against guarded scratch
-    // state. Keep its SSH isolation explicit without changing normal clients.
-    if let scratch = environment["GHOSTHUB_DEMO_SCRATCH"],
-       let directory = environment["GHOSTHUB_DEMO_SSH_DIR"],
-       scratch.hasPrefix("/"), directory == "\(scratch)/ssh" {
-        arguments.insert(contentsOf: [
-            "-F", "\(directory)/config",
-            "-o", "UserKnownHostsFile=\(directory)/known_hosts",
-            "-o", "GlobalKnownHostsFile=/dev/null",
-            "-o", "StrictHostKeyChecking=yes",
-            "-o", "ProxyCommand=none",
-            "-o", "ProxyJump=none",
-        ], at: 0)
-    }
-    return arguments
 }
 
 public func shellQuotedCommandArgument(_ value: String) -> String {
     "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+}
+
+private func accountShellCommandArgument(_ value: String) -> String {
+    value.split(separator: "`", omittingEmptySubsequences: false)
+        .map { segment in
+            let escaped = String(segment)
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "$", with: "\\$")
+            return "\"\(escaped)\""
+        }
+        .joined(separator: "'`'")
+}
+
+public func accountShellCommand(_ command: String) -> String {
+    "exec /bin/sh -c " + accountShellCommandArgument(command)
 }
 
 /// Keeps caller-controlled text out of PowerShell source. The generated
@@ -78,16 +92,15 @@ public func powerShellKwtAvailabilityPrelude(
     """
 }
 
-/// Initializes the remote account's login environment, then delegates
-/// Ghosthub-owned POSIX command text to `/bin/sh`. The outer simple command is
-/// accepted by POSIX shells and non-POSIX account shells such as fish.
-public func remoteAccountLoginShellCommand(_ command: String) -> String {
+/// Initializes an account's login environment, then delegates
+/// Ghosthub-owned POSIX command text to `/bin/sh`. The outer command argument
+/// is accepted by POSIX shells and non-POSIX account shells such as fish.
+public func accountLoginShellCommand(_ command: String) -> String {
     let posixCommand = "exec /bin/sh -c "
         + shellQuotedCommandArgument(command)
-    let accountShellCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
+    let loginCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
         + shellQuotedCommandArgument(posixCommand)
-    return "exec /bin/sh -c "
-        + shellQuotedCommandArgument(accountShellCommand)
+    return accountShellCommand(loginCommand)
 }
 
 public enum ConnectionState: Codable, Equatable, Sendable {
@@ -215,52 +228,54 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 workingDirectory: workingDirectory
             )
         case let .ssh(info):
+            let command: String
             if info.platform == .windows {
                 if launchMode == .create {
-                    return remoteCreateThenAttachCommand(
+                    command = remoteCreateThenAttachCommand(
                         info: info,
                         tmuxPath: tmuxPath,
                         workingDirectory: workingDirectory,
                         sshConnectionArguments: sshConnectionArguments
                     )
-                }
-                if protectedWorkspacePath == nil, workspacePath != nil {
-                    return windowsRemoteWorkspaceAttachCommand(
+                } else if protectedWorkspacePath == nil,
+                          workspacePath != nil {
+                    command = windowsRemoteWorkspaceAttachCommand(
+                        info: info,
+                        tmuxPath: tmuxPath,
+                        windowsKwtRelativePath: windowsKwtRelativePath,
+                        sshConnectionArguments: sshConnectionArguments
+                    )
+                } else {
+                    command = windowsRemoteAttachCommand(
                         info: info,
                         tmuxPath: tmuxPath,
                         windowsKwtRelativePath: windowsKwtRelativePath,
                         sshConnectionArguments: sshConnectionArguments
                     )
                 }
-                return windowsRemoteAttachCommand(
-                    info: info,
-                    tmuxPath: tmuxPath,
-                    windowsKwtRelativePath: windowsKwtRelativePath,
-                    sshConnectionArguments: sshConnectionArguments
-                )
-            }
-            if launchMode == .create {
-                return remoteCreateThenAttachCommand(
+            } else if launchMode == .create {
+                command = remoteCreateThenAttachCommand(
                     info: info,
                     tmuxPath: tmuxPath,
                     workingDirectory: workingDirectory,
                     sshConnectionArguments: sshConnectionArguments
                 )
-            }
-            if protectedWorkspacePath == nil, workspacePath != nil {
-                return remoteWorkspaceAttachCommand(
+            } else if protectedWorkspacePath == nil, workspacePath != nil {
+                command = remoteWorkspaceAttachCommand(
+                    info: info,
+                    tmuxPath: tmuxPath,
+                    remoteKwtCommandPrelude: remoteKwtCommandPrelude,
+                    sshConnectionArguments: sshConnectionArguments
+                )
+            } else {
+                command = remoteAttachCommand(
                     info: info,
                     tmuxPath: tmuxPath,
                     remoteKwtCommandPrelude: remoteKwtCommandPrelude,
                     sshConnectionArguments: sshConnectionArguments
                 )
             }
-            return remoteAttachCommand(
-                info: info,
-                tmuxPath: tmuxPath,
-                remoteKwtCommandPrelude: remoteKwtCommandPrelude,
-                sshConnectionArguments: sshConnectionArguments
-            )
+            return accountLoginShellCommand(command)
         }
     }
 
@@ -534,7 +549,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 || protectedWorkspacePath != nil
                 || presentationStyle != nil
         let remoteAttach = requiresAccountLoginShell
-            ? remoteAccountLoginShellCommand(remoteAttachBody)
+            ? accountLoginShellCommand(remoteAttachBody)
             : remoteAttachBody
         return shellCommand(
             [
@@ -585,7 +600,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             sshArguments(
                 info: info,
                 allocateTTY: true,
-                remoteCommand: remoteAccountLoginShellCommand(initialBody),
+                remoteCommand: accountLoginShellCommand(initialBody),
                 sshConnectionArguments: sshConnectionArguments
             )
         )
@@ -609,7 +624,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             ] + sshArguments(
                 info: info,
                 allocateTTY: false,
-                remoteCommand: remoteAccountLoginShellCommand(remoteProbe),
+                remoteCommand: accountLoginShellCommand(remoteProbe),
                 sshConnectionArguments: sshConnectionArguments
             )
         )

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -70,6 +70,49 @@ struct TmuxBinaryResolverTests {
         #expect(resolver.resolveTmuxPath() == .success(tmux.path))
     }
 
+    @Test("configured account shell launches a quoted executable")
+    func configuredAccountShellLaunchesExecutable() throws {
+        let password = try #require(getpwuid(getuid()))
+        let shell = String(cString: password.pointee.pw_shell)
+        let argument = #"exec /bin/sh -c "marker=$(printf '%s' 'ready'); printf '%s\n' "$marker"""#
+
+        let result = TmuxBinaryResolver.runProcessInLoginShell(
+            executable: "/usr/bin/printf",
+            arguments: ["%s", argument],
+            timeout: 2,
+            accountShell: shell
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout == argument)
+    }
+
+    @Test("remote POSIX command runs under the configured account shell")
+    func remotePOSIXCommandRunsUnderConfiguredAccountShell() throws {
+        let password = try #require(getpwuid(getuid()))
+        let shell = String(cString: password.pointee.pw_shell)
+        let host = SSHHostInfo(
+            user: nil,
+            hostname: "remote.example",
+            port: nil
+        )
+        let command = TmuxBinaryResolver.remoteLoginCommand(
+            host: host,
+            command:
+            "marker=$(printf '%s' 'REMOTE_SHELL_READY'); "
+                + "printf 'GHOSTHUB_%s\\n' \"$marker\""
+        )
+
+        let result = TmuxBinaryResolver.runProcess(
+            executable: shell,
+            arguments: ["-c", command],
+            timeout: 2
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout == "GHOSTHUB_REMOTE_SHELL_READY\n")
+    }
+
     @Test("rejects unsupported tmux versions")
     func rejectsOldVersion() {
         let resolver = TmuxBinaryResolver(processRunner: { _, _ in

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import GhosthubTmux
@@ -473,7 +474,10 @@ struct TmuxAttachmentInfoTests {
 
         let command = info.attachCommand(tmuxPath: "/opt/bin/tmux")
 
-        #expect(command.contains("'/usr/bin/ssh' '-tt'"))
+        #expect(command.contains("/usr/bin/ssh"))
+        #expect(command.contains("-tt"))
+        #expect(command.contains("${SHELL:-/bin/sh}"))
+        #expect(command.contains(" -lc "))
         #expect(command.contains("'ServerAliveInterval=15'"))
         #expect(command.contains("'ServerAliveCountMax=3'"))
         #expect(command.contains("'TCPKeepAlive=yes'"))
@@ -484,7 +488,9 @@ struct TmuxAttachmentInfoTests {
         #expect(!command.contains("status-style"))
         #expect(!command.contains("message-style"))
         #expect(!command.contains("message-command-style"))
-        #expect(command.contains("[ \"$status\" -eq 255 ] || exit \"$status\""))
+        #expect(command.contains(
+            "[ \\\"\\$status\\\" -eq 255 ] || exit \\\"\\$status\\\""
+        ))
         #expect(!command.contains("-CC"))
         #expect(!command.contains("KexAlgorithms"))
         #expect(!command.contains("bind-key"))
@@ -507,7 +513,8 @@ struct TmuxAttachmentInfoTests {
             #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
         )
 
-        #expect(command.contains("'/usr/bin/ssh' '-tt'"))
+        #expect(command.contains("/usr/bin/ssh"))
+        #expect(command.contains("-tt"))
         #expect(command.contains("'wesm@arm-builder'"))
         #expect(command.contains("-EncodedCommand"))
         #expect(command.contains("ghosthub-ssh-psmux"))
@@ -630,9 +637,8 @@ struct TmuxAttachmentInfoTests {
         ))
         #expect(command.contains("${SHELL:-/bin/sh}"))
         #expect(command.contains("-lc"))
-        #expect(command.contains(
-            "[ -x \"$ghosthub_kwt_path\" ] || exit 127"
-        ))
+        #expect(command.contains("ghosthub_kwt_path"))
+        #expect(command.contains("exit 127"))
         #expect(!command.contains("exec ghosthub_kwt_path="))
         #expect(command.contains("pr"))
         #expect(command.contains("attach"))
@@ -644,6 +650,14 @@ struct TmuxAttachmentInfoTests {
         if let kwtPosition, let stylePosition {
             #expect(kwtPosition < stylePosition)
         }
+    }
+
+    @Test("normal SSH arguments preserve OpenSSH connection sharing")
+    func normalSSHArgumentsPreserveOpenSSHConnectionSharing() {
+        let arguments = tmuxSSHConnectionArguments(environment: [:])
+
+        #expect(!arguments.contains("ControlMaster=no"))
+        #expect(!arguments.contains("ControlPath=none"))
     }
 
     @Test("demo SSH arguments isolate config, trust, and routing")
@@ -663,14 +677,16 @@ struct TmuxAttachmentInfoTests {
             sshConnectionArguments: arguments
         )
 
-        #expect(command.contains("'-F' '/tmp/ghosthub demo/ssh/config'"))
+        #expect(command.contains("/tmp/ghosthub demo/ssh/config"))
         #expect(command.contains(
-            "'UserKnownHostsFile=/tmp/ghosthub demo/ssh/known_hosts'"
+            "UserKnownHostsFile=/tmp/ghosthub demo/ssh/known_hosts"
         ))
-        #expect(command.contains("'GlobalKnownHostsFile=/dev/null'"))
-        #expect(command.contains("'StrictHostKeyChecking=yes'"))
-        #expect(command.contains("'ProxyCommand=none'"))
-        #expect(command.contains("'ProxyJump=none'"))
+        #expect(command.contains("GlobalKnownHostsFile=/dev/null"))
+        #expect(command.contains("StrictHostKeyChecking=yes"))
+        #expect(command.contains("ProxyCommand=none"))
+        #expect(command.contains("ProxyJump=none"))
+        #expect(command.contains("ControlMaster=no"))
+        #expect(command.contains("ControlPath=none"))
     }
 
     @Test("local creation atomically attaches under destroy-unattached")
@@ -751,7 +767,7 @@ struct TmuxAttachmentInfoTests {
         #expect(
             command.components(
                 separatedBy: "${SHELL:-/bin/sh}"
-            ).count - 1 == 3
+            ).count - 1 == 4
         )
     }
 
@@ -809,6 +825,35 @@ struct TmuxAttachmentInfoTests {
         if let loginShellPosition, let presentationPosition {
             #expect(loginShellPosition < presentationPosition)
         }
+    }
+
+    @Test("account login handoff runs under the configured shell")
+    func accountLoginHandoffRunsUnderConfiguredShell() throws {
+        let password = try #require(getpwuid(getuid()))
+        let shell = String(cString: password.pointee.pw_shell)
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = [
+            "-c", accountLoginShellCommand(
+                "printf 'GHOSTHUB_ACCOUNT_SHELL_READY\\n'"
+            ),
+        ]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "SHELL": shell,
+        ]) { _, new in new }
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+        let text = String(
+            decoding: output.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+
+        #expect(process.terminationStatus == 0)
+        #expect(text == "GHOSTHUB_ACCOUNT_SHELL_READY\n")
     }
 
     @Test("remote worktree switches to tmux only after transport loss")


### PR DESCRIPTION
Ghosthub could report a prompt-free SSH host as unreachable even when the same host worked in Terminal. Normal clients overrode OpenSSH control-connection settings, while GUI-launched SSH and SCP missed authentication state initialized by the user's login shell.

This change leaves connection-sharing policy to OpenSSH during normal operation while retaining explicit isolation for guarded demo sessions. SSH, SCP, and remote tmux commands now cross a portable login-shell handoff before POSIX command execution, so fish and POSIX-family account shells initialize authentication consistently without enabling prompts or weakening host-key checks. The verification message now describes the actual trust and key-based authentication requirements instead of asking users to warm up SSH manually.

Windows command handling remains on its existing PowerShell path. Demo traffic continues to use scratch configuration and host-key files with connection sharing disabled.
