### PR TITLE
Make self-update relaunch graceful

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,20 @@ jobs:
             echo "dmg_name=Ghosthub_${VERSION}_macos_$(uname -m).dmg"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Validate release changelog section
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          RELEASE_APP_VERSION: ${{ steps.release.outputs.version }}
+        shell: bash
+        # The appcast step runs this same extraction after signing and
+        # notarization; validating here fails a bad changelog in seconds.
+        run: |
+          uv run --frozen python tools/extract_changelog.py \
+            --changelog CHANGELOG.md \
+            --version "$RELEASE_APP_VERSION" \
+            --release-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/v$RELEASE_APP_VERSION" \
+            --output /dev/null
+
       - name: Build pinned kwt helper
         shell: bash
         working-directory: .release-inputs/kwt-source

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -9,9 +9,7 @@ import AppKit
 
 enum QuitPolicy {
     static func needsConfirmation(
-        confirmBeforeQuitting: Bool,
-        runtimeNeedsConfirmQuit: Bool,
-        openTerminalSurfaceCount: Int
+        confirmBeforeQuitting: Bool
     ) -> Bool {
         confirmBeforeQuitting
     }
@@ -42,11 +40,11 @@ struct GhosthubApp: App {
         WindowGroup(
             "Ghosthub",
             id: "workspace",
-            for: UUID.self
-        ) { requestID in
+            for: WorkspaceWindowState.self
+        ) { windowState in
             WorkspaceWindow(
                 applicationDelegate: appDelegate,
-                requestID: requestID.wrappedValue
+                windowState: windowState
             )
             .environmentObject(terminalRuntime)
             .onAppear {
@@ -54,24 +52,29 @@ struct GhosthubApp: App {
                 AppAppearance.apply(
                     settingsStore.interfaceAppearance
                 )
-                appDelegate.openWorkspaceWindow = { requestID in
+                appDelegate.openWorkspaceWindow = { windowState in
                     openWindow(
                         id: "workspace",
-                        value: requestID
+                        value: windowState
                     )
                 }
                 appDelegate.needsConfirmQuit = {
                     QuitPolicy.needsConfirmation(
                         confirmBeforeQuitting:
-                        settingsStore.confirmBeforeQuitting,
-                        runtimeNeedsConfirmQuit:
-                        terminalRuntime
-                            .needsConfirmQuit,
-                        openTerminalSurfaceCount:
-                        WindowRegistry.shared
-                            .totalOpenTerminalSurfaceCount
+                        settingsStore.confirmBeforeQuitting
                     )
                 }
+                updateController.configureRelaunch(
+                    refreshRestorationState: {
+                        WindowRegistry.shared.refreshRestorationStates()
+                    },
+                    authorizeTermination: {
+                        appDelegate.authorizeNextUpdaterTermination()
+                    },
+                    clearTerminationAuthorization: {
+                        appDelegate.clearUpdaterTerminationAuthorization()
+                    }
+                )
                 updateController.start()
                 requestLaunchActivationIfNeeded()
                 #endif
@@ -83,6 +86,8 @@ struct GhosthubApp: App {
                 AppAppearance.apply(appearance)
                 #endif
             }
+        } defaultValue: {
+            WorkspaceWindowState.fresh()
         }
         .defaultSize(width: 1600, height: 1000)
         .windowStyle(.hiddenTitleBar)

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -108,11 +108,12 @@ final class ApplicationDelegate: NSObject,
         NSApplication.shared.terminate(nil)
     }
 
-    var openWorkspaceWindow: (UUID) -> Void = { _ in }
+    var openWorkspaceWindow: (WorkspaceWindowState) -> Void = { _ in }
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
     private(set) var terminationConfirmed = false
     private(set) var terminationConfirmationPending = false
+    private var updaterTerminationAuthorized = false
 
     override init() {
         confirmTermination = { false }
@@ -182,10 +183,12 @@ final class ApplicationDelegate: NSObject,
         window.makeKeyAndOrderFront(nil)
     }
 
-    private func requestWorkspaceWindow(parent: NSWindow?) -> UUID {
-        let id = UUID()
-        windowRequests.add(id, parent: parent)
-        return id
+    private func requestWorkspaceWindow(
+        parent: NSWindow?
+    ) -> WorkspaceWindowState {
+        let state = WorkspaceWindowState.fresh()
+        windowRequests.add(state.windowID, parent: parent)
+        return state
     }
 
     @discardableResult
@@ -266,15 +269,32 @@ final class ApplicationDelegate: NSObject,
         }
     }
 
+    func authorizeNextUpdaterTermination() {
+        updaterTerminationAuthorized = true
+    }
+
+    func clearUpdaterTerminationAuthorization() {
+        updaterTerminationAuthorized = false
+    }
+
+    private func consumeUpdaterTerminationAuthorization() -> Bool {
+        guard updaterTerminationAuthorized else { return false }
+        updaterTerminationAuthorized = false
+        return true
+    }
+
     func applicationShouldTerminate(
         _ sender: NSApplication
     ) -> NSApplication.TerminateReply {
+        if consumeUpdaterTerminationAuthorization() {
+            return .terminateNow
+        }
         if terminationConfirmed {
             return .terminateNow
         }
-        // Shutdown, restart, logout, and system-update requests intentionally
-        // use the same confirmation gate. Ghosthub must not silently disappear
-        // while terminal presentations are still open.
+        // Shutdown, restart, logout, and ordinary quit requests intentionally
+        // use the same confirmation gate. Only Sparkle receives the narrow
+        // one-shot authorization above after the user accepts its relaunch.
         return prepareUserInitiatedTermination()
             ? .terminateNow : .terminateCancel
     }
@@ -299,8 +319,8 @@ final class ApplicationDelegate: NSObject,
     private func makeTerminationAlert() -> NSAlert {
         let alert = NSAlert()
         alert.messageText = "Quit Ghosthub?"
-        alert.informativeText = "This will close Ghosthub "
-            + "and all active terminal surfaces."
+        alert.informativeText = "Ghosthub will close its terminal "
+            + "presentations. Your tmux sessions will remain running."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Quit")
         alert.addButton(withTitle: "Cancel")

--- a/Sources/App/UpdateController.swift
+++ b/Sources/App/UpdateController.swift
@@ -56,7 +56,76 @@ struct UpdateConfiguration: Equatable {
 }
 
 @MainActor
+final class UpdateInstallationDelegate: NSObject, SPUUpdaterDelegate {
+    private var refreshRestorationState: () -> Void
+    private var authorizeTermination: () -> Void
+    private var clearTerminationAuthorization: () -> Void
+    private var isRelaunchPending = false
+
+    init(
+        refreshRestorationState: @escaping () -> Void = {},
+        authorizeTermination: @escaping () -> Void = {},
+        clearTerminationAuthorization: @escaping () -> Void = {}
+    ) {
+        self.refreshRestorationState = refreshRestorationState
+        self.authorizeTermination = authorizeTermination
+        self.clearTerminationAuthorization = clearTerminationAuthorization
+        super.init()
+    }
+
+    func configure(
+        refreshRestorationState: @escaping () -> Void,
+        authorizeTermination: @escaping () -> Void,
+        clearTerminationAuthorization: @escaping () -> Void
+    ) {
+        self.refreshRestorationState = refreshRestorationState
+        self.authorizeTermination = authorizeTermination
+        self.clearTerminationAuthorization = clearTerminationAuthorization
+    }
+
+    func prepareForRelaunch() {
+        isRelaunchPending = true
+        refreshRestorationState()
+        authorizeTermination()
+    }
+
+    func updateSessionDidAbort() {
+        isRelaunchPending = false
+        clearTerminationAuthorization()
+    }
+
+    func updateSessionDidFinish(error: Bool) {
+        // A successful cycle-finish callback can race ahead of the updater's
+        // termination request; disarming here would resurface the quit
+        // confirmation mid-relaunch.
+        guard error || !isRelaunchPending else { return }
+        isRelaunchPending = false
+        clearTerminationAuthorization()
+    }
+
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        prepareForRelaunch()
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didAbortWithError error: any Error
+    ) {
+        updateSessionDidAbort()
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: (any Error)?
+    ) {
+        updateSessionDidFinish(error: error != nil)
+    }
+}
+
+@MainActor
 final class UpdateController {
+    private let installationDelegate: UpdateInstallationDelegate?
     private let controller: SPUStandardUpdaterController?
     private var didStart = false
 
@@ -66,19 +135,34 @@ final class UpdateController {
         guard UpdateConfiguration(
             infoDictionary: infoDictionary
         ).isReady else {
+            installationDelegate = nil
             controller = nil
             return
         }
 
+        let installationDelegate = UpdateInstallationDelegate()
+        self.installationDelegate = installationDelegate
         controller = SPUStandardUpdaterController(
             startingUpdater: false,
-            updaterDelegate: nil,
+            updaterDelegate: installationDelegate,
             userDriverDelegate: nil
         )
     }
 
     var isAvailable: Bool {
         controller != nil
+    }
+
+    func configureRelaunch(
+        refreshRestorationState: @escaping () -> Void,
+        authorizeTermination: @escaping () -> Void,
+        clearTerminationAuthorization: @escaping () -> Void
+    ) {
+        installationDelegate?.configure(
+            refreshRestorationState: refreshRestorationState,
+            authorizeTermination: authorizeTermination,
+            clearTerminationAuthorization: clearTerminationAuthorization
+        )
     }
 
     func start() {

--- a/Sources/App/WindowRegistry.swift
+++ b/Sources/App/WindowRegistry.swift
@@ -7,21 +7,44 @@ import SwiftUI
 final class WindowRegistry: ObservableObject {
     static let shared = WindowRegistry()
 
-    private(set) var sceneModels: [ObjectIdentifier: WorkspaceSceneModel] = [:]
+    private struct Entry {
+        let model: WorkspaceSceneModel
+        let refreshRestorationState: () -> Void
 
-    func register(_ model: WorkspaceSceneModel) {
-        sceneModels[ObjectIdentifier(model)] = model
+        init(
+            model: WorkspaceSceneModel,
+            refreshRestorationState: @escaping () -> Void
+        ) {
+            self.model = model
+            self.refreshRestorationState = refreshRestorationState
+        }
+    }
+
+    private var sceneEntries: [ObjectIdentifier: Entry] = [:]
+
+    func register(
+        _ model: WorkspaceSceneModel,
+        refreshRestorationState: @escaping () -> Void
+    ) {
+        sceneEntries[ObjectIdentifier(model)] = Entry(
+            model: model,
+            refreshRestorationState: refreshRestorationState
+        )
     }
 
     func unregister(_ model: WorkspaceSceneModel) {
-        sceneModels.removeValue(forKey: ObjectIdentifier(model))
+        sceneEntries.removeValue(forKey: ObjectIdentifier(model))
+    }
+
+    func refreshRestorationStates() {
+        sceneEntries.values.forEach { $0.refreshRestorationState() }
     }
 
     var totalOpenTerminalSurfaceCount: Int {
-        sceneModels.values.reduce(0) { $0 + $1.openTerminalSurfaceCount }
+        sceneEntries.values.reduce(0) { $0 + $1.model.openTerminalSurfaceCount }
     }
 
     var workspaceWindowCount: Int {
-        sceneModels.count
+        sceneEntries.count
     }
 }

--- a/Sources/App/WorkspaceSceneModel+Selection.swift
+++ b/Sources/App/WorkspaceSceneModel+Selection.swift
@@ -55,7 +55,7 @@ extension WorkspaceSceneModel {
             index, from: selection, in: snapshot,
             visibility: worktreeVisibility
         ) {
-            selection = updated
+            selectFromUser(updated)
         }
     }
 
@@ -64,7 +64,7 @@ extension WorkspaceSceneModel {
             from: selection, in: snapshot, step: step,
             visibility: worktreeVisibility
         ) {
-            selection = updated
+            selectFromUser(updated)
         }
     }
 }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -230,6 +230,12 @@ final class WorkspaceSceneModel: ObservableObject {
     private var activeBorrowedTmuxHandle: BorrowedTmuxSessionHandle?
     private(set) var activeBorrowedTmuxLaunchMode:
         TmuxAttachmentLaunchMode?
+    @Published private(set) var isWorkspaceRestorationPending = false
+    @Published private(set) var suppressesAutomaticWorktreeSessionOpen = false
+    private var pendingRestoration: WorkspaceWindowState?
+    private var protectedRestorationProbeTask: Task<Void, Never>?
+    private var protectedRestorationProbeID: UUID?
+    private var protectedRestorationRefreshPending = false
     var activeBorrowedTmuxSessionIsConnected: Bool {
         guard let handle = activeBorrowedTmuxHandle else {
             return false
@@ -778,6 +784,192 @@ final class WorkspaceSceneModel: ObservableObject {
         activityControllerBacking = nil
     }
 
+    func beginRestoration(_ state: WorkspaceWindowState) {
+        guard state.navigation != nil || state.tmux != nil else { return }
+        pendingRestoration = state
+        isWorkspaceRestorationPending = true
+        suppressesAutomaticWorktreeSessionOpen = true
+        attemptPendingRestoration()
+    }
+
+    func cancelPendingRestoration() {
+        pendingRestoration = nil
+        isWorkspaceRestorationPending = false
+        suppressesAutomaticWorktreeSessionOpen = false
+        protectedRestorationProbeTask?.cancel()
+        protectedRestorationProbeTask = nil
+        protectedRestorationProbeID = nil
+        protectedRestorationRefreshPending = false
+    }
+
+    func restorationState(windowID: UUID) -> WorkspaceWindowState {
+        if var pendingRestoration {
+            pendingRestoration.windowID = windowID
+            return pendingRestoration
+        }
+        return WorkspaceWindowState.capture(
+            windowID: windowID,
+            selection: selection,
+            activeTmux: activeBorrowedTmuxSelection,
+            snapshot: snapshot
+        )
+    }
+
+    func selectFromUser(_ newSelection: WorkspaceSelection) {
+        cancelPendingRestoration()
+        selection = newSelection
+        attachReplacedWorktreeSessionIfNeeded()
+    }
+
+    /// An active presentation keeps the worktree generation it observed even
+    /// when inventory replaces the worktree behind the same runtime ID.
+    /// Explicitly reselecting that worktree is the user asking for the
+    /// canonical target, so attach the replacement session.
+    private func attachReplacedWorktreeSessionIfNeeded() {
+        guard let active = activeBorrowedTmuxSelection,
+              let activeGeneration = active.worktreeGeneration,
+              let replacement = WorkspaceSidebarModel.tmuxSessionSelection(
+                  for: selection,
+                  in: snapshot
+              ),
+              replacement.worktreeID == active.worktreeID,
+              let generation = WorktreeGeneration.canonical(
+                  replacement.worktreeGeneration
+              ),
+              generation != activeGeneration
+        else { return }
+        openBorrowedTmuxSession(replacement)
+    }
+
+    func synchronizeSelection(_ newSelection: WorkspaceSelection) {
+        guard newSelection != selection else { return }
+        selection = newSelection
+    }
+
+    private func applyRestoredSelection(_ restored: WorkspaceSelection) {
+        selection = restored
+    }
+
+    private func attemptPendingRestoration() {
+        guard let pendingRestoration else { return }
+        guard protectedRestorationProbeTask == nil else {
+            protectedRestorationRefreshPending = true
+            return
+        }
+        switch WorkspaceWindowRestorationResolver.resolve(
+            pendingRestoration,
+            in: snapshot
+        ) {
+        case .invalid:
+            cancelPendingRestoration()
+        case let .pending(resolvedSelection):
+            if let resolvedSelection {
+                applyRestoredSelection(resolvedSelection)
+            }
+        case let .ready(resolvedSelection, tmuxSelection):
+            applyRestoredSelection(resolvedSelection)
+            if let tmuxSelection {
+                _ = presentTmuxSession(
+                    tmuxSelection,
+                    launchMode: .attach,
+                    intent: .restoreOnly
+                )
+                suppressesAutomaticWorktreeSessionOpen = false
+            }
+            self.pendingRestoration = nil
+            isWorkspaceRestorationPending = false
+        case let .needsProtectedProbe(resolvedSelection, tmuxSelection):
+            beginProtectedRestorationProbe(
+                selection: resolvedSelection,
+                tmuxSelection: tmuxSelection,
+                expectedState: pendingRestoration
+            )
+        }
+    }
+
+    private func beginProtectedRestorationProbe(
+        selection resolvedSelection: WorkspaceSelection,
+        tmuxSelection: WorkspaceTmuxSessionSelection,
+        expectedState: WorkspaceWindowState
+    ) {
+        guard protectedRestorationProbeTask == nil,
+              let hostSummary = snapshot.host(id: tmuxSelection.hostID),
+              let host = TmuxHostResolver.resolve(hostSummary)
+        else { return }
+        let probeID = UUID()
+        protectedRestorationProbeID = probeID
+        protectedRestorationProbeTask = Task { [weak self] in
+            defer {
+                if self?.protectedRestorationProbeID == probeID {
+                    self?.protectedRestorationProbeTask = nil
+                    self?.protectedRestorationProbeID = nil
+                }
+            }
+            do {
+                _ = try await self?.tmuxSessionIdentityReader(
+                    tmuxSelection,
+                    host
+                )
+            } catch {
+                self?.retryProtectedRestorationAfterProbeCleanupIfNeeded(
+                    probeID
+                )
+                return
+            }
+            guard !Task.isCancelled,
+                  let self,
+                  protectedRestorationProbeID == probeID else {
+                return
+            }
+            guard pendingRestoration == expectedState,
+                  case let .needsProtectedProbe(
+                      currentSelection,
+                      currentTmuxSelection
+                  ) = WorkspaceWindowRestorationResolver.resolve(
+                      expectedState,
+                      in: snapshot
+                  ),
+                  let currentHostSummary = snapshot.host(
+                      id: tmuxSelection.hostID
+                  ),
+                  let currentHost = TmuxHostResolver.resolve(
+                      currentHostSummary
+                  )
+            else {
+                retryProtectedRestorationAfterProbeCleanupIfNeeded(probeID)
+                return
+            }
+            guard currentSelection == resolvedSelection,
+                  currentTmuxSelection == tmuxSelection,
+                  currentHost == host else {
+                retryProtectedRestorationAfterProbeCleanupIfNeeded(probeID)
+                return
+            }
+            protectedRestorationRefreshPending = false
+            applyRestoredSelection(resolvedSelection)
+            _ = presentTmuxSession(
+                tmuxSelection,
+                launchMode: .attach,
+                intent: .restoreOnly
+            )
+            pendingRestoration = nil
+            isWorkspaceRestorationPending = false
+            suppressesAutomaticWorktreeSessionOpen = false
+        }
+    }
+
+    private func retryProtectedRestorationAfterProbeCleanupIfNeeded(
+        _ probeID: UUID
+    ) {
+        guard protectedRestorationProbeID == probeID,
+              protectedRestorationRefreshPending else { return }
+        protectedRestorationRefreshPending = false
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            self?.attemptPendingRestoration()
+        }
+    }
+
     /// Releases per-window terminal connection resources while preserving the
     /// tmux server sessions they attach to. Called by `WorkspaceWindow` before
     /// the scene model leaves the app-level window registry.
@@ -847,6 +1039,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
         do {
             try await kwtWorktreeCreator(request, project.rootPath, host)
+            cancelPendingRestoration()
 
             let refreshed = try await kwtInventoryLoader(host)
             let previous = kwtInventoriesByHost[project.hostID]
@@ -874,11 +1067,13 @@ final class WorkspaceSceneModel: ObservableObject {
                 branch: request.branchName
             )
         }
-        selection.select(
+        var createdSelection = selection
+        createdSelection.select(
             .worktree(created.id),
             in: snapshot,
             visibility: worktreeVisibility
         )
+        selectFromUser(createdSelection)
     }
 
     func branches(
@@ -910,7 +1105,7 @@ final class WorkspaceSceneModel: ObservableObject {
         guard snapshot.canRemoveWorktree(worktree) else {
             throw KwtWorktreeError.worktreeUnavailable
         }
-        guard Self.isCanonicalWorktreeGeneration(
+        guard WorktreeGeneration.isCanonical(
             worktree.generation
         ) else {
             throw KwtWorktreeError.removalIdentityUnavailable
@@ -1062,6 +1257,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     confirmedHost
                 )
             }
+            cancelPendingRestoration()
             removalTombstones.insert(
                 WorktreeMutationCoordinator.RemovalTombstone(
                     path: worktree.path,
@@ -1156,20 +1352,6 @@ final class WorkspaceSceneModel: ObservableObject {
         return (worktree, project)
     }
 
-    private static func isCanonicalWorktreeGeneration(
-        _ value: String?
-    ) -> Bool {
-        guard let value,
-              value.range(
-                  of: #"^[0-9a-f]{32}$"#,
-                  options: .regularExpression
-              ) != nil
-        else {
-            return false
-        }
-        return true
-    }
-
     private func removalRequest(
         _ request: WorktreeRemovalRequest,
         matches worktree: WorktreeSummary,
@@ -1226,11 +1408,12 @@ final class WorkspaceSceneModel: ObservableObject {
         snapshot.worktrees.removeAll { $0.id == worktree.id }
         snapshot.sessions.removeAll { $0.worktreeID == worktree.id }
         applyInventoryOverlayIfNeeded()
-        selection = Self.selectionAfterWorktreeRemoval(
+        let removalSelection = Self.selectionAfterWorktreeRemoval(
             selection,
             in: snapshot,
             visibility: worktreeVisibility
         )
+        selectFromUser(removalSelection)
         updateWorkspaceInventoryState()
     }
 
@@ -1323,6 +1506,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 project.scopedKey,
                 host
             )
+            cancelPendingRestoration()
         } catch {
             if isRemoteKwtUnavailable(error, hostID: project.hostID) {
                 kwtAvailabilityByHost[project.hostID] = false
@@ -1369,11 +1553,13 @@ final class WorkspaceSceneModel: ObservableObject {
                 path: result.workspace.path
             )
         }
-        selection.select(
+        var importedSelection = selection
+        importedSelection.select(
             .worktree(imported.id),
             in: snapshot,
             visibility: worktreeVisibility
         )
+        selectFromUser(importedSelection)
     }
 
     private func mergeImportedWorkspace(
@@ -1536,10 +1722,12 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func applyInventoryOverlayIfNeeded() {
         let overlaid = applyingCachedInventories(to: snapshot)
-        guard overlaid != snapshot else { return }
-        isApplyingInventoryOverlay = true
-        snapshot = overlaid
-        isApplyingInventoryOverlay = false
+        if overlaid != snapshot {
+            isApplyingInventoryOverlay = true
+            snapshot = overlaid
+            isApplyingInventoryOverlay = false
+        }
+        attemptPendingRestoration()
     }
 
     private func scheduleKwtInventory() {
@@ -2418,6 +2606,7 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func openBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        cancelPendingRestoration()
         let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
             Self.sameTmuxSession($0, selection)
         }
@@ -2430,6 +2619,7 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func createTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        cancelPendingRestoration()
         let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
             Self.sameTmuxSession($0, selection)
         }
@@ -2456,11 +2646,24 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    private enum TmuxPresentationIntent: Equatable {
+        case userInitiated
+        case restoreOnly
+    }
+
     @discardableResult
     private func presentTmuxSession(
         _ selection: WorkspaceTmuxSessionSelection,
-        launchMode: TmuxAttachmentLaunchMode
+        launchMode: TmuxAttachmentLaunchMode,
+        intent: TmuxPresentationIntent = .userInitiated
     ) -> BorrowedTmuxSessionHandle? {
+        var selection = selection
+        if let worktreeID = selection.worktreeID,
+           selection.worktreeGeneration == nil,
+           let generation = snapshot.worktree(id: worktreeID)?.generation,
+           WorktreeGeneration.isCanonical(generation) {
+            selection.worktreeGeneration = generation
+        }
         let effectiveLaunchMode: TmuxAttachmentLaunchMode =
             selection.socketName == nil ? launchMode : .attach
         if let active = activeBorrowedTmuxSelection, active != selection {
@@ -2481,7 +2684,8 @@ final class WorkspaceSceneModel: ObservableObject {
         let managedKwtUnavailable = host.remoteDiagnostics.contains {
             $0.code == .missingKwt
         }
-        let openWorkspace = effectiveLaunchMode == .attach
+        let openWorkspace = intent == .userInitiated
+            && effectiveLaunchMode == .attach
             && selection.socketName == nil
             && selection.worktreePath != nil
             && (!sessionIsDiscovered || !managedKwtUnavailable)
@@ -2505,6 +2709,17 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private static func sameTmuxSession(
+        _ lhs: WorkspaceTmuxSessionSelection,
+        _ rhs: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        sameTmuxEndpoint(lhs, rhs)
+            && lhs.worktreeGeneration == rhs.worktreeGeneration
+    }
+
+    /// Kill targets a live tmux endpoint; inventory can change the owning
+    /// worktree generation while that endpoint keeps running, so kill
+    /// probing and cleanup must not compare generations.
+    private static func sameTmuxEndpoint(
         _ lhs: WorkspaceTmuxSessionSelection,
         _ rhs: WorkspaceTmuxSessionSelection
     ) -> Bool {
@@ -2536,6 +2751,7 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        cancelPendingRestoration()
         guard activeBorrowedTmuxSelection == selection else { return }
         if let handle = activeBorrowedTmuxHandle {
             confirmedEndedTmuxSessionHandles.remove(handle.id)
@@ -2643,7 +2859,7 @@ final class WorkspaceSceneModel: ObservableObject {
         )
 
         let activeTargetAfterKill = activeBorrowedTmuxSelection.flatMap {
-            Self.sameTmuxSession($0, tmuxSelection) ? $0 : nil
+            Self.sameTmuxEndpoint($0, tmuxSelection) ? $0 : nil
         }
         if let activeTargetAfterKill {
             closeBorrowedTmuxSession(activeTargetAfterKill)
@@ -2669,7 +2885,7 @@ final class WorkspaceSceneModel: ObservableObject {
         _ selection: WorkspaceTmuxSessionSelection
     ) -> Bool {
         guard let activeSelection = activeBorrowedTmuxSelection,
-              Self.sameTmuxSession(activeSelection, selection),
+              Self.sameTmuxEndpoint(activeSelection, selection),
               let activeHandle = activeBorrowedTmuxHandle
         else {
             return false

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -520,7 +520,7 @@ private struct CompactToolbarButton: View {
 struct WorkspaceWindow: View {
     #if canImport(AppKit)
     let applicationDelegate: ApplicationDelegate
-    let requestID: UUID?
+    @Binding var windowState: WorkspaceWindowState
     #endif
     @StateObject private var sceneModel = WorkspaceSceneModel()
     @EnvironmentObject private var terminalRuntime: LibghosttyRuntime
@@ -564,6 +564,10 @@ struct WorkspaceWindow: View {
                 sceneModel.workspaceInventoryWarning,
                 workspaceInventoryWarningsByHost:
                 sceneModel.workspaceInventoryWarningsByHost,
+                isWorkspaceRestorationPending:
+                sceneModel.isWorkspaceRestorationPending,
+                suppressesAutomaticWorktreeSessionOpen:
+                sceneModel.suppressesAutomaticWorktreeSessionOpen,
                 activeTmuxSession:
                 sceneModel.activeBorrowedTmuxSelection,
                 activeTmuxSessionIsConnected:
@@ -643,6 +647,9 @@ struct WorkspaceWindow: View {
                 reloadTerminalConfig: {
                     sceneModel.reloadTerminalConfig()
                 },
+                selectWorkspace: { [sceneModel] selection in
+                    sceneModel.selectFromUser(selection)
+                },
                 openTmuxSession: { [sceneModel] selection in
                     sceneModel.openBorrowedTmuxSession(selection)
                 },
@@ -684,7 +691,10 @@ struct WorkspaceWindow: View {
                 }
             ),
             settingsStore: settingsStore,
-            selection: $sceneModel.selection,
+            selection: Binding(
+                get: { sceneModel.selection },
+                set: { sceneModel.synchronizeSelection($0) }
+            ),
             isSidePanelVisible: Binding(
                 get: { sceneModel.isSidePanelVisible },
                 set: { sceneModel.setSidePanelVisible($0) }
@@ -731,7 +741,7 @@ struct WorkspaceWindow: View {
         .background(
             WindowFocusTracker(
                 applicationDelegate: applicationDelegate,
-                requestID: requestID,
+                requestID: windowState.windowID,
                 isFocused: Binding(
                     get: { sceneModel.isFocusedWindow },
                     set: { sceneModel.isFocusedWindow = $0 }
@@ -767,8 +777,18 @@ struct WorkspaceWindow: View {
             )
         )
         #endif
+        .onChange(of: sceneModel.restorationState(
+            windowID: windowState.windowID
+        )) { _, state in
+            windowState = state
+        }
         .onAppear {
-            registry.register(sceneModel)
+            sceneModel.beginRestoration(windowState)
+            refreshWindowState()
+            registry.register(
+                sceneModel,
+                refreshRestorationState: refreshWindowState
+            )
             if terminalRuntime.configReloadNotice?.kind == .error {
                 visibleConfigReloadNotice =
                     terminalRuntime.configReloadNotice
@@ -793,11 +813,18 @@ struct WorkspaceWindow: View {
             }
         }
         .onDisappear {
+            sceneModel.cancelPendingRestoration()
             registry.unregister(sceneModel)
             Task { [sceneModel] in
                 await sceneModel.shutdown()
             }
         }
+    }
+
+    private func refreshWindowState() {
+        windowState = sceneModel.restorationState(
+            windowID: windowState.windowID
+        )
     }
 
     private var canCreateWorktree: Bool {

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -1,0 +1,267 @@
+import Foundation
+import GhosthubUI
+import GhosthubWorkspace
+
+enum WorktreeGeneration {
+    /// Returns the value only when it is a durable kwt generation
+    /// (32 lowercase hex characters); any other value is not identity.
+    static func canonical(_ value: String?) -> String? {
+        guard let value,
+              value.range(
+                  of: #"^[0-9a-f]{32}$"#,
+                  options: .regularExpression
+              ) != nil
+        else { return nil }
+        return value
+    }
+
+    static func isCanonical(_ value: String?) -> Bool {
+        canonical(value) != nil
+    }
+}
+
+private func isValidOptionalWorktreeGeneration(_ value: String?) -> Bool {
+    value == nil || WorktreeGeneration.isCanonical(value)
+}
+
+struct WorkspaceNavigationDescriptor: Codable, Hashable, Sendable {
+    var hostKey: String
+    var projectKey: String?
+    var worktreeGeneration: String?
+}
+
+enum WorkspaceTmuxOwnerDescriptor: Codable, Hashable, Sendable {
+    case unbound
+    case worktree(generation: String)
+}
+
+struct WorkspaceTmuxDescriptor: Codable, Hashable, Sendable {
+    var hostKey: String
+    var sessionName: String
+    var socketName: String?
+    var owner: WorkspaceTmuxOwnerDescriptor
+}
+
+struct WorkspaceWindowState: Codable, Hashable, Sendable {
+    var windowID: UUID
+    var navigation: WorkspaceNavigationDescriptor?
+    var tmux: WorkspaceTmuxDescriptor?
+
+    static func fresh(windowID: UUID = UUID()) -> Self {
+        Self(windowID: windowID, navigation: nil, tmux: nil)
+    }
+
+    static func capture(
+        windowID: UUID,
+        selection: WorkspaceSelection,
+        activeTmux: WorkspaceTmuxSessionSelection?,
+        snapshot: WorkspaceSnapshot
+    ) -> Self {
+        let host = snapshot.host(id: selection.selectedHostID)
+        let project = selection.selectedProjectID.flatMap {
+            snapshot.project(id: $0)
+        }
+        let worktree = selection.selectedWorktreeID.flatMap {
+            snapshot.worktree(id: $0)
+        }
+        let observedGeneration = activeTmux.flatMap { active -> String? in
+            guard active.worktreeID == selection.selectedWorktreeID,
+                  active.worktreeGeneration != nil
+            else { return nil }
+            return WorktreeGeneration.canonical(active.worktreeGeneration)
+        }
+        let worktreeGeneration: String?
+        if activeTmux?.worktreeID == selection.selectedWorktreeID,
+           activeTmux?.worktreeGeneration != nil {
+            worktreeGeneration = observedGeneration
+        } else {
+            worktreeGeneration = WorktreeGeneration.canonical(
+                worktree?.generation
+            )
+        }
+        let navigation = host.map {
+            WorkspaceNavigationDescriptor(
+                hostKey: $0.configKey,
+                projectKey: project?.scopedKey,
+                worktreeGeneration: worktreeGeneration
+            )
+        }
+        // A session can outlive navigation elsewhere for one frame before
+        // the lifecycle modifier detaches it. Persist a tmux descriptor
+        // only when its host and worktree ownership match the captured
+        // navigation; otherwise keep the navigation alone rather than
+        // emitting a combination the resolver rejects outright.
+        let tmux = activeTmux.flatMap { active -> WorkspaceTmuxDescriptor? in
+            guard let activeHost = snapshot.host(id: active.hostID),
+                  let navigation,
+                  activeHost.configKey == navigation.hostKey
+            else { return nil }
+            let owner: WorkspaceTmuxOwnerDescriptor
+            if let worktreeID = active.worktreeID {
+                let generation = active.worktreeGeneration == nil
+                    ? WorktreeGeneration.canonical(
+                        snapshot.worktree(id: worktreeID)?.generation
+                    )
+                    : WorktreeGeneration.canonical(
+                        active.worktreeGeneration
+                    )
+                guard let generation,
+                      generation == navigation.worktreeGeneration
+                else { return nil }
+                owner = .worktree(generation: generation)
+            } else {
+                guard selection.selectedProjectID == nil,
+                      selection.selectedWorktreeID == nil,
+                      active.socketName == nil
+                else { return nil }
+                owner = .unbound
+            }
+            return WorkspaceTmuxDescriptor(
+                hostKey: activeHost.configKey,
+                sessionName: active.name,
+                socketName: active.socketName,
+                owner: owner
+            )
+        }
+        return Self(windowID: windowID, navigation: navigation, tmux: tmux)
+    }
+}
+
+enum WorkspaceRestorationResolution: Equatable, Sendable {
+    case invalid
+    case pending(selection: WorkspaceSelection?)
+    case ready(
+        selection: WorkspaceSelection,
+        tmux: WorkspaceTmuxSessionSelection?
+    )
+    case needsProtectedProbe(
+        selection: WorkspaceSelection,
+        tmux: WorkspaceTmuxSessionSelection
+    )
+}
+
+enum WorkspaceWindowRestorationResolver {
+    static func resolve(
+        _ state: WorkspaceWindowState,
+        in snapshot: WorkspaceSnapshot
+    ) -> WorkspaceRestorationResolution {
+        guard let navigation = state.navigation,
+              isNonblank(navigation.hostKey),
+              isValidOptional(navigation.projectKey),
+              isValidOptionalWorktreeGeneration(
+                  navigation.worktreeGeneration
+              ),
+              navigation.worktreeGeneration == nil
+              || navigation.projectKey != nil
+        else { return .invalid }
+
+        if let tmux = state.tmux {
+            guard isNonblank(tmux.hostKey),
+                  isNonblank(tmux.sessionName),
+                  isValidOptional(tmux.socketName),
+                  tmux.hostKey == navigation.hostKey
+            else { return .invalid }
+            switch tmux.owner {
+            case .unbound:
+                guard navigation.worktreeGeneration == nil,
+                      tmux.socketName == nil
+                else { return .invalid }
+            case let .worktree(generation):
+                guard WorktreeGeneration.canonical(generation) != nil,
+                      generation == navigation.worktreeGeneration
+                else { return .invalid }
+            }
+        }
+
+        guard let host = snapshot.hosts.first(where: {
+            $0.configKey == navigation.hostKey
+        }) else {
+            return .pending(selection: nil)
+        }
+        var selection = WorkspaceSelection(selectedHostID: host.id)
+
+        if let projectKey = navigation.projectKey {
+            guard let project = snapshot.projects.first(where: {
+                $0.hostID == host.id
+                    && $0.scopedKey == projectKey
+                    && !$0.isStale
+            }) else {
+                return .pending(selection: selection)
+            }
+            selection.selectedProjectID = project.id
+
+            if let worktreeGeneration = navigation.worktreeGeneration {
+                guard let worktree = snapshot.worktrees.first(where: {
+                    $0.hostID == host.id
+                        && $0.projectID == project.id
+                        && $0.generation == worktreeGeneration
+                        && !$0.isStale
+                }) else {
+                    return .pending(selection: selection)
+                }
+                selection.selectedWorktreeID = worktree.id
+            }
+        }
+
+        guard let tmux = state.tmux else {
+            return .ready(selection: selection, tmux: nil)
+        }
+        if host.kind == .remote, host.connectionState == .offline {
+            return .pending(selection: selection)
+        }
+        let worktreeGeneration: String?
+        switch tmux.owner {
+        case .unbound:
+            worktreeGeneration = nil
+        case let .worktree(generation):
+            worktreeGeneration = generation
+        }
+        let owner = worktreeGeneration.flatMap { worktreeGeneration in
+            snapshot.worktrees.first {
+                $0.hostID == host.id
+                    && $0.projectID == selection.selectedProjectID
+                    && $0.generation == worktreeGeneration
+                    && !$0.isStale
+            }
+        }
+        if worktreeGeneration != nil, owner == nil {
+            return .pending(selection: selection)
+        }
+        if let owner,
+           owner.tmuxSessionName != tmux.sessionName
+           || owner.tmuxSocketName != tmux.socketName {
+            return .pending(selection: selection)
+        }
+        let tmuxSelection = WorkspaceTmuxSessionSelection(
+            hostID: host.id,
+            name: tmux.sessionName,
+            worktreeID: owner?.id,
+            worktreePath: owner?.path,
+            worktreeGeneration: worktreeGeneration,
+            socketName: tmux.socketName
+        )
+
+        if tmux.socketName != nil {
+            guard owner != nil
+            else { return .pending(selection: selection) }
+            return .needsProtectedProbe(
+                selection: selection,
+                tmux: tmuxSelection
+            )
+        }
+        guard host.tmuxSessions.contains(where: {
+            $0.name == tmux.sessionName
+        }) else {
+            return .pending(selection: selection)
+        }
+        return .ready(selection: selection, tmux: tmuxSelection)
+    }
+
+    private static func isNonblank(_ value: String) -> Bool {
+        !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func isValidOptional(_ value: String?) -> Bool {
+        value.map(isNonblank) ?? true
+    }
+}

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -177,6 +177,7 @@ public struct RootView: View {
             .onAppear {
                 normalizeSelectionForWorktreeVisibilityChanges()
                 synchronizeSelectedWorktreeSession()
+                initializeTmuxSelectionBaselineIfNeeded()
             }
             .onChange(of: worktreeVisibility) { _, _ in
                 normalizeSelectionForWorktreeVisibilityChanges()
@@ -185,10 +186,18 @@ public struct RootView: View {
             .onChange(of: selection) { _, _ in
                 synchronizeSelectedWorktreeSession()
             }
+            .onChange(
+                of: display.suppressesAutomaticWorktreeSessionOpen
+            ) { wasSuppressed, isSuppressed in
+                guard wasSuppressed, !isSuppressed else { return }
+                synchronizeSelectedWorktreeSession()
+            }
             .onChange(of: activeTmuxSession) { _, activeSession in
-                if activeSession == nil {
+                guard activeSession != nil else {
                     tmuxSelectionBaseline = nil
+                    return
                 }
+                initializeTmuxSelectionBaselineIfNeeded()
             }
             .onReceive(
                 NotificationCenter.default.publisher(
@@ -349,7 +358,10 @@ public struct RootView: View {
     private var workspaceSidebarColumn: some View {
         WorkspaceSidebarView(
             snapshot: snapshot,
-            selection: $selection,
+            selection: Binding(
+                get: { selection },
+                set: { selectWorkspace($0) }
+            ),
             visibility: worktreeVisibility,
             tmuxSessionVisibility: tmuxSessionVisibility,
             activeTmuxSession: activeTmuxSession,
@@ -382,11 +394,7 @@ public struct RootView: View {
             inventoryWarningsByHost:
             display.workspaceInventoryWarningsByHost,
             onOpen: { worktree in
-                selection.select(
-                    .worktree(worktree.id),
-                    in: snapshot,
-                    visibility: worktreeVisibility
-                )
+                selectWorkspace(.worktree(worktree.id))
             }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -406,6 +414,12 @@ public struct RootView: View {
         handlers.openTmuxSession?(session)
     }
 
+    private func initializeTmuxSelectionBaselineIfNeeded() {
+        guard activeTmuxSession != nil,
+              tmuxSelectionBaseline == nil else { return }
+        tmuxSelectionBaseline = selection
+    }
+
     private func createTmuxSession(on host: HostSummary, name: String) {
         let session = WorkspaceTmuxSessionSelection(
             hostID: host.id,
@@ -414,12 +428,12 @@ public struct RootView: View {
         if let previous = activeTmuxSession {
             handlers.closeTmuxSession?(previous)
         }
-        selection = Self.selectionForHostTmuxSession(
+        selectWorkspace(Self.selectionForHostTmuxSession(
             session,
             from: selection,
             in: snapshot,
             visibility: worktreeVisibility
-        )
+        ))
         tmuxSelectionBaseline = selection
         handlers.createTmuxSession?(session)
     }
@@ -572,13 +586,36 @@ public struct RootView: View {
 
     private var selectedWorktreeTmuxSession:
         WorkspaceTmuxSessionSelection? {
-        WorkspaceSidebarModel.tmuxSessionSelection(
+        let selected = WorkspaceSidebarModel.tmuxSessionSelection(
             for: selection,
             in: snapshot
         )
+        guard let selected,
+              let activeTmuxSession,
+              selected.worktreeID == activeTmuxSession.worktreeID,
+              selected.worktreeGeneration
+              != activeTmuxSession.worktreeGeneration else {
+            return selected
+        }
+        if activeTmuxSession.worktreeGeneration == nil {
+            // A presentation opened before its canonical generation was
+            // available is enriched, not replaced, as long as the tmux
+            // endpoint is unchanged; keep the live terminal.
+            guard selected.hostID == activeTmuxSession.hostID,
+                  selected.name == activeTmuxSession.name,
+                  selected.socketName == activeTmuxSession.socketName
+            else { return selected }
+            return activeTmuxSession
+        }
+
+        // Inventory may reuse a runtime worktree ID after a same-path
+        // replacement or temporarily omit its generation. Keep the observed
+        // presentation until the user explicitly selects a canonical target.
+        return activeTmuxSession
     }
 
     private func synchronizeSelectedWorktreeSession() {
+        guard !display.suppressesAutomaticWorktreeSessionOpen else { return }
         guard let session = selectedWorktreeTmuxSession else {
             if activeTmuxSession?.worktreeID != nil {
                 deactivateTmuxSession()
@@ -600,6 +637,14 @@ public struct RootView: View {
                 presentedSession.name
             ) {
             view
+        } else if display.suppressesAutomaticWorktreeSessionOpen,
+                  !display.isWorkspaceRestorationPending,
+                  selectedWorktreeTmuxSession != nil {
+            ContentUnavailableView {
+                Label("Session detached", systemImage: "terminal")
+            } description: {
+                Text("Select this worktree to attach its tmux session.")
+            }
         } else if let pendingSession = selectedWorktreeTmuxSession {
             ProgressView("Opening \(displayName(for: pendingSession))…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -728,7 +773,7 @@ public struct RootView: View {
                 step: -1,
                 visibility: worktreeVisibility
             ) {
-                selection = updatedSelection
+                selectWorkspace(updatedSelection)
             }
         case .nextWorktree:
             if let updatedSelection = KeyboardNavigationModel.steppedSelection(
@@ -737,7 +782,7 @@ public struct RootView: View {
                 step: 1,
                 visibility: worktreeVisibility
             ) {
-                selection = updatedSelection
+                selectWorkspace(updatedSelection)
             }
         case let .newTmuxSession(hostID):
             guard let host = snapshot.host(id: hostID) else { return }
@@ -747,18 +792,14 @@ public struct RootView: View {
             addProjectHost = host
         case let .openTmuxSession(tmuxSession):
             if let worktreeID = tmuxSession.worktreeID {
-                selection.select(
-                    .worktree(worktreeID),
-                    in: snapshot,
-                    visibility: worktreeVisibility
-                )
+                selectWorkspace(.worktree(worktreeID))
             } else {
-                selection = Self.selectionForHostTmuxSession(
+                selectWorkspace(Self.selectionForHostTmuxSession(
                     tmuxSession,
                     from: selection,
                     in: snapshot,
                     visibility: worktreeVisibility
-                )
+                ))
             }
             activateTmuxSession(tmuxSession)
         case let .killTmuxSession(tmuxSession):
@@ -776,11 +817,7 @@ public struct RootView: View {
         case let .setInterfaceAppearance(appearance):
             settingsStore.setInterfaceAppearance(appearance)
         case let .select(target):
-            selection.select(
-                target,
-                in: snapshot,
-                visibility: worktreeVisibility
-            )
+            selectWorkspace(target)
         case .showLogViewer:
             isLogViewerPresented = true
         }
@@ -866,6 +903,24 @@ public struct RootView: View {
             in: snapshot,
             visibility: worktreeVisibility
         ) {
+            selectWorkspace(updatedSelection)
+        }
+    }
+
+    private func selectWorkspace(_ target: WorkspaceNavigationTarget) {
+        var updatedSelection = selection
+        updatedSelection.select(
+            target,
+            in: snapshot,
+            visibility: worktreeVisibility
+        )
+        selectWorkspace(updatedSelection)
+    }
+
+    private func selectWorkspace(_ updatedSelection: WorkspaceSelection) {
+        if let selectWorkspace = handlers.selectWorkspace {
+            selectWorkspace(updatedSelection)
+        } else {
             selection = updatedSelection
         }
     }

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -19,6 +19,8 @@ public struct WorkspaceDisplayState {
     public let workspaceInventoryError: String?
     public let workspaceInventoryWarning: String?
     public let workspaceInventoryWarningsByHost: [UUID: String]
+    public let isWorkspaceRestorationPending: Bool
+    public let suppressesAutomaticWorktreeSessionOpen: Bool
     public let activeTmuxSession: WorkspaceTmuxSessionSelection?
     public let activeTmuxSessionIsConnected: Bool
 
@@ -37,6 +39,8 @@ public struct WorkspaceDisplayState {
         workspaceInventoryError: String? = nil,
         workspaceInventoryWarning: String? = nil,
         workspaceInventoryWarningsByHost: [UUID: String] = [:],
+        isWorkspaceRestorationPending: Bool = false,
+        suppressesAutomaticWorktreeSessionOpen: Bool = false,
         activeTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeTmuxSessionIsConnected: Bool = false
     ) {
@@ -55,6 +59,10 @@ public struct WorkspaceDisplayState {
         self.workspaceInventoryWarning = workspaceInventoryWarning
         self.workspaceInventoryWarningsByHost =
             workspaceInventoryWarningsByHost
+        self.isWorkspaceRestorationPending =
+            isWorkspaceRestorationPending
+        self.suppressesAutomaticWorktreeSessionOpen =
+            suppressesAutomaticWorktreeSessionOpen
         self.activeTmuxSession = activeTmuxSession
         self.activeTmuxSessionIsConnected =
             activeTmuxSessionIsConnected
@@ -126,6 +134,7 @@ public struct InteractionHandlers {
     public let closeWindow: (() -> Void)?
     public let dismissLogViewer: (() -> Void)?
     public let reloadTerminalConfig: (() -> Void)?
+    public let selectWorkspace: ((WorkspaceSelection) -> Void)?
     public let openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let prepareTmuxSessionKill:
@@ -154,6 +163,7 @@ public struct InteractionHandlers {
         closeWindow: (() -> Void)? = nil,
         dismissLogViewer: (() -> Void)? = nil,
         reloadTerminalConfig: (() -> Void)? = nil,
+        selectWorkspace: ((WorkspaceSelection) -> Void)? = nil,
         openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         prepareTmuxSessionKill:
@@ -181,6 +191,7 @@ public struct InteractionHandlers {
         self.closeWindow = closeWindow
         self.dismissLogViewer = dismissLogViewer
         self.reloadTerminalConfig = reloadTerminalConfig
+        self.selectWorkspace = selectWorkspace
         self.openTmuxSession = openTmuxSession
         self.closeTmuxSession = closeTmuxSession
         self.prepareTmuxSessionKill = prepareTmuxSessionKill

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -7,6 +7,7 @@ public struct WorkspaceTmuxSessionSelection:
     public var name: String
     public var worktreeID: UUID?
     public var worktreePath: String?
+    public var worktreeGeneration: String?
     public var socketName: String?
 
     public init(
@@ -14,12 +15,14 @@ public struct WorkspaceTmuxSessionSelection:
         name: String,
         worktreeID: UUID? = nil,
         worktreePath: String? = nil,
+        worktreeGeneration: String? = nil,
         socketName: String? = nil
     ) {
         self.hostID = hostID
         self.name = name
         self.worktreeID = worktreeID
         self.worktreePath = worktreePath
+        self.worktreeGeneration = worktreeGeneration
         self.socketName = socketName
     }
 
@@ -148,6 +151,7 @@ public enum WorkspaceSidebarModel {
             name: name,
             worktreeID: worktree.id,
             worktreePath: worktree.path,
+            worktreeGeneration: worktree.generation,
             socketName: worktree.tmuxSocketName
         )
     }

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -336,6 +336,36 @@ final class ApplicationDelegateTests: XCTestCase {
         )
     }
 
+    func testUpdaterAuthorizationBypassesExactlyOneTerminationGate() {
+        let delegate = ApplicationDelegate.forTesting(
+            confirmTerminationResult: false
+        )
+        delegate.authorizeNextUpdaterTermination()
+
+        XCTAssertEqual(
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateNow
+        )
+        XCTAssertFalse(delegate.terminationConfirmed)
+        XCTAssertEqual(
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateCancel
+        )
+    }
+
+    func testClearedUpdaterAuthorizationDoesNotBypassQuit() {
+        let delegate = ApplicationDelegate.forTesting(
+            confirmTerminationResult: false
+        )
+        delegate.authorizeNextUpdaterTermination()
+        delegate.clearUpdaterTerminationAuthorization()
+
+        XCTAssertEqual(
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateCancel
+        )
+    }
+
     func testTerminateSkipsConfirmWhenNoActiveSessions() {
         let delegate = ApplicationDelegate.forTesting(
             needsConfirmQuit: false,
@@ -735,44 +765,5 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertEqual(window.titleVisibility, .hidden)
     }
 
-    func testQuitPolicyRequiresConfirmationWhenRuntimeRequestsIt() {
-        XCTAssertTrue(
-            QuitPolicy.needsConfirmation(
-                confirmBeforeQuitting: true,
-                runtimeNeedsConfirmQuit: true,
-                openTerminalSurfaceCount: 0
-            )
-        )
-    }
-
-    func testQuitPolicyRequiresConfirmationWhenTerminalSurfacesRemainOpen() {
-        XCTAssertTrue(
-            QuitPolicy.needsConfirmation(
-                confirmBeforeQuitting: true,
-                runtimeNeedsConfirmQuit: false,
-                openTerminalSurfaceCount: 2
-            )
-        )
-    }
-
-    func testQuitPolicyRequiresConfirmationWhenEnabled() {
-        XCTAssertTrue(
-            QuitPolicy.needsConfirmation(
-                confirmBeforeQuitting: true,
-                runtimeNeedsConfirmQuit: false,
-                openTerminalSurfaceCount: 0
-            )
-        )
-    }
-
-    func testQuitPolicySkipsConfirmationWhenDisabled() {
-        XCTAssertFalse(
-            QuitPolicy.needsConfirmation(
-                confirmBeforeQuitting: false,
-                runtimeNeedsConfirmQuit: true,
-                openTerminalSurfaceCount: 2
-            )
-        )
-    }
 }
 #endif

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -10,7 +10,7 @@ import Testing
 struct NativeTmuxSessionCoordinatorTests {
     @Test("new named sessions use tmux create-or-attach mode")
     func namedSessionUsesCreateMode() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
@@ -52,7 +52,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("new session launch reads the current terminal presentation style")
     func newSessionLaunchReadsCurrentPresentationStyle() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         var style = TmuxPresentationStyle(
             foreground: "#3B4851",
             background: "#FFFFFF"
@@ -88,7 +88,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("existing sessions keep their current presentation by default")
     func existingSessionKeepsCurrentPresentation() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
@@ -119,7 +119,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("existing sessions accept the shared presentation opt-in")
     func existingSessionAcceptsPresentationOptIn() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
@@ -151,7 +151,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("isolated session socket participates in command routing")
     func isolatedSessionUsesReturnedSocket() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/usr/bin/tmux") },
@@ -186,12 +186,14 @@ struct NativeTmuxSessionCoordinatorTests {
             "/Applications/Ghosthub.app/Contents/Helpers/kwt"
         ))
         #expect(command.contains("/worktrees/pr-32"))
+        #expect(command.contains(#"'\''pr'\'' '\''attach'\''"#))
         #expect(command.contains("kwt-pr-0123456789abcdef"))
+        #expect(!command.contains("'open'"))
     }
 
     @Test("ordinary worktree path attaches directly through kwt")
     func ordinaryWorktreeUsesKwtAttachment() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/usr/bin/tmux") },
@@ -224,7 +226,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("endpoint changes replace provisioning and active handles")
     func endpointChangesReplaceHandles() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/usr/bin/tmux") },
@@ -280,7 +282,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("rejected terminal surfaces never report command launch")
     func rejectedSurfaceDoesNotLaunch() async {
-        let store = TmuxSurfaceStoreStub(
+        let store = RecordingTmuxSurfaceStore(
             launchError: SurfaceLaunchTestError.rejected
         )
         let coordinator = NativeTmuxSessionCoordinator(
@@ -322,7 +324,7 @@ struct NativeTmuxSessionCoordinatorTests {
 
     @Test("an exited tmux client records a closed attachment")
     func exitedClientClosesAttachment() async throws {
-        let store = TmuxSurfaceStoreStub()
+        let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/usr/bin/tmux") }
@@ -354,47 +356,4 @@ private enum SurfaceLaunchTestError: LocalizedError {
     case rejected
 
     var errorDescription: String? { "Surface launch rejected" }
-}
-
-@MainActor
-private final class TmuxPaneSurfaceStub: TmuxPaneSurfacing {
-    var blocksClipboardReads = false
-    let launchError: Error?
-    private(set) var closeObservers: [UUID: (Bool) -> Void] = [:]
-
-    init(launchError: Error? = nil) {
-        self.launchError = launchError
-    }
-
-    func registerSurfaceCloseObserver(
-        id: UUID,
-        onSurfaceClosed: @escaping (Bool) -> Void
-    ) {
-        closeObservers[id] = onSurfaceClosed
-    }
-}
-
-@MainActor
-private final class TmuxSurfaceStoreStub: TmuxSurfaceStoring {
-    let surface: TmuxPaneSurfaceStub
-    private(set) var requestedKeys: [SurfaceKey] = []
-    private(set) var requestedConfigurations: [TerminalSurfaceConfiguration] = []
-    private(set) var removedKeys: [SurfaceKey] = []
-
-    init(launchError: Error? = nil) {
-        surface = TmuxPaneSurfaceStub(launchError: launchError)
-    }
-
-    func paneSurface(
-        for key: SurfaceKey,
-        configuration: TerminalSurfaceConfiguration
-    ) -> (any TmuxPaneSurfacing)? {
-        requestedKeys.append(key)
-        requestedConfigurations.append(configuration)
-        return surface
-    }
-
-    func removeSurface(for key: SurfaceKey) {
-        removedKeys.append(key)
-    }
 }

--- a/Tests/App/QuitPolicyTests.swift
+++ b/Tests/App/QuitPolicyTests.swift
@@ -1,0 +1,13 @@
+import Testing
+@testable import GhosthubApp
+
+@Suite("Quit policy")
+struct QuitPolicyTests {
+    @Test(arguments: [true, false])
+    func followsTheUserSetting(_ enabled: Bool) {
+        #expect(
+            QuitPolicy.needsConfirmation(confirmBeforeQuitting: enabled)
+                == enabled
+        )
+    }
+}

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -373,6 +373,51 @@ func makeModel(
 
 // MARK: - Protocol Stubs
 
+@MainActor
+final class RecordingTmuxSurfaceStore: TmuxSurfaceStoring {
+    let surface: RecordingTmuxPaneSurface
+    private(set) var requestedKeys: [SurfaceKey] = []
+    private(set) var requestedConfigurations: [TerminalSurfaceConfiguration] = []
+    private(set) var removedKeys: [SurfaceKey] = []
+
+    var lastCommand: String? { requestedConfigurations.last?.command }
+
+    init(launchError: Error? = nil) {
+        surface = RecordingTmuxPaneSurface(launchError: launchError)
+    }
+
+    func paneSurface(
+        for key: SurfaceKey,
+        configuration: TerminalSurfaceConfiguration
+    ) -> (any TmuxPaneSurfacing)? {
+        requestedKeys.append(key)
+        requestedConfigurations.append(configuration)
+        return surface
+    }
+
+    func removeSurface(for key: SurfaceKey) {
+        removedKeys.append(key)
+    }
+}
+
+@MainActor
+final class RecordingTmuxPaneSurface: TmuxPaneSurfacing {
+    var blocksClipboardReads = false
+    let launchError: Error?
+    private(set) var closeObservers: [UUID: (Bool) -> Void] = [:]
+
+    init(launchError: Error? = nil) {
+        self.launchError = launchError
+    }
+
+    func registerSurfaceCloseObserver(
+        id: UUID,
+        onSurfaceClosed: @escaping (Bool) -> Void
+    ) {
+        closeObservers[id] = onSurfaceClosed
+    }
+}
+
 final class NotificationServiceStub: NotificationService {
     struct IdleNotification: Equatable {
         let worktreeName: String

--- a/Tests/App/UpdateControllerTests.swift
+++ b/Tests/App/UpdateControllerTests.swift
@@ -75,4 +75,74 @@ struct UpdateControllerTests {
             ).isReady
         )
     }
+
+    @MainActor
+    @Test("pre-relaunch refreshes scenes before arming termination")
+    func preRelaunchOrdering() {
+        var events: [String] = []
+        let delegate = UpdateInstallationDelegate(
+            refreshRestorationState: { events.append("refresh") },
+            authorizeTermination: { events.append("authorize") },
+            clearTerminationAuthorization: { events.append("clear") }
+        )
+
+        delegate.prepareForRelaunch()
+
+        #expect(events == ["refresh", "authorize"])
+    }
+
+    @MainActor
+    @Test("aborted or finished update sessions clear unused authorization")
+    func updateSessionCleanup() {
+        var clearCount = 0
+        let delegate = UpdateInstallationDelegate(
+            refreshRestorationState: {},
+            authorizeTermination: {},
+            clearTerminationAuthorization: { clearCount += 1 }
+        )
+
+        delegate.updateSessionDidAbort()
+        delegate.updateSessionDidFinish(error: false)
+
+        #expect(clearCount == 2)
+    }
+
+    @MainActor
+    @Test("a cycle finish racing a pending relaunch keeps termination armed")
+    func pendingRelaunchSurvivesCycleFinish() {
+        var clearCount = 0
+        let delegate = UpdateInstallationDelegate(
+            refreshRestorationState: {},
+            authorizeTermination: {},
+            clearTerminationAuthorization: { clearCount += 1 }
+        )
+
+        delegate.prepareForRelaunch()
+        delegate.updateSessionDidFinish(error: false)
+
+        #expect(clearCount == 0)
+    }
+
+    @MainActor
+    @Test(
+        "a failed relaunch disarms termination",
+        arguments: [true, false]
+    )
+    func failedRelaunchDisarmsTermination(_ aborts: Bool) {
+        var clearCount = 0
+        let delegate = UpdateInstallationDelegate(
+            refreshRestorationState: {},
+            authorizeTermination: {},
+            clearTerminationAuthorization: { clearCount += 1 }
+        )
+
+        delegate.prepareForRelaunch()
+        if aborts {
+            delegate.updateSessionDidAbort()
+        } else {
+            delegate.updateSessionDidFinish(error: true)
+        }
+
+        #expect(clearCount == 1)
+    }
 }

--- a/Tests/App/WindowRegistryTests.swift
+++ b/Tests/App/WindowRegistryTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+@Suite("Workspace window registry")
+struct WindowRegistryTests {
+    @Test("refreshes each live scene and drops unregistered scenes")
+    func refreshesLiveSceneBindings() throws {
+        let firstEnvironment = try setupHostEnvironment()
+        let secondEnvironment = try setupHostEnvironment()
+        let first = try makeModel(
+            database: firstEnvironment.database,
+            localHostID: firstEnvironment.host.id,
+            snapshot: firstEnvironment.snapshot
+        )
+        let second = try makeModel(
+            database: secondEnvironment.database,
+            localHostID: secondEnvironment.host.id,
+            snapshot: secondEnvironment.snapshot
+        )
+        let registry = WindowRegistry()
+        var firstRefreshes = 0
+        var secondRefreshes = 0
+        registry.register(first) { firstRefreshes += 1 }
+        registry.register(second) { secondRefreshes += 1 }
+
+        registry.refreshRestorationStates()
+        #expect(firstRefreshes == 1)
+        #expect(secondRefreshes == 1)
+
+        registry.unregister(first)
+        registry.refreshRestorationStates()
+        #expect(firstRefreshes == 1)
+        #expect(secondRefreshes == 2)
+    }
+}

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -1,0 +1,864 @@
+import Foundation
+import GhosthubTerminal
+import GhosthubTmux
+import GhosthubUI
+import GhosthubWorkspace
+import GhosthubSettings
+import Testing
+@testable import GhosthubApp
+
+private let restorationWorktreeGeneration =
+    "0123456789abcdef0123456789abcdef"
+
+final class RestorationInventoryState: @unchecked Sendable {
+    private let lock = NSLock()
+    private let sessionName: String
+    private var isReachable: Bool
+    private var isPublished = false
+    private var attempts = 0
+
+    init(sessionName: String, initiallyReachable: Bool = true) {
+        self.sessionName = sessionName
+        isReachable = initiallyReachable
+    }
+
+    func publishExactSession() {
+        lock.lock()
+        isReachable = true
+        isPublished = true
+        lock.unlock()
+    }
+
+    var attemptCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return attempts
+    }
+
+    func discover(
+        _ host: TmuxHost
+    ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+        lock.lock()
+        attempts += 1
+        let reachable = isReachable
+        let published = isPublished
+        lock.unlock()
+        guard reachable else {
+            return .failure(.sshConnectionFailed(host: host.displayName))
+        }
+        return .success(published ? [
+            DiscoveredTmuxSession(
+                name: sessionName,
+                windowCount: 1,
+                createdAt: "1721552400",
+                managed: false
+            ),
+        ] : [])
+    }
+}
+
+@MainActor
+private struct RemoteRestorationHarness {
+    let model: WorkspaceSceneModel
+    let inventory: RestorationInventoryState
+    let surfaceStore: RecordingTmuxSurfaceStore
+    let savedState: WorkspaceWindowState
+
+    static func make(
+        publishSession: Bool,
+        additionalHost: HostSummary? = nil
+    ) throws -> Self {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "editor"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        if let additionalHost {
+            snapshot.hosts.append(additionalHost)
+        }
+        let inventory = RestorationInventoryState(
+            sessionName: "editor",
+            initiallyReachable: publishSession
+        )
+        if publishSession {
+            inventory.publishExactSession()
+        }
+        let surfaceStore = RecordingTmuxSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: inventory.discover
+        )
+        let savedState = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "editor",
+                socketName: nil,
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+        return Self(
+            model: model,
+            inventory: inventory,
+            surfaceStore: surfaceStore,
+            savedState: savedState
+        )
+    }
+}
+
+private final class ProtectedProbeSpy: @unchecked Sendable {
+    enum Outcome: Sendable {
+        case present
+        case absent
+        case failed
+    }
+
+    private let lock = NSLock()
+    private var outcome: Outcome
+    private var recordedSelections: [WorkspaceTmuxSessionSelection] = []
+    private var completedReads = 0
+
+    init(outcome: Outcome) {
+        self.outcome = outcome
+    }
+
+    var selections: [WorkspaceTmuxSessionSelection] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSelections
+    }
+
+    var completionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return completedReads
+    }
+
+    func setOutcome(_ outcome: Outcome) {
+        lock.lock()
+        self.outcome = outcome
+        lock.unlock()
+    }
+
+    func read(
+        _ selection: WorkspaceTmuxSessionSelection,
+        _ host: TmuxHost
+    ) async throws -> TmuxSessionIdentity {
+        let current = record(selection)
+        defer { recordCompletion() }
+        switch current {
+        case .present:
+            return TmuxSessionIdentity(
+                serverPID: "123",
+                sessionID: "$7",
+                createdAt: "1721552400"
+            )
+        case .absent:
+            throw TmuxSessionKillError.sessionNotRunning(
+                host: host.displayName,
+                session: selection.name
+            )
+        case .failed:
+            throw TmuxSessionKillError.identityCommandFailed(
+                host: host.displayName,
+                session: selection.name,
+                status: 255
+            )
+        }
+    }
+
+    private func record(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) -> Outcome {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedSelections.append(selection)
+        return outcome
+    }
+
+    private func recordCompletion() {
+        lock.lock()
+        completedReads += 1
+        lock.unlock()
+    }
+}
+
+private final class ControlledProtectedProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedHosts: [TmuxHost] = []
+    private var recordedSelections: [WorkspaceTmuxSessionSelection] = []
+    private var continuations:
+        [Int: CheckedContinuation<TmuxSessionIdentity, any Error>] = [:]
+    private var completedReads = 0
+
+    var hosts: [TmuxHost] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedHosts
+    }
+
+    var selections: [WorkspaceTmuxSessionSelection] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSelections
+    }
+
+    var completionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return completedReads
+    }
+
+    func read(
+        _ selection: WorkspaceTmuxSessionSelection,
+        _ host: TmuxHost
+    ) async throws -> TmuxSessionIdentity {
+        defer { recordCompletion() }
+        return try await withCheckedThrowingContinuation {
+            continuation in
+            lock.lock()
+            let index = recordedHosts.count
+            recordedHosts.append(host)
+            recordedSelections.append(selection)
+            continuations[index] = continuation
+            lock.unlock()
+        }
+    }
+
+    func complete(_ index: Int) {
+        lock.lock()
+        let continuation = continuations.removeValue(forKey: index)
+        lock.unlock()
+        continuation?.resume(returning: TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$7",
+            createdAt: "1721552400"
+        ))
+    }
+
+    func fail(_ index: Int) {
+        lock.lock()
+        let continuation = continuations.removeValue(forKey: index)
+        let host = recordedHosts[index]
+        let selection = recordedSelections[index]
+        lock.unlock()
+        continuation?.resume(throwing: TmuxSessionKillError
+            .identityCommandFailed(
+                host: host.displayName,
+                session: selection.name,
+                status: 255
+            ))
+    }
+
+    private func recordCompletion() {
+        lock.lock()
+        completedReads += 1
+        lock.unlock()
+    }
+}
+
+@MainActor
+private struct ProtectedRestorationHarness {
+    let model: WorkspaceSceneModel
+    let probe: ProtectedProbeSpy
+    let savedState: WorkspaceWindowState
+
+    static func make(outcome: ProtectedProbeSpy.Outcome) throws -> Self {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName = "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(name: "pr-42", managed: false, windows: []),
+        ]
+        let probe = ProtectedProbeSpy(outcome: outcome)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: probe.read
+        )
+        let savedState = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt-pr-0123456789abcdef",
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+        return Self(model: model, probe: probe, savedState: savedState)
+    }
+}
+
+@MainActor
+@Suite("Workspace restoration")
+struct WorkspaceRestorationTests {
+    @Test("ordinary restoration waits for exact direct discovery then attaches only")
+    func ordinaryRestorationIsAttachOnly() async throws {
+        let inventory = RestorationInventoryState(sessionName: "editor")
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "editor"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let store = RecordingTmuxSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: store,
+            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            tmuxSessionDiscovery: inventory.discover
+        )
+        model.startTmuxSessionDiscovery()
+        model.beginRestoration(WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "editor",
+                socketName: nil,
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        ))
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        inventory.publishExactSession()
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection?.name == "editor"
+        }
+        #expect(!model.suppressesAutomaticWorktreeSessionOpen)
+
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return store.lastCommand != nil
+        }
+        let command = try #require(store.lastCommand)
+        #expect(command.contains("attach-session"))
+        #expect(command.contains("'=editor'"))
+        #expect(!command.contains("kwt"))
+        #expect(!command.contains("new-session"))
+    }
+
+    @Test("remote restoration keeps SSH reconnect while avoiding kwt open")
+    func remoteRestorationIsAttachOnly() async throws {
+        let harness = try RemoteRestorationHarness.make(publishSession: true)
+        harness.model.startTmuxSessionDiscovery()
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntilMainActor {
+            harness.model.prepareActiveBorrowedTmuxSurface()
+            return harness.surfaceStore.lastCommand != nil
+        }
+
+        let command = try #require(harness.surfaceStore.lastCommand)
+        #expect(command.contains("ServerAliveInterval=15"))
+        #expect(command.contains("attach-session"))
+        #expect(!command.contains("'open'"))
+        #expect(!command.contains("new-session"))
+    }
+
+    @Test("protected restoration probes exact socket before kwt attach")
+    func protectedRestorationProbesBeforeAttach() async throws {
+        let harness = try ProtectedRestorationHarness.make(outcome: .present)
+
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntil { harness.probe.selections.count == 1 }
+
+        let selection = try #require(harness.probe.selections.first)
+        #expect(selection.name == "pr-42")
+        #expect(
+            selection.socketName
+                == "kwt-pr-0123456789abcdef"
+        )
+        await waitUntilMainActor {
+            harness.model.activeBorrowedTmuxSelection != nil
+        }
+        #expect(
+            harness.model.activeBorrowedTmuxSelection?.socketName
+                == "kwt-pr-0123456789abcdef"
+        )
+        #expect(!harness.model.suppressesAutomaticWorktreeSessionOpen)
+    }
+
+    @Test("absent protected session remains pending without fallback")
+    func protectedAbsenceStaysPending() async throws {
+        let harness = try ProtectedRestorationHarness.make(outcome: .absent)
+
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntil { harness.probe.completionCount >= 1 }
+
+        #expect(harness.model.activeBorrowedTmuxSelection == nil)
+        #expect(
+            harness.model.restorationState(
+                windowID: harness.savedState.windowID
+            ) == harness.savedState
+        )
+    }
+
+    @Test("failed protected probe retries only after inventory refresh")
+    func protectedFailureRetriesOnRefresh() async throws {
+        let harness = try ProtectedRestorationHarness.make(outcome: .failed)
+
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntil { harness.probe.completionCount >= 1 }
+        #expect(harness.model.activeBorrowedTmuxSelection == nil)
+
+        harness.probe.setOutcome(.present)
+        harness.model.startTmuxSessionDiscovery()
+        harness.model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            harness.model.activeBorrowedTmuxSelection != nil
+        }
+
+        let secondSelection = try #require(harness.probe.selections.last)
+        #expect(secondSelection.name == "pr-42")
+        #expect(
+            secondSelection.socketName
+                == "kwt-pr-0123456789abcdef"
+        )
+    }
+
+    @Test("offline remote restoration retries after inventory refresh")
+    func offlineRemoteRetries() async throws {
+        let harness = try RemoteRestorationHarness.make(publishSession: false)
+        harness.model.startTmuxSessionDiscovery()
+        harness.model.beginRestoration(harness.savedState)
+        #expect(harness.model.activeBorrowedTmuxSelection == nil)
+        await waitUntilMainActor {
+            harness.inventory.attemptCount >= 1
+                && harness.model.snapshot.hosts.contains {
+                    $0.kind == .remote && $0.connectionState == .offline
+                }
+        }
+        #expect(
+            harness.model.restorationState(
+                windowID: harness.savedState.windowID
+            ) == harness.savedState
+        )
+
+        harness.inventory.publishExactSession()
+        harness.model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            harness.model.activeBorrowedTmuxSelection?.name == "editor"
+        }
+    }
+
+    @Test("explicit navigation cancels pending remote restoration")
+    func navigationCancelsPendingRestoration() async throws {
+        let otherHostID = UUID()
+        let otherHost = HostSummary(
+            id: otherHostID,
+            configKey: "other-host",
+            name: "Other Host",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "other.example.test"
+        )
+        let harness = try RemoteRestorationHarness.make(
+            publishSession: false,
+            additionalHost: otherHost
+        )
+        harness.model.startTmuxSessionDiscovery()
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntilMainActor {
+            harness.inventory.attemptCount >= 1
+                && harness.model.snapshot.hosts.contains {
+                    $0.kind == .remote && $0.connectionState == .offline
+                }
+        }
+        #expect(
+            harness.model.restorationState(
+                windowID: harness.savedState.windowID
+            ) == harness.savedState
+        )
+
+        var userSelection = harness.model.selection
+        userSelection.select(.host(otherHostID), in: harness.model.snapshot)
+        harness.model.selectFromUser(userSelection)
+        #expect(
+            harness.model.restorationState(
+                windowID: harness.savedState.windowID
+            ) != harness.savedState
+        )
+        let attemptsBeforeRefresh = harness.inventory.attemptCount
+        harness.inventory.publishExactSession()
+        harness.model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            harness.inventory.attemptCount > attemptsBeforeRefresh
+                && harness.model.workspaceInventoryState == .loaded
+        }
+
+        #expect(harness.model.selection.selectedHostID == otherHostID)
+        #expect(harness.model.activeBorrowedTmuxSelection == nil)
+    }
+
+    @Test("indexed worktree shortcut cancels pending restoration")
+    func indexedShortcutCancelsPendingRestoration() throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        let secondWorktree = WorktreeSummary(
+            id: UUID(),
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "worktree:/tmp/ghosthub-second",
+            name: "second",
+            path: "/tmp/ghosthub-second",
+            branch: "second"
+        )
+        snapshot.worktrees.append(secondWorktree)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot
+        )
+        let pending = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "unavailable-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        )
+        model.beginRestoration(pending)
+
+        model.selectIndexedWorktree(2)
+
+        #expect(model.selection.selectedWorktreeID == secondWorktree.id)
+        #expect(
+            model.restorationState(windowID: pending.windowID) != pending
+        )
+    }
+
+    @Test(
+        "previous and next worktree shortcuts cancel pending restoration",
+        arguments: [-1, 1]
+    )
+    func steppedShortcutCancelsPendingRestoration(_ step: Int) throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        let secondWorktree = WorktreeSummary(
+            id: UUID(),
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "worktree:/tmp/ghosthub-second",
+            name: "second",
+            path: "/tmp/ghosthub-second",
+            branch: "second"
+        )
+        snapshot.worktrees.append(secondWorktree)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot
+        )
+        model.synchronizeSelection(WorkspaceSelection(
+            selectedHostID: environment.host.id,
+            selectedProjectID: environment.project.id,
+            selectedWorktreeID: environment.worktree.id
+        ))
+        let pending = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "unavailable-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        )
+        model.beginRestoration(pending)
+
+        model.stepWorktree(by: step)
+
+        #expect(model.selection.selectedWorktreeID == secondWorktree.id)
+        #expect(
+            model.restorationState(windowID: pending.windowID) != pending
+        )
+    }
+
+    @Test("automatic selection normalization preserves pending restoration")
+    func automaticSelectionPreservesPendingRestoration() throws {
+        let harness = try RemoteRestorationHarness.make(publishSession: false)
+        harness.model.beginRestoration(harness.savedState)
+        var normalizedSelection = harness.model.selection
+        normalizedSelection.selectedProjectID = nil
+        normalizedSelection.selectedWorktreeID = nil
+
+        harness.model.synchronizeSelection(normalizedSelection)
+
+        #expect(
+            harness.model.restorationState(
+                windowID: harness.savedState.windowID
+            ) == harness.savedState
+        )
+    }
+
+    @Test("navigation-only restoration suppression lasts until explicit navigation")
+    func navigationOnlySuppressionRequiresNavigation() throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: nil
+        )
+
+        model.beginRestoration(state)
+
+        #expect(model.selection.selectedWorktreeID == environment.worktree.id)
+        #expect(!model.isWorkspaceRestorationPending)
+        #expect(model.suppressesAutomaticWorktreeSessionOpen)
+
+        model.selectFromUser(model.selection)
+
+        #expect(!model.suppressesAutomaticWorktreeSessionOpen)
+    }
+
+    @Test("protected restoration retries inventory changed during its probe")
+    func protectedInventoryRefreshRetriesAfterProbe() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName =
+            "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let probe = ControlledProtectedProbe()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: probe.read
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt-pr-0123456789abcdef",
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+
+        model.beginRestoration(state)
+        await waitUntil { probe.selections.count == 1 }
+        var updatedSnapshot = model.snapshot
+        updatedSnapshot.worktrees[0].path = "/tmp/ghosthub-refreshed"
+        model.snapshot = updatedSnapshot
+        guard case .needsProtectedProbe = WorkspaceWindowRestorationResolver
+            .resolve(state, in: model.snapshot) else {
+            Issue.record("updated target should still require a probe")
+            return
+        }
+        probe.complete(0)
+        await waitUntil { probe.completionCount == 1 }
+
+        await waitUntil { probe.selections.count == 2 }
+        #expect(
+            probe.selections.last?.worktreePath
+                == "/tmp/ghosthub-refreshed"
+        )
+        probe.complete(1)
+        await waitUntil { probe.completionCount == 2 }
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection != nil
+        }
+
+        #expect(model.activeBorrowedTmuxSelection?.name == "pr-42")
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreePath
+                == "/tmp/ghosthub-refreshed"
+        )
+    }
+
+    @Test("failed protected probe retries an inventory refresh queued during the probe")
+    func failedProtectedProbeRetriesQueuedRefresh() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName =
+            "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let probe = ControlledProtectedProbe()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: probe.read
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt-pr-0123456789abcdef",
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+
+        model.beginRestoration(state)
+        await waitUntil { probe.selections.count == 1 }
+        var updatedSnapshot = model.snapshot
+        updatedSnapshot.worktrees[0].path = "/tmp/ghosthub-refreshed"
+        model.snapshot = updatedSnapshot
+        probe.fail(0)
+        await waitUntil { probe.completionCount == 1 }
+
+        await waitUntil { probe.selections.count == 2 }
+        probe.complete(1)
+        await waitUntil { probe.completionCount == 2 }
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection != nil
+        }
+
+        #expect(model.activeBorrowedTmuxSelection?.name == "pr-42")
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreePath
+                == "/tmp/ghosthub-refreshed"
+        )
+    }
+
+    @Test("protected restoration rejects worktree ownership changed during its probe")
+    func protectedWorktreeOwnershipMustRemainStable() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName =
+            "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let probe = ControlledProtectedProbe()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: probe.read
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt-pr-0123456789abcdef",
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+
+        model.beginRestoration(state)
+        await waitUntil { probe.hosts.count == 1 }
+        model.snapshot.worktrees[0].tmuxSessionName = "replacement"
+        probe.complete(0)
+        await waitUntil { probe.completionCount == 1 }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.restorationState(windowID: state.windowID) == state)
+    }
+
+    @Test("a canceled protected probe cannot authorize restarted restoration")
+    func canceledProtectedProbeCannotAttach() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName =
+            "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let probe = ControlledProtectedProbe()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: probe.read
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt-pr-0123456789abcdef",
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+
+        model.beginRestoration(state)
+        await waitUntil { probe.hosts.count == 1 }
+        model.cancelPendingRestoration()
+        model.beginRestoration(state)
+        await waitUntil { probe.hosts.count == 2 }
+
+        probe.complete(0)
+        await waitUntil { probe.completionCount == 1 }
+        #expect(model.activeBorrowedTmuxSelection == nil)
+
+        probe.complete(1)
+        await waitUntil { probe.completionCount == 2 }
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection != nil
+        }
+    }
+}

--- a/Tests/App/WorkspaceTabRequestTests.swift
+++ b/Tests/App/WorkspaceTabRequestTests.swift
@@ -19,26 +19,26 @@ struct WorkspaceTabRequestTests {
 
     @Test("outstanding requests retain their own tab parents")
     func outstandingRequestsRetainParents() {
-        let firstID = UUID()
-        let secondID = UUID()
+        let firstState = WorkspaceWindowState.fresh()
+        let secondState = WorkspaceWindowState.fresh()
         let firstParent = Window(isWorkspace: true)
         let secondParent = Window(isWorkspace: true)
         let firstWindow = Window(isWorkspace: true)
         let secondWindow = Window(isWorkspace: true)
         let requests = WorkspaceWindowRequests<Window>()
 
-        requests.add(firstID, parent: firstParent)
-        requests.add(secondID, parent: secondParent)
+        requests.add(firstState.windowID, parent: firstParent)
+        requests.add(secondState.windowID, parent: secondParent)
 
         #expect(
             requests.consumeParent(
-                for: secondID,
+                for: secondState.windowID,
                 window: secondWindow
             ) === secondParent
         )
         #expect(
             requests.consumeParent(
-                for: firstID,
+                for: firstState.windowID,
                 window: firstWindow
             ) === firstParent
         )
@@ -46,31 +46,38 @@ struct WorkspaceTabRequestTests {
 
     @Test("an independent request does not overwrite tab intent")
     func independentRequestDoesNotOverwriteTab() {
-        let tabID = UUID()
-        let windowID = UUID()
+        let tabState = WorkspaceWindowState.fresh()
+        let independentState = WorkspaceWindowState.fresh()
+        let restoredState = WorkspaceWindowState.fresh()
         let parent = Window(isWorkspace: true)
         let tabWindow = Window(isWorkspace: true)
         let independentWindow = Window(isWorkspace: true)
         let requests = WorkspaceWindowRequests<Window>()
 
-        requests.add(tabID, parent: parent)
-        requests.add(windowID, parent: nil)
+        requests.add(tabState.windowID, parent: parent)
+        requests.add(independentState.windowID, parent: nil)
 
         #expect(
             requests.consumeParent(
-                for: windowID,
+                for: independentState.windowID,
                 window: independentWindow
             ) == nil
         )
         #expect(
             requests.consumeParent(
-                for: tabID,
+                for: restoredState.windowID,
+                window: independentWindow
+            ) == nil
+        )
+        #expect(
+            requests.consumeParent(
+                for: tabState.windowID,
                 window: tabWindow
             ) === parent
         )
         #expect(
             requests.consumeParent(
-                for: tabID,
+                for: tabState.windowID,
                 window: tabWindow
             ) == nil
         )

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -333,10 +333,13 @@ struct WorkspaceTmuxDiscoveryTests {
     @Test("ordinary worktree navigation attaches without creating")
     func worktreeNavigationUsesAttachMode() throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -350,6 +353,51 @@ struct WorkspaceTmuxDiscoveryTests {
 
         #expect(model.activeBorrowedTmuxLaunchMode == .attach)
         #expect(model.pendingCreatedTmuxSessionCount == 0)
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreeGeneration
+                == "0123456789abcdef0123456789abcdef"
+        )
+    }
+
+    @MainActor
+    @Test("explicit reselection attaches a replaced worktree's session")
+    func explicitReselectionAttachesReplacedSession() throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "editor"
+        snapshot.worktrees[0].generation =
+            "fedcba9876543210fedcba9876543210"
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+        )
+        let observed = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "editor",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(observed)
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreeGeneration
+                == "0123456789abcdef0123456789abcdef"
+        )
+
+        var reselection = model.selection
+        reselection.select(
+            .worktree(environment.worktree.id),
+            in: model.snapshot
+        )
+        model.selectFromUser(reselection)
+
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreeGeneration
+                == "fedcba9876543210fedcba9876543210"
+        )
+        #expect(model.activeBorrowedTmuxLaunchMode == .attach)
     }
 
     @MainActor
@@ -657,6 +705,89 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(request.sessionID == "$42")
         #expect(request.sessionCreatedAt == "1721552400")
         #expect(identityReads.count == 1)
+    }
+
+    @MainActor
+    @Test("protected kill availability survives a generation change")
+    func protectedKillSurvivesGenerationChange() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { _, _ in
+                _ = identityReads.increment()
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            }
+        )
+        var selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
+            socketName: "protected"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await Task.yield()
+
+        selection.worktreeGeneration =
+            "fedcba9876543210fedcba9876543210"
+        let request = try await model.prepareTmuxSessionKill(selection)
+
+        #expect(request.serverPID == "31415")
+        #expect(identityReads.count == 1)
+    }
+
+    @MainActor
+    @Test("kill closes the active attachment across a generation change")
+    func killClosesAttachmentAcrossGenerationChange() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "kwt-ghosthub-main",
+                managed: false,
+                windows: [],
+                serverPID: "31415",
+                sessionID: "$8",
+                createdAt: "1721552400"
+            ),
+        ]
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            tmuxSessionKiller: { _, _, _ in }
+        )
+        var selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(selection)
+
+        selection.worktreeGeneration =
+            "fedcba9876543210fedcba9876543210"
+        let request = try await model.prepareTmuxSessionKill(selection)
+        try await model.killTmuxSession(request)
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(
+            model.selection.selectedHostID == environment.host.id
+        )
     }
 
     @MainActor

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -1,0 +1,595 @@
+import Foundation
+import GhosthubUI
+import GhosthubWorkspace
+import Testing
+@testable import GhosthubApp
+
+private struct RestorationFixture {
+    static let worktreeGeneration =
+        "0123456789abcdef0123456789abcdef"
+
+    let snapshot: WorkspaceSnapshot
+    let selection: WorkspaceSelection
+    let tmuxSelection: WorkspaceTmuxSessionSelection
+
+    static func local(
+        sessionName: String,
+        socketName: String? = nil
+    ) -> Self {
+        let hostID = UUID()
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let projectKey = "github.com/kenn-io/ghosthub"
+        let worktreeScopedKey = "worktree:pr-42"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [
+                HostSummary(
+                    id: hostID,
+                    configKey: "local",
+                    name: "This Mac",
+                    kind: .selfHost,
+                    platform: .macOS,
+                    preferredTransport: .local,
+                    tmuxSessions: socketName == nil ? [
+                        TmuxSessionSummary(
+                            name: sessionName,
+                            managed: false,
+                            windows: []
+                        ),
+                    ] : [],
+                    decodedConnectionState: .local
+                ),
+            ],
+            projects: [
+                ProjectSummary(
+                    id: projectID,
+                    hostID: hostID,
+                    scopedKey: projectKey,
+                    name: "Ghosthub",
+                    rootPath: "/tmp/ghosthub"
+                ),
+            ],
+            worktrees: [
+                WorktreeSummary(
+                    id: worktreeID,
+                    hostID: hostID,
+                    projectID: projectID,
+                    scopedKey: worktreeScopedKey,
+                    name: "pr-42",
+                    path: "/tmp/ghosthub-pr-42",
+                    branch: "pr-42",
+                    generation: worktreeGeneration,
+                    tmuxSessionName: sessionName,
+                    tmuxSocketName: socketName,
+                    sessionBackend: .localTmux
+                ),
+            ]
+        )
+        return Self(
+            snapshot: snapshot,
+            selection: WorkspaceSelection(
+                selectedHostID: hostID,
+                selectedProjectID: projectID,
+                selectedWorktreeID: worktreeID
+            ),
+            tmuxSelection: WorkspaceTmuxSessionSelection(
+                hostID: hostID,
+                name: sessionName,
+                worktreeID: worktreeID,
+                worktreePath: "/tmp/ghosthub-pr-42",
+                worktreeGeneration: worktreeGeneration,
+                socketName: socketName
+            )
+        )
+    }
+
+    func reidentified() -> Self {
+        Self.local(
+            sessionName: tmuxSelection.name,
+            socketName: tmuxSelection.socketName
+        )
+    }
+
+    static let invalidStates = [
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: " ", projectKey: nil, worktreeGeneration: nil
+            ),
+            tmux: nil
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local",
+                projectKey: nil,
+                worktreeGeneration: worktreeGeneration
+            ),
+            tmux: nil
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local",
+                projectKey: "github.com/kenn-io/ghosthub",
+                worktreeGeneration: "not-a-generation"
+            ),
+            tmux: nil
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local", projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: .init(
+                hostKey: "remote",
+                sessionName: "editor",
+                socketName: nil,
+                owner: .unbound
+            )
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local", projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: .init(
+                hostKey: "local",
+                sessionName: " ",
+                socketName: nil,
+                owner: .unbound
+            )
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local",
+                projectKey: "github.com/kenn-io/ghosthub",
+                worktreeGeneration: worktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: "local",
+                sessionName: "editor",
+                socketName: " ",
+                owner: .worktree(generation: worktreeGeneration)
+            )
+        ),
+        WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "local",
+                projectKey: "github.com/kenn-io/ghosthub",
+                worktreeGeneration: worktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: "local",
+                sessionName: "editor",
+                socketName: nil,
+                owner: .unbound
+            )
+        ),
+    ]
+}
+
+@Suite("Workspace window restoration state")
+struct WorkspaceWindowStateTests {
+    enum OrdinaryOwnershipDrift: CaseIterable, Sendable {
+        case sessionName
+        case socket
+    }
+
+    @Test("capture stores stable keys and exact tmux identity")
+    func captureUsesStableIdentity() {
+        let fixture = RestorationFixture.local(
+            sessionName: "kwt-ghosthub-main",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+
+        #expect(state.navigation?.hostKey == "local")
+        #expect(state.navigation?.projectKey == "github.com/kenn-io/ghosthub")
+        #expect(
+            state.navigation?.worktreeGeneration
+                == RestorationFixture.worktreeGeneration
+        )
+        #expect(state.tmux?.sessionName == "kwt-ghosthub-main")
+        #expect(state.tmux?.socketName == "kwt-pr-0123456789abcdef")
+        #expect(
+            state.tmux?.owner == .worktree(
+                generation: RestorationFixture.worktreeGeneration
+            )
+        )
+    }
+
+    @Test("an unbound session beside worktree navigation keeps navigation only")
+    func unboundSessionBesideWorktreeNavigationDropsTmux() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let unboundSession = WorkspaceTmuxSessionSelection(
+            hostID: fixture.tmuxSelection.hostID,
+            name: "docbank"
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: unboundSession,
+            snapshot: fixture.snapshot
+        )
+
+        #expect(state.tmux == nil)
+        #expect(
+            state.navigation?.worktreeGeneration
+                == RestorationFixture.worktreeGeneration
+        )
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: fixture.snapshot
+            ) == .ready(selection: fixture.selection, tmux: nil)
+        )
+    }
+
+    @Test("an unbound session persists only for host-level navigation")
+    func unboundSessionPersistsOnlyAtHostLevel() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let unboundSession = WorkspaceTmuxSessionSelection(
+            hostID: fixture.tmuxSelection.hostID,
+            name: "docbank"
+        )
+        let hostOnly = WorkspaceSelection(
+            selectedHostID: fixture.selection.selectedHostID
+        )
+
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: hostOnly,
+            activeTmux: unboundSession,
+            snapshot: fixture.snapshot
+        )
+
+        #expect(state.tmux?.sessionName == "docbank")
+        #expect(state.tmux?.owner == .unbound)
+    }
+
+    enum UnboundOverlapNavigation: CaseIterable, Sendable {
+        case project
+        case generationlessWorktree
+    }
+
+    @Test(
+        "navigating below host level drops a lingering unbound session",
+        arguments: UnboundOverlapNavigation.allCases
+    )
+    func unboundSessionDroppedBelowHostLevel(
+        _ navigation: UnboundOverlapNavigation
+    ) {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        var snapshot = fixture.snapshot
+        var selection = fixture.selection
+        switch navigation {
+        case .project:
+            selection.selectedWorktreeID = nil
+        case .generationlessWorktree:
+            snapshot.worktrees[0].generation = nil
+        }
+        let unboundSession = WorkspaceTmuxSessionSelection(
+            hostID: fixture.tmuxSelection.hostID,
+            name: "docbank"
+        )
+
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: selection,
+            activeTmux: unboundSession,
+            snapshot: snapshot
+        )
+
+        #expect(state.tmux == nil)
+        #expect(state.navigation?.projectKey != nil)
+    }
+
+    @Test("a session owned by another worktree keeps navigation only")
+    func foreignWorktreeSessionBesideNavigationDropsTmux() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let foreignSession = WorkspaceTmuxSessionSelection(
+            hostID: fixture.tmuxSelection.hostID,
+            name: "other-editor",
+            worktreeID: UUID(),
+            worktreePath: "/tmp/ghosthub-other",
+            worktreeGeneration: "fedcba9876543210fedcba9876543210"
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: foreignSession,
+            snapshot: fixture.snapshot
+        )
+
+        #expect(state.tmux == nil)
+        #expect(
+            state.navigation?.worktreeGeneration
+                == RestorationFixture.worktreeGeneration
+        )
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: fixture.snapshot
+            ) == .ready(selection: fixture.selection, tmux: nil)
+        )
+    }
+
+    @Test("stable keys resolve after runtime UUIDs change")
+    func resolvesFreshRuntimeObjects() {
+        let before = RestorationFixture.local(sessionName: "editor")
+        let saved = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: before.selection,
+            activeTmux: before.tmuxSelection,
+            snapshot: before.snapshot
+        )
+        let after = before.reidentified()
+
+        let result = WorkspaceWindowRestorationResolver.resolve(
+            saved,
+            in: after.snapshot
+        )
+
+        #expect(result == .ready(
+            selection: after.selection,
+            tmux: after.tmuxSelection
+        ))
+    }
+
+    @Test("same-path replacement does not inherit restored identity")
+    func samePathReplacementStaysPending() {
+        let before = RestorationFixture.local(sessionName: "editor")
+        let saved = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: before.selection,
+            activeTmux: before.tmuxSelection,
+            snapshot: before.snapshot
+        )
+        let after = before.reidentified()
+        var replacement = after.snapshot
+        replacement.worktrees[0].generation =
+            "fedcba9876543210fedcba9876543210"
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                saved,
+                in: replacement
+            ) == .pending(
+                selection: WorkspaceSelection(
+                    selectedHostID: replacement.hosts[0].id,
+                    selectedProjectID: replacement.projects[0].id
+                )
+            )
+        )
+    }
+
+    @Test("active presentation keeps its observed generation after ID reuse")
+    func activePresentationRejectsGenerationReplacement() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        var replacement = fixture.snapshot
+        replacement.worktrees[0].generation =
+            "fedcba9876543210fedcba9876543210"
+
+        let saved = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: replacement
+        )
+
+        #expect(
+            saved.navigation?.worktreeGeneration
+                == RestorationFixture.worktreeGeneration
+        )
+        #expect(
+            saved.tmux?.owner == .worktree(
+                generation: RestorationFixture.worktreeGeneration
+            )
+        )
+        guard case .pending = WorkspaceWindowRestorationResolver.resolve(
+            saved,
+            in: replacement
+        ) else {
+            Issue.record("replacement generation must remain pending")
+            return
+        }
+    }
+
+    @Test("canonical generation enrichment changes captured window state")
+    func generationEnrichmentRefreshesCaptureValue() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        var incomplete = fixture.snapshot
+        incomplete.worktrees[0].generation = nil
+        var unboundPresentation = fixture.tmuxSelection
+        unboundPresentation.worktreeGeneration = nil
+        let before = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: unboundPresentation,
+            snapshot: incomplete
+        )
+        var enriched = incomplete
+        enriched.worktrees[0].generation =
+            RestorationFixture.worktreeGeneration
+
+        let after = WorkspaceWindowState.capture(
+            windowID: before.windowID,
+            selection: fixture.selection,
+            activeTmux: unboundPresentation,
+            snapshot: enriched
+        )
+
+        #expect(before.navigation?.worktreeGeneration == nil)
+        #expect(before.tmux == nil)
+        #expect(
+            after.navigation?.worktreeGeneration
+                == RestorationFixture.worktreeGeneration
+        )
+        #expect(
+            after.tmux?.owner == .worktree(
+                generation: RestorationFixture.worktreeGeneration
+            )
+        )
+        #expect(after != before)
+    }
+
+    @Test("missing durable worktree identity captures project only")
+    func missingGenerationDropsWorktreeAndTmuxIdentity() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        var snapshot = fixture.snapshot
+        snapshot.worktrees[0].generation = nil
+        var activeTmux = fixture.tmuxSelection
+        activeTmux.worktreeGeneration = nil
+        let saved = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: activeTmux,
+            snapshot: snapshot
+        )
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(saved, in: snapshot)
+                == .ready(
+                    selection: WorkspaceSelection(
+                        selectedHostID: snapshot.hosts[0].id,
+                        selectedProjectID: snapshot.projects[0].id
+                    ),
+                    tmux: nil
+                )
+        )
+    }
+
+    @Test(
+        "semantic invalid state is ignored without partial selection",
+        arguments: RestorationFixture.invalidStates
+    )
+    func ignoresInvalidState(_ state: WorkspaceWindowState) {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: fixture.snapshot
+            ) == .invalid
+        )
+    }
+
+    @Test("unknown exact identities stay pending")
+    func unknownIdentityStaysPending() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "offline-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: .init(
+                hostKey: "offline-host",
+                sessionName: "editor",
+                socketName: nil,
+                owner: .unbound
+            )
+        )
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: fixture.snapshot
+            ) == .pending(selection: nil)
+        )
+    }
+
+    @Test("stale or conflicting ownership never retargets")
+    func staleOwnershipStaysPending() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        var changed = fixture.snapshot
+        changed.worktrees[0].projectID = UUID()
+        changed.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(name: "editor", managed: false, windows: []),
+        ]
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(state, in: changed)
+                == .pending(
+                    selection: WorkspaceSelection(
+                        selectedHostID: changed.hosts[0].id,
+                        selectedProjectID: changed.projects[0].id
+                    )
+                )
+        )
+    }
+
+    @Test("a named socket ignores a same-named default-server session")
+    func namedSocketDoesNotFallBack() {
+        let fixture = RestorationFixture.local(
+            sessionName: "editor",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        var changed = fixture.snapshot
+        changed.worktrees[0].tmuxSocketName = "different-socket"
+        changed.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(name: "editor", managed: false, windows: []),
+        ]
+
+        guard case .pending = WorkspaceWindowRestorationResolver.resolve(
+            state,
+            in: changed
+        ) else {
+            Issue.record("named-socket restoration must stay pending")
+            return
+        }
+    }
+
+    @Test(
+        "ordinary worktree restoration rejects changed tmux ownership",
+        arguments: OrdinaryOwnershipDrift.allCases
+    )
+    func ordinaryWorktreeOwnershipMustStillMatch(
+        _ drift: OrdinaryOwnershipDrift
+    ) {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        var changed = fixture.snapshot
+        switch drift {
+        case .sessionName:
+            changed.worktrees[0].tmuxSessionName = "renamed"
+        case .socket:
+            changed.worktrees[0].tmuxSocketName =
+                "kwt-pr-0123456789abcdef"
+        }
+
+        guard case .pending = WorkspaceWindowRestorationResolver.resolve(
+            state,
+            in: changed
+        ) else {
+            Issue.record("changed worktree ownership must stay pending")
+            return
+        }
+    }
+}

