### PR TITLE
Keep Ghosthub running after its last window closes

### DIFF
--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -49,27 +49,6 @@ enum WorkspaceWindowIdentity {
     static func group(containing window: NSWindow) -> [NSWindow] {
         window.tabGroup?.windows ?? [window]
     }
-
-    static func hasAnotherOpenWindow(
-        besides windows: [NSWindow]
-    ) -> Bool {
-        let excluded = Set(windows.map(ObjectIdentifier.init))
-        for window in windows {
-            if window.tabGroup?.windows.contains(where: {
-                !excluded.contains(ObjectIdentifier($0))
-                    && matches($0)
-            }) == true {
-                return true
-            }
-        }
-        return NSApplication.shared.windows.contains {
-            !excluded.contains(ObjectIdentifier($0))
-                && matches($0)
-                && ($0.isVisible || $0.isMiniaturized)
-                && $0.frame.width > 1
-                && $0.frame.height > 1
-        }
-    }
 }
 
 enum WorkspaceWindowResolver {
@@ -127,10 +106,6 @@ final class ApplicationDelegate: NSObject,
 
     var terminateApplication: () -> Void = {
         NSApplication.shared.terminate(nil)
-    }
-
-    var hasAnotherWorkspaceWindow: ([NSWindow]) -> Bool = {
-        WorkspaceWindowIdentity.hasAnotherOpenWindow(besides: $0)
     }
 
     var openWorkspaceWindow: (UUID) -> Void = { _ in }
@@ -307,29 +282,18 @@ final class ApplicationDelegate: NSObject,
     func applicationShouldTerminateAfterLastWindowClosed(
         _ sender: NSApplication
     ) -> Bool {
-        terminationConfirmed
+        false
     }
 
     func requestWorkspaceTabClose(_ window: NSWindow?) {
         guard let window, !window.isSheet else { return }
-        guard !hasAnotherWorkspaceWindow([window]) else {
-            window.close()
-            return
-        }
-        requestApplicationTermination()
+        window.close()
     }
 
     func requestWorkspaceWindowClose(_ window: NSWindow?) {
         guard let window, !window.isSheet else { return }
         let group = WorkspaceWindowIdentity.group(containing: window)
-        guard !hasAnotherWorkspaceWindow(group) else {
-            group.forEach { $0.close() }
-            return
-        }
-        // The final window group follows the same asynchronous path as
-        // Command-Q. Keeping every tab open while the sheet is presented
-        // avoids a nested run loop and never re-enters NSWindow.close().
-        requestApplicationTermination()
+        group.forEach { $0.close() }
     }
 
     private func makeTerminationAlert() -> NSAlert {

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -286,8 +286,8 @@ public struct SettingsView: View {
                 )
 
                 Text(
-                    "Ghosthub asks before quitting or closing the final workspace."
-                        + " Tmux sessions keep running either way."
+                    "Ghosthub asks before quitting. Closing windows does not quit"
+                        + " Ghosthub, and tmux sessions keep running either way."
                 )
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -455,8 +455,9 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertTrue(delegate.terminationConfirmed)
     }
 
-    func testApplicationWaitsForPreCloseConfirmation() {
+    func testApplicationDoesNotTerminateAfterLastWindowCloses() {
         let delegate = ApplicationDelegate.forTesting()
+        XCTAssertTrue(delegate.prepareUserInitiatedTermination())
 
         XCTAssertFalse(
             delegate.applicationShouldTerminateAfterLastWindowClosed(
@@ -480,81 +481,11 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertFalse(NSWindow.allowsAutomaticWindowTabbing)
     }
 
-    func testLastWindowStaysOpenWhenConfirmationCancels() {
-        let delegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: false
-        )
-        let window = CloseSpyWindow()
-        var terminationRequests = 0
-        delegate.terminateApplication = {
-            terminationRequests += 1
-        }
-
-        delegate.requestWorkspaceWindowClose(window)
-
-        XCTAssertEqual(window.closeCallCount, 0)
-        XCTAssertEqual(terminationRequests, 0)
-        XCTAssertFalse(delegate.terminationConfirmed)
-    }
-
-    func testLastWindowRequestsTerminationAfterConfirmation() {
+    func testLastWindowClosesWithoutRequestingTermination() {
         let delegate = ApplicationDelegate.forTesting(
             confirmTerminationResult: true
         )
         let window = CloseSpyWindow()
-        var terminationRequests = 0
-        delegate.terminateApplication = {
-            terminationRequests += 1
-        }
-
-        delegate.requestWorkspaceWindowClose(window)
-
-        XCTAssertEqual(window.closeCallCount, 0)
-        XCTAssertEqual(terminationRequests, 1)
-        XCTAssertTrue(delegate.terminationConfirmed)
-
-        // After confirmation, termination proceeds without
-        // a second dialog.
-        XCTAssertTrue(
-            delegate.applicationShouldTerminateAfterLastWindowClosed(
-                NSApplication.shared
-            )
-        )
-        XCTAssertEqual(
-            delegate.applicationShouldTerminate(NSApplication.shared),
-            .terminateNow
-        )
-    }
-
-    func testWindowCloseSkipsConfirmWhenNoActiveSessions() {
-        let delegate = ApplicationDelegate()
-        let window = CloseSpyWindow()
-        delegate.needsConfirmQuit = { false }
-        var terminationRequests = 0
-        delegate.terminateApplication = {
-            terminationRequests += 1
-        }
-
-        var confirmCalled = false
-        delegate.confirmTermination = {
-            confirmCalled = true
-            return false
-        }
-
-        delegate.requestWorkspaceWindowClose(window)
-
-        XCTAssertEqual(window.closeCallCount, 0)
-        XCTAssertEqual(terminationRequests, 1)
-        XCTAssertFalse(confirmCalled)
-        XCTAssertTrue(delegate.terminationConfirmed)
-    }
-
-    func testClosingNonLastWindowDoesNotArmTermination() {
-        let delegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: true
-        )
-        let window = CloseSpyWindow()
-        delegate.hasAnotherWorkspaceWindow = { _ in true }
         var terminationRequests = 0
         delegate.terminateApplication = {
             terminationRequests += 1
@@ -564,16 +495,11 @@ final class ApplicationDelegateTests: XCTestCase {
 
         XCTAssertEqual(window.closeCallCount, 1)
         XCTAssertEqual(terminationRequests, 0)
-        XCTAssertFalse(
-            delegate.terminationConfirmed,
-            "terminationConfirmed must not be set when other managed windows remain"
-        )
+        XCTAssertFalse(delegate.terminationConfirmed)
     }
 
-    func testClosingHiddenTabBarGroupConfirmsBeforeClosingTabs() {
-        let delegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: false
-        )
+    func testClosingHiddenTabBarGroupDoesNotRequestTermination() {
+        let delegate = ApplicationDelegate.forTesting()
         let window = HiddenTabBarWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .resizable],
@@ -587,27 +513,20 @@ final class ApplicationDelegateTests: XCTestCase {
             defer: false
         )
         window.addTabbedWindow(tab, ordered: .above)
-        var inspectedGroup: [NSWindow] = []
-        delegate.hasAnotherWorkspaceWindow = {
-            inspectedGroup = $0
-            return false
-        }
-        var confirmationRequests = 0
-        delegate.requestTerminationConfirmation = { completion in
-            confirmationRequests += 1
-            completion(false)
+        var terminationRequests = 0
+        delegate.terminateApplication = {
+            terminationRequests += 1
         }
 
         delegate.requestWorkspaceWindowClose(window)
 
-        XCTAssertEqual(inspectedGroup.count, 2)
-        XCTAssertEqual(confirmationRequests, 1)
-        XCTAssertEqual(window.closeCallCount, 0)
-        XCTAssertEqual(tab.closeCallCount, 0)
+        XCTAssertEqual(window.closeCallCount, 1)
+        XCTAssertEqual(tab.closeCallCount, 1)
+        XCTAssertEqual(terminationRequests, 0)
         XCTAssertFalse(delegate.terminationConfirmed)
     }
 
-    func testTrafficLightClosesHiddenTabBarGroupWhenAnotherWindowRemains()
+    func testTrafficLightClosesHiddenTabBarGroupWithoutTerminating()
         throws {
         let delegate = ApplicationDelegate.forTesting()
         let window = HiddenTabBarWindow(
@@ -623,7 +542,10 @@ final class ApplicationDelegateTests: XCTestCase {
             defer: false
         )
         window.addTabbedWindow(tab, ordered: .above)
-        delegate.hasAnotherWorkspaceWindow = { _ in true }
+        var terminationRequests = 0
+        delegate.terminateApplication = {
+            terminationRequests += 1
+        }
         let controller = CompactWorkspaceTitlebarController(
             applicationDelegate: delegate
         )
@@ -636,6 +558,7 @@ final class ApplicationDelegateTests: XCTestCase {
 
         XCTAssertEqual(window.closeCallCount, 1)
         XCTAssertEqual(tab.closeCallCount, 1)
+        XCTAssertEqual(terminationRequests, 0)
         XCTAssertFalse(delegate.terminationConfirmed)
     }
 
@@ -643,16 +566,9 @@ final class ApplicationDelegateTests: XCTestCase {
         let delegate = ApplicationDelegate.forTesting()
         let window = CloseSpyWindow()
         let sibling = CloseSpyWindow()
-        var inspectedWindows: [NSWindow] = []
-        delegate.hasAnotherWorkspaceWindow = {
-            inspectedWindows = $0
-            return true
-        }
 
         delegate.requestWorkspaceTabClose(window)
 
-        XCTAssertEqual(inspectedWindows.count, 1)
-        XCTAssertTrue(inspectedWindows.first === window)
         XCTAssertEqual(window.closeCallCount, 1)
         XCTAssertEqual(sibling.closeCallCount, 0)
         XCTAssertFalse(delegate.terminationConfirmed)
@@ -720,10 +636,8 @@ final class ApplicationDelegateTests: XCTestCase {
         )
     }
 
-    func testWindowCloseDelegateUsesGhosthubConfirmation() throws {
-        let delegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: false
-        )
+    func testWindowCloseDelegateClosesWithoutTerminating() throws {
+        let delegate = ApplicationDelegate.forTesting()
         var terminationRequests = 0
         delegate.terminateApplication = {
             terminationRequests += 1
@@ -743,23 +657,12 @@ final class ApplicationDelegateTests: XCTestCase {
             applicationDelegate: delegate
         )
         controller.install(on: window)
-        let closeButton = try XCTUnwrap(
-            window.standardWindowButton(.closeButton)
-        )
-
         let shouldClose = try XCTUnwrap(
             window.delegate?.windowShouldClose?(window)
         )
         XCTAssertFalse(shouldClose)
-        XCTAssertEqual(window.closeCallCount, 0)
+        XCTAssertEqual(window.closeCallCount, 1)
         XCTAssertEqual(terminationRequests, 0)
-
-        delegate.requestTerminationConfirmation = { completion in
-            completion(true)
-        }
-        closeButton.performClick(nil)
-        XCTAssertEqual(window.closeCallCount, 0)
-        XCTAssertEqual(terminationRequests, 1)
     }
 
     func testWindowCloseDelegateForwardsOtherCallbacks() throws {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,12 +31,13 @@ window's native tab group. AppKit owns the tab bar, tab movement, and window
 merging; Ghosthub does not render a custom tab strip or project tmux windows
 into native UI.
 
-Closing a native tab closes only that workspace presentation. Closing the last
-tab of the last workspace follows the same app-termination policy as closing
-the final standalone window. Ghosthub confirms app termination by default;
-users can disable the shared confirmation in **Settings -> Terminal**. This
-preference never terminates a tmux session: quitting still detaches clients,
-while Kill Session remains a separate confirmed action.
+Closing a native tab or window closes only that workspace presentation. Closing
+the final workspace window leaves Ghosthub running, matching ordinary macOS
+terminal behavior; Cmd-Q remains the explicit app-termination path. Ghosthub
+confirms app termination by default, and users can disable that confirmation in
+**Settings -> Terminal**. Closing presentations or quitting never terminates a
+tmux session: both detach clients, while Kill Session remains a separate
+confirmed action.
 
 ## Process Boundaries
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -351,8 +351,9 @@ const imageAlt = {
           <p>
             Quit confirmation is on by default. Change it at{' '}
             <strong>Settings → Terminal → Confirm before quitting Ghosthub</strong>.
-            Turning it off also skips the prompt when you close the final workspace,
-            but Ghosthub still only detaches and leaves every tmux session running.
+            Closing the final workspace leaves Ghosthub running; use Command-Q to
+            quit. Quitting or closing windows only detaches and leaves every tmux
+            session running.
           </p>
           <p>
             The file uses{' '}<a href="https://ghostty.org/docs/config/reference">Ghostty’s


### PR DESCRIPTION
Closing a window and quitting the application are distinct actions on macOS. Ghosthub currently turns the final workspace close into app termination, which differs from Ghostty and gives the close button Command-Q semantics. This keeps Ghosthub active after its last tab or window closes while leaving Command-Q and its confirmation policy unchanged; closing and quitting continue to detach rather than terminate tmux sessions.

Lifecycle coverage now exercises final-window, tab-group, traffic-light, and delegate-driven closes. All 861 Swift tests passed with 5 expected headless skips, along with formatting, the app build, and the website production build.