### PR TITLE
Restore remote tmux copy and attachment

### DIFF
--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -5,7 +5,7 @@ import GhosthubWorkspace
 
 @MainActor
 protocol TmuxPaneSurfacing: AnyObject {
-    var blocksClipboardAccess: Bool { get set }
+    var blocksClipboardReads: Bool { get set }
     var launchError: Error? { get }
     func registerSurfaceCloseObserver(
         id: UUID,
@@ -355,7 +355,7 @@ final class NativeTmuxSessionCoordinator {
             )
             return nil
         }
-        surface.blocksClipboardAccess = attachment.host.isRemote
+        surface.blocksClipboardReads = attachment.host.isRemote
         surface.registerSurfaceCloseObserver(
             id: handle.id,
             onSurfaceClosed: { [weak self] _ in

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2693,7 +2693,15 @@ final class WorkspaceSceneModel: ObservableObject {
         case .connected:
             reconcileCreatedTmuxSession(handleID: handle.id)
         case .disconnected:
-            discardPendingTmuxSession(handleID: handle.id)
+            guard nativeTmuxSessionCoordinator.hasLaunched(handle) else {
+                discardPendingTmuxSession(handleID: handle.id)
+                return
+            }
+            endedCreatedTmuxSessionHandles.insert(handle.id)
+            reconcileCreatedTmuxSession(
+                handleID: handle.id,
+                immediately: true
+            )
         case .connecting, .reconnecting:
             break
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2547,14 +2547,8 @@ final class WorkspaceSceneModel: ObservableObject {
                     handleID: handle.id,
                     immediately: true
                 )
-            } else if let pending = pendingCreatedTmuxSessions[handle.id] {
-                createdSessionDiscoveryTasks.removeValue(
-                    forKey: handle.id
-                )?.cancel()
-                pendingCreatedTmuxSessions.removeValue(forKey: handle.id)
-                exhaustedCreatedTmuxSessionHandles.remove(handle.id)
-                endedCreatedTmuxSessionHandles.remove(handle.id)
-                removeOptimisticTmuxSession(pending)
+            } else if pendingCreatedTmuxSessions[handle.id] != nil {
+                discardPendingTmuxSession(handleID: handle.id)
             }
         }
         activeBorrowedTmuxSelection = nil
@@ -2699,17 +2693,21 @@ final class WorkspaceSceneModel: ObservableObject {
         case .connected:
             reconcileCreatedTmuxSession(handleID: handle.id)
         case .disconnected:
-            guard nativeTmuxSessionCoordinator.hasLaunched(handle) else {
-                return
-            }
-            endedCreatedTmuxSessionHandles.insert(handle.id)
-            reconcileCreatedTmuxSession(
-                handleID: handle.id,
-                immediately: true
-            )
+            discardPendingTmuxSession(handleID: handle.id)
         case .connecting, .reconnecting:
             break
         }
+    }
+
+    private func discardPendingTmuxSession(handleID: UUID) {
+        guard let selection = pendingCreatedTmuxSessions[handleID] else {
+            return
+        }
+        createdSessionDiscoveryTasks.removeValue(forKey: handleID)?.cancel()
+        pendingCreatedTmuxSessions.removeValue(forKey: handleID)
+        exhaustedCreatedTmuxSessionHandles.remove(handleID)
+        endedCreatedTmuxSessionHandles.remove(handleID)
+        removeOptimisticTmuxSession(selection)
     }
 
     private func reconcileCreatedTmuxSession(
@@ -2878,6 +2876,13 @@ final class WorkspaceSceneModel: ObservableObject {
     ) {
         tmuxSessionsByHost[selection.hostID]?.removeAll {
             $0.name == selection.name
+        }
+        if let hostIndex = snapshot.hosts.firstIndex(where: {
+            $0.id == selection.hostID
+        }) {
+            snapshot.hosts[hostIndex].tmuxSessions.removeAll {
+                $0.name == selection.name
+            }
         }
         applyInventoryOverlayIfNeeded()
     }

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -759,7 +759,7 @@ public final class LibghosttyRuntime: ObservableObject {
             // User-configured paste bindings may read the clipboard, while
             // OSC 52 reads remain empty regardless of `clipboard-read`.
             let contents = clipboardReadContents(
-                blocked: surfaceView.blocksClipboardAccess,
+                blocked: surfaceView.blocksClipboardReads,
                 request: request,
                 contents: NSPasteboard.general.string(forType: .string)
             )
@@ -787,7 +787,7 @@ public final class LibghosttyRuntime: ObservableObject {
             guard let surfaceHandle = surfaceView.surfaceHandle else { return }
             let requestState = stateValue.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
             if !allowsClipboardConfirmation(
-                blocked: surfaceView.blocksClipboardAccess,
+                blocked: surfaceView.blocksClipboardReads,
                 request: request
             ) {
                 "".withCString { buffer in
@@ -842,11 +842,8 @@ public final class LibghosttyRuntime: ObservableObject {
             )
         }
         dispatchToMainSync {
-            guard let surfaceView = surfaceView(from: userdataValue),
-                  let acceptedEntries = acceptedClipboardWriteEntries(
-                      blocked: surfaceView.blocksClipboardAccess,
-                      entries: entries
-                  ) else { return }
+            guard surfaceView(from: userdataValue) != nil else { return }
+            let acceptedEntries = acceptedClipboardWriteEntries(entries)
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             let types = acceptedEntries.compactMap {
@@ -884,12 +881,9 @@ public final class LibghosttyRuntime: ObservableObject {
     }
 
     static func acceptedClipboardWriteEntries(
-        blocked: Bool,
-        entries: [ClipboardWriteEntry]
-    ) -> [ClipboardWriteEntry]? {
-        let isOSC52 = entries.contains { $0.mime == osc52ClipboardWriteMIME }
-        guard !blocked || !isOSC52 else { return nil }
-        return entries.filter { $0.mime != osc52ClipboardWriteMIME }
+        _ entries: [ClipboardWriteEntry]
+    ) -> [ClipboardWriteEntry] {
+        entries.filter { $0.mime != osc52ClipboardWriteMIME }
     }
 
     static func pasteboardType(

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -165,7 +165,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// clipboard through terminal escape sequences. Explicit user paste
     /// remains available because libghostty labels semantic paste requests
     /// before the runtime reads the pasteboard.
-    public var blocksClipboardAccess = false
+    public var blocksClipboardReads = false
     private var isClipboardConfirmationPending = false
     private var tmuxTerminalModeTracker = AttachedTmuxTerminalModeTracker()
     /// The surface's grid dimensions (columns, rows) changed. Task-8 addition:

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -88,8 +88,8 @@ public final class TerminalSurfaceView: ObservableObject {
     public var onChildWrite: ((Data) -> Void)?
     /// Mirrors `TerminalSurfaceView.onGridSizeChanged`.
     public var onGridSizeChanged: ((Int, Int) -> Void)?
-    /// Mirrors clipboard isolation for remote and control-mode surfaces.
-    public var blocksClipboardAccess: Bool = false
+    /// Mirrors clipboard-read isolation for remote surfaces.
+    public var blocksClipboardReads: Bool = false
     var fontZoomShortcutHandler: ((TerminalFontZoomCommand) -> Bool)?
 
     public init(

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -95,12 +95,22 @@ public func powerShellKwtAvailabilityPrelude(
 /// Initializes an account's login environment, then delegates
 /// Ghosthub-owned POSIX command text to `/bin/sh`. The outer command argument
 /// is accepted by POSIX shells and non-POSIX account shells such as fish.
-public func accountLoginShellCommand(_ command: String) -> String {
+private func accountLoginCommand(_ command: String) -> String {
     let posixCommand = "exec /bin/sh -c "
         + shellQuotedCommandArgument(command)
-    let loginCommand = "exec \"${SHELL:-/bin/sh}\" -lc "
+    return "exec \"${SHELL:-/bin/sh}\" -lc "
         + shellQuotedCommandArgument(posixCommand)
-    return accountShellCommand(loginCommand)
+}
+
+public func accountLoginShellCommand(_ command: String) -> String {
+    accountShellCommand(accountLoginCommand(command))
+}
+
+/// Libghostty's macOS surface startup prepends `exec -l` to custom commands,
+/// so its command must begin with the executable rather than the `exec`
+/// shell builtin. The nested account login and POSIX handoffs remain the same.
+public func surfaceAccountLoginShellCommand(_ command: String) -> String {
+    "/bin/sh -c " + accountShellCommandArgument(accountLoginCommand(command))
 }
 
 public enum ConnectionState: Codable, Equatable, Sendable {
@@ -275,7 +285,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     sshConnectionArguments: sshConnectionArguments
                 )
             }
-            return accountLoginShellCommand(command)
+            return surfaceAccountLoginShellCommand(command)
         }
     }
 

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -358,7 +358,7 @@ private enum SurfaceLaunchTestError: LocalizedError {
 
 @MainActor
 private final class TmuxPaneSurfaceStub: TmuxPaneSurfacing {
-    var blocksClipboardAccess = false
+    var blocksClipboardReads = false
     let launchError: Error?
     private(set) var closeObservers: [UUID: (Bool) -> Void] = [:]
 

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2235,7 +2235,7 @@ struct WorkspaceTmuxDiscoveryTests {
 
 @MainActor
 private final class SceneTmuxPaneSurfaceStub: TmuxPaneSurfacing {
-    var blocksClipboardAccess = false
+    var blocksClipboardReads = false
     var launchError: Error? { nil }
     private(set) var closeObservers: [UUID: (Bool) -> Void] = [:]
 

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -978,6 +978,72 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("failed remote provisioning removes the optimistic session")
+    func failedRemoteProvisioningRemovesOptimisticSession() async throws {
+        let environment = try setupRemoteEnvironment()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            remoteTmuxPathProvider: { _ in
+                .failure(.sshConnectionFailed(host: "office-linux"))
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "release-work"
+        )
+
+        model.createTmuxSession(selection)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        await waitUntilMainActor {
+            model.pendingCreatedTmuxSessionCount == 0
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxSessions.map(\.name) == []
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("failed remote creation command removes the optimistic session")
+    func failedRemoteCreationCommandRemovesOptimisticSession() async throws {
+        let environment = try setupRemoteEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "release-work"
+        )
+
+        model.createTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let close = try #require(
+            surfaceStore.surface.closeObservers.values.first
+        )
+        close(false)
+
+        #expect(model.pendingCreatedTmuxSessionCount == 0)
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxSessions.map(\.name) == []
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("protected workspaces never inherit default-server creation")
     func protectedWorkspaceDoesNotReusePendingDefaultSession() throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1010,16 +1010,33 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("failed remote creation command removes the optimistic session")
-    func failedRemoteCreationCommandRemovesOptimisticSession() async throws {
+    @Test("launched remote creation reconciles before removing its session")
+    func launchedRemoteCreationReconcilesBeforeRemoval() async throws {
         let environment = try setupRemoteEnvironment()
+        let attempts = Counter()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in
+                guard attempts.increment() > 1 else {
+                    return .failure(.sshConnectionFailed(
+                        host: "office-linux"
+                    ))
+                }
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: "1721552400",
+                        managed: false
+                    ),
+                ])
+            },
+            createdSessionDiscoveryDelays: [.milliseconds(100)]
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1033,13 +1050,19 @@ struct WorkspaceTmuxDiscoveryTests {
         )
         close(false)
 
-        #expect(model.pendingCreatedTmuxSessionCount == 0)
-        #expect(model.activeBorrowedTmuxSelection == selection)
-        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        await waitUntilMainActor { attempts.count == 1 }
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
         #expect(
             model.snapshot.host(id: environment.host.id)?
-                .tmuxSessions.map(\.name) == []
+                .tmuxSessions.map(\.name) == ["release-work"]
         )
+
+        await waitUntilMainActor {
+            model.pendingCreatedTmuxSessionCount == 0
+        }
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.activeBorrowedTmuxLaunchMode == .attach)
+        #expect(attempts.count == 2)
         await model.shutdown()
     }
 

--- a/Tests/Terminal/ClipboardAccessPolicyTests.swift
+++ b/Tests/Terminal/ClipboardAccessPolicyTests.swift
@@ -73,8 +73,8 @@ struct ClipboardAccessPolicyTests {
         )
     }
 
-    @Test("remote OSC 52 writes are rejected before touching the pasteboard")
-    func blockedOSC52WriteIsRejected() {
+    @Test("OSC 52 writes discard the private origin marker")
+    func osc52WriteDiscardsOriginMarker() {
         let entries = [
             LibghosttyRuntime.ClipboardWriteEntry(
                 mime: "text/plain",
@@ -88,14 +88,13 @@ struct ClipboardAccessPolicyTests {
 
         #expect(
             LibghosttyRuntime.acceptedClipboardWriteEntries(
-                blocked: true,
-                entries: entries
-            ) == nil
+                entries
+            ) == [entries[0]]
         )
     }
 
-    @Test("user-initiated copy remains available on remote surfaces")
-    func blockedSurfaceAcceptsOrdinaryCopy() {
+    @Test("user-initiated copy remains available")
+    func acceptsOrdinaryCopy() {
         let copy = LibghosttyRuntime.ClipboardWriteEntry(
             mime: "text/plain",
             data: "selected text"
@@ -103,28 +102,8 @@ struct ClipboardAccessPolicyTests {
 
         #expect(
             LibghosttyRuntime.acceptedClipboardWriteEntries(
-                blocked: true,
-                entries: [copy]
+                [copy]
             ) == [copy]
-        )
-    }
-
-    @Test("local OSC 52 writes discard the private origin marker")
-    func ordinarySurfaceAcceptsOSC52WithoutMarker() {
-        let payload = LibghosttyRuntime.ClipboardWriteEntry(
-            mime: "text/plain",
-            data: "local payload"
-        )
-        let marker = LibghosttyRuntime.ClipboardWriteEntry(
-            mime: LibghosttyRuntime.osc52ClipboardWriteMIME,
-            data: ""
-        )
-
-        #expect(
-            LibghosttyRuntime.acceptedClipboardWriteEntries(
-                blocked: false,
-                entries: [payload, marker]
-            ) == [payload]
         )
     }
 }

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -806,7 +806,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
-    func testRemoteClipboardPolicyAllowsCopyButRejectsOSC52Write() throws {
+    func testRemoteClipboardPolicyAllowsCopyAndOSC52Write() throws {
         try skipUnlessLibghosttyReady()
         let runtime = retainedRuntime()
         let appHandle = try XCTUnwrap(runtime.unsafeAppHandle)
@@ -814,7 +814,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
             app: appHandle,
             configuration: TerminalSurfaceConfiguration()
         )
-        view.blocksClipboardAccess = true
+        view.blocksClipboardReads = true
         let userdata = Unmanaged.passUnretained(view.callbackToken).toOpaque()
         let pasteboard = NSPasteboard.general
         let priorContents = pasteboard.string(forType: .string)
@@ -870,8 +870,8 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         }
         XCTAssertEqual(
             pasteboard.string(forType: .string),
-            "selected text",
-            "OSC 52 must not overwrite the clipboard on an SSH surface"
+            "remote payload",
+            "OSC 52 copy must reach the clipboard from an SSH surface"
         )
     }
 

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -2288,7 +2288,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 command: "python3 '\(scriptURL.path)'"
             )
         )
-        view.blocksClipboardAccess = true
+        view.blocksClipboardReads = true
         let previousPresenter =
             TerminalSurfaceView.clipboardConfirmationPresenter
         var confirmation: ((Bool) -> Void)?
@@ -2371,7 +2371,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 command: "python3 '\(scriptURL.path)'"
             )
         )
-        view.blocksClipboardAccess = true
+        view.blocksClipboardReads = true
 
         let previousPresenter =
             TerminalSurfaceView.clipboardConfirmationPresenter
@@ -2442,7 +2442,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 command: "python3 '\(scriptURL.path)'"
             )
         )
-        view.blocksClipboardAccess = true
+        view.blocksClipboardReads = true
         let window = hostInWindow(view)
         waitUntil(timeout: 5.0) { view.error == nil }
         waitForProbeReady(in: view)
@@ -2502,7 +2502,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 command: "python3 '\(scriptURL.path)'"
             )
         )
-        view.blocksClipboardAccess = true
+        view.blocksClipboardReads = true
 
         let pasteboard = NSPasteboard.general
         let priorContents = pasteboard.string(forType: .string)
@@ -2532,6 +2532,54 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 Data("local-secret".utf8).base64EncodedString()
             ),
             "Remote OSC 52 reads must never receive local clipboard data."
