### PR TITLE
Hide tool-owned tmux sessions by pattern

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,26 +20,6 @@ func loadJSONDictionary(at url: URL) -> [String: Any]? {
     return object
 }
 
-func xcframeworkModuleMap(at root: URL) -> URL? {
-    let infoURL = root.appendingPathComponent("Info.plist")
-    guard let data = try? Data(contentsOf: infoURL),
-          let plist = try? PropertyListSerialization.propertyList(
-              from: data,
-              format: nil
-          ) as? [String: Any],
-          let library = (plist["AvailableLibraries"] as? [[String: Any]])?.first,
-          let identifier = library["LibraryIdentifier"] as? String,
-          let headersPath = library["HeadersPath"] as? String
-    else {
-        return nil
-    }
-
-    return root
-        .appendingPathComponent(identifier, isDirectory: true)
-        .appendingPathComponent(headersPath, isDirectory: true)
-        .appendingPathComponent("module.modulemap")
-}
-
 let hasBootstrappedLibghostty: Bool = {
     guard ProcessInfo.processInfo.environment[
         "GHOSTHUB_FORCE_TERMINAL_UNAVAILABLE"
@@ -276,29 +256,15 @@ var terminalTestDependencies: [Target.Dependency] = [
     "GhosthubWorkspace",
     "GhosthubTestSupport",
 ]
-var terminalTestSwiftSettings: [SwiftSetting] = []
 if hasBootstrappedLibghostty {
     // AttachedTmuxInputTests imports the XCFramework's Clang module directly.
     terminalTestDependencies.append("CGhostty")
-    let xcframework = libghosttyBuildRoot.appendingPathComponent(
-        "GhosttyKit.xcframework",
-        isDirectory: true
-    )
-    if let moduleMap = xcframeworkModuleMap(at: xcframework) {
-        terminalTestSwiftSettings.append(
-            .unsafeFlags([
-                "-Xcc",
-                "-fmodule-map-file=\(moduleMap.path)",
-            ])
-        )
-    }
 }
 targets.append(
     .testTarget(
         name: "GhosthubTerminalTests",
         dependencies: terminalTestDependencies,
-        path: "Tests/Terminal",
-        swiftSettings: terminalTestSwiftSettings
+        path: "Tests/Terminal"
     )
 )
 targets.append(

--- a/Sources/Settings/AppConfigEditor.swift
+++ b/Sources/Settings/AppConfigEditor.swift
@@ -13,20 +13,23 @@ enum AppConfigEditor {
         )
         let renderedValue = "[\(renderedValues.joined(separator: ", "))]"
         let renderedLine = "\(key) = \(renderedValue)"
-        var lines = contents.components(separatedBy: "\n")
+        let newline = contents.contains("\r\n") ? "\r\n" : "\n"
+        var lines = contents.components(separatedBy: newline)
         let sectionHeader = "[\(sectionName)]"
 
         guard let sectionIndex = lines.firstIndex(where: {
-            TOMLConfigParser.strippedTOMLLine($0) == sectionHeader
+            TOMLConfigParser.sectionHeaderName(
+                from: TOMLConfigParser.strippedTOMLLine($0)
+            ) == sectionName
         }) else {
             var updated = contents
-            if !updated.isEmpty, !updated.hasSuffix("\n") {
-                updated += "\n"
+            if !updated.isEmpty, !updated.hasSuffix(newline) {
+                updated += newline
             }
-            if !updated.isEmpty, !updated.hasSuffix("\n\n") {
-                updated += "\n"
+            if !updated.isEmpty, !updated.hasSuffix(newline + newline) {
+                updated += newline
             }
-            return updated + sectionHeader + "\n" + renderedLine + "\n"
+            return updated + sectionHeader + newline + renderedLine + newline
         }
 
         let sectionEnd = lines[(sectionIndex + 1)...].firstIndex(where: {
@@ -52,6 +55,6 @@ enum AppConfigEditor {
         } else {
             lines.insert(renderedLine, at: sectionEnd)
         }
-        return lines.joined(separator: "\n")
+        return lines.joined(separator: newline)
     }
 }

--- a/Sources/Settings/AppConfigEditor.swift
+++ b/Sources/Settings/AppConfigEditor.swift
@@ -1,0 +1,57 @@
+import Foundation
+import GhosthubWorkspace
+
+enum AppConfigEditor {
+    static func replacingStringArray(
+        sectionName: String,
+        key: String,
+        values: [String],
+        in contents: String
+    ) -> String {
+        let renderedValues = values.map(
+            TOMLConfigParser.renderTOMLString
+        )
+        let renderedValue = "[\(renderedValues.joined(separator: ", "))]"
+        let renderedLine = "\(key) = \(renderedValue)"
+        var lines = contents.components(separatedBy: "\n")
+        let sectionHeader = "[\(sectionName)]"
+
+        guard let sectionIndex = lines.firstIndex(where: {
+            TOMLConfigParser.strippedTOMLLine($0) == sectionHeader
+        }) else {
+            var updated = contents
+            if !updated.isEmpty, !updated.hasSuffix("\n") {
+                updated += "\n"
+            }
+            if !updated.isEmpty, !updated.hasSuffix("\n\n") {
+                updated += "\n"
+            }
+            return updated + sectionHeader + "\n" + renderedLine + "\n"
+        }
+
+        let sectionEnd = lines[(sectionIndex + 1)...].firstIndex(where: {
+            TOMLConfigParser.sectionHeaderName(
+                from: TOMLConfigParser.strippedTOMLLine($0)
+            ) != nil
+        }) ?? lines.endIndex
+        if let keyIndex = lines[(sectionIndex + 1) ..< sectionEnd]
+            .firstIndex(where: { line in
+                let trimmed = TOMLConfigParser.strippedTOMLLine(line)
+                guard trimmed.hasPrefix(key) else { return false }
+                let remainder = trimmed.dropFirst(key.count)
+                    .trimmingCharacters(in: .whitespaces)
+                return remainder.hasPrefix("=")
+            }) {
+            let valueRange = TOMLConfigParser
+                .appConfigStringArrayLineRange(
+                    sectionName: sectionName,
+                    key: key,
+                    in: contents
+                ) ?? keyIndex ..< (keyIndex + 1)
+            lines.replaceSubrange(valueRange, with: [renderedLine])
+        } else {
+            lines.insert(renderedLine, at: sectionEnd)
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/Settings/SettingsDomain.swift
+++ b/Sources/Settings/SettingsDomain.swift
@@ -40,7 +40,7 @@ public enum SettingsDomain: String, CaseIterable, Identifiable, Sendable {
         case .keyboard:
             return "Application and workspace navigation shortcuts."
         case .worktrees:
-            return "Kwt workspace visibility and sidebar behavior."
+            return "Workspace and standalone tmux session visibility."
         case .agents:
             return "Attention notifications for active agent sessions."
         case .privacy:

--- a/Sources/Settings/SettingsPreferences.swift
+++ b/Sources/Settings/SettingsPreferences.swift
@@ -14,6 +14,14 @@ public struct WorktreePreferences: Equatable, Sendable {
     }
 }
 
+public struct TmuxSessionPreferences: Equatable, Sendable {
+    public var hiddenSessionPatterns: [String]
+
+    public init(hiddenSessionPatterns: [String] = []) {
+        self.hiddenSessionPatterns = hiddenSessionPatterns
+    }
+}
+
 public struct AgentPreferences: Equatable, Sendable {
     public init() {}
 }

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -67,6 +67,8 @@ public final class SettingsStore: ObservableObject {
         showHiddenWorktreesByDefault: false
     )
 
+    public static let defaultTmuxSessionPreferences = TmuxSessionPreferences()
+
     public static let defaultAgentPreferences = AgentPreferences()
 
     @Published public var selectedDomain: SettingsDomain = .appearance
@@ -77,6 +79,7 @@ public final class SettingsStore: ObservableObject {
     ) var terminalAppearancePreferences: TerminalAppearancePreferences
     @Published public private(set) var terminalPreferences: TerminalPreferences
     @Published public private(set) var worktreePreferences: WorktreePreferences
+    @Published public private(set) var tmuxSessionPreferences: TmuxSessionPreferences
     @Published public private(set) var agentPreferences: AgentPreferences
     @Published public private(set) var shareAnonymousUsageData: Bool
     @Published public private(set) var sshHosts: [SSHHost]
@@ -91,6 +94,13 @@ public final class SettingsStore: ObservableObject {
 
     public var terminalAppearanceConfigFile: URL {
         configPipeline.paths.terminalAppearanceConfigFile
+    }
+
+    public var appConfigFile: URL {
+        configPipeline.paths.configDirectory.appendingPathComponent(
+            "config.toml",
+            isDirectory: false
+        )
     }
 
     public init(
@@ -117,6 +127,12 @@ public final class SettingsStore: ObservableObject {
         let loadedWorktrees = Self.loadWorktreePreferences(
             using: userDefaults
         )
+        let loadedTmuxSessions = Self.loadTmuxSessionPreferences(
+            from: configPipeline.paths.configDirectory.appendingPathComponent(
+                "config.toml",
+                isDirectory: false
+            )
+        )
         let loadedAgents = Self.loadAgentPreferences(
             using: userDefaults
         )
@@ -131,6 +147,7 @@ public final class SettingsStore: ObservableObject {
         terminalAppearancePreferences = loadedTerminalAppearance
         terminalPreferences = loadedTerminal
         worktreePreferences = loadedWorktrees
+        tmuxSessionPreferences = loadedTmuxSessions
         agentPreferences = loadedAgents
         shareAnonymousUsageData = loadedShareAnonymousUsageData
         sshHosts = loadedSSHHosts
@@ -155,6 +172,9 @@ public final class SettingsStore: ObservableObject {
             userDefaults: userDefaults
         )
         worktreePreferences = Self.loadWorktreePreferences(using: userDefaults)
+        tmuxSessionPreferences = Self.loadTmuxSessionPreferences(
+            from: appConfigFile
+        )
         agentPreferences = Self.loadAgentPreferences(using: userDefaults)
         shareAnonymousUsageData =
             Self.loadShareAnonymousUsageData(
@@ -349,6 +369,23 @@ public final class SettingsStore: ObservableObject {
         userDefaults.set(enabled, forKey: DefaultsKey.showHiddenWorktreesByDefault)
     }
 
+    @discardableResult
+    public func setHiddenTmuxSessionPatterns(_ patterns: [String]) -> Bool {
+        let updated = TmuxSessionPreferences(
+            hiddenSessionPatterns: Self.normalizedPatterns(patterns)
+        )
+        guard updated != tmuxSessionPreferences else { return true }
+        do {
+            try persistTmuxSessionPreferences(updated)
+            tmuxSessionPreferences = updated
+            lastErrorMessage = nil
+            return true
+        } catch {
+            lastErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
     public func setSSHHosts(_ sshHosts: [SSHHost]) {
         self.sshHosts =
             SSHHostSanitizer.sshHosts(sshHosts)
@@ -480,6 +517,34 @@ public final class SettingsStore: ObservableObject {
         } catch {
             lastErrorMessage = error.localizedDescription
         }
+    }
+
+    private func persistTmuxSessionPreferences(
+        _ preferences: TmuxSessionPreferences
+    ) throws {
+        try configPipeline.fileManager.createDirectory(
+            at: configPipeline.paths.configDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        let contents = if configPipeline.fileManager.fileExists(
+            atPath: appConfigFile.path
+        ) {
+            try String(contentsOf: appConfigFile, encoding: .utf8)
+        } else {
+            ""
+        }
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: preferences.hiddenSessionPatterns,
+            in: contents
+        )
+        try updated.write(
+            to: appConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
     }
 
     private static func loadSSHHosts(
@@ -629,6 +694,39 @@ public final class SettingsStore: ObservableObject {
                 forKey: DefaultsKey.showHiddenWorktreesByDefault
             ) as? Bool ?? defaults.showHiddenWorktreesByDefault
         )
+    }
+
+    private static func loadTmuxSessionPreferences(
+        from configFile: URL
+    ) -> TmuxSessionPreferences {
+        guard let contents = try? String(
+            contentsOf: configFile,
+            encoding: .utf8
+        ),
+            let patterns = TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: contents
+            )
+        else {
+            return defaultTmuxSessionPreferences
+        }
+        return TmuxSessionPreferences(
+            hiddenSessionPatterns: normalizedPatterns(patterns)
+        )
+    }
+
+    private static func normalizedPatterns(_ patterns: [String]) -> [String] {
+        var seen: Set<String> = []
+        return patterns.compactMap { pattern in
+            let trimmed = pattern.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else {
+                return nil
+            }
+            return trimmed
+        }
     }
 
     private static func loadAgentPreferences(

--- a/Sources/Settings/SettingsViewDraft.swift
+++ b/Sources/Settings/SettingsViewDraft.swift
@@ -4,13 +4,16 @@ import GhosthubWorkspace
 public struct SettingsPersistResult: Equatable, Sendable {
     public var shouldRefreshHosts: Bool
     public var shouldReloadTerminalConfig: Bool
+    public var didPersistTmuxSessionPatterns: Bool
 
     public init(
         shouldRefreshHosts: Bool,
-        shouldReloadTerminalConfig: Bool
+        shouldReloadTerminalConfig: Bool,
+        didPersistTmuxSessionPatterns: Bool
     ) {
         self.shouldRefreshHosts = shouldRefreshHosts
         self.shouldReloadTerminalConfig = shouldReloadTerminalConfig
+        self.didPersistTmuxSessionPatterns = didPersistTmuxSessionPatterns
     }
 }
 
@@ -28,6 +31,7 @@ public struct SettingsViewDraft: Equatable {
     public var copySelectionToClipboard: Bool
     public var hideRootCheckout: Bool
     public var showHiddenWorktreesByDefault: Bool
+    public var hiddenTmuxSessionPatterns: [String]
     public var showMacOSNotifications: Bool
     public var attentionSound: WorkspaceNotificationSound
     public var sshHosts: [SSHHostDraft]
@@ -57,6 +61,8 @@ public struct SettingsViewDraft: Equatable {
         hideRootCheckout = store.worktreePreferences.hideRootCheckout
         showHiddenWorktreesByDefault = store.worktreePreferences
             .showHiddenWorktreesByDefault
+        hiddenTmuxSessionPatterns = store.tmuxSessionPreferences
+            .hiddenSessionPatterns
         showMacOSNotifications = store.notificationConfiguration
             .showMacOSNotifications
         attentionSound = store.notificationConfiguration.attentionSound
@@ -103,6 +109,8 @@ public struct SettingsViewDraft: Equatable {
         store.setShowHiddenWorktreesByDefault(
             showHiddenWorktreesByDefault
         )
+        let didPersistTmuxSessionPatterns = store
+            .setHiddenTmuxSessionPatterns(hiddenTmuxSessionPatterns)
         store.setShowMacOSNotifications(showMacOSNotifications)
         store.setNotificationAttentionSound(attentionSound)
 
@@ -111,7 +119,8 @@ public struct SettingsViewDraft: Equatable {
         }
         return SettingsPersistResult(
             shouldRefreshHosts: shouldRefreshHosts,
-            shouldReloadTerminalConfig: shouldReloadTerminalConfig
+            shouldReloadTerminalConfig: shouldReloadTerminalConfig,
+            didPersistTmuxSessionPatterns: didPersistTmuxSessionPatterns
         )
     }
 

--- a/Sources/UI/CommandPaletteModel.swift
+++ b/Sources/UI/CommandPaletteModel.swift
@@ -124,6 +124,7 @@ public enum CommandPaletteModel {
         isSidePanelVisible: Bool,
         interfaceAppearance: AppearancePreference = .system,
         worktreeVisibility: WorktreeVisibility = .default,
+        tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
         supportsSettings: Bool = true
     ) -> [WorkspaceCommandItem] {
         var commands = [
@@ -187,7 +188,8 @@ public enum CommandPaletteModel {
             in: snapshot,
             activeSelection: activeTmuxSession,
             activeSelectionIsConnected: activeTmuxSessionIsConnected,
-            visibility: worktreeVisibility
+            visibility: worktreeVisibility,
+            tmuxSessionVisibility: tmuxSessionVisibility
         ))
         commands.append(contentsOf: newWorktreeCommands(
             in: snapshot,
@@ -377,11 +379,13 @@ public enum CommandPaletteModel {
         in snapshot: WorkspaceSnapshot,
         activeSelection: WorkspaceTmuxSessionSelection?,
         activeSelectionIsConnected: Bool,
-        visibility: WorktreeVisibility
+        visibility: WorktreeVisibility,
+        tmuxSessionVisibility: TmuxSessionVisibility
     ) -> [WorkspaceCommandItem] {
         let sections = WorkspaceSidebarModel.sections(
             in: snapshot,
-            visibility: visibility
+            visibility: visibility,
+            tmuxSessionVisibility: tmuxSessionVisibility
         )
         let sessions = sections.flatMap { section -> [(
             session: WorkspaceTmuxSessionSelection,

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -351,6 +351,7 @@ public struct RootView: View {
             snapshot: snapshot,
             selection: $selection,
             visibility: worktreeVisibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
             activeTmuxSession: activeTmuxSession,
             activeTmuxSessionIsConnected:
             display.activeTmuxSessionIsConnected,
@@ -668,6 +669,13 @@ public struct RootView: View {
         )
     }
 
+    private var tmuxSessionVisibility: TmuxSessionVisibility {
+        TmuxSessionVisibility(
+            hiddenPatterns: settingsStore.tmuxSessionPreferences
+                .hiddenSessionPatterns
+        )
+    }
+
     private var paletteCommands: [WorkspaceCommandItem] {
         CommandPaletteModel.commands(
             in: snapshot,
@@ -680,6 +688,7 @@ public struct RootView: View {
             isSidePanelVisible: isSidePanelVisible,
             interfaceAppearance: settingsStore.interfaceAppearance,
             worktreeVisibility: worktreeVisibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
             supportsSettings: content.settingsSheetBuilder != nil
         )
     }

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -150,8 +150,9 @@ public struct SettingsView: View {
             content.toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") {
-                        persist()
-                        dismiss()
+                        if persist().didPersistTmuxSessionPatterns {
+                            dismiss()
+                        }
                     }
                 }
             }
@@ -302,6 +303,41 @@ public struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
 
+            settingsSection("Standalone Tmux Sessions") {
+                Text("Hidden session patterns")
+                    .font(.system(size: 13, weight: .semibold))
+
+                TextEditor(text: hiddenTmuxSessionPatternsText)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(minHeight: 96)
+                    .padding(6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(.background)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(.separator, lineWidth: 1)
+                    )
+                    .accessibilityLabel("Hidden tmux session patterns")
+
+                Text(
+                    "Enter one case-sensitive wildcard pattern per line."
+                        + " Use * for any number of characters and ? for one."
+                        + " Matching standalone sessions are hidden from the"
+                        + " sidebar and command palette; kwt workspaces remain"
+                        + " discoverable under their projects."
+                )
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                configPathRow(
+                    "Ghosthub stores these patterns in:",
+                    path: store.appConfigFile.path
+                )
+            }
+
             settingsSection("Workspace Sessions") {
                 Label(
                     "Kwt supplies each workspace’s exact tmux session name.",
@@ -322,6 +358,19 @@ public struct SettingsView: View {
                 .foregroundStyle(.secondary)
             }
         }
+    }
+
+    private var hiddenTmuxSessionPatternsText: Binding<String> {
+        Binding(
+            get: {
+                draft.hiddenTmuxSessionPatterns.joined(separator: "\n")
+            },
+            set: { value in
+                draft.hiddenTmuxSessionPatterns = value.components(
+                    separatedBy: .newlines
+                )
+            }
+        )
     }
 
     private var agentsDetail: some View {
@@ -593,7 +642,8 @@ public struct SettingsView: View {
         }
     }
 
-    private func persist() {
+    @discardableResult
+    private func persist() -> SettingsPersistResult {
         let result = draft.persist(to: store)
         if result.shouldRefreshHosts {
             actions.refreshHosts()
@@ -601,6 +651,7 @@ public struct SettingsView: View {
         if result.shouldReloadTerminalConfig {
             actions.reloadTerminalConfig()
         }
+        return result
     }
 
 }

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -189,7 +189,8 @@ public enum WorkspaceSidebarModel {
 
     public static func sections(
         in snapshot: WorkspaceSnapshot,
-        visibility: WorktreeVisibility = .default
+        visibility: WorktreeVisibility = .default,
+        tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility()
     ) -> [WorkspaceSidebarSection] {
         snapshot.hosts.map { host in
             // Discovery only lists the host's default tmux server. A
@@ -228,7 +229,10 @@ public enum WorkspaceSidebarModel {
                 host: host,
                 projects: projects,
                 tmuxSessionRows: host.tmuxSessions
-                    .filter { !defaultServerSessionNames.contains($0.name) }
+                    .filter {
+                        !defaultServerSessionNames.contains($0.name)
+                            && !tmuxSessionVisibility.isHidden($0.name)
+                    }
                     .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
                     .map { tmuxSessionRow($0, hostID: host.id) }
             )

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -56,6 +56,7 @@ struct WorkspaceSidebarView: View {
     let snapshot: WorkspaceSnapshot
     @Binding var selection: WorkspaceSelection
     let visibility: WorktreeVisibility
+    let tmuxSessionVisibility: TmuxSessionVisibility
     let onOpen: (WorktreeSummary) -> Void
     let activeTmuxSession: WorkspaceTmuxSessionSelection?
     let activeTmuxSessionIsConnected: Bool
@@ -88,6 +89,7 @@ struct WorkspaceSidebarView: View {
         snapshot: WorkspaceSnapshot,
         selection: Binding<WorkspaceSelection>,
         visibility: WorktreeVisibility,
+        tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
         activeTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeTmuxSessionIsConnected: Bool = false,
         onOpenTmuxSession: @escaping (
@@ -113,6 +115,7 @@ struct WorkspaceSidebarView: View {
         self.snapshot = snapshot
         _selection = selection
         self.visibility = visibility
+        self.tmuxSessionVisibility = tmuxSessionVisibility
         self.activeTmuxSession = activeTmuxSession
         self.activeTmuxSessionIsConnected = activeTmuxSessionIsConnected
         self.onOpenTmuxSession = onOpenTmuxSession
@@ -135,7 +138,8 @@ struct WorkspaceSidebarView: View {
     private var sections: [WorkspaceSidebarSection] {
         WorkspaceSidebarModel.sections(
             in: snapshot,
-            visibility: visibility
+            visibility: visibility,
+            tmuxSessionVisibility: tmuxSessionVisibility
         )
     }
 

--- a/Sources/Workspace/TOMLConfigParser.swift
+++ b/Sources/Workspace/TOMLConfigParser.swift
@@ -32,7 +32,7 @@ public enum TOMLConfigParser {
             }
         }
 
-        return result.trimmingCharacters(in: .whitespaces)
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Header / Key Extraction

--- a/Sources/Workspace/TOMLConfigParser.swift
+++ b/Sources/Workspace/TOMLConfigParser.swift
@@ -9,18 +9,23 @@ public enum TOMLConfigParser {
     /// Strip inline comments from a raw TOML line, respecting quoted strings.
     public static func strippedTOMLLine(_ rawLine: String) -> String {
         var result = ""
-        var inQuotes = false
+        var quote: Character?
         var isEscaped = false
 
         for character in rawLine {
-            if character == "\"", !isEscaped {
-                inQuotes.toggle()
+            if let activeQuote = quote {
+                if character == activeQuote,
+                   activeQuote == "'" || !isEscaped {
+                    quote = nil
+                }
+            } else if character == "\"" || character == "'" {
+                quote = character
             }
-            if character == "#", !inQuotes {
+            if character == "#", quote == nil {
                 break
             }
             result.append(character)
-            if character == "\\", !isEscaped {
+            if quote == "\"", character == "\\", !isEscaped {
                 isEscaped = true
             } else {
                 isEscaped = false
@@ -65,9 +70,28 @@ public enum TOMLConfigParser {
 
     /// Wrap a string in double quotes with TOML escaping.
     public static func renderTOMLString(_ value: String) -> String {
-        let escaped = value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
+        let escaped = value.unicodeScalars.map { scalar -> String in
+            switch scalar.value {
+            case 0x08:
+                return "\\b"
+            case 0x09:
+                return "\\t"
+            case 0x0A:
+                return "\\n"
+            case 0x0C:
+                return "\\f"
+            case 0x0D:
+                return "\\r"
+            case 0x22:
+                return "\\\""
+            case 0x5C:
+                return "\\\\"
+            case 0x00 ... 0x1F, 0x7F:
+                return String(format: "\\u%04X", scalar.value)
+            default:
+                return String(scalar)
+            }
+        }.joined()
         return "\"\(escaped)\""
     }
 
@@ -256,6 +280,49 @@ public enum TOMLConfigParser {
         )
     }
 
+    /// Parse a TOML array of basic or literal strings under a named section.
+    public static func parseAppConfigStringArrayValue(
+        sectionName: String,
+        key: String,
+        in contents: String
+    ) -> [String]? {
+        guard let assignment = appConfigAssignment(
+            sectionName: sectionName,
+            key: key,
+            in: contents
+        ) else {
+            return nil
+        }
+        var parser = TOMLStringArrayParser(assignment.value)
+        return parser.parse()?.values
+    }
+
+    /// Locate every line occupied by a valid string-array assignment.
+    public static func appConfigStringArrayLineRange(
+        sectionName: String,
+        key: String,
+        in contents: String
+    ) -> Range<Int>? {
+        guard let assignment = appConfigAssignment(
+            sectionName: sectionName,
+            key: key,
+            in: contents
+        ) else {
+            return nil
+        }
+        var parser = TOMLStringArrayParser(assignment.value)
+        guard let parsed = parser.parse() else { return nil }
+        let occupiedLineCount = assignment.value[..<parsed.endIndex]
+            .reduce(into: 1) { count, character in
+                if character.isNewline {
+                    count += 1
+                }
+            }
+        return assignment.lineIndex ..< (
+            assignment.lineIndex + occupiedLineCount
+        )
+    }
+
     /// Parse a boolean value under a named section.
     public static func parseAppConfigBoolValue(
         sectionName: String,
@@ -294,5 +361,254 @@ public enum TOMLConfigParser {
             return nil
         }
         return Double(value)
+    }
+
+    private static func appConfigAssignment(
+        sectionName: String,
+        key: String,
+        in contents: String
+    ) -> (value: String, lineIndex: Int)? {
+        let lines = contents.components(separatedBy: "\n")
+        var currentSection: String?
+
+        for (lineIndex, rawLine) in lines.enumerated() {
+            let line = strippedTOMLLine(rawLine)
+            guard !line.isEmpty else { continue }
+            if let headerName = sectionHeaderName(from: line) {
+                currentSection = headerName
+                continue
+            }
+            guard currentSection == sectionName,
+                  let separatorIndex = line.firstIndex(of: "=")
+            else {
+                continue
+            }
+            let candidateKey = line[..<separatorIndex]
+                .trimmingCharacters(in: .whitespaces)
+            guard candidateKey == key else { continue }
+
+            let firstLine = line[line.index(after: separatorIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+            let sectionEnd = lines[(lineIndex + 1)...]
+                .firstIndex(where: { candidate in
+                    sectionHeaderName(
+                        from: strippedTOMLLine(candidate)
+                    ) != nil
+                }) ?? lines.endIndex
+            let continuation = lines[(lineIndex + 1) ..< sectionEnd]
+            return (
+                ([String(firstLine)] + Array(continuation))
+                    .joined(separator: "\n"),
+                lineIndex
+            )
+        }
+        return nil
+    }
+}
+
+private struct TOMLStringArrayParser {
+    struct Result {
+        var values: [String]
+        var endIndex: String.Index
+    }
+
+    private let source: String
+    private var index: String.Index
+
+    init(_ source: String) {
+        self.source = source
+        index = source.startIndex
+    }
+
+    mutating func parse() -> Result? {
+        skipTrivia()
+        guard consume("[") else { return nil }
+        skipTrivia()
+        if consume("]") {
+            return Result(values: [], endIndex: index)
+        }
+
+        var values: [String] = []
+        while true {
+            guard let value = parseString() else { return nil }
+            values.append(value)
+            skipTrivia()
+            if consume("]") {
+                return Result(values: values, endIndex: index)
+            }
+            guard consume(",") else { return nil }
+            skipTrivia()
+            if consume("]") {
+                return Result(values: values, endIndex: index)
+            }
+        }
+    }
+
+    private mutating func parseString() -> String? {
+        if hasPrefix("\"\"\"") {
+            return parseMultilineString(delimiter: "\"", basic: true)
+        }
+        if hasPrefix("'''") {
+            return parseMultilineString(delimiter: "'", basic: false)
+        }
+        if consume("\"") {
+            return parseSingleLineString(delimiter: "\"", basic: true)
+        }
+        if consume("'") {
+            return parseSingleLineString(delimiter: "'", basic: false)
+        }
+        return nil
+    }
+
+    private mutating func parseSingleLineString(
+        delimiter: Character,
+        basic: Bool
+    ) -> String? {
+        var result = ""
+        while let character = currentCharacter {
+            advance()
+            if character == delimiter {
+                return result
+            }
+            guard !character.isNewline else { return nil }
+            if basic, character == "\\" {
+                guard let escaped = parseEscape() else { return nil }
+                result.append(contentsOf: escaped)
+            } else {
+                result.append(character)
+            }
+        }
+        return nil
+    }
+
+    private mutating func parseMultilineString(
+        delimiter: Character,
+        basic: Bool
+    ) -> String? {
+        advance(by: 3)
+        consumeOpeningNewline()
+        var result = ""
+        let closing = String(repeating: delimiter, count: 3)
+
+        while currentCharacter != nil {
+            if hasPrefix(closing) {
+                advance(by: 3)
+                return result
+            }
+            guard let character = currentCharacter else { return nil }
+            advance()
+            if basic, character == "\\" {
+                if consumeNewline() {
+                    skipWhitespaceAndNewlines()
+                    continue
+                }
+                guard let escaped = parseEscape() else { return nil }
+                result.append(contentsOf: escaped)
+            } else {
+                result.append(character)
+            }
+        }
+        return nil
+    }
+
+    private mutating func parseEscape() -> String? {
+        guard let character = currentCharacter else { return nil }
+        advance()
+        switch character {
+        case "b":
+            return "\u{8}"
+        case "t":
+            return "\t"
+        case "n":
+            return "\n"
+        case "f":
+            return "\u{C}"
+        case "r":
+            return "\r"
+        case "\"":
+            return "\""
+        case "\\":
+            return "\\"
+        case "u":
+            return parseUnicodeEscape(length: 4)
+        case "U":
+            return parseUnicodeEscape(length: 8)
+        default:
+            return nil
+        }
+    }
+
+    private mutating func parseUnicodeEscape(length: Int) -> String? {
+        var digits = ""
+        for _ in 0 ..< length {
+            guard let character = currentCharacter,
+                  character.isHexDigit
+            else {
+                return nil
+            }
+            digits.append(character)
+            advance()
+        }
+        guard let value = UInt32(digits, radix: 16),
+              let scalar = UnicodeScalar(value)
+        else {
+            return nil
+        }
+        return String(scalar)
+    }
+
+    private mutating func skipTrivia() {
+        while let character = currentCharacter {
+            if character.isWhitespace {
+                advance()
+            } else if character == "#" {
+                while let commentCharacter = currentCharacter,
+                      !commentCharacter.isNewline {
+                    advance()
+                }
+            } else {
+                return
+            }
+        }
+    }
+
+    private mutating func consumeOpeningNewline() {
+        _ = consumeNewline()
+    }
+
+    private mutating func consumeNewline() -> Bool {
+        if consume("\r") {
+            _ = consume("\n")
+            return true
+        }
+        return consume("\n")
+    }
+
+    private mutating func skipWhitespaceAndNewlines() {
+        while let character = currentCharacter,
+              character.isWhitespace {
+            advance()
+        }
+    }
+
+    private var currentCharacter: Character? {
+        index < source.endIndex ? source[index] : nil
+    }
+
+    private func hasPrefix(_ value: String) -> Bool {
+        source[index...].hasPrefix(value)
+    }
+
+    @discardableResult
+    private mutating func consume(_ character: Character) -> Bool {
+        guard currentCharacter == character else { return false }
+        advance()
+        return true
+    }
+
+    private mutating func advance(by count: Int = 1) {
+        for _ in 0 ..< count where index < source.endIndex {
+            index = source.index(after: index)
+        }
     }
 }

--- a/Sources/Workspace/TmuxSessionVisibility.swift
+++ b/Sources/Workspace/TmuxSessionVisibility.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct TmuxSessionVisibility: Equatable, Sendable {
+    public var hiddenPatterns: [String]
+
+    public init(hiddenPatterns: [String] = []) {
+        self.hiddenPatterns = hiddenPatterns
+    }
+
+    public func isHidden(_ sessionName: String) -> Bool {
+        hiddenPatterns.contains { pattern in
+            Self.matches(sessionName, pattern: pattern)
+        }
+    }
+
+    private static func matches(
+        _ value: String,
+        pattern: String
+    ) -> Bool {
+        let value = Array(value)
+        var previous = Array(repeating: false, count: value.count + 1)
+        previous[0] = true
+
+        for token in pattern {
+            var current = Array(repeating: false, count: value.count + 1)
+            if token == "*" {
+                current[0] = previous[0]
+                for index in value.indices {
+                    current[index + 1] = previous[index + 1]
+                        || current[index]
+                }
+            } else {
+                for index in value.indices {
+                    current[index + 1] = previous[index]
+                        && (token == "?" || token == value[index])
+                }
+            }
+            previous = current
+        }
+
+        return previous[value.count]
+    }
+}

--- a/Tests/Settings/AppConfigEditorTests.swift
+++ b/Tests/Settings/AppConfigEditorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import GhosthubSettings
+import GhosthubWorkspace
 
 struct AppConfigEditorTests {
     @Test("string array replacement preserves surrounding config")
@@ -57,6 +58,52 @@ struct AppConfigEditorTests {
         #expect(updated.contains(
             "hidden_session_patterns = [\"forge-*\"]"
         ))
+    }
+
+    @Test("string array replacement recognizes a spaced section header")
+    func recognizesSpacedSectionHeader() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*"],
+            in: """
+            [ tmux ]
+            hidden_session_patterns = ["old-*"]
+            status = true
+            """
+        )
+
+        #expect(!updated.contains("[tmux]"))
+        #expect(updated.contains("[ tmux ]"))
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: updated
+            ) == ["forge-*"]
+        )
+    }
+
+    @Test("string array replacement preserves CRLF configuration")
+    func preservesCRLFConfiguration() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*"],
+            in: "[tmux]\r\nhidden_session_patterns = [\"old-*\"]\r\n"
+                + "status = true\r\n"
+        )
+
+        #expect(updated.components(separatedBy: "[tmux]").count == 2)
+        #expect(updated.replacingOccurrences(of: "\r\n", with: "")
+            .contains("\n") == false)
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: updated
+            ) == ["forge-*"]
+        )
     }
 
     @Test("string array replacement removes a multiline old value")

--- a/Tests/Settings/AppConfigEditorTests.swift
+++ b/Tests/Settings/AppConfigEditorTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import GhosthubSettings
+
+struct AppConfigEditorTests {
+    @Test("string array replacement preserves surrounding config")
+    func replacesStringArray() {
+        let original = """
+        [general]
+        default_shell = "/bin/zsh"
+
+        [tmux]
+        hidden_session_patterns = ["old-*"]
+        status = true
+        """
+
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*", "quoted-\"name\""],
+            in: original
+        )
+
+        #expect(updated.contains("default_shell = \"/bin/zsh\""))
+        #expect(updated.contains("status = true"))
+        #expect(
+            updated.contains(
+                #"hidden_session_patterns = ["forge-*", "quoted-\"name\""]"#
+            )
+        )
+        #expect(!updated.contains("old-*"))
+    }
+
+    @Test("string array replacement adds a missing section")
+    func addsMissingSection() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*"],
+            in: "[general]\nappearance = \"system\"\n"
+        )
+
+        #expect(updated.hasSuffix(
+            "[tmux]\nhidden_session_patterns = [\"forge-*\"]\n"
+        ))
+    }
+
+    @Test("string array replacement recognizes a commented section header")
+    func recognizesCommentedSectionHeader() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*"],
+            in: "[tmux] # standalone sessions\nstatus = true\n"
+        )
+
+        #expect(updated.components(separatedBy: "[tmux]").count == 2)
+        #expect(updated.contains(
+            "hidden_session_patterns = [\"forge-*\"]"
+        ))
+    }
+
+    @Test("string array replacement removes a multiline old value")
+    func replacesMultilineArray() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*", "team/*"],
+            in: """
+            [tmux]
+            hidden_session_patterns = [
+                "old-*",
+                'old-literal',
+            ]
+            status = true
+            """
+        )
+
+        #expect(!updated.contains("old-*"))
+        #expect(!updated.contains("old-literal"))
+        #expect(updated.contains(
+            #"hidden_session_patterns = ["forge-*", "team/*"]"#
+        ))
+        #expect(!updated.contains(#"team\/*"#))
+        #expect(updated.contains("status = true"))
+    }
+
+    @Test("multiline replacement preserves a first-line literal hash")
+    func replacesMultilineArrayStartingWithLiteralHash() {
+        let updated = AppConfigEditor.replacingStringArray(
+            sectionName: "tmux",
+            key: "hidden_session_patterns",
+            values: ["forge-*"],
+            in: """
+            [tmux]
+            hidden_session_patterns = ['team/#*',
+                'old-*',
+            ]
+            status = true
+            """
+        )
+
+        #expect(!updated.contains("team/#*"))
+        #expect(!updated.contains("old-*"))
+        #expect(updated.contains(
+            #"hidden_session_patterns = ["forge-*"]"#
+        ))
+        #expect(updated.contains("status = true"))
+    }
+}

--- a/Tests/Settings/SettingsDomainTests.swift
+++ b/Tests/Settings/SettingsDomainTests.swift
@@ -24,7 +24,7 @@ struct SettingsDomainTests {
             (
                 .worktrees,
                 "Worktrees",
-                "Kwt workspace visibility and sidebar behavior."
+                "Workspace and standalone tmux session visibility."
             ),
             (
                 .agents,

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -158,7 +158,89 @@ final class SettingsStoreTests {
                 .appliesThemeToTmuxSessions
         )
         #expect(!store.worktreePreferences.hideRootCheckout)
+        #expect(store.tmuxSessionPreferences.hiddenSessionPatterns.isEmpty)
         #expect(store.shareAnonymousUsageData)
+    }
+
+    @Test
+    func testLoadingHiddenTmuxSessionPatternsFromAppConfig() throws {
+        try writeAppConfig(toml: """
+        [tmux]
+        hidden_session_patterns = ["forge-*", "scratch-?"]
+        """)
+
+        let store = makeSUT()
+
+        #expect(
+            store.tmuxSessionPreferences.hiddenSessionPatterns
+                == ["forge-*", "scratch-?"]
+        )
+    }
+
+    @Test
+    func testUpdatingHiddenTmuxSessionPatternsPreservesAppConfig() throws {
+        try writeAppConfig(toml: """
+        [general]
+        default_shell = "/bin/bash"
+        """)
+        let store = makeSUT()
+
+        store.setHiddenTmuxSessionPatterns([
+            " forge-* ", "", "scratch-?", "forge-*",
+        ])
+
+        #expect(
+            store.tmuxSessionPreferences.hiddenSessionPatterns
+                == ["forge-*", "scratch-?"]
+        )
+        let contents = try readAppConfig()
+        #expect(contents.contains("default_shell = \"/bin/bash\""))
+
+        let reloaded = makeSUT()
+        #expect(
+            reloaded.tmuxSessionPreferences.hiddenSessionPatterns
+                == ["forge-*", "scratch-?"]
+        )
+    }
+
+    @Test
+    func testUnchangedHiddenTmuxSessionPatternsDoNotCreateAppConfig() {
+        let store = makeSUT()
+
+        store.setHiddenTmuxSessionPatterns([])
+
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: store.appConfigFile.path
+            )
+        )
+    }
+
+    @Test
+    func testFailedHiddenTmuxSessionPatternWriteCanBeRetried() throws {
+        try FileManager.default.createDirectory(
+            at: paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        let configFile = paths.configDirectory
+            .appendingPathComponent("config.toml")
+        try FileManager.default.createDirectory(
+            at: configFile,
+            withIntermediateDirectories: false
+        )
+        let store = makeSUT()
+
+        #expect(!store.setHiddenTmuxSessionPatterns(["forge-*"]))
+        #expect(store.tmuxSessionPreferences.hiddenSessionPatterns.isEmpty)
+        #expect(store.lastErrorMessage != nil)
+
+        try FileManager.default.removeItem(at: configFile)
+        #expect(store.setHiddenTmuxSessionPatterns(["forge-*"]))
+        #expect(
+            store.tmuxSessionPreferences.hiddenSessionPatterns
+                == ["forge-*"]
+        )
+        #expect(store.lastErrorMessage == nil)
     }
 
     @Test
@@ -305,8 +387,8 @@ final class SettingsStoreTests {
         let store = makeSUT()
         store.setInterfaceAppearance(.light)
 
-        // App-concept settings persist in UserDefaults, not in
-        // config.toml (which does not own configured SSH hosts).
+        // Appearance remains in UserDefaults. config.toml owns only explicit
+        // file-backed settings such as standalone tmux session visibility.
         let contents = try readAppConfig()
         #expect(contents.contains("appearance") == false)
 

--- a/Tests/Settings/SettingsViewDraftTests.swift
+++ b/Tests/Settings/SettingsViewDraftTests.swift
@@ -15,6 +15,7 @@ struct SettingsViewDraftTests {
         store.setTerminalThemeAppliesToTmuxSessions(true)
         store.setHideRootCheckout(true)
         store.setShowHiddenWorktreesByDefault(true)
+        store.setHiddenTmuxSessionPatterns(["forge-*", "scratch-?"])
         store.setShowMacOSNotifications(false)
         store.setNotificationAttentionSound(.glass)
         store.setSSHHosts([host(configKey: "epyc", name: "EPYC")])
@@ -27,6 +28,9 @@ struct SettingsViewDraftTests {
         #expect(draft.appliesTerminalThemeToTmuxSessions)
         #expect(draft.hideRootCheckout)
         #expect(draft.showHiddenWorktreesByDefault)
+        #expect(
+            draft.hiddenTmuxSessionPatterns == ["forge-*", "scratch-?"]
+        )
         #expect(!draft.showMacOSNotifications)
         #expect(draft.attentionSound == .glass)
         #expect(draft.sshHosts.map(\.configKey) == ["epyc"])
@@ -57,6 +61,7 @@ struct SettingsViewDraftTests {
         var draft = SettingsViewDraft(store: store)
         draft.hideRootCheckout = true
         draft.showHiddenWorktreesByDefault = true
+        draft.hiddenTmuxSessionPatterns = ["forge-*", "scratch-?"]
         draft.showMacOSNotifications = false
         draft.attentionSound = .ping
 
@@ -64,8 +69,28 @@ struct SettingsViewDraftTests {
 
         #expect(store.worktreePreferences.hideRootCheckout)
         #expect(store.worktreePreferences.showHiddenWorktreesByDefault)
+        #expect(
+            store.tmuxSessionPreferences.hiddenSessionPatterns
+                == ["forge-*", "scratch-?"]
+        )
         #expect(!store.notificationConfiguration.showMacOSNotifications)
         #expect(store.notificationConfiguration.attentionSound == .ping)
+    }
+
+    @Test("persist reports a failed tmux pattern write")
+    func persistReportsFailedTmuxPatternWrite() throws {
+        let store = makeStore()
+        try FileManager.default.createDirectory(
+            at: store.appConfigFile,
+            withIntermediateDirectories: true
+        )
+        var draft = SettingsViewDraft(store: store)
+        draft.hiddenTmuxSessionPatterns = ["forge-*"]
+
+        let result = draft.persist(to: store)
+
+        #expect(!result.didPersistTmuxSessionPatterns)
+        #expect(store.tmuxSessionPreferences.hiddenSessionPatterns.isEmpty)
     }
 
     @Test("persist reports terminal reload for terminal settings")

--- a/Tests/UI/CommandPaletteModelTests.swift
+++ b/Tests/UI/CommandPaletteModelTests.swift
@@ -539,6 +539,42 @@ struct CommandPaletteModelTests {
         )
     }
 
+    @Test("hidden tmux session patterns remove lifecycle commands")
+    func hiddenTmuxSessionsAreNotDiscoverable() {
+        let host = HostSummary.fixture(
+            name: "This Mac",
+            tmuxSessions: [
+                TmuxSessionSummary(
+                    name: "forge-2ce60210419f1730",
+                    managed: false,
+                    windows: []
+                ),
+                TmuxSessionSummary(
+                    name: "homelab",
+                    managed: false,
+                    windows: []
+                ),
+            ]
+        )
+
+        let commands = makeCommandPaletteCommands(
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            selection: WorkspaceSelection(selectedHostID: host.id),
+            tmuxSessionVisibility: TmuxSessionVisibility(
+                hiddenPatterns: ["forge-*"]
+            )
+        )
+
+        commands.expectCommandNotContains(
+            title: "Open tmux session: forge-2ce60210419f1730"
+        )
+        commands.expectCommandContains(title: "Open tmux session: homelab")
+    }
+
     @Test("import PR command hidden without GitHub-linked projects")
     func importPRCommandHiddenWithoutGitHubLink() {
         let host = HostSummary.fixture(
@@ -665,6 +701,7 @@ private func makeCommandPaletteCommands(
     isSidebarVisible: Bool = true,
     isSidePanelVisible: Bool = false,
     interfaceAppearance: AppearancePreference = .system,
+    tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
     supportsSettings: Bool = true
 ) -> [WorkspaceCommandItem] {
     let bootstrap = WorkspaceBootstrap.preview()
@@ -679,6 +716,7 @@ private func makeCommandPaletteCommands(
         isSidebarVisible: isSidebarVisible,
         isSidePanelVisible: isSidePanelVisible,
         interfaceAppearance: interfaceAppearance,
+        tmuxSessionVisibility: tmuxSessionVisibility,
         supportsSettings: supportsSettings
     )
 }

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -406,6 +406,63 @@ struct WorkspaceSidebarModelTests {
         #expect(sections[0].projects[0].worktrees.map(\.id) == [worktree.id])
     }
 
+    @Test("hidden patterns remove only standalone tmux session rows")
+    func hiddenPatternsRemoveStandaloneSessions() {
+        let hostID = UUID()
+        let projectID = UUID()
+        var worktree = WorktreeSummary.fixture(
+            hostID: hostID,
+            projectID: projectID,
+            name: "forge-project",
+            path: "/code/forge-project",
+            branch: "main"
+        )
+        worktree.tmuxSessionName = "forge-worktree"
+        let snapshot = WorkspaceSnapshot.fixture(
+            hosts: [
+                .fixture(
+                    id: hostID,
+                    tmuxSessions: [
+                        TmuxSessionSummary(
+                            name: "forge-2ce60210419f1730",
+                            managed: false,
+                            windows: []
+                        ),
+                        TmuxSessionSummary(
+                            name: "forge-worktree",
+                            managed: false,
+                            windows: []
+                        ),
+                        TmuxSessionSummary(
+                            name: "homelab",
+                            managed: false,
+                            windows: []
+                        ),
+                    ]
+                ),
+            ],
+            projects: [
+                .fixture(
+                    id: projectID,
+                    hostID: hostID,
+                    name: "forge-project",
+                    rootPath: "/code/forge-project"
+                ),
+            ],
+            worktrees: [worktree]
+        )
+
+        let sections = WorkspaceSidebarModel.sections(
+            in: snapshot,
+            tmuxSessionVisibility: TmuxSessionVisibility(
+                hiddenPatterns: ["forge-*"]
+            )
+        )
+
+        #expect(sections[0].tmuxSessionRows.map(\.title) == ["homelab"])
+        #expect(sections[0].projects[0].worktrees.map(\.id) == [worktree.id])
+    }
+
     @Test("protected workspace names never hide default-server sessions")
     func keepsDefaultServerSessionSharingProtectedName() {
         let hostID = UUID()

--- a/Tests/Workspace/TOMLConfigParserTests.swift
+++ b/Tests/Workspace/TOMLConfigParserTests.swift
@@ -19,6 +19,13 @@ struct TOMLConfigParserTests {
         #expect(result == "key = \"value # not a comment\"")
     }
 
+    @Test func strippedTOMLLine_preservesHashInsideLiteralString() {
+        let result = TOMLConfigParser.strippedTOMLLine(
+            "key = 'value#part' # comment"
+        )
+        #expect(result == "key = 'value#part'")
+    }
+
     @Test func strippedTOMLLine_handlesEscapedQuote() {
         let result = TOMLConfigParser.strippedTOMLLine(
             "key = \"val\\\"ue\" # comment"
@@ -461,5 +468,72 @@ struct TOMLConfigParserTests {
         let rendered = TOMLConfigParser.renderTOMLString(original)
         let recovered = TOMLConfigParser.unquoteTOMLString(rendered)
         #expect(recovered == original)
+    }
+
+    // MARK: - parseAppConfigStringArrayValue
+
+    @Test func parseAppConfigStringArrayValue_readsQuotedPatterns() {
+        let contents = #"""
+        [tmux]
+        hidden_session_patterns = ["forge-*", "scratch-?", "quoted-\"name\""]
+        """#
+
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: contents
+            ) == ["forge-*", "scratch-?", "quoted-\"name\""]
+        )
+    }
+
+    @Test func parseAppConfigStringArrayValue_readsMultilineArray() {
+        let contents = """
+        [tmux]
+        hidden_session_patterns = [
+            "forge-*",
+            'team/#*', # TOML literal string
+            "scratch-?",
+        ]
+        status = true
+        """
+
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: contents
+            ) == ["forge-*", "team/#*", "scratch-?"]
+        )
+    }
+
+    @Test func parseAppConfigStringArrayValue_preservesLiteralHash() {
+        let contents = """
+        [tmux]
+        hidden_session_patterns = ['team/#*', "forge-*"]
+        """
+
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: contents
+            ) == ["team/#*", "forge-*"]
+        )
+    }
+
+    @Test func parseAppConfigStringArrayValue_rejectsMalformedArray() {
+        let contents = """
+        [tmux]
+        hidden_session_patterns = "forge-*"
+        """
+
+        #expect(
+            TOMLConfigParser.parseAppConfigStringArrayValue(
+                sectionName: "tmux",
+                key: "hidden_session_patterns",
+                in: contents
+            ) == nil
+        )
     }
 }

--- a/Tests/Workspace/TmuxSessionVisibilityTests.swift
+++ b/Tests/Workspace/TmuxSessionVisibilityTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import GhosthubWorkspace
+
+struct TmuxSessionVisibilityTests {
+    @Test(
+        "wildcards hide matching session names",
+        arguments: [
+            ("forge-*", "forge-2ce60210419f1730", true),
+            ("forge-*", "forge-", true),
+            ("scratch-?", "scratch-a", true),
+            ("scratch-?", "scratch-ab", false),
+            ("forge-*", "Forge-2ce60210419f1730", false),
+            ("forge-*", "homelab", false),
+        ]
+    )
+    func wildcardMatching(
+        pattern: String,
+        sessionName: String,
+        expectedHidden: Bool
+    ) {
+        let visibility = TmuxSessionVisibility(
+            hiddenPatterns: [pattern]
+        )
+
+        #expect(visibility.isHidden(sessionName) == expectedHidden)
+    }
+
+    @Test("any matching pattern hides a session")
+    func anyPatternHidesSession() {
+        let visibility = TmuxSessionVisibility(
+            hiddenPatterns: ["ci-*", "forge-*", "scratch-?"]
+        )
+
+        #expect(visibility.isHidden("forge-123"))
+        #expect(!visibility.isHidden("homelab"))
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,12 @@ the [Threat Model](threat-model.md).
 - **Session:** an ordinary tmux session on a host.
 
 The sidebar is a host-wide session navigator. It shows registered worktrees and
-every directly discovered tmux session on each host, including sessions that
-were not created by Ghosthub or kwt. General tmux sessions are presented as one
-ordinary native tmux client; tmux alone owns and renders their layout.
+directly discovered tmux sessions on each host, including sessions that were
+not created by Ghosthub or kwt. Users may hide matching standalone sessions
+from navigation with case-sensitive wildcard patterns; discovery retains the
+complete inventory so worktree status and session identity remain accurate.
+General tmux sessions are presented as one ordinary native tmux client; tmux
+alone owns and renders their layout.
 
 ## Window Model
 

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -194,9 +194,13 @@ actions are hidden. Discovery never installs or updates remote software
 implicitly.
 
 Kwt session names are removed from the generic session group and rendered
-under their project/worktree. Every remaining tmux session is shown in the
-host-level session group. No naming convention or ownership marker is used to
-hide Middleman-created sessions.
+under their project/worktree. Every remaining tmux session is eligible for the
+host-level session group. Case-sensitive `*` and `?` wildcard patterns in
+`hidden_session_patterns` under `[tmux]` inside
+`~/.config/ghosthub/config.toml` hide matching standalone sessions from the
+sidebar and command palette. Settings → Worktrees edits the same list, one
+pattern per line. Filtering occurs after discovery and never suppresses a kwt
+worktree, its running state, duplicate-name checks, or session identity.
 
 Pull-request imports are the one alternate-socket case. Kwt returns the named
 socket reserved for the workspace-specific server, and Ghosthub carries that

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -87,6 +87,15 @@ const imageAlt = {
             plus commands to open any discovered session.
           </p>
           <p>
+            To keep tool-owned standalone sessions out of navigation, open{' '}
+            <strong>Settings → Worktrees</strong> and add hidden tmux session
+            patterns, one per line. Patterns are case-sensitive and support{' '}
+            <code>*</code> for any number of characters and <code>?</code> for
+            one character. Ghosthub stores them in{' '}
+            <code>~/.config/ghosthub/config.toml</code>; matching kwt workspaces
+            remain visible under their projects.
+          </p>
+          <p>
             Closing the Ghosthub window only detaches—your work keeps running
             in tmux. To end a standalone session Ghosthub knows is running,
             hover its row and click the subtle <strong>×</strong>. A


### PR DESCRIPTION
Tool-managed tmux session fleets such as `forge-*` can overwhelm Ghosthub navigation, but suppressing them during discovery would undermine authoritative worktree and attachment state.

This adds user-owned, case-sensitive wildcard patterns in `config.toml`, editable from Settings → Worktrees, and applies them only to standalone-session presentation in the sidebar and command palette. Kwt worktrees, duplicate checks, and session identity continue to use complete discovery. TOML updates preserve surrounding configuration, and failed saves do not change live visibility.

Validated with the full Swift suite (153 XCTest and 696 Swift Testing cases, with 5 expected headless skips), `make test-essential-workflows`, `make build`, formatting checks, and the website check, test, and production build.