### PR TITLE
Coalesce terminal resizes until dragging ends

### DIFF
--- a/Sources/Terminal/SurfaceResizeState.swift
+++ b/Sources/Terminal/SurfaceResizeState.swift
@@ -1,13 +1,9 @@
-import Foundation
-
 struct SurfaceResizeState: Equatable {
     struct Size: Equatable {
         let width: UInt32
         let height: UInt32
     }
 
-    private(set) var lastAppliedAt: TimeInterval?
-    private(set) var lastEventAt: TimeInterval?
     private(set) var lastPixelSize: Size?
     private(set) var pendingPixelSize: Size?
 
@@ -17,10 +13,6 @@ struct SurfaceResizeState: Equatable {
     ) -> Bool {
         let size = Size(width: width, height: height)
         return pendingPixelSize != size || lastPixelSize != size
-    }
-
-    mutating func recordEvent(at timestamp: TimeInterval) {
-        lastEventAt = timestamp
     }
 
     mutating func setPending(
@@ -37,12 +29,9 @@ struct SurfaceResizeState: Equatable {
 
     mutating func apply(
         width: UInt32,
-        height: UInt32,
-        at timestamp: TimeInterval
+        height: UInt32
     ) {
         pendingPixelSize = nil
         lastPixelSize = Size(width: width, height: height)
-        lastAppliedAt = timestamp
-        lastEventAt = timestamp
     }
 }

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -134,7 +134,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     var lastPerformKeyEvent: TimeInterval?
     private var consumedCommandKeyCodes: Set<UInt16> = []
     private var surfaceResizeState = SurfaceResizeState()
-    private var pendingSurfaceResizeTask: DispatchWorkItem?
+    private var isDeferringLiveResize = false
     private var hasSyncedFocusState = false
     private let keyEventInterpreter: (([NSEvent]) -> Void)?
     let textInputObserver: ((String) -> Void)?
@@ -392,50 +392,16 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             height: height
         ) else { return }
 
-        let now = ProcessInfo.processInfo.systemUptime
-        defer { surfaceResizeState.recordEvent(at: now) }
-
-        // Only defer during live window resize (drag). Programmatic
-        // resizes (split pane close, tab switch) must apply
-        // immediately to avoid rendering at stale dimensions.
-        let decision: SurfaceResizeDecision
-        if inLiveResize {
-            decision = SurfaceResizePolicy.decision(
-                now: now,
-                lastAppliedAt: surfaceResizeState.lastAppliedAt,
-                lastEventAt: surfaceResizeState.lastEventAt
-            )
-        } else {
-            decision = .immediate
-        }
-
-        switch decision {
+        switch SurfaceResizePolicy.decision(
+            isLiveResize: isDeferringLiveResize
+        ) {
         case .immediate:
-            pendingSurfaceResizeTask?.cancel()
-            pendingSurfaceResizeTask = nil
-            applySurfaceSize(width: width, height: height, at: now)
+            applySurfaceSize(width: width, height: height)
 
-        case let .deferred(delay):
+        case .deferredUntilLiveResizeEnds:
             surfaceResizeState.setPending(
                 width: width,
                 height: height
-            )
-            pendingSurfaceResizeTask?.cancel()
-            let task = DispatchWorkItem { [weak self] in
-                guard let self,
-                      let pending = surfaceResizeState.consumePending()
-                else { return }
-                pendingSurfaceResizeTask = nil
-                applySurfaceSize(
-                    width: pending.width,
-                    height: pending.height,
-                    at: ProcessInfo.processInfo.systemUptime
-                )
-            }
-            pendingSurfaceResizeTask = task
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + delay,
-                execute: task
             )
         }
     }
@@ -472,13 +438,11 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
 
     private func applySurfaceSize(
         width: UInt32,
-        height: UInt32,
-        at timestamp: TimeInterval
+        height: UInt32
     ) {
         surfaceResizeState.apply(
             width: width,
-            height: height,
-            at: timestamp
+            height: height
         )
         setSurfaceSize(width: width, height: height)
     }
@@ -487,12 +451,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         guard let pendingSurfacePixelSize = surfaceResizeState.consumePending() else {
             return
         }
-        pendingSurfaceResizeTask?.cancel()
-        pendingSurfaceResizeTask = nil
         applySurfaceSize(
             width: pendingSurfacePixelSize.width,
-            height: pendingSurfacePixelSize.height,
-            at: ProcessInfo.processInfo.systemUptime
+            height: pendingSurfacePixelSize.height
         )
     }
 
@@ -929,17 +890,20 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         let xScale = fbFrame.size.width / frame.size.width
         let yScale = fbFrame.size.height / frame.size.height
         ghostty_surface_set_content_scale(surface, xScale, yScale)
-        pendingSurfaceResizeTask?.cancel()
-        pendingSurfaceResizeTask = nil
         applySurfaceSize(
             width: UInt32(fbFrame.size.width),
-            height: UInt32(fbFrame.size.height),
-            at: ProcessInfo.processInfo.systemUptime
+            height: UInt32(fbFrame.size.height)
         )
