### PR TITLE
Allow disabling quit confirmation

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -9,10 +9,11 @@ import AppKit
 
 enum QuitPolicy {
     static func needsConfirmation(
+        confirmBeforeQuitting: Bool,
         runtimeNeedsConfirmQuit: Bool,
         openTerminalSurfaceCount: Int
     ) -> Bool {
-        true
+        confirmBeforeQuitting
     }
 }
 
@@ -61,6 +62,8 @@ struct GhosthubApp: App {
                 }
                 appDelegate.needsConfirmQuit = {
                     QuitPolicy.needsConfirmation(
+                        confirmBeforeQuitting:
+                        settingsStore.confirmBeforeQuitting,
                         runtimeNeedsConfirmQuit:
                         terminalRuntime
                             .needsConfirmQuit,

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -14,6 +14,8 @@ public final class SettingsStore: ObservableObject {
     private enum DefaultsKey {
         static let showPaneResourceUsage = "ghosthub.settings.terminal.showPaneResourceUsage"
         static let confirmPaneClose = "ghosthub.settings.terminal.confirmPaneClose"
+        static let confirmBeforeQuitting =
+            "ghosthub.settings.application.confirmBeforeQuitting"
         static let hideRootCheckout = "ghosthub.settings.worktrees.hideRootCheckout"
         static let showHiddenWorktreesByDefault = "ghosthub.settings.worktrees.showHiddenWorktreesByDefault"
         static let interfaceAppearance = "ghosthub.settings.appearance.interfaceAppearance"
@@ -70,6 +72,7 @@ public final class SettingsStore: ObservableObject {
     public static let defaultAgentPreferences = AgentPreferences()
 
     @Published public var selectedDomain: SettingsDomain = .appearance
+    @Published public private(set) var confirmBeforeQuitting: Bool
     @Published public private(set) var interfaceAppearance: AppearancePreference
     @Published public private(set) var notificationConfiguration: NotificationsConfiguration
     @Published public private(
@@ -100,6 +103,9 @@ public final class SettingsStore: ObservableObject {
         self.configPipeline = configPipeline
         self.userDefaults = userDefaults
 
+        let loadedConfirmBeforeQuitting = Self.loadConfirmBeforeQuitting(
+            using: userDefaults
+        )
         let loadedAppearance = Self.loadInterfaceAppearance(
             using: userDefaults
         )
@@ -126,6 +132,7 @@ public final class SettingsStore: ObservableObject {
             )
         let loadedSSHHosts = Self.loadSSHHosts(using: userDefaults)
 
+        confirmBeforeQuitting = loadedConfirmBeforeQuitting
         interfaceAppearance = loadedAppearance
         notificationConfiguration = loadedNotifications
         terminalAppearancePreferences = loadedTerminalAppearance
@@ -139,6 +146,9 @@ public final class SettingsStore: ObservableObject {
     }
 
     public func reload() {
+        confirmBeforeQuitting = Self.loadConfirmBeforeQuitting(
+            using: userDefaults
+        )
         interfaceAppearance = Self.loadInterfaceAppearance(
             using: userDefaults
         )
@@ -172,6 +182,14 @@ public final class SettingsStore: ObservableObject {
         userDefaults.set(
             appearance.rawValue,
             forKey: DefaultsKey.interfaceAppearance
+        )
+    }
+
+    public func setConfirmBeforeQuitting(_ enabled: Bool) {
+        confirmBeforeQuitting = enabled
+        userDefaults.set(
+            enabled,
+            forKey: DefaultsKey.confirmBeforeQuitting
         )
     }
 
@@ -559,6 +577,14 @@ public final class SettingsStore: ObservableObject {
         )
         .flatMap(AppearancePreference.init(rawValue:))
         ?? .system
+    }
+
+    private static func loadConfirmBeforeQuitting(
+        using userDefaults: UserDefaults
+    ) -> Bool {
+        userDefaults.object(
+            forKey: DefaultsKey.confirmBeforeQuitting
+        ) as? Bool ?? true
     }
 
     private static func loadNotificationConfiguration(

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -274,6 +274,24 @@ public struct SettingsView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }
+
+            settingsSection("Quit Behavior") {
+                Toggle(
+                    "Confirm before quitting Ghosthub",
+                    isOn: Binding(
+                        get: { store.confirmBeforeQuitting },
+                        set: { store.setConfirmBeforeQuitting($0) }
+                    )
+                )
+
+                Text(
+                    "Ghosthub asks before quitting or closing the final workspace."
+                        + " Tmux sessions keep running either way."
+                )
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -835,6 +835,7 @@ final class ApplicationDelegateTests: XCTestCase {
     func testQuitPolicyRequiresConfirmationWhenRuntimeRequestsIt() {
         XCTAssertTrue(
             QuitPolicy.needsConfirmation(
+                confirmBeforeQuitting: true,
                 runtimeNeedsConfirmQuit: true,
                 openTerminalSurfaceCount: 0
             )
@@ -844,17 +845,29 @@ final class ApplicationDelegateTests: XCTestCase {
     func testQuitPolicyRequiresConfirmationWhenTerminalSurfacesRemainOpen() {
         XCTAssertTrue(
             QuitPolicy.needsConfirmation(
+                confirmBeforeQuitting: true,
                 runtimeNeedsConfirmQuit: false,
                 openTerminalSurfaceCount: 2
             )
         )
     }
 
-    func testQuitPolicyAlwaysRequiresConfirmation() {
+    func testQuitPolicyRequiresConfirmationWhenEnabled() {
         XCTAssertTrue(
             QuitPolicy.needsConfirmation(
+                confirmBeforeQuitting: true,
                 runtimeNeedsConfirmQuit: false,
                 openTerminalSurfaceCount: 0
+            )
+        )
+    }
+
+    func testQuitPolicySkipsConfirmationWhenDisabled() {
+        XCTAssertFalse(
+            QuitPolicy.needsConfirmation(
+                confirmBeforeQuitting: false,
+                runtimeNeedsConfirmQuit: true,
+                openTerminalSurfaceCount: 2
             )
         )
     }

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -161,6 +161,21 @@ final class SettingsStoreTests {
         #expect(store.shareAnonymousUsageData)
     }
 
+    @Test("quit confirmation is enabled by default")
+    func quitConfirmationDefaultsToEnabled() {
+        #expect(makeSUT().confirmBeforeQuitting)
+    }
+
+    @Test("quit confirmation preference persists")
+    func quitConfirmationPreferencePersists() {
+        let store = makeSUT()
+        store.setConfirmBeforeQuitting(false)
+
+        let reloaded = makeSUT()
+
+        #expect(!reloaded.confirmBeforeQuitting)
+    }
+
     @Test
     func testRefreshingAnonymousUsageDataReadsPersistedPreference() {
         let store = makeSUT()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,11 @@ merging; Ghosthub does not render a custom tab strip or project tmux windows
 into native UI.
 
 Closing a native tab closes only that workspace presentation. Closing the last
-tab of the last workspace follows the same quit-confirmation policy as closing
-the final standalone window.
+tab of the last workspace follows the same app-termination policy as closing
+the final standalone window. Ghosthub confirms app termination by default;
+users can disable the shared confirmation in **Settings -> Terminal**. This
+preference never terminates a tmux session: quitting still detaches clients,
+while Kill Session remains a separate confirmed action.
 
 ## Process Boundaries
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -334,6 +334,12 @@ const imageAlt = {
             <code>~/.config/ghosthub/ghostty.conf</code>.
           </p>
           <p>
+            Quit confirmation is on by default. Change it at{' '}
+            <strong>Settings → Terminal → Confirm before quitting Ghosthub</strong>.
+            Turning it off also skips the prompt when you close the final workspace,
+            but Ghosthub still only detaches and leaves every tmux session running.
+          </p>
+          <p>
             The file uses{' '}<a href="https://ghostty.org/docs/config/reference">Ghostty’s
               configuration format</a>, but is isolated from Ghostty.app.
             The Tmux Theme picker supplies colors for new sessions created by


### PR DESCRIPTION
Ghosthub currently asks for confirmation every time the app terminates, even when a user deliberately wants quitting to be immediate.

This adds a default-on **Confirm before quitting Ghosthub** setting under Terminal. The preference controls the shared app-termination gate, so explicit quit and closing the final workspace stay consistent. Turning it off still only detaches from tmux; **Kill Session** remains a separate confirmed action.

The architecture and website guide now document that scope and the default behavior.
