### PR TITLE
Make Tailscale imports work in production builds

### DIFF
--- a/Sources/App/TailscaleDiscovery.swift
+++ b/Sources/App/TailscaleDiscovery.swift
@@ -12,9 +12,21 @@ enum TailscaleDiscovery {
     static func discoverPeers() async -> Result<
         [TailscalePeer], TailscaleError
     > {
+        await discoverPeers(
+            tailscalePaths: tailscalePaths,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    static func discoverPeers(
+        tailscalePaths: [String],
+        environment: [String: String]
+    ) async -> Result<[TailscalePeer], TailscaleError> {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
-                guard let binary = findTailscaleBinary()
+                guard let binary = findTailscaleBinary(
+                    in: tailscalePaths
+                )
                 else {
                     continuation.resume(
                         returning: .failure(.notInstalled)
@@ -27,6 +39,9 @@ enum TailscaleDiscovery {
                     fileURLWithPath: binary
                 )
                 process.arguments = ["status", "--json"]
+                var processEnvironment = environment
+                processEnvironment["TAILSCALE_BE_CLI"] = "1"
+                process.environment = processEnvironment
 
                 let pipe = Pipe()
                 process.standardOutput = pipe
@@ -70,8 +85,10 @@ enum TailscaleDiscovery {
         }
     }
 
-    private static func findTailscaleBinary() -> String? {
-        for path in tailscalePaths {
+    private static func findTailscaleBinary(
+        in paths: [String]
+    ) -> String? {
+        for path in paths {
             if FileManager.default.isExecutableFile(
                 atPath: path
             ) {

--- a/Tests/App/TailscaleDiscoveryTests.swift
+++ b/Tests/App/TailscaleDiscoveryTests.swift
@@ -1,0 +1,29 @@
+import GhosthubTestSupport
+import Testing
+@testable import GhosthubApp
+
+@Suite("Tailscale discovery")
+struct TailscaleDiscoveryTests {
+    @Test("forces the macOS application binary into CLI mode")
+    func forcesCLIEnvironment() async throws {
+        let fixture = try TempDirectoryFixture()
+        let tailscale = try fixture.createExecutable(
+            name: "tailscale",
+            content: """
+            #!/bin/sh
+            if [ "${TAILSCALE_BE_CLI:-}" != "1" ]; then
+              printf 'launched application instead of CLI'
+              exit 0
+            fi
+            printf '{"Peer":{}}\n'
+            """
+        )
+
+        let result = await TailscaleDiscovery.discoverPeers(
+            tailscalePaths: [tailscale.path],
+            environment: [:]
+        )
+
+        #expect(try result.get().isEmpty)
+    }
+}


### PR DESCRIPTION
Finder-launched release builds do not inherit the shell variables that the macOS Tailscale application uses to distinguish CLI execution from launching its GUI. As a result, host import could receive non-JSON output and fail with a parsing error even though the same code worked when a development build inherited a terminal environment.

Ghosthub now explicitly selects Tailscale CLI mode while preserving the rest of the process environment, making import independent of how the app was launched. A subprocess regression exercises discovery from an empty, Finder-like environment, and the installed Tailscale application was also queried successfully under a stripped environment. All 681 Swift tests and the app build pass.