--- a/Tests/App/WorkspaceWorktreeCreationTests.swift
+++ b/Tests/App/WorkspaceWorktreeCreationTests.swift
@@ -461,6 +461,122 @@ struct WorkspaceWorktreeCreationTests {
         await model.shutdown()
     }
 
+    @Test("successful creation cancels pending window restoration")
+    @MainActor
+    func creationCancelsPendingRestoration() async throws {
+        let environment = try setupStandardEnvironment()
+        let createdBranch = "feature/restoration-boundary"
+        let loadedInventory = inventory(
+            project: environment.project,
+            worktrees: [
+                worktree(
+                    path: environment.worktree.path,
+                    branch: environment.worktree.branch,
+                    isMain: true
+                ),
+                worktree(
+                    path: "/tmp/ghosthub-restoration-boundary",
+                    branch: createdBranch,
+                    isMain: false
+                ),
+            ]
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            kwtInventoryLoader: { _ in loadedInventory },
+            kwtWorktreeCreator: { _, _, _ in }
+        )
+        model.beginRestoration(WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "unavailable-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        ))
+
+        try await model.createWorktree(WorktreeCreateRequest(
+            projectID: environment.project.id,
+            branchName: createdBranch,
+            createsBranch: true
+        ))
+
+        #expect(!model.isWorkspaceRestorationPending)
+        let selectedID = try #require(model.selection.selectedWorktreeID)
+        #expect(model.snapshot.worktree(id: selectedID)?.branch == createdBranch)
+        await model.shutdown()
+    }
+
+    @Test("successful PR import cancels pending window restoration")
+    @MainActor
+    func pullRequestImportCancelsPendingRestoration() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.projects[0].scopedKey = "github.com/kenn-io/ghosthub"
+        let workspace = PullRequestWorkspace(
+            id: "workspace-43",
+            repository: "github.com/kenn-io/ghosthub",
+            branch: "pr-43-restoration-boundary",
+            path: "/tmp/ghosthub-pr-43",
+            state: "ready",
+            sessionName: "kwt-workspace-pr-43",
+            tmuxSocketName: "kwt-pr-fedcba9876543210"
+        )
+        let candidate = PullRequestCandidate(
+            id: "github:github.com/kenn-io/ghosthub#43",
+            number: 43,
+            url: "https://github.com/kenn-io/ghosthub/pull/43",
+            title: "Preserve user mutation authority",
+            author: "wesm",
+            sourceBranch: "feature/restoration-boundary",
+            targetBranch: "main",
+            isDraft: false,
+            state: "open",
+            isImported: true,
+            workspace: workspace
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in
+                throw KwtInventoryError.commandFailed(
+                    host: "this Mac",
+                    status: 1
+                )
+            },
+            kwtPullRequestImporter: { _, _, _ in
+                KwtPullRequestImportResult(
+                    status: "created",
+                    pullRequest: candidate,
+                    workspace: workspace
+                )
+            }
+        )
+        model.beginRestoration(WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "unavailable-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        ))
+
+        try await model.importPullRequest(PullRequestImportRequest(
+            projectID: environment.project.id,
+            pullRequestID: candidate.id
+        ))
+
+        #expect(!model.isWorkspaceRestorationPending)
+        let selectedID = try #require(model.selection.selectedWorktreeID)
+        #expect(model.snapshot.worktree(id: selectedID)?.path == workspace.path)
+        await model.shutdown()
+    }
+
     @Test("PR import survives a failed inventory refresh")
     @MainActor
     func pullRequestSurvivesInventoryFailure() async throws {

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -835,6 +835,59 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("successful removal cancels pending window restoration")
+    func removalCancelsPendingRestoration() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-restoration-boundary",
+            name: "feature/restoration-boundary",
+            path: "/tmp/ghosthub-restoration-boundary",
+            branch: "feature/restoration-boundary",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-restoration-boundary"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let loads = LockedValue(0)
+        let beforeRemoval = inventory(environment, including: removable)
+        let afterRemoval = inventory(environment)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1 ? beforeRemoval : afterRemoval
+            },
+            kwtWorktreeRemover: { _, _, _, _ in },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        model.beginRestoration(WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: "unavailable-host",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        ))
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        try await model.removeWorktree(request)
+
+        #expect(!model.isWorkspaceRestorationPending)
+        #expect(model.snapshot.worktree(id: removable.id) == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test(
         "changed target metadata invalidates the removal confirmation",
         arguments: [

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -100,11 +100,193 @@ struct TmuxSessionPresentationLifecycleTests {
             ) == nil
         )
     }