+    }
+
+    override public func viewWillStartLiveResize() {
+        super.viewWillStartLiveResize()
+        isDeferringLiveResize = true
     }
 
     override public func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
+        isDeferringLiveResize = false
         flushPendingSurfaceResize()
     }
 

--- a/Sources/TerminalSupport/SurfaceResizePolicy.swift
+++ b/Sources/TerminalSupport/SurfaceResizePolicy.swift
@@ -1,41 +1,12 @@
-import Foundation
-
 package enum SurfaceResizeDecision: Equatable {
     case immediate
-    case deferred(delay: TimeInterval)
+    case deferredUntilLiveResizeEnds
 }
 
 package enum SurfaceResizePolicy {
-    /// After a resize event arrives, wait this long for more
-    /// events before applying. Each new event resets the timer,
-    /// so during continuous dragging the terminal never
-    /// re-layouts — it only updates once events stop arriving.
-    package static let settleDelay: TimeInterval = 0.08
-
-    /// After this much idle time since the last apply, treat
-    /// the next event as the start of a new gesture and apply
-    /// immediately (gives instant feedback on first interaction).
-    package static let idleThreshold: TimeInterval = 0.5
-
     package static func decision(
-        now: TimeInterval,
-        lastAppliedAt: TimeInterval?,
-        lastEventAt: TimeInterval?
+        isLiveResize: Bool
     ) -> SurfaceResizeDecision {
-        guard let lastAppliedAt else {
-            return .immediate
-        }
-
-        let sinceLastApply = now - lastAppliedAt
-        let sinceLastEvent = lastEventAt.map { now - $0 }
-            ?? sinceLastApply
-
-        // First event after idle: apply immediately
-        if sinceLastEvent >= idleThreshold {
-            return .immediate
-        }
-
-        // During rapid events: always defer
-        return .deferred(delay: settleDelay)
+        isLiveResize ? .deferredUntilLiveResizeEnds : .immediate
     }
 }

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -266,8 +266,6 @@ struct SurfaceResizeState: Equatable {
         let height: UInt32
     }
 
-    private(set) var lastAppliedAt: TimeInterval?
-    private(set) var lastEventAt: TimeInterval?
     private(set) var lastPixelSize: Size?
     private(set) var pendingPixelSize: Size?
 
@@ -276,10 +274,6 @@ struct SurfaceResizeState: Equatable {
     ) -> Bool {
         let size = Size(width: width, height: height)
         return pendingPixelSize != size || lastPixelSize != size
-    }
-
-    mutating func recordEvent(at timestamp: TimeInterval) {
-        lastEventAt = timestamp
     }
 
     mutating func setPending(width: UInt32, height: UInt32) {
@@ -292,12 +286,10 @@ struct SurfaceResizeState: Equatable {
     }
 
     mutating func apply(
-        width: UInt32, height: UInt32, at timestamp: TimeInterval
+        width: UInt32, height: UInt32
     ) {
         pendingPixelSize = nil
         lastPixelSize = Size(width: width, height: height)
-        lastAppliedAt = timestamp
-        lastEventAt = timestamp
     }
 }
 

--- a/Tests/Terminal/SurfaceResizeStateTests.swift
+++ b/Tests/Terminal/SurfaceResizeStateTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Testing
 @testable import GhosthubTerminal
 
@@ -8,14 +7,11 @@ struct SurfaceResizeStateTests {
     @Test("applying a backing-scale resize clears stale deferred state")
     mutating func applyClearsPendingDeferredResize() {
         state.setPending(width: 800, height: 600)
-        state.recordEvent(at: 10)
-        state.apply(width: 1600, height: 1200, at: 11)
+        state.apply(width: 1600, height: 1200)
 
         expectState(
             pending: nil,
-            last: .init(width: 1600, height: 1200),
-            lastAppliedAt: 11,
-            lastEventAt: 11
+            last: .init(width: 1600, height: 1200)
         )
     }
 
@@ -32,8 +28,6 @@ struct SurfaceResizeStateTests {
     private func expectState(
         pending: SurfaceResizeState.Size? = nil,
         last: SurfaceResizeState.Size? = nil,
-        lastAppliedAt: TimeInterval? = nil,
-        lastEventAt: TimeInterval? = nil,
         sourceLocation: SourceLocation = #_sourceLocation
     ) {
         #expect(
@@ -42,14 +36,6 @@ struct SurfaceResizeStateTests {
         )
         #expect(
             state.lastPixelSize == last,
-            sourceLocation: sourceLocation
-        )
-        #expect(
-            state.lastAppliedAt == lastAppliedAt,
-            sourceLocation: sourceLocation
-        )
-        #expect(
-            state.lastEventAt == lastEventAt,
             sourceLocation: sourceLocation
         )
     }

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -1774,6 +1774,41 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         )
     }
 