+        )
+    }
+
+    func testRemoteSurfaceWritesOSC52CopyToPasteboard() throws {
+        let runtime = try runtimeWithTerminalConfig(
+            "clipboard-write = allow\n"
+        )
+        let appHandle = try requireAppHandle(from: runtime)
+        let copiedText = "remote tmux copy"
+        let encodedText = Data(copiedText.utf8).base64EncodedString()
+        let scriptURL = makeExecutableScript(
+            """
+            #!/usr/bin/env python3
+            import os
+
+            os.write(1, b"\\x1b]52;c;\(encodedText)\\x07")
+            print("<WROTE>", flush=True)
+            """
+        )
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        view.blocksClipboardReads = true
+
+        let pasteboard = NSPasteboard.general
+        let priorContents = pasteboard.string(forType: .string)
+        pasteboard.clearContents()
+        defer {
+            pasteboard.clearContents()
+            if let priorContents {
+                pasteboard.setString(priorContents, forType: .string)
+            }
+        }
+
+        _ = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForViewportText("<WROTE>", in: view)
+        waitUntil(timeout: 3.0) {
+            pasteboard.string(forType: .string) == copiedText
+        }
+
+        XCTAssertEqual(
+            pasteboard.string(forType: .string),
+            copiedText,
+            "OSC 52 copy from a remote surface must reach the Mac clipboard."
         )
     }
 

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -827,15 +827,16 @@ struct TmuxAttachmentInfoTests {
         }
     }
 