+
+    @Test("restoration suppression stays idle until explicit selection")
+    func restorationSuppressionStaysIdle() {
+        let hostID = UUID()
+        let project = ProjectSummary.fixture(hostID: hostID)
+        var worktree = WorktreeSummary.fixture(
+            hostID: hostID,
+            projectID: project.id
+        )
+        worktree.tmuxSessionName = "editor"
+        let snapshot = WorkspaceSnapshot.fixture(
+            hosts: [.fixture(id: hostID)],
+            projects: [project],
+            worktrees: [worktree]
+        )
+        var selection = WorkspaceSelection(
+            selectedHostID: hostID,
+            selectedProjectID: project.id,
+            selectedWorktreeID: worktree.id
+        )
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+
+        let hostingView = hostView(
+            RootView(
+                display: WorkspaceDisplayState(
+                    snapshot: snapshot,
+                    suppressesAutomaticWorktreeSessionOpen: true
+                ),
+                handlers: InteractionHandlers(
+                    openTmuxSession: { requestedSessions.append($0) }
+                ),
+                selection: Binding(
+                    get: { selection },
+                    set: { selection = $0 }
+                )
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        #expect(requestedSessions.isEmpty)
+        #expect(
+            !viewDescendants(of: hostingView).contains {
+                $0 is NSProgressIndicator
+            }
+        )
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("automatic selection normalization is not explicit navigation")
+    func automaticNormalizationDoesNotNavigate() {
+        let environment = makeWorkspaceEnvironment()
+        var selection = WorkspaceSelection(
+            selectedHostID: environment.host.id,
+            selectedProjectID: environment.project.id,
+            selectedWorktreeID: UUID()
+        )
+        var explicitSelections: [WorkspaceSelection] = []
+
+        let hostingView = hostView(
+            RootView(
+                display: WorkspaceDisplayState(
+                    snapshot: environment.snapshot
+                ),
+                handlers: InteractionHandlers(
+                    selectWorkspace: { explicitSelections.append($0) }
+                ),
+                selection: Binding(
+                    get: { selection },
+                    set: { selection = $0 }
+                )
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        #expect(explicitSelections.isEmpty)
+        #expect(selection.selectedWorktreeID == environment.worktrees[0].id)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test(
+        "non-authoritative generation does not replace active presentation",
+        arguments: ["generation-b", nil] as [String?]
+    )
+    func nonAuthoritativeGenerationDoesNotReplaceActivePresentation(
+        _ generation: String?
+    ) {
+        let model = WorktreeReplacementPresentationModel()
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+        let hostingView = hostView(
+            WorktreeReplacementPresentationHarness(
+                model: model,
+                onOpen: { requestedSessions.append($0) }
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        #expect(requestedSessions.isEmpty)
+
+        model.refreshWorktreeGeneration(generation)
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(requestedSessions.isEmpty)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("generation enrichment does not reopen the active presentation")
+    func generationEnrichmentKeepsActivePresentation() {
+        let model = WorktreeReplacementPresentationModel(generation: nil)
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+        let hostingView = hostView(
+            WorktreeReplacementPresentationHarness(
+                model: model,
+                onOpen: { requestedSessions.append($0) }
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        #expect(requestedSessions.isEmpty)
+
+        model.refreshWorktreeGeneration(
+            "0123456789abcdef0123456789abcdef"
+        )
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(requestedSessions.isEmpty)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("releasing restoration suppression opens an unchanged selection")
+    func releasedSuppressionSynchronizesUnchangedSelection() {
+        let model = WorktreeReplacementPresentationModel()
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+        let hostingView = hostView(
+            WorktreeReplacementPresentationHarness(
+                model: model,
+                onOpen: { requestedSessions.append($0) }
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        model.setRestorationSuppression(true)
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        #expect(requestedSessions.isEmpty)
+
+        model.setRestorationSuppression(false)
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(requestedSessions.count == 1)
+        #expect(requestedSessions.first?.name == "editor")
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("navigation detaches an initially restored unbound session")
+    func navigationDetachesInitiallyRestoredUnboundSession() {
+        let hostID = UUID()
+        let model = EndpointChangePresentationModel(
+            hostID: hostID,
+            activeSession: WorkspaceTmuxSessionSelection(
+                hostID: hostID,
+                name: "docbank"
+            )
+        )
+        let hostingView = hostView(
+            EndpointChangePresentationHarness(model: model),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        model.navigateToAnotherHost()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(model.closedSessions.count == 1)
+        #expect(model.closedSessions.first?.name == "docbank")
+        withExtendedLifetime(hostingView) {}
+    }
 }
 
 @MainActor
 private final class EndpointChangePresentationModel: ObservableObject {
     @Published var display: WorkspaceDisplayState
+    @Published var selection: WorkspaceSelection
+    private(set) var closedSessions: [WorkspaceTmuxSessionSelection] = []
+    private let alternateHostID = UUID()
     let hostID: UUID
 
     init(
@@ -112,8 +294,10 @@ private final class EndpointChangePresentationModel: ObservableObject {
         activeSession: WorkspaceTmuxSessionSelection
     ) {
         self.hostID = hostID
+        selection = WorkspaceSelection(selectedHostID: hostID)
         display = Self.display(
             hostID: hostID,
+            alternateHostID: alternateHostID,
             destination: "old-builder",
             activeSession: activeSession
         )
@@ -122,13 +306,23 @@ private final class EndpointChangePresentationModel: ObservableObject {
     func replaceEndpointAndInvalidatePresentation() {
         display = Self.display(
             hostID: hostID,
+            alternateHostID: alternateHostID,
             destination: "new-builder",
             activeSession: nil
         )
     }
 
+    func navigateToAnotherHost() {
+        selection = WorkspaceSelection(selectedHostID: alternateHostID)
+    }
+
+    func recordClosedSession(_ session: WorkspaceTmuxSessionSelection) {
+        closedSessions.append(session)
+    }
+
     private static func display(
         hostID: UUID,
+        alternateHostID: UUID,
         destination: String,
         activeSession: WorkspaceTmuxSessionSelection?
     ) -> WorkspaceDisplayState {
@@ -151,7 +345,7 @@ private final class EndpointChangePresentationModel: ObservableObject {
         )
         return WorkspaceDisplayState(
             snapshot: WorkspaceSnapshot(
-                hosts: [host],
+                hosts: [host, .fixture(id: alternateHostID)],
                 projects: [],
                 worktrees: []
             ),
@@ -162,16 +356,6 @@ private final class EndpointChangePresentationModel: ObservableObject {
 
 private struct EndpointChangePresentationHarness: View {
     @ObservedObject var model: EndpointChangePresentationModel
-    @State private var selection: WorkspaceSelection
-
-    init(model: EndpointChangePresentationModel) {
-        self.model = model
-        _selection = State(
-            initialValue: WorkspaceSelection(
-                selectedHostID: model.hostID
-            )
-        )
-    }
 
     var body: some View {
         RootView(
@@ -183,7 +367,10 @@ private struct EndpointChangePresentationHarness: View {
                     )
                 }
             ),
-            selection: $selection
+            handlers: InteractionHandlers(
+                closeTmuxSession: model.recordClosedSession
+            ),
+            selection: $model.selection
         )
     }
 }
@@ -196,4 +383,84 @@ private struct ActiveTmuxPresentationMarker: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+@MainActor
+private final class WorktreeReplacementPresentationModel: ObservableObject {
+    @Published var display: WorkspaceDisplayState
+    let selection: WorkspaceSelection
+
+    init(generation: String? = "generation-a") {
+        let host = HostSummary.fixture()
+        let project = ProjectSummary.fixture(hostID: host.id)
+        var worktree = WorktreeSummary.fixture(
+            hostID: host.id,
+            projectID: project.id
+        )
+        worktree.generation = generation
+        worktree.tmuxSessionName = "editor"
+        let snapshot = WorkspaceSnapshot.fixture(
+            hosts: [host],
+            projects: [project],
+            worktrees: [worktree]
+        )
+        selection = WorkspaceSelection(
+            selectedHostID: host.id,
+            selectedProjectID: project.id,
+            selectedWorktreeID: worktree.id
+        )
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            activeTmuxSession: WorkspaceTmuxSessionSelection(
+                hostID: host.id,
+                name: "editor",
+                worktreeID: worktree.id,
+                worktreePath: worktree.path,
+                worktreeGeneration: generation
+            )
+        )
+    }
+
+    func refreshWorktreeGeneration(_ generation: String?) {
+        var worktree = display.snapshot.worktrees[0]
+        worktree.generation = generation
+        display = WorkspaceDisplayState(
+            snapshot: WorkspaceSnapshot.fixture(
+                hosts: display.snapshot.hosts,
+                projects: display.snapshot.projects,
+                worktrees: [worktree]
+            ),
+            activeTmuxSession: display.activeTmuxSession
+        )
+    }
+
+    func setRestorationSuppression(_ isSuppressed: Bool) {
+        display = WorkspaceDisplayState(
+            snapshot: display.snapshot,
+            suppressesAutomaticWorktreeSessionOpen: isSuppressed
+        )
+    }
+}
+
+private struct WorktreeReplacementPresentationHarness: View {
+    @ObservedObject var model: WorktreeReplacementPresentationModel
+    let onOpen: (WorkspaceTmuxSessionSelection) -> Void
+    @State private var selection: WorkspaceSelection
+
+    init(
+        model: WorktreeReplacementPresentationModel,
+        onOpen: @escaping (WorkspaceTmuxSessionSelection) -> Void
+    ) {
+        self.model = model
+        self.onOpen = onOpen
+        _selection = State(initialValue: model.selection)
+    }
+
+    var body: some View {
+        RootView(
+            display: model.display,
+            handlers: InteractionHandlers(openTmuxSession: onOpen),
+            selection: $selection
+        )
+    }
 }

--- a/Tests/test_generate_update_appcast.py
+++ b/Tests/test_generate_update_appcast.py
@@ -10,6 +10,12 @@ from pathlib import Path
 import pytest
 
 
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from extract_changelog import ChangelogError, extract_release_notes  # noqa: E402
+
+
 PUBLIC_KEY = "MKL5y44upnEoZrnm3VLLDocsBTD+3DgnH161eEQPhMQ="
 LEGACY_PRIVATE_KEY = bytes(
     [
@@ -33,6 +39,60 @@ LEGACY_PUBLIC_KEY = bytes(
 )
 
 
+def test_extracts_the_exact_release_section():
+    changelog = """# Changelog
+
+## [Unreleased]
+
+## [1.2.0] - 2026-07-31
+
+### Added
+
+- Restored windows.
+
+### Fixed
+
+- Preserved exact tmux sockets.
+
+## [1.1.0] - 2026-07-01
+
+### Fixed
+
+- Older fix.
+"""
+
+    notes = extract_release_notes(
+        changelog,
+        version="1.2.0",
+        release_url="https://github.com/kenn-io/ghosthub/releases/tag/v1.2.0",
+    )
+
+    assert notes.startswith("# Ghosthub 1.2.0\n\n")
+    assert "### Added\n\n- Restored windows." in notes
+    assert "### Fixed\n\n- Preserved exact tmux sockets." in notes
+    assert "Older fix" not in notes
+    assert "releases/tag/v1.2.0" in notes
+
+
+@pytest.mark.parametrize(
+    "changelog",
+    [
+        "# Changelog\n\n## [1.1.0] - 2026-07-01\n\n### Fixed\n\n- Old.\n",
+        "# Changelog\n\n## [1.2.0] - 2026-07-31\n\n## [1.2.0] - 2026-07-31\n",
+        "# Changelog\n\n## [1.2.0] - 2026-07-31\n\n",
+        "# Changelog\n\n## [1.2.0]\n\n### Fixed\n\n- Missing date.\n",
+        "# Changelog\n\n## [1.2.0] - 2026-07-31\n\nRelease prose without a subsection or list.\n",
+    ],
+)
+def test_rejects_unusable_release_sections(changelog):
+    with pytest.raises(ChangelogError):
+        extract_release_notes(
+            changelog,
+            version="1.2.0",
+            release_url="https://example.test/v1.2.0",
+        )
+
+
 def write_fake_generator(path: Path) -> None:
     path.write_text(
         """#!/usr/bin/env python3
@@ -43,6 +103,9 @@ assert sys.stdin.read() == "private-seed"
 prefix = sys.argv[sys.argv.index("--download-url-prefix") + 1]
 release_root = pathlib.Path(sys.argv[-1])
 archive = next(release_root.glob("*.dmg"))
+notes = archive.with_suffix(".md")
+assert notes.is_file()
+(release_root / "captured-release-notes.md").write_text(notes.read_text())
 (release_root / "appcast.xml").write_text(
     '<?xml version="1.0"?>'
     '<rss xmlns:sparkle="https://sparkle-project.org/xml-namespaces/sparkle">'
@@ -84,6 +147,18 @@ def make_release(tmp_path: Path, public_key: str = PUBLIC_KEY) -> dict[str, str]
 
     dmg_name = "Ghosthub_0.1.2_macos_arm64.dmg"
     (release_root / dmg_name).write_bytes(b"dmg")
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        """# Changelog
+
+## [0.1.2] - 2026-07-31
+
+### Fixed
+
+- Restores exact tmux sessions.
+""",
+        encoding="utf-8",
+    )
     generator = tmp_path / "generate_appcast"
     write_fake_generator(generator)
     deriver = tmp_path / "derive_public_key"
@@ -98,6 +173,7 @@ def make_release(tmp_path: Path, public_key: str = PUBLIC_KEY) -> dict[str, str]
         "RELEASE_DMG_NAME": dmg_name,
         "RELEASE_DMG_PATH": str(release_root / dmg_name),
         "RELEASE_TAG": "v0.1.2",
+        "CHANGELOG_PATH": str(changelog),
         "SPARKLE_GENERATE_APPCAST": str(generator),
         "SPARKLE_DERIVE_PUBLIC_KEY": str(deriver),
         "SPARKLE_ED_PRIVATE_KEY": "private-seed",
@@ -126,6 +202,11 @@ def test_generates_signed_appcast_without_exposing_the_private_key(tmp_path):
         "https://github.com/kenn-io/ghosthub/releases/download/v0.1.2/"
         "Ghosthub_0.1.2_macos_arm64.dmg"
     ) in appcast
+    captured = (tmp_path / "release" / "captured-release-notes.md").read_text()
+    assert "# Ghosthub 0.1.2" in captured
+    assert "### Fixed" in captured
+    assert "- Restores exact tmux sessions." in captured
+    assert "releases/tag/v0.1.2" in captured
     assert not (tmp_path / "release" / "Ghosthub_0.1.2_macos_arm64.md").exists()
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,34 @@ window's native tab group. AppKit owns the tab bar, tab movement, and window
 merging; Ghosthub does not render a custom tab strip or project tmux windows
 into native UI.
 
+The workspace `WindowGroup` is data-backed. Each scene continuously captures a
+small logical descriptor containing stable host and project keys, the durable
+kwt worktree generation, and exact tmux session and protected-socket identity.
+Its window UUID exists only for native scene adoption; runtime model UUIDs and
+paths are never persisted as host, project, or worktree identity. A worktree
+without a canonical generation degrades to project-only navigation and does
+not persist its worktree-owned tmux presentation. SwiftUI and macOS remain
+responsible for restoring scene count, native tab groups, and window geometry.
+An active tmux presentation retains the worktree generation observed when it
+was established; a later non-nil generation change is a replacement even when
+inventory reuses the same runtime UUID. Scene persistence observes the complete
+captured restoration value so later generation enrichment is written without
+requiring another navigation event.
+Once a restored scene has current inventory, Ghosthub resolves the descriptor
+back to live models and reattaches only to the confirmed exact session.
+Missing or offline targets fail soft and remain pending across later inventory
+refreshes. Explicit user navigation cancels pending restoration so a stale
+scene can never take the window back.
+A scene captured without an active tmux presentation restores its navigation
+without opening or creating the worktree session; the user explicitly selects
+the worktree to attach again.
+
+The host-scoped console panel is not part of workspace scene restoration. Its
+existing global visibility preference is unchanged, and the user reopens the
+surface when needed. Restoring the same session in more than one window may
+reproduce the existing shared-presentation behavior tracked by kata `s75s`;
+restoration does not add a separate collision policy.
+
 Closing a native tab or window closes only that workspace presentation. Closing
 the final workspace window leaves Ghosthub running, matching ordinary macOS
 terminal behavior; Cmd-Q remains the explicit app-termination path. Ghosthub
@@ -63,6 +91,16 @@ Updates…**, and Sparkle performs automatic background checks using its standar
 native UI and installation flow. Development binaries without the packaged
 feed and public key disable the update command instead of contacting a release
 service.
+
+When the user accepts Sparkle's **Install and Relaunch**, Ghosthub refreshes
+the continuously maintained scene descriptors and authorizes exactly one
+updater-driven AppKit termination request. This one-shot authorization is
+separate from ordinary quit confirmation and is cleared when an update cycle
+aborts or finishes with an error. A successful cycle-finish notification that
+arrives after the relaunch was requested does not disarm it, so Sparkle's
+callback ordering cannot resurface the quit confirmation mid-relaunch.
+Command-Q, final-window close, logout, restart, and
+shutdown continue through the ordinary user preference and confirmation path.
 
 The release workflow generates the appcast only after the DMG is Developer ID
 signed, notarized, stapled, and checksummed. The update archive and appcast are

--- a/docs/release.md
+++ b/docs/release.md
@@ -266,10 +266,16 @@ appcast, and creates
 - `SHA256SUMS`
 - `appcast.xml`
 
-The appcast contains only the current full DMG, embeds a link to the GitHub
-release notes, and uses the tag-specific asset URL. The stable `latest/download`
-feed redirects clients to this release's appcast. Publishing is aborted if the
-protected private key does not match the public key embedded in the app.
+The appcast contains only the current full DMG and embeds the exact dated
+`CHANGELOG.md` section for `RELEASE_APP_VERSION`, along with a link to the
+tag-specific GitHub release. Appcast generation stops before signing when that
+section is missing, duplicated, empty, or malformed; it never publishes
+placeholder release notes. The tag workflow also runs this same changelog
+extraction as a validation step before building anything, so a bad changelog
+fails the release in seconds instead of after signing and notarization.
+The stable `latest/download` feed redirects clients
+to this release's appcast. Publishing is also aborted if the protected private
+key does not match the public key embedded in the app.
 Release bundles set `SUSignedFeedFailureExpirationInterval` to `0`, so an
 invalid feed never ages into Sparkle's key-rotation fallback. This is the exact
 Info.plist key declared by Sparkle 2.9.4's

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -74,6 +74,43 @@ Native Windows attachment leaves psmux's status and message styles user-owned;
 psmux does not preserve tmux's session-scoped rendering for these style resets
 and may apply `reverse` across the client rather than only its status line.
 
+## Relaunch Restoration
+
+Quitting Ghosthub or installing an update only drops disposable clients. When
+macOS restores workspace scenes, Ghosthub resolves each scene's stable logical
+descriptor against current inventory and uses attach-only restoration; it
+never creates a missing session or falls back to a same-named target on a
+different host or socket. Worktree identity is the durable generation reported
+by kwt, so removing and recreating a worktree at the same path cannot inherit a
+saved presentation; a missing generation restores only as far as the project.
+Once a worktree presentation has observed a generation, incomplete inventory
+cannot erase it and a different non-nil generation is treated as a replacement;
+explicitly reselecting the worktree detaches the observed presentation and
+attaches the replacement session.
+An ordinary local session must be present in direct discovery before Ghosthub
+runs the exact `attach-session` path. Remote sessions use that same rule and the
+existing SSH keepalive and transport-reconnect loop.
+Offline or otherwise unavailable targets remain pending and retry when normal
+inventory refreshes publish new state. Navigating the window elsewhere cancels
+the pending target. If a scene was captured without an active tmux
+presentation, Ghosthub restores its host, project, and worktree navigation but
+does not open or create the worktree session until the user explicitly selects
+it.
+
+A protected worktree is distinct from a same-named session on the default tmux
+server. Restoration first probes the descriptor's exact host, protected socket,
+and session name. Only a successful probe may delegate attachment to `kwt pr
+attach`, which remains authoritative for validating and repairing that
+workspace before executing the ordinary tmux client. The session can still
+disappear between Ghosthub's probe and kwt's command; eliminating that benign
+race requires a future atomic kwt attach-only contract. Ghosthub does not use
+the default server as a fallback when the probe is absent or fails.
+
+The host-scoped console surface is outside workspace scene restoration and is
+reopened by the user. Restoring one session into multiple windows preserves
+the same tmux-native shared-presentation behavior that existed before quit;
+the broader collision and console policy remains tracked by kata `s75s`.
+
 Explicit local creation uses one atomic `new-session -A` create-or-attach
 client invocation. This closes the detached-session race when the user's tmux
 server has `destroy-unattached` enabled. Explicit remote creation performs a

--- a/tools/extract_changelog.py
+++ b/tools/extract_changelog.py
@@ -1,0 +1,62 @@
+import argparse
+import re
+from pathlib import Path
+
+
+class ChangelogError(ValueError):
+    pass
+
+
+def extract_release_notes(changelog: str, version: str, release_url: str) -> str:
+    escaped = re.escape(version)
+    exact_heading = re.compile(rf"^## \[{escaped}\] - \d{{4}}-\d{{2}}-\d{{2}}$")
+    version_heading = re.compile(rf"^## \[{escaped}\](?:\s|$)")
+    lines = changelog.splitlines()
+    candidates = [
+        index for index, line in enumerate(lines) if version_heading.match(line)
+    ]
+    if len(candidates) != 1 or not exact_heading.match(lines[candidates[0]]):
+        raise ChangelogError(f"expected one dated changelog section for {version}")
+
+    start = candidates[0] + 1
+    end = next(
+        (
+            index
+            for index in range(start, len(lines))
+            if lines[index].startswith("## ")
+        ),
+        len(lines),
+    )
+    body = "\n".join(lines[start:end]).strip()
+    if not body:
+        raise ChangelogError(f"changelog section for {version} is empty")
+    body_lines = body.splitlines()
+    if not any(line.startswith("### ") for line in body_lines) or not any(
+        line.startswith("- ") for line in body_lines
+    ):
+        raise ChangelogError(f"changelog section for {version} is malformed")
+
+    return (
+        f"# Ghosthub {version}\n\n"
+        f"[View this release on GitHub]({release_url})\n\n"
+        f"{body}\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--changelog", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release-url", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    notes = extract_release_notes(
+        args.changelog.read_text(encoding="utf-8"),
+        args.version,
+        args.release_url,
+    )
+    args.output.write_text(notes, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_update_appcast.sh
+++ b/tools/generate_update_appcast.sh
@@ -19,6 +19,7 @@ SPARKLE_DERIVE_PUBLIC_KEY="${SPARKLE_DERIVE_PUBLIC_KEY:-tools/derive_sparkle_pub
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
 SPARKLE_ED_PRIVATE_KEY="${SPARKLE_ED_PRIVATE_KEY:-}"
 RELEASE_REPOSITORY="${RELEASE_REPOSITORY:-kenn-io/ghosthub}"
+CHANGELOG_PATH="${CHANGELOG_PATH:-CHANGELOG.md}"
 
 if [[ -z "$SPARKLE_PUBLIC_ED_KEY" ]]; then
   echo "SPARKLE_PUBLIC_ED_KEY must contain the reviewed public key." >&2
@@ -83,10 +84,11 @@ cleanup_notes() {
 }
 trap cleanup_notes EXIT
 
-{
-  printf '# Ghosthub %s\n\n' "$RELEASE_APP_VERSION"
-  printf 'See the [GitHub release](%s) for details.\n' "$RELEASE_URL"
-} > "$NOTES_PATH"
+uv run --frozen python tools/extract_changelog.py \
+  --changelog "$CHANGELOG_PATH" \
+  --version "$RELEASE_APP_VERSION" \
+  --release-url "$RELEASE_URL" \
+  --output "$NOTES_PATH"
 
 printf '%s' "$SPARKLE_ED_PRIVATE_KEY" \
   | "$SPARKLE_GENERATE_APPCAST" \

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -405,9 +405,12 @@ const imageAlt = {
       <h2>Your sessions keep running</h2>
       <p>
         Ghosthub never replaces tmux windows, panes, history, or plugins.
-        Quit the app or close a presentation and the sessions remain where
-        you left them. Lose the network and Ghosthub automatically reconnects
-        and reattaches when it returns.
+        Quit the app or install an update and the sessions remain where you
+        left them. When macOS restores your windows, Ghosthub reopens each
+        exact session it can confirm and keeps retrying offline SSH hosts as
+        inventory refreshes. A window that had no terminal attached restores
+        its navigation without creating a worktree session; select the
+        worktree when you want to attach again.
       </p>
       <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
     </div>


### PR DESCRIPTION
Sparkle's Install and Relaunch currently collides with Ghosthub's ordinary quit confirmation and returns users to a fresh workspace, even though tmux preserves the sessions underneath. Release prompts also omit the matching changelog, leaving users without enough context when deciding whether to install.

This gives updater-driven termination a narrow one-shot authorization while leaving every ordinary quit path unchanged. macOS remains responsible for native window count, tabs, and geometry; Ghosthub continuously persists only stable logical identities, resolves them fail-soft against fresh inventory, and reattaches exact local, SSH, or protected-socket sessions without creating or retargeting a missing session. The appcast now embeds the canonical dated changelog section and fails closed when those notes are unusable.

The full Swift suite, Python release-tooling suite, libghostty bootstrap tests, essential tmux workflows, formatting, app build, and docs build pass. A signed local Sparkle dialog plus native window/tab/geometry smoke still needs a window-server release-candidate environment; kata x6dx remains open for that check.