+    func testLiveWindowResizeAppliesOnlyTheFinalSurfaceSize() throws {
+        let appHandle = try requireAppHandle()
+        let previousSetter = TerminalSurfaceView.sizeSetter
+        var appliedSizes: [(width: UInt32, height: UInt32)] = []
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            appliedSizes.append((width, height))
+            ghostty_surface_set_size(surface, width, height)
+        }
+        defer {
+            TerminalSurfaceView.sizeSetter = previousSetter
+        }
+
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        appliedSizes.removeAll()
+
+        view.viewWillStartLiveResize()
+        view.setFrameSize(NSSize(width: 700, height: 450))
+        view.setFrameSize(NSSize(width: 760, height: 480))
+        view.viewDidEndLiveResize()
+
+        let expectedSize = view.convertToBacking(view.bounds.size)
+        XCTAssertEqual(
+            appliedSizes.count,
+            1,
+            "A live window drag must notify the PTY only after the final size is known."
+        )
+        XCTAssertEqual(appliedSizes.last?.width, UInt32(expectedSize.width))
+        XCTAssertEqual(appliedSizes.last?.height, UInt32(expectedSize.height))
+    }
+
     func testDetachingViewMarksSurfaceOccluded() throws {
         let appHandle = try requireAppHandle()
         let previousSetter = TerminalSurfaceView.occlusionSetter

--- a/Tests/TerminalSupport/SurfaceResizePolicyTests.swift
+++ b/Tests/TerminalSupport/SurfaceResizePolicyTests.swift
@@ -1,78 +1,19 @@
-import Foundation
 import Testing
 @testable import GhosthubTerminalSupport
 
 struct SurfaceResizePolicyTests {
-    private static let deferred: SurfaceResizeDecision =
-        .deferred(delay: SurfaceResizePolicy.settleDelay)
-
-    private func expectDecision(
-        now: TimeInterval,
-        lastApplied: TimeInterval?,
-        lastEvent: TimeInterval?,
-        _ expected: SurfaceResizeDecision,
-        sourceLocation: SourceLocation = #_sourceLocation
-    ) {
+    @Test("live window resizing waits for the drag to end")
+    func liveResizeDefers() {
         #expect(
-            SurfaceResizePolicy.decision(
-                now: now,
-                lastAppliedAt: lastApplied,
-                lastEventAt: lastEvent
-            ) == expected,
-            sourceLocation: sourceLocation
+            SurfaceResizePolicy.decision(isLiveResize: true)
+                == .deferredUntilLiveResizeEnds
         )
     }
 
-    @Test("first resize applies immediately")
-    func firstResizeAppliesImmediately() {
-        expectDecision(
-            now: 5, lastApplied: nil, lastEvent: nil,
-            .immediate
-        )
-    }
-
-    @Test("rapid consecutive resize defers by the settle delay")
-    func rapidResizeDefers() {
-        expectDecision(
-            now: 10.02, lastApplied: 10, lastEvent: 10.01,
-            Self.deferred
-        )
-    }
-
-    @Test("resize after idle threshold applies immediately")
-    func idleResizeAppliesImmediately() {
-        expectDecision(
-            now: 10 + SurfaceResizePolicy.idleThreshold + 0.01,
-            lastApplied: 9, lastEvent: 10,
-            .immediate
-        )
-    }
-
-    @Test("resize during active dragging always defers")
-    func activeDraggingDefers() {
-        expectDecision(
-            now: 10.05, lastApplied: 10, lastEvent: 10.03,
-            Self.deferred
-        )
-    }
-
-    @Test("slower drag cadence still defers while events stay inside the idle threshold")
-    func slowerDragCadenceStillDefers() {
-        expectDecision(
-            now: 10.14, lastApplied: 10, lastEvent: 10.03,
-            Self.deferred
-        )
-    }
-
-    @Test("events only restart immediate resizing after the idle threshold")
-    func idleThresholdControlsImmediateRestart() {
-        expectDecision(
-            now: 10.49, lastApplied: 10, lastEvent: 10.01,
-            Self.deferred
-        )
-        expectDecision(
-            now: 10.52, lastApplied: 10, lastEvent: 10.01,
-            .immediate
+    @Test("non-live layout changes resize immediately")
+    func nonLiveResizeIsImmediate() {
+        #expect(
+            SurfaceResizePolicy.decision(isLiveResize: false) == .immediate
         )
     }
 }


### PR DESCRIPTION
Dragging a macOS window edge sends a stream of PTY resize notifications. Inline Codex and Claude TUIs redraw retained transcripts for each SIGWINCH, so the previous immediate-first and timer-based policy could make history appear to replay while rendering work accumulated.

This keeps the terminal grid stable throughout AppKit live resize and applies only the final dimensions when the gesture ends. Non-live layout changes remain immediate, preserving responsiveness for tab, split, and programmatic updates. The regression drives a real TerminalSurfaceView and confirms multiple frame changes during one drag produce exactly one final libghostty surface resize.

The full Swift suite passed with 155 XCTest cases and 704 Swift Testing cases, with five expected headless skips. The app build, terminal fallback build, formatting checks, and commit hooks also passed.