-    @Test("account login handoff runs under the configured shell")
-    func accountLoginHandoffRunsUnderConfiguredShell() throws {
+    @Test("account login handoff survives libghostty's macOS exec wrapper")
+    func accountLoginHandoffSurvivesLibghosttyExecWrapper() throws {
         let password = try #require(getpwuid(getuid()))
         let shell = String(cString: password.pointee.pw_shell)
         let process = Process()
         let output = Pipe()
-        process.executableURL = URL(fileURLWithPath: shell)
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
         process.arguments = [
-            "-c", accountLoginShellCommand(
+            "--noprofile", "--norc", "-c",
+            "exec -l " + surfaceAccountLoginShellCommand(
                 "printf 'GHOSTHUB_ACCOUNT_SHELL_READY\\n'"
             ),
         ]

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -151,13 +151,15 @@ psmux `ssh -T` wrapper and is not part of this experiment.
 
 Tmux remains alive on the remote host while the network is unavailable. After
 connectivity returns, the client reattaches to the same exact session and tmux
-renders its authoritative state. Remote terminal surfaces cannot read the
-local Mac clipboard through terminal escape sequences, regardless of the
-user's `clipboard-read` or `clipboard-write` configuration. libghostty exposes
-the semantic type of every clipboard request: Ghosthub supplies clipboard
-contents only for a configured `paste_from_clipboard` action, independent of
-which key triggers it. libghostty retains bracketed-paste framing and requires
-confirmation before unsafe unbracketed text can reach the PTY.
+renders its authoritative state. Copy-mode and programs on configured remote
+hosts may write the Mac clipboard through OSC 52 when allowed by the user's
+`clipboard-write` configuration, so remote tmux copy behaves like local tmux
+copy. Remote terminal surfaces cannot read the local Mac clipboard through
+OSC 52, regardless of `clipboard-read`. libghostty exposes the semantic type
+of every clipboard request: Ghosthub supplies clipboard contents only for a
+configured `paste_from_clipboard` action, independent of which key triggers
+it. libghostty retains bracketed-paste framing and requires confirmation before
+unsafe unbracketed text can reach the PTY.
 
 ## Inventory and Startup
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -60,18 +60,19 @@ a supported security boundary.
 Trusting a host does not grant it every local app capability. Ghosthub still
 applies its clipboard policy and other explicit terminal-integration controls
 so routine remote programs cannot silently exercise local UI capabilities that
-the user did not enable. In particular, remote surfaces never service OSC 52
-clipboard reads or writes, regardless of the `clipboard-read` or
-`clipboard-write` values in the user's Ghostty-compatible configuration.
-Ghosthub reads libghostty's semantic request type before touching the Mac
-pasteboard. Only `paste_from_clipboard` may receive clipboard contents;
-OSC 52 reads receive an empty value. This follows the configured binding
-instead of assuming a physical shortcut. Bracketed-paste framing remains
-authoritative, and unsafe unbracketed text requires user confirmation before
-reaching the PTY. Selecting Copy may
-similarly write the user's chosen terminal selection. Those intentional
-interactions necessarily disclose their selected contents to the attached
-pane.
+the user did not enable. Remote panes may write the Mac clipboard through OSC
+52 when allowed by the user's `clipboard-write` configuration. This is a
+required terminal capability so copy-mode in a configured remote tmux session
+can propagate copied text to macOS. Remote surfaces never service OSC 52
+clipboard reads, regardless of `clipboard-read`. Ghosthub reads libghostty's
+semantic request type before touching the Mac pasteboard. Only
+`paste_from_clipboard` may receive clipboard contents; OSC 52 reads receive an
+empty value. This follows the configured binding instead of assuming a
+physical shortcut. Bracketed-paste framing remains authoritative, and unsafe
+unbracketed text requires user confirmation before reaching the PTY. Selecting
+Copy may similarly write the user's chosen terminal selection. Those
+intentional interactions necessarily disclose their selected contents to the
+attached pane.
 
 ### Network
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -233,7 +233,9 @@ const imageAlt = {
             Selecting a listed worktree creates or repairs its canonical tmux
             session when needed, then attaches an ordinary tmux client.
             Kwt remains optional if you only want a local and remote tmux
-            session switcher.
+            session switcher. Remote tmux copy-mode can write copied text to
+            the Mac clipboard through OSC 52, while paste follows the
+            configured terminal shortcut and libghostty’s safe paste path.
           </p>
           <p>
             To remove a non-primary worktree, hover its sidebar row and click


### PR DESCRIPTION
Remote tmux is Ghosthub’s core product path, but two terminal boundaries made it unusable: SSH surfaces discarded tmux OSC 52 clipboard writes, and a recent account-shell handoff duplicated libghostty’s own `exec -l` wrapper so bash tried to launch a program named `exec`. A failed create could then leave Ghosthub’s speculative session row stranded in the sidebar.

This restores remote copy while continuing to block remote clipboard reads and preserving libghostty’s explicit-paste safety path. Terminal surfaces now use a libghostty-compatible outer command while process-based SSH probes retain the 9e2b411 login-shell behavior required for authentication state, connection sharing, non-POSIX account shells, and PATH initialization.

Failures before the terminal command launches discard the optimistic row immediately. Once launch occurs, disconnection no longer proves creation failed: the row stays pending through retrying authoritative inventory reconciliation, preventing a transient SSH or discovery failure from hiding a live tmux session. The connection error and Retry flow remain available.

The executable-launch regression, creation-reconciliation coverage, full tmux attachment and binary-resolver suites, essential tmux workflows, warnings-as-errors, formatting, app build, 120 Python tests, and 42 bootstrap tests pass. All 710 Swift Testing cases pass. The combined XCTest run exhausted PTYs near the end and reported five dependent smoke failures; the three affected terminal tests and all three tmux injection tests pass in isolated reruns.