### PR TITLE
Isolate tmux tests from PTY leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
         # Keep tests marked Pasteboard out of this lane because they mutate
         # NSPasteboard.general, which is shared across worker processes.
         run: >-
+          sh tools/run_swift_tests.sh
           swift test --skip-build --disable-swift-testing
           --filter GhosthubTerminalSmokeTests
           --skip 'Clipboard|Paste'
@@ -130,17 +131,21 @@ jobs:
 
       - name: Run pasteboard terminal smoke tests
         run: >-
+          sh tools/run_swift_tests.sh
           swift test --skip-build --disable-swift-testing
           --filter 'Clipboard|Paste' --no-parallel
 
       - name: Run remaining XCTest suites
         # Keep deadline-sensitive monitor and lifecycle tests serialized.
         run: >-
+          sh tools/run_swift_tests.sh
           swift test --skip-build --disable-swift-testing
           --skip GhosthubTerminalSmokeTests --no-parallel
 
       - name: Run Swift Testing suites
-        run: swift test --skip-build --disable-xctest --no-parallel
+        run: >-
+          sh tools/run_swift_tests.sh
+          swift test --skip-build --disable-xctest --no-parallel
 
       - name: Run essential kwt and tmux workflows
         run: make test-essential-workflows

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ KWT_SOURCE_REVISION ?= unpinned
 endif
 SWIFT_TEST_FILTER ?=
 
-.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach python-test test smoke-test docs-build docs-serve site-deploy reset-app-state install-hooks format format-check
+.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach purge-test-tmux python-test test smoke-test docs-build docs-serve site-deploy reset-app-state install-hooks format format-check
 
 help:
 	@printf '%s\n' \
@@ -96,6 +96,8 @@ help:
 		'      Run SwiftPM tests. Set SWIFT_TEST_FILTER=... for a narrower slice.' \
 		'  make test-tmux-attach' \
 		'      Run the native tmux attachment tests.' \
+		'  make purge-test-tmux' \
+		'      Stop leaked test tmux processes and remove their sockets.' \
 		'  make python-test' \
 		'      Run the full Python test suite via uv-managed pytest.' \
 		'  make test' \
@@ -263,7 +265,8 @@ test-essential-workflows:
 		TmuxAttachmentInfoTests \
 		WorkspaceSidebarModelTests \
 	; do \
-		sh tools/run_with_timeout.sh 600 $(SWIFT) test --filter $$filter; \
+		sh tools/run_with_timeout.sh 600 sh tools/run_swift_tests.sh \
+			$(SWIFT) test --filter $$filter; \
 	done
 
 build: bootstrap-libghostty
@@ -377,7 +380,7 @@ run-app: debug-app
 
 swift-test:
 	@set -euo pipefail; \
-	cmd=($(SWIFT) test); \
+	cmd=(sh tools/run_swift_tests.sh $(SWIFT) test); \
 	if [[ -n "$(SWIFT_TEST_FILTER)" ]]; then \
 		cmd+=(--filter "$(SWIFT_TEST_FILTER)"); \
 	fi; \
@@ -388,8 +391,13 @@ swift-test:
 
 test-tmux-attach: bootstrap-libghostty
 	@set -euo pipefail; \
-	sh tools/run_with_timeout.sh 600 $(SWIFT) test --filter GhosthubTmuxTests; \
-	sh tools/run_with_timeout.sh 600 $(SWIFT) test --filter TmuxInjectionSmokeTests
+	sh tools/run_with_timeout.sh 600 sh tools/run_swift_tests.sh \
+		$(SWIFT) test --filter GhosthubTmuxTests; \
+	sh tools/run_with_timeout.sh 600 sh tools/run_swift_tests.sh \
+		$(SWIFT) test --filter TmuxInjectionSmokeTests
+
+purge-test-tmux:
+	@sh tools/purge_test_tmux.sh
 
 python-test:
 	@$(UV) run --frozen --group dev pytest Tests
@@ -397,7 +405,8 @@ python-test:
 test: swift-test python-test
 
 smoke-test: bootstrap-libghostty
-	@$(SWIFT) test --filter LibghosttyRuntimeSmokeTests
+	@sh tools/run_swift_tests.sh \
+		$(SWIFT) test --filter LibghosttyRuntimeSmokeTests
 
 docs-build:
 	@cd docs && $(UV) run --frozen ./zensical-docs.sh build

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -13,7 +13,10 @@ struct TmuxSessionKillerTests {
         else {
             return
         }
-        let socketName = "ghosthub-kill-\(UUID().uuidString.lowercased())"
+        let socketName = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ].map { "ghosthub-kill-\($0)" }
+            ?? "ghosthub-kill-\(UUID().uuidString.lowercased())"
         let sessionName = "same-name"
         defer {
             _ = TmuxBinaryResolver.runProcess(

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -372,7 +372,10 @@ struct TmuxAttachmentInfoTests {
         let kwt = directory.appendingPathComponent("kwt")
         let config = directory.appendingPathComponent("tmux.conf")
         let marker = directory.appendingPathComponent("session-ran")
-        let socketName = "ghosthub-test-\(UUID().uuidString.lowercased())"
+        let socketName = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ].map { "ghosthub-test-\($0)" }
+            ?? "ghosthub-test-\(UUID().uuidString.lowercased())"
         defer {
             let cleanup = Process()
             cleanup.executableURL = URL(fileURLWithPath: tmuxPath)

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -152,8 +152,14 @@ def test_cancellation_still_kills_group_without_run_directory(
     pytest.fail("test command survived cancellation without its run directory")
 
 
+@pytest.mark.parametrize(
+    "inherited_grace",
+    [None, "30"],
+    ids=["default-grace", "inherited-grace"],
+)
 def test_outer_timeout_leaves_inner_wrapper_time_to_cleanup(
     tmp_path: Path,
+    inherited_grace: str | None,
 ) -> None:
     pid_file = tmp_path / "command-pids"
     tmux_dirs_file = tmp_path / "tmux-dirs"
@@ -167,6 +173,12 @@ def test_outer_timeout_leaves_inner_wrapper_time_to_cleanup(
     )
     command.chmod(0o755)
 
+    # An inherited grace above the watchdog's five-second escalation must
+    # not survive into the nested wrapper, or the watchdog reaps the wrapper
+    # before it can purge its run directory.
+    environment = os.environ.copy()
+    if inherited_grace is not None:
+        environment["GHOSTHUB_TEST_STOP_GRACE"] = inherited_grace
     result = subprocess.run(
         [
             "sh",
@@ -179,6 +191,7 @@ def test_outer_timeout_leaves_inner_wrapper_time_to_cleanup(
         capture_output=True,
         text=True,
         timeout=15,
+        env=environment,
     )
 
     assert result.returncode != 0

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -12,6 +12,7 @@ import pytest
 
 SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "run_swift_tests.sh"
 TIMEOUT_SCRIPT = SCRIPT.with_name("run_with_timeout.sh")
+PURGE_SCRIPT = SCRIPT.with_name("purge_test_tmux.sh")
 
 
 @pytest.mark.parametrize(
@@ -54,6 +55,7 @@ def test_terminating_wrapper_stops_group_before_cleanup(
         ["sh", str(SCRIPT), str(command)],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        env={**os.environ, "GHOSTHUB_TEST_STOP_GRACE": "2"},
     )
     required_files = [
         child_pid_file,
@@ -97,6 +99,57 @@ def test_terminating_wrapper_stops_group_before_cleanup(
     if not ignores_term:
         assert signal_marker.read_text().strip() == "present"
     assert not tmux_dir.exists()
+
+
+def test_cancellation_still_kills_group_without_run_directory(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "child.pid"
+    tmux_dir_file = tmp_path / "tmux-dir"
+    command = tmp_path / "ignore-term.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        "trap '' TERM\n"
+        f'echo $$ > "{child_pid_file}"\n'
+        f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
+        "sleep 30\n"
+    )
+    command.chmod(0o755)
+
+    wrapper = subprocess.Popen(
+        ["sh", str(SCRIPT), str(command)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GHOSTHUB_TEST_STOP_GRACE": "1"},
+    )
+    deadline = time.monotonic() + 10
+    while (
+        not (child_pid_file.exists() and tmux_dir_file.exists())
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.05)
+    if not (child_pid_file.exists() and tmux_dir_file.exists()):
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        pytest.fail("test command did not start")
+    child_pid = int(child_pid_file.read_text().strip())
+
+    # The deadline KILL must not depend on the run directory: an external
+    # deletion mid-run previously left the wrapper waiting forever for a
+    # marker it could no longer create.
+    shutil.rmtree(tmux_dir_file.read_text().strip())
+    wrapper.terminate()
+    assert wrapper.wait(timeout=10) == 143
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    os.killpg(child_pid, signal.SIGKILL)
+    pytest.fail("test command survived cancellation without its run directory")
 
 
 def test_outer_timeout_leaves_inner_wrapper_time_to_cleanup(
@@ -189,6 +242,44 @@ def test_cleanup_stops_every_socket_in_private_run_directory(
     else:
         os.kill(server_pid, signal.SIGKILL)
         pytest.fail("tmux server on an unexpected test socket survived cleanup")
+
+
+def test_default_purge_skips_active_run_directories() -> None:
+    test_root = Path(f"/tmp/ghosthub-{os.getuid()}/tmux-tests")
+    test_root.parent.mkdir(mode=0o700, exist_ok=True)
+    test_root.mkdir(mode=0o700, exist_ok=True)
+
+    dead_pid = None
+    for _ in range(5):
+        probe = subprocess.Popen(["true"])
+        probe.wait(timeout=10)
+        try:
+            os.kill(probe.pid, 0)
+        except ProcessLookupError:
+            dead_pid = probe.pid
+            break
+    if dead_pid is None:
+        pytest.skip("could not obtain a dead PID")
+
+    live_dir = test_root / f"run.{os.getpid()}.aaaaaa"
+    dead_dir = test_root / f"run.{dead_pid}.bbbbbb"
+    try:
+        live_dir.mkdir(mode=0o700)
+        dead_dir.mkdir(mode=0o700)
+
+        result = subprocess.run(
+            ["sh", str(PURGE_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert live_dir.exists(), "purge removed an active run directory"
+        assert not dead_dir.exists(), "purge kept a dead run directory"
+    finally:
+        for directory in (live_dir, dead_dir):
+            shutil.rmtree(directory, ignore_errors=True)
 
 
 def test_cleanup_bounds_a_stalled_tmux_client(tmp_path: Path) -> None:

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -8,6 +10,7 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "run_swift_tests.sh"
+TIMEOUT_SCRIPT = SCRIPT.with_name("run_with_timeout.sh")
 
 
 @pytest.mark.parametrize(
@@ -93,3 +96,95 @@ def test_terminating_wrapper_stops_group_before_cleanup(
     if not ignores_term:
         assert signal_marker.read_text().strip() == "present"
     assert not tmux_dir.exists()
+
+
+def test_outer_timeout_leaves_inner_wrapper_time_to_cleanup(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "command-pids"
+    tmux_dirs_file = tmp_path / "tmux-dirs"
+    command = tmp_path / "ignore-term.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        "trap '' TERM\n"
+        f'echo $$ >> "{pid_file}"\n'
+        f'echo "$TMUX_TMPDIR" >> "{tmux_dirs_file}"\n'
+        "sleep 30\n"
+    )
+    command.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            "sh",
+            str(TIMEOUT_SCRIPT),
+            "1",
+            "sh",
+            str(SCRIPT),
+            str(command),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode != 0
+    command_pids = [
+        int(value) for value in pid_file.read_text().splitlines()
+    ]
+    tmux_dirs = [
+        Path(value) for value in tmux_dirs_file.read_text().splitlines()
+    ]
+    assert len(command_pids) == 2
+    assert len(tmux_dirs) == 2
+
+    alive = []
+    for pid in command_pids:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            continue
+        alive.append(pid)
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    assert not alive, "nested timeout left a test command running"
+    assert not any(directory.exists() for directory in tmux_dirs)
+
+
+def test_cleanup_stops_every_socket_in_private_run_directory(
+    tmp_path: Path,
+) -> None:
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux is unavailable")
+
+    server_pid_file = tmp_path / "server.pid"
+    command = tmp_path / "start-unexpected-server.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        'socket="$TMUX_TMPDIR/unexpected-socket"\n'
+        'tmux -S "$socket" new-session -d\n'
+        f'tmux -S "$socket" display-message -p "#{{pid}}" > "{server_pid_file}"\n'
+    )
+    command.chmod(0o755)
+
+    result = subprocess.run(
+        ["sh", str(SCRIPT), str(command)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    server_pid = int(server_pid_file.read_text().strip())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(server_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        os.kill(server_pid, signal.SIGKILL)
+        pytest.fail("tmux server on an unexpected test socket survived cleanup")

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -10,26 +10,38 @@ import pytest
 SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "run_swift_tests.sh"
 
 
+@pytest.mark.parametrize(
+    "ignores_term",
+    [False, True],
+    ids=["handles-term", "ignores-term"],
+)
 def test_terminating_wrapper_stops_group_before_cleanup(
     tmp_path: Path,
+    ignores_term: bool,
 ) -> None:
     child_pid_file = tmp_path / "child.pid"
     grandchild_pid_file = tmp_path / "grandchild.pid"
     tmux_dir_file = tmp_path / "tmux-dir"
     signal_marker = tmp_path / "signal-marker"
     command = tmp_path / "command.sh"
+    if ignores_term:
+        term_trap = "trap '' TERM\n"
+    else:
+        term_trap = (
+            "trap 'if [ -d \"$TMUX_TMPDIR\" ]; then "
+            f'echo present > "{signal_marker}"; '
+            "else "
+            f'echo missing > "{signal_marker}"; '
+            "fi; wait \"$grandchild\" 2>/dev/null || true; exit 0' TERM\n"
+        )
     command.write_text(
         "#!/bin/sh\n"
         f'echo $$ > "{child_pid_file}"\n'
         f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
+        f"{term_trap}"
         "sleep 30 &\n"
         "grandchild=$!\n"
         f'echo "$grandchild" > "{grandchild_pid_file}"\n'
-        "trap 'if [ -d \"$TMUX_TMPDIR\" ]; then "
-        f'echo present > "{signal_marker}"; '
-        "else "
-        f'echo missing > "{signal_marker}"; '
-        "fi; wait \"$grandchild\" 2>/dev/null || true; exit 0' TERM\n"
         "wait \"$grandchild\"\n"
     )
     command.chmod(0o755)
@@ -62,7 +74,7 @@ def test_terminating_wrapper_stops_group_before_cleanup(
     tmux_dir = Path(tmux_dir_file.read_text().strip())
 
     wrapper.terminate()
-    assert wrapper.wait(timeout=10) == 143
+    assert wrapper.wait(timeout=12) == 143
 
     deadline = time.monotonic() + 5
     alive = child_pids
@@ -78,5 +90,6 @@ def test_terminating_wrapper_stops_group_before_cleanup(
             time.sleep(0.05)
 
     assert not alive, "test process group survived wrapper termination"
-    assert signal_marker.read_text().strip() == "present"
+    if not ignores_term:
+        assert signal_marker.read_text().strip() == "present"
     assert not tmux_dir.exists()

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "run_swift_tests.sh"
+
+
+def test_terminating_wrapper_stops_group_before_cleanup(
+    tmp_path: Path,
+) -> None:
+    child_pid_file = tmp_path / "child.pid"
+    grandchild_pid_file = tmp_path / "grandchild.pid"
+    tmux_dir_file = tmp_path / "tmux-dir"
+    signal_marker = tmp_path / "signal-marker"
+    command = tmp_path / "command.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        f'echo $$ > "{child_pid_file}"\n'
+        f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
+        "sleep 30 &\n"
+        "grandchild=$!\n"
+        f'echo "$grandchild" > "{grandchild_pid_file}"\n'
+        "trap 'if [ -d \"$TMUX_TMPDIR\" ]; then "
+        f'echo present > "{signal_marker}"; '
+        "else "
+        f'echo missing > "{signal_marker}"; '
+        "fi; wait \"$grandchild\" 2>/dev/null || true; exit 0' TERM\n"
+        "wait \"$grandchild\"\n"
+    )
+    command.chmod(0o755)
+
+    wrapper = subprocess.Popen(
+        ["sh", str(SCRIPT), str(command)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    required_files = [
+        child_pid_file,
+        grandchild_pid_file,
+        tmux_dir_file,
+    ]
+    deadline = time.monotonic() + 10
+    while (
+        not all(path.exists() for path in required_files)
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.05)
+    if not all(path.exists() for path in required_files):
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        pytest.fail("test command did not start")
+
+    child_pids = [
+        int(child_pid_file.read_text().strip()),
+        int(grandchild_pid_file.read_text().strip()),
+    ]
+    tmux_dir = Path(tmux_dir_file.read_text().strip())
+
+    wrapper.terminate()
+    assert wrapper.wait(timeout=10) == 143
+
+    deadline = time.monotonic() + 5
+    alive = child_pids
+    while alive and time.monotonic() < deadline:
+        alive = []
+        for pid in child_pids:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                continue
+            alive.append(pid)
+        if alive:
+            time.sleep(0.05)
+
+    assert not alive, "test process group survived wrapper termination"
+    assert signal_marker.read_text().strip() == "present"
+    assert not tmux_dir.exists()

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -101,6 +101,43 @@ def test_terminating_wrapper_stops_group_before_cleanup(
     assert not tmux_dir.exists()
 
 
+def test_forwarded_interrupt_keeps_its_grace(tmp_path: Path) -> None:
+    child_pid_file = tmp_path / "child.pid"
+    term_file = tmp_path / "term-received"
+    done_file = tmp_path / "int-done"
+    command = tmp_path / "graceful-int.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        f"trap 'echo term > \"{term_file}\"; exit 1' TERM\n"
+        f"trap 'sleep 1; echo done > \"{done_file}\"; exit 0' INT\n"
+        f'echo $$ > "{child_pid_file}"\n'
+        "while :; do sleep 0.1; done\n"
+    )
+    command.chmod(0o755)
+
+    wrapper = subprocess.Popen(
+        ["sh", str(SCRIPT), str(command)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GHOSTHUB_TEST_STOP_GRACE": "5"},
+    )
+    deadline = time.monotonic() + 10
+    while not child_pid_file.exists() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not child_pid_file.exists():
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        pytest.fail("test command did not start")
+
+    # An interrupt handler that needs cleanup time must see only the
+    # forwarded INT; piling TERM on top makes second-signal-quits tools
+    # abort before their grace elapses.
+    wrapper.send_signal(signal.SIGINT)
+    assert wrapper.wait(timeout=10) == 130
+    assert done_file.exists(), "INT handler was cut short"
+    assert not term_file.exists(), "cancelled child received an extra TERM"
+
+
 def test_cancellation_still_kills_group_without_run_directory(
     tmp_path: Path,
 ) -> None:
@@ -349,14 +386,14 @@ def test_default_purge_skips_active_run_directories() -> None:
             shutil.rmtree(directory, ignore_errors=True)
 
 
-def test_cleanup_bounds_a_stalled_tmux_client(tmp_path: Path) -> None:
+def test_cleanup_bounds_stalled_tmux_clients(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    fake_pid_file = tmp_path / "fake-tmux.pid"
+    fake_pid_file = tmp_path / "fake-tmux.pids"
     fake_tmux = fake_bin / "tmux"
     fake_tmux.write_text(
         "#!/bin/sh\n"
-        f'echo $$ > "{fake_pid_file}"\n'
+        f'echo $$ >> "{fake_pid_file}"\n'
         "trap '' TERM\n"
         "sleep 30\n"
     )
@@ -371,12 +408,16 @@ def test_cleanup_bounds_a_stalled_tmux_client(tmp_path: Path) -> None:
         "sock.close()\n"
     )
     tmux_dir_file = tmp_path / "tmux-dir"
-    command = tmp_path / "create-socket.sh"
+    # Six sockets so a serialized one-second-per-socket shutdown would blow
+    # the five-second bound; the shared deadline finishes in about a second.
+    command = tmp_path / "create-sockets.sh"
     command.write_text(
         "#!/bin/sh\n"
         f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
-        f'"{sys.executable}" "{socket_writer}" '
-        '"$TMUX_TMPDIR/stalled-socket"\n'
+        "for name in a b c d e f; do\n"
+        f'    "{sys.executable}" "{socket_writer}" '
+        '"$TMUX_TMPDIR/stalled-$name"\n'
+        "done\n"
     )
     command.chmod(0o755)
     environment = os.environ.copy()
@@ -391,12 +432,17 @@ def test_cleanup_bounds_a_stalled_tmux_client(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    fake_pid = int(fake_pid_file.read_text().strip())
-    try:
-        os.kill(fake_pid, 0)
-    except ProcessLookupError:
-        pass
-    else:
+    fake_pids = [
+        int(value) for value in fake_pid_file.read_text().split()
+    ]
+    assert len(fake_pids) == 6
+    survivors = []
+    for fake_pid in fake_pids:
+        try:
+            os.kill(fake_pid, 0)
+        except ProcessLookupError:
+            continue
+        survivors.append(fake_pid)
         os.killpg(fake_pid, signal.SIGKILL)
-        pytest.fail("stalled tmux client survived its cleanup deadline")
+    assert not survivors, "stalled tmux clients survived the shared deadline"
     assert not Path(tmux_dir_file.read_text().strip()).exists()

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -188,3 +189,56 @@ def test_cleanup_stops_every_socket_in_private_run_directory(
     else:
         os.kill(server_pid, signal.SIGKILL)
         pytest.fail("tmux server on an unexpected test socket survived cleanup")
+
+
+def test_cleanup_bounds_a_stalled_tmux_client(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_pid_file = tmp_path / "fake-tmux.pid"
+    fake_tmux = fake_bin / "tmux"
+    fake_tmux.write_text(
+        "#!/bin/sh\n"
+        f'echo $$ > "{fake_pid_file}"\n'
+        "trap '' TERM\n"
+        "sleep 30\n"
+    )
+    fake_tmux.chmod(0o755)
+
+    socket_writer = tmp_path / "write-socket.py"
+    socket_writer.write_text(
+        "import socket\n"
+        "import sys\n"
+        "sock = socket.socket(socket.AF_UNIX)\n"
+        "sock.bind(sys.argv[1])\n"
+        "sock.close()\n"
+    )
+    tmux_dir_file = tmp_path / "tmux-dir"
+    command = tmp_path / "create-socket.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
+        f'"{sys.executable}" "{socket_writer}" '
+        '"$TMUX_TMPDIR/stalled-socket"\n'
+    )
+    command.chmod(0o755)
+    environment = os.environ.copy()
+    environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+
+    result = subprocess.run(
+        ["sh", str(SCRIPT), str(command)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    fake_pid = int(fake_pid_file.read_text().strip())
+    try:
+        os.kill(fake_pid, 0)
+    except ProcessLookupError:
+        pass
+    else:
+        os.killpg(fake_pid, signal.SIGKILL)
+        pytest.fail("stalled tmux client survived its cleanup deadline")
+    assert not Path(tmux_dir_file.read_text().strip()).exists()

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -257,6 +257,60 @@ def test_cleanup_stops_every_socket_in_private_run_directory(
         pytest.fail("tmux server on an unexpected test socket survived cleanup")
 
 
+def test_cancellation_reaps_daemonized_server_without_run_directory(
+    tmp_path: Path,
+) -> None:
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux is unavailable")
+
+    server_pid_file = tmp_path / "server.pid"
+    tmux_dir_file = tmp_path / "tmux-dir"
+    command = tmp_path / "start-server-and-wait.sh"
+    command.write_text(
+        "#!/bin/sh\n"
+        'socket="$TMUX_TMPDIR/orphan-socket"\n'
+        'tmux -S "$socket" new-session -d\n'
+        f'tmux -S "$socket" display-message -p "#{{pid}}" > "{server_pid_file}"\n'
+        f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
+        "sleep 30\n"
+    )
+    command.chmod(0o755)
+
+    wrapper = subprocess.Popen(
+        ["sh", str(SCRIPT), str(command)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GHOSTHUB_TEST_STOP_GRACE": "1"},
+    )
+    deadline = time.monotonic() + 10
+    while (
+        not (server_pid_file.exists() and tmux_dir_file.exists())
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.05)
+    if not (server_pid_file.exists() and tmux_dir_file.exists()):
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        pytest.fail("tmux server did not start")
+    server_pid = int(server_pid_file.read_text().strip())
+
+    # The server daemonized outside the test process group, so once its run
+    # directory is gone only identity-based process cleanup can reach it.
+    shutil.rmtree(tmux_dir_file.read_text().strip())
+    wrapper.terminate()
+    assert wrapper.wait(timeout=10) == 143
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(server_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    os.kill(server_pid, signal.SIGKILL)
+    pytest.fail("daemonized tmux server survived run-directory removal")
+
+
 def test_default_purge_skips_active_run_directories() -> None:
     test_root = Path(f"/tmp/ghosthub-{os.getuid()}/tmux-tests")
     test_root.parent.mkdir(mode=0o700, exist_ok=True)

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,9 +55,12 @@ swift test list   # enumerate tests without running
 ```
 
 The test target gives every run its own pre-created `TMUX_TMPDIR` and removes
-its tmux servers and sockets afterward. If a test runner was hard-killed, use
-`make purge-test-tmux` to stop only Ghosthub's test-prefixed tmux processes and
-remove their isolated and legacy sockets.
+its tmux servers and sockets afterward. Cancelling a run forwards the signal
+and gives the test group `GHOSTHUB_TEST_STOP_GRACE` seconds (default 20, or 2
+under `tools/run_with_timeout.sh`) to unwind before it is force-killed. If a
+test runner was hard-killed, use `make purge-test-tmux` to stop only
+Ghosthub's test-prefixed tmux processes and remove their isolated and legacy
+sockets; runs whose owning wrapper is still alive are left untouched.
 
 ## Python tooling
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,9 +50,14 @@ make format-check   # report without changing anything
 Run Swift tests:
 
 ```bash
-swift test
+make swift-test
 swift test list   # enumerate tests without running
 ```
+
+The test target gives every run its own pre-created `TMUX_TMPDIR` and removes
+its tmux servers and sockets afterward. If a test runner was hard-killed, use
+`make purge-test-tmux` to stop only Ghosthub's test-prefixed tmux processes and
+remove their isolated and legacy sockets.
 
 ## Python tooling
 

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -56,20 +56,38 @@ fi
 kill_socket() {
     socket=$1
     if [ -n "$tmux_bin" ]; then
-        "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 || true
+        set -m
+        "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 &
+        socket_client_pid=$!
+        (
+            sleep 1
+            kill -KILL -- -"$socket_client_pid" 2>/dev/null ||
+                kill -KILL "$socket_client_pid" 2>/dev/null || true
+        ) &
+        socket_deadline_pid=$!
+        set +m
+        wait "$socket_client_pid" 2>/dev/null || true
+        kill -TERM -- -"$socket_deadline_pid" 2>/dev/null || true
+        wait "$socket_deadline_pid" 2>/dev/null || true
     fi
     rm -f "$socket"
 }
 
 run_tmux_pids() {
     run_id=$1
-    ps -axo pid=,command= | awk -v run_id="$run_id" '
+    run_dir=$2
+    ps -axo pid=,command= | awk -v run_id="$run_id" \
+        -v run_dir="$run_dir" '
         BEGIN {
             socket_pattern = "^ghosthub-(test|kill|style|ready)-" run_id "$"
         }
         /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
             for (field = 2; field < NF; field++) {
-                if ($field == "-L" && $(field + 1) ~ socket_pattern) {
+                socket_path = $(field + 1)
+                if (($field == "-L" && $(field + 1) ~ socket_pattern) ||
+                    ($field == "-S" &&
+                     index(socket_path, run_dir "/") == 1 &&
+                     socket_path !~ /(^|\/)\.\.(\/|$)/)) {
                     print $1
                     break
                 }
@@ -89,13 +107,14 @@ signal_pids() {
 
 kill_run_tmux_processes() {
     run_id=$1
-    pids=$(run_tmux_pids "$run_id")
+    run_dir=$2
+    pids=$(run_tmux_pids "$run_id" "$run_dir")
     if [ -n "$pids" ]; then
         signal_pids TERM "$pids"
         sleep 1
     fi
 
-    pids=$(run_tmux_pids "$run_id")
+    pids=$(run_tmux_pids "$run_id" "$run_dir")
     if [ -n "$pids" ]; then
         signal_pids KILL "$pids"
     fi
@@ -110,7 +129,7 @@ purge_run_directory() {
         while IFS= read -r socket; do
             kill_socket "$socket"
         done
-    kill_run_tmux_processes "$run_id"
+    kill_run_tmux_processes "$run_id" "$directory"
     rm -rf "$directory"
 }
 

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -79,7 +79,7 @@ run_tmux_pids() {
     ps -axo pid=,command= | awk -v run_id="$run_id" \
         -v run_dir="$run_dir" '
         BEGIN {
-            socket_pattern = "^ghosthub-(test|kill|style|ready)-" run_id "$"
+            socket_pattern = "^ghosthub-(test|kill)-" run_id "$"
         }
         /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
             for (field = 2; field < NF; field++) {
@@ -149,19 +149,19 @@ if [ -e "$test_root" ] || [ -L "$test_root" ]; then
     find "$test_root" -mindepth 1 -maxdepth 1 -type d \
         -name 'run.*.??????' -print |
         while IFS= read -r directory; do
-            if [ "$mode" = stale ]; then
-                run_name=$(basename -- "$directory")
-                owner_pid=${run_name#run.}
-                owner_pid=${owner_pid%%.*}
-                case "$owner_pid" in
-                    '' | *[!0-9]*) continue ;;
-                    *)
-                        if kill -0 "$owner_pid" 2>/dev/null; then
-                            continue
-                        fi
-                        ;;
-                esac
-            fi
+            # A live owner PID marks an active run. Never purge one out from
+            # under a concurrent test invocation, in any mode.
+            run_name=$(basename -- "$directory")
+            owner_pid=${run_name#run.}
+            owner_pid=${owner_pid%%.*}
+            case "$owner_pid" in
+                '' | *[!0-9]*) continue ;;
+                *)
+                    if kill -0 "$owner_pid" 2>/dev/null; then
+                        continue
+                    fi
+                    ;;
+            esac
             purge_run_directory "$directory"
         done
 fi
@@ -174,7 +174,7 @@ if [ -e "$legacy_socket_root" ] || [ -L "$legacy_socket_root" ]; then
     require_secure_directory "$legacy_socket_root" "legacy tmux socket"
     find "$legacy_socket_root" -mindepth 1 -maxdepth 1 -type s -print |
         awk -F/ '
-            $NF ~ /^ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+            $NF ~ /^ghosthub-(test|kill)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
         ' |
         while IFS= read -r socket; do
             kill_socket "$socket"
@@ -184,7 +184,7 @@ fi
 legacy_test_tmux_pids() {
     ps -axo pid=,command= | awk '
         /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ &&
-        /-L[[:space:]]+ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}([[:space:]]|$)/ {
+        /-L[[:space:]]+ghosthub-(test|kill)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}([[:space:]]|$)/ {
             print $1
         }
     '

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -122,18 +122,25 @@ kill_run_tmux_processes() {
 
 purge_run_directory() {
     directory=$1
-    [ -d "$directory" ] || return 0
+    run_id=${directory##*.}
+    # A tmux server daemonizes outside the test process group and can
+    # outlive an externally removed run directory, so process cleanup for
+    # the validated run identity happens even when the directory is gone.
+    if [ ! -d "$directory" ] && [ ! -L "$directory" ]; then
+        kill_run_tmux_processes "$run_id" "$directory"
+        return 0
+    fi
     if ! require_secure_directory "$directory" "tmux test run" 2>/dev/null; then
         # A concurrent sweep may remove the same dead run directory at any
-        # point during validation; gone is a completed purge, while a
-        # directory that remains insecure is still refused.
+        # point during validation, while a directory that remains insecure
+        # is still refused.
         if [ ! -d "$directory" ] && [ ! -L "$directory" ]; then
+            kill_run_tmux_processes "$run_id" "$directory"
             return 0
         fi
         echo "refusing insecure tmux test run directory: $directory" >&2
         return 1
     fi
-    run_id=${directory##*.}
     find "$directory" -type s -print |
         while IFS= read -r socket; do
             kill_socket "$socket"

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -123,7 +123,16 @@ kill_run_tmux_processes() {
 purge_run_directory() {
     directory=$1
     [ -d "$directory" ] || return 0
-    require_secure_directory "$directory" "tmux test run"
+    if ! require_secure_directory "$directory" "tmux test run" 2>/dev/null; then
+        # A concurrent sweep may remove the same dead run directory at any
+        # point during validation; gone is a completed purge, while a
+        # directory that remains insecure is still refused.
+        if [ ! -d "$directory" ] && [ ! -L "$directory" ]; then
+            return 0
+        fi
+        echo "refusing insecure tmux test run directory: $directory" >&2
+        return 1
+    fi
     run_id=${directory##*.}
     find "$directory" -type s -print |
         while IFS= read -r socket; do

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+set -eu
+
+test_root=/tmp/ghosthub-tmux-tests
+legacy_socket_root="/tmp/tmux-$(id -u)"
+tmux_bin=$(command -v tmux || true)
+mode=all
+run_dir=
+
+if [ -L "$test_root" ]; then
+    echo "refusing to use symlinked tmux test root: $test_root" >&2
+    exit 2
+fi
+
+if [ "$#" -gt 1 ]; then
+    echo "usage: $0 [--stale | run-directory]" >&2
+    exit 2
+fi
+
+if [ "$#" -eq 1 ]; then
+    if [ "$1" = --stale ]; then
+        mode=stale
+    else
+        mode=run
+        run_dir=$1
+        run_name=$(basename -- "$run_dir")
+        run_parent=$(dirname -- "$run_dir")
+        if [ "$run_parent" != "$test_root" ] ||
+            ! printf '%s\n' "$run_name" | grep -Eq '^run\.[A-Za-z0-9]{6}$'
+        then
+            echo "refusing to purge unexpected tmux test directory: $run_dir" >&2
+            exit 2
+        fi
+    fi
+fi
+
+kill_socket() {
+    socket=$1
+    socket_name=$(basename -- "$socket")
+    if [ -n "$tmux_bin" ]; then
+        "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 || true
+    fi
+    rm -f "$socket"
+    kill_named_tmux_processes "$socket_name"
+}
+
+named_tmux_pids() {
+    socket_name=$1
+    ps -axo pid=,command= | awk -v socket_name="$socket_name" '
+        /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
+            for (field = 2; field < NF; field++) {
+                if ($field == "-L" && $(field + 1) == socket_name) {
+                    print $1
+                    break
+                }
+            }
+        }
+    '
+}
+
+kill_named_tmux_processes() {
+    socket_name=$1
+    pids=$(named_tmux_pids "$socket_name")
+    if [ -n "$pids" ]; then
+        kill -TERM $pids 2>/dev/null || true
+        sleep 1
+    fi
+
+    pids=$(named_tmux_pids "$socket_name")
+    if [ -n "$pids" ]; then
+        kill -KILL $pids 2>/dev/null || true
+    fi
+}
+
+purge_run_directory() {
+    directory=$1
+    [ -d "$directory" ] || return 0
+    find "$directory" -type s -print | while IFS= read -r socket; do
+        kill_socket "$socket"
+    done
+    kill_run_tmux_processes "${directory##*.}"
+    rm -rf "$directory"
+}
+
+run_tmux_pids() {
+    run_id=$1
+    ps -axo pid=,command= | awk -v run_id="$run_id" '
+        BEGIN {
+            socket_pattern = "^ghosthub-(test|kill|style|ready)-" run_id "$"
+        }
+        /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
+            for (field = 2; field < NF; field++) {
+                if ($field == "-L" && $(field + 1) ~ socket_pattern) {
+                    print $1
+                    break
+                }
+            }
+        }
+    '
+}
+
+kill_run_tmux_processes() {
+    run_id=$1
+    pids=$(run_tmux_pids "$run_id")
+    if [ -n "$pids" ]; then
+        kill -TERM $pids 2>/dev/null || true
+        sleep 1
+    fi
+
+    pids=$(run_tmux_pids "$run_id")
+    if [ -n "$pids" ]; then
+        kill -KILL $pids 2>/dev/null || true
+    fi
+}
+
+if [ "$mode" = run ]; then
+    purge_run_directory "$run_dir"
+    exit 0
+fi
+
+if [ -d "$test_root" ]; then
+    find "$test_root" -mindepth 1 -maxdepth 1 -type d -name 'run.??????' -print |
+        while IFS= read -r directory; do
+            if [ "$mode" = stale ]; then
+                owner_pid=$(cat "$directory/owner.pid" 2>/dev/null || true)
+                case "$owner_pid" in
+                    '' | *[!0-9]*) ;;
+                    *)
+                        if kill -0 "$owner_pid" 2>/dev/null; then
+                            continue
+                        fi
+                        ;;
+                esac
+            fi
+            purge_run_directory "$directory"
+        done
+    rmdir "$test_root" 2>/dev/null || true
+fi
+
+if [ "$mode" = stale ]; then
+    exit 0
+fi
+
+if [ -d "$legacy_socket_root" ]; then
+    find "$legacy_socket_root" -mindepth 1 -maxdepth 1 -type s -print |
+        awk -F/ '
+            $NF ~ /^ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+        ' |
+        while IFS= read -r socket; do
+            kill_socket "$socket"
+        done
+fi
+
+test_tmux_pids() {
+    ps -axo pid=,command= | awk '
+        /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ &&
+        /-L[[:space:]]+ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}([[:space:]]|$)/ {
+            print $1
+        }
+    '
+}
+
+pids=$(test_tmux_pids)
+if [ -n "$pids" ]; then
+    kill -TERM $pids 2>/dev/null || true
+    sleep 1
+fi
+
+pids=$(test_tmux_pids)
+if [ -n "$pids" ]; then
+    kill -KILL $pids 2>/dev/null || true
+fi

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -2,16 +2,33 @@
 
 set -eu
 
-test_root=/tmp/ghosthub-tmux-tests
-legacy_socket_root="/tmp/tmux-$(id -u)"
+current_uid=$(id -u)
+user_tmpdir="/tmp/ghosthub-$current_uid"
+test_root="$user_tmpdir/tmux-tests"
+legacy_socket_root="/tmp/tmux-$current_uid"
 tmux_bin=$(command -v tmux || true)
 mode=all
 run_dir=
 
-if [ -L "$test_root" ]; then
-    echo "refusing to use symlinked tmux test root: $test_root" >&2
-    exit 2
-fi
+directory_owner() {
+    stat -f '%u' "$1" 2>/dev/null || stat -c '%u' "$1"
+}
+
+directory_mode() {
+    stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+require_secure_directory() {
+    directory=$1
+    description=$2
+    if [ ! -d "$directory" ] || [ -L "$directory" ] ||
+        [ "$(directory_owner "$directory")" != "$current_uid" ] ||
+        [ "$(directory_mode "$directory")" != 700 ]
+    then
+        echo "refusing insecure $description directory: $directory" >&2
+        return 1
+    fi
+}
 
 if [ "$#" -gt 1 ]; then
     echo "usage: $0 [--stale | run-directory]" >&2
@@ -27,9 +44,10 @@ if [ "$#" -eq 1 ]; then
         run_name=$(basename -- "$run_dir")
         run_parent=$(dirname -- "$run_dir")
         if [ "$run_parent" != "$test_root" ] ||
-            ! printf '%s\n' "$run_name" | grep -Eq '^run\.[A-Za-z0-9]{6}$'
+            ! printf '%s\n' "$run_name" |
+                grep -Eq '^run\.[0-9]+\.[A-Za-z0-9]{6}$'
         then
-            echo "refusing to purge unexpected tmux test directory: $run_dir" >&2
+            echo "refusing unexpected tmux test directory: $run_dir" >&2
             exit 2
         fi
     fi
@@ -37,50 +55,10 @@ fi
 
 kill_socket() {
     socket=$1
-    socket_name=$(basename -- "$socket")
     if [ -n "$tmux_bin" ]; then
         "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 || true
     fi
     rm -f "$socket"
-    kill_named_tmux_processes "$socket_name"
-}
-
-named_tmux_pids() {
-    socket_name=$1
-    ps -axo pid=,command= | awk -v socket_name="$socket_name" '
-        /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
-            for (field = 2; field < NF; field++) {
-                if ($field == "-L" && $(field + 1) == socket_name) {
-                    print $1
-                    break
-                }
-            }
-        }
-    '
-}
-
-kill_named_tmux_processes() {
-    socket_name=$1
-    pids=$(named_tmux_pids "$socket_name")
-    if [ -n "$pids" ]; then
-        kill -TERM $pids 2>/dev/null || true
-        sleep 1
-    fi
-
-    pids=$(named_tmux_pids "$socket_name")
-    if [ -n "$pids" ]; then
-        kill -KILL $pids 2>/dev/null || true
-    fi
-}
-
-purge_run_directory() {
-    directory=$1
-    [ -d "$directory" ] || return 0
-    find "$directory" -type s -print | while IFS= read -r socket; do
-        kill_socket "$socket"
-    done
-    kill_run_tmux_processes "${directory##*.}"
-    rm -rf "$directory"
 }
 
 run_tmux_pids() {
@@ -100,32 +78,67 @@ run_tmux_pids() {
     '
 }
 
+signal_pids() {
+    signal=$1
+    pid_list=$2
+    printf '%s\n' "$pid_list" | while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        kill "-$signal" "$pid" 2>/dev/null || true
+    done
+}
+
 kill_run_tmux_processes() {
     run_id=$1
     pids=$(run_tmux_pids "$run_id")
     if [ -n "$pids" ]; then
-        kill -TERM $pids 2>/dev/null || true
+        signal_pids TERM "$pids"
         sleep 1
     fi
 
     pids=$(run_tmux_pids "$run_id")
     if [ -n "$pids" ]; then
-        kill -KILL $pids 2>/dev/null || true
+        signal_pids KILL "$pids"
     fi
 }
 
+purge_run_directory() {
+    directory=$1
+    [ -d "$directory" ] || return 0
+    require_secure_directory "$directory" "tmux test run"
+    run_id=${directory##*.}
+    find "$directory" -type s -print |
+        awk -F/ -v run_id="$run_id" '
+            $NF ~ "^ghosthub-(test|kill|style|ready)-" run_id "$"
+        ' |
+        while IFS= read -r socket; do
+            kill_socket "$socket"
+        done
+    kill_run_tmux_processes "$run_id"
+    rm -rf "$directory"
+}
+
 if [ "$mode" = run ]; then
+    require_secure_directory "$user_tmpdir" "user temporary"
+    require_secure_directory "$test_root" "tmux test root"
     purge_run_directory "$run_dir"
     exit 0
 fi
 
-if [ -d "$test_root" ]; then
-    find "$test_root" -mindepth 1 -maxdepth 1 -type d -name 'run.??????' -print |
+if [ -e "$user_tmpdir" ] || [ -L "$user_tmpdir" ]; then
+    require_secure_directory "$user_tmpdir" "user temporary"
+fi
+
+if [ -e "$test_root" ] || [ -L "$test_root" ]; then
+    require_secure_directory "$test_root" "tmux test root"
+    find "$test_root" -mindepth 1 -maxdepth 1 -type d \
+        -name 'run.*.??????' -print |
         while IFS= read -r directory; do
             if [ "$mode" = stale ]; then
-                owner_pid=$(cat "$directory/owner.pid" 2>/dev/null || true)
+                run_name=$(basename -- "$directory")
+                owner_pid=${run_name#run.}
+                owner_pid=${owner_pid%%.*}
                 case "$owner_pid" in
-                    '' | *[!0-9]*) ;;
+                    '' | *[!0-9]*) continue ;;
                     *)
                         if kill -0 "$owner_pid" 2>/dev/null; then
                             continue
@@ -135,14 +148,14 @@ if [ -d "$test_root" ]; then
             fi
             purge_run_directory "$directory"
         done
-    rmdir "$test_root" 2>/dev/null || true
 fi
 
 if [ "$mode" = stale ]; then
     exit 0
 fi
 
-if [ -d "$legacy_socket_root" ]; then
+if [ -e "$legacy_socket_root" ] || [ -L "$legacy_socket_root" ]; then
+    require_secure_directory "$legacy_socket_root" "legacy tmux socket"
     find "$legacy_socket_root" -mindepth 1 -maxdepth 1 -type s -print |
         awk -F/ '
             $NF ~ /^ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
@@ -152,7 +165,7 @@ if [ -d "$legacy_socket_root" ]; then
         done
 fi
 
-test_tmux_pids() {
+legacy_test_tmux_pids() {
     ps -axo pid=,command= | awk '
         /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ &&
         /-L[[:space:]]+ghosthub-(test|kill|style|ready)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}([[:space:]]|$)/ {
@@ -161,13 +174,13 @@ test_tmux_pids() {
     '
 }
 
-pids=$(test_tmux_pids)
+pids=$(legacy_test_tmux_pids)
 if [ -n "$pids" ]; then
-    kill -TERM $pids 2>/dev/null || true
+    signal_pids TERM "$pids"
     sleep 1
 fi
 
-pids=$(test_tmux_pids)
+pids=$(legacy_test_tmux_pids)
 if [ -n "$pids" ]; then
-    kill -KILL $pids 2>/dev/null || true
+    signal_pids KILL "$pids"
 fi

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -107,9 +107,6 @@ purge_run_directory() {
     require_secure_directory "$directory" "tmux test run"
     run_id=${directory##*.}
     find "$directory" -type s -print |
-        awk -F/ -v run_id="$run_id" '
-            $NF ~ "^ghosthub-(test|kill|style|ready)-" run_id "$"
-        ' |
         while IFS= read -r socket; do
             kill_socket "$socket"
         done

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -53,24 +53,43 @@ if [ "$#" -eq 1 ]; then
     fi
 fi
 
-kill_socket() {
-    socket=$1
+kill_sockets() {
+    socket_list=$1
+    [ -n "$socket_list" ] || return 0
     if [ -n "$tmux_bin" ]; then
+        # Stop every client concurrently under one shared deadline so purge
+        # stays inside the outer watchdog's escalation window no matter how
+        # many stalled sockets a run left behind.
+        client_pids=
         set -m
-        "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 &
-        socket_client_pid=$!
+        while IFS= read -r socket; do
+            [ -n "$socket" ] || continue
+            "$tmux_bin" -S "$socket" kill-server >/dev/null 2>&1 &
+            client_pids="$client_pids $!"
+        done <<EOF_SOCKETS
+$socket_list
+EOF_SOCKETS
         (
             sleep 1
-            kill -KILL -- -"$socket_client_pid" 2>/dev/null ||
-                kill -KILL "$socket_client_pid" 2>/dev/null || true
+            # shellcheck disable=SC2086  # deliberate PID list splitting
+            for client in $client_pids; do
+                kill -KILL -- -"$client" 2>/dev/null ||
+                    kill -KILL "$client" 2>/dev/null || true
+            done
         ) &
         socket_deadline_pid=$!
         set +m
-        wait "$socket_client_pid" 2>/dev/null || true
+        # shellcheck disable=SC2086  # deliberate PID list splitting
+        for client in $client_pids; do
+            wait "$client" 2>/dev/null || true
+        done
         kill -TERM -- -"$socket_deadline_pid" 2>/dev/null || true
         wait "$socket_deadline_pid" 2>/dev/null || true
     fi
-    rm -f "$socket"
+    printf '%s\n' "$socket_list" | while IFS= read -r socket; do
+        [ -n "$socket" ] || continue
+        rm -f "$socket"
+    done
 }
 
 run_tmux_pids() {
@@ -141,10 +160,8 @@ purge_run_directory() {
         echo "refusing insecure tmux test run directory: $directory" >&2
         return 1
     fi
-    find "$directory" -type s -print |
-        while IFS= read -r socket; do
-            kill_socket "$socket"
-        done
+    run_sockets=$(find "$directory" -type s -print 2>/dev/null || true)
+    kill_sockets "$run_sockets"
     kill_run_tmux_processes "$run_id" "$directory"
     rm -rf "$directory"
 }
@@ -188,13 +205,14 @@ fi
 
 if [ -e "$legacy_socket_root" ] || [ -L "$legacy_socket_root" ]; then
     require_secure_directory "$legacy_socket_root" "legacy tmux socket"
-    find "$legacy_socket_root" -mindepth 1 -maxdepth 1 -type s -print |
-        awk -F/ '
-            $NF ~ /^ghosthub-(test|kill)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-        ' |
-        while IFS= read -r socket; do
-            kill_socket "$socket"
-        done
+    legacy_sockets=$(
+        find "$legacy_socket_root" -mindepth 1 -maxdepth 1 -type s -print \
+            2>/dev/null |
+            awk -F/ '
+                $NF ~ /^ghosthub-(test|kill)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+            '
+    )
+    kill_sockets "$legacy_sockets"
 fi
 
 legacy_test_tmux_pids() {

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -77,12 +77,12 @@ trap 'forward_signal HUP' HUP
 export TMUX_TMPDIR="$tmux_tmpdir"
 export GHOSTHUB_TEST_TMUX_RUN_ID="$run_id"
 
-# macOS has no setsid utility. Start the test command as its own process-group
-# leader so cancellation reaches SwiftPM and every helper it launched.
-python3 -c 'import os, sys
-os.setpgid(0, 0)
-os.execvp(sys.argv[1], sys.argv[1:])' "$@" &
+# Monitor mode places the background command in its own process group so
+# cancellation reaches SwiftPM and every helper it launched.
+set -m
+"$@" &
 child_pid=$!
+set +m
 
 # A signal may arrive between fork and setpgid. Keep the trap active during
 # that window and deliver any pending signal once the group is published.

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -22,18 +22,94 @@ sh "$script_dir/purge_test_tmux.sh" --stale
 # concurrent stale sweeps distinguish active runs without a marker-file race.
 tmux_tmpdir=$(mktemp -d "$test_root/run.$$.XXXXXX")
 run_id=${tmux_tmpdir##*.}
+child_pid=
+pending_signal=
+signal_status=
+
+forward_signal() {
+    signal=$1
+    pending_signal=$signal
+    case "$signal" in
+        INT) signal_status=130 ;;
+        TERM) signal_status=143 ;;
+        HUP) signal_status=129 ;;
+    esac
+    if [ -n "$child_pid" ]; then
+        kill -"$signal" -- -"$child_pid" 2>/dev/null || true
+    fi
+}
+
+stop_child_group() {
+    [ -n "$child_pid" ] || return 0
+
+    if kill -0 -- -"$child_pid" 2>/dev/null; then
+        kill -TERM -- -"$child_pid" 2>/dev/null || true
+    elif kill -0 "$child_pid" 2>/dev/null; then
+        kill -TERM "$child_pid" 2>/dev/null || true
+    fi
+    wait "$child_pid" 2>/dev/null || true
+
+    attempts=0
+    while kill -0 -- -"$child_pid" 2>/dev/null &&
+        [ "$attempts" -lt 50 ]
+    do
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    if kill -0 -- -"$child_pid" 2>/dev/null; then
+        kill -KILL -- -"$child_pid" 2>/dev/null || true
+    fi
+}
 
 cleanup() {
     status=$1
     trap - EXIT INT TERM HUP
+    set +e
+    stop_child_group
     sh "$script_dir/purge_test_tmux.sh" "$tmux_tmpdir" || true
     exit "$status"
 }
 trap 'cleanup $?' EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-trap 'exit 129' HUP
+trap 'forward_signal INT' INT
+trap 'forward_signal TERM' TERM
+trap 'forward_signal HUP' HUP
 
 export TMUX_TMPDIR="$tmux_tmpdir"
 export GHOSTHUB_TEST_TMUX_RUN_ID="$run_id"
-"$@"
+
+# macOS has no setsid utility. Start the test command as its own process-group
+# leader so cancellation reaches SwiftPM and every helper it launched.
+python3 -c 'import os, sys
+os.setpgid(0, 0)
+os.execvp(sys.argv[1], sys.argv[1:])' "$@" &
+child_pid=$!
+
+# A signal may arrive between fork and setpgid. Keep the trap active during
+# that window and deliver any pending signal once the group is published.
+while kill -0 "$child_pid" 2>/dev/null &&
+    ! kill -0 -- -"$child_pid" 2>/dev/null
+do
+    :
+done
+if [ -n "$signal_status" ]; then
+    forward_signal "$pending_signal"
+fi
+
+set +e
+while :; do
+    wait "$child_pid"
+    status=$?
+    if ! kill -0 "$child_pid" 2>/dev/null; then
+        break
+    fi
+done
+set -e
+
+# The test command may finish before one of its helpers. Do not remove the
+# tmux directory until every process left in the test group has stopped.
+stop_child_group
+child_pid=
+if [ -n "$signal_status" ]; then
+    status=$signal_status
+fi
+exit "$status"

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -7,12 +7,20 @@ if [ "$#" -eq 0 ]; then
     exit 2
 fi
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-test_root=/tmp/ghosthub-tmux-tests
+script_dir=$(unset CDPATH; cd -- "$(dirname -- "$0")" && pwd)
+current_uid=$(id -u)
+# Keep this below tmux's Unix-socket path limit. The sticky /tmp parent and
+# strict UID/mode checks in purge_test_tmux.sh protect the per-user hierarchy.
+user_tmpdir="/tmp/ghosthub-$current_uid"
+test_root="$user_tmpdir/tmux-tests"
+umask 077
+mkdir -m 700 "$user_tmpdir" 2>/dev/null || true
 sh "$script_dir/purge_test_tmux.sh" --stale
-mkdir -p "$test_root"
-tmux_tmpdir=$(mktemp -d "$test_root/run.XXXXXX")
-printf '%s\n' "$$" >"$tmux_tmpdir/owner.pid"
+mkdir -m 700 "$test_root" 2>/dev/null || true
+sh "$script_dir/purge_test_tmux.sh" --stale
+# Publishing the owner PID in the atomically created directory name lets
+# concurrent stale sweeps distinguish active runs without a marker-file race.
+tmux_tmpdir=$(mktemp -d "$test_root/run.$$.XXXXXX")
 run_id=${tmux_tmpdir##*.}
 
 cleanup() {

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -23,8 +23,32 @@ sh "$script_dir/purge_test_tmux.sh" --stale
 tmux_tmpdir=$(mktemp -d "$test_root/run.$$.XXXXXX")
 run_id=${tmux_tmpdir##*.}
 child_pid=
+deadline_marker="$tmux_tmpdir/stop-deadline"
+deadline_pid=
 pending_signal=
 signal_status=
+
+start_kill_deadline() {
+    [ -z "$deadline_pid" ] || return 0
+
+    set -m
+    (
+        sleep 5
+        : > "$deadline_marker"
+        kill -KILL -- -"$child_pid" 2>/dev/null ||
+            kill -KILL "$child_pid" 2>/dev/null || true
+    ) &
+    deadline_pid=$!
+    set +m
+}
+
+cancel_kill_deadline() {
+    [ -n "$deadline_pid" ] || return 0
+
+    kill -TERM -- -"$deadline_pid" 2>/dev/null || true
+    wait "$deadline_pid" 2>/dev/null || true
+    deadline_pid=
+}
 
 forward_signal() {
     signal=$1
@@ -36,29 +60,42 @@ forward_signal() {
     esac
     if [ -n "$child_pid" ]; then
         kill -"$signal" -- -"$child_pid" 2>/dev/null || true
+        start_kill_deadline
     fi
+}
+
+group_has_live_processes() {
+    ps -axo pgid=,state= | awk -v pgid="$child_pid" '
+        $1 == pgid && $2 !~ /^Z/ { found = 1; exit }
+        END { exit found ? 0 : 1 }
+    '
 }
 
 stop_child_group() {
     [ -n "$child_pid" ] || return 0
 
-    if kill -0 -- -"$child_pid" 2>/dev/null; then
+    if group_has_live_processes; then
         kill -TERM -- -"$child_pid" 2>/dev/null || true
     elif kill -0 "$child_pid" 2>/dev/null; then
         kill -TERM "$child_pid" 2>/dev/null || true
+    else
+        cancel_kill_deadline
+        wait "$child_pid" 2>/dev/null || true
+        return 0
     fi
-    wait "$child_pid" 2>/dev/null || true
 
-    attempts=0
-    while kill -0 -- -"$child_pid" 2>/dev/null &&
-        [ "$attempts" -lt 50 ]
+    start_kill_deadline
+    while group_has_live_processes && [ ! -e "$deadline_marker" ]
     do
         sleep 0.1
-        attempts=$((attempts + 1))
     done
-    if kill -0 -- -"$child_pid" 2>/dev/null; then
+    if group_has_live_processes; then
         kill -KILL -- -"$child_pid" 2>/dev/null || true
+    elif kill -0 "$child_pid" 2>/dev/null; then
+        kill -KILL "$child_pid" 2>/dev/null || true
     fi
+    cancel_kill_deadline
+    wait "$child_pid" 2>/dev/null || true
 }
 
 cleanup() {
@@ -96,7 +133,7 @@ if [ -n "$signal_status" ]; then
 fi
 
 set +e
-while :; do
+while [ -z "$signal_status" ]; do
     wait "$child_pid"
     status=$?
     if ! kill -0 "$child_pid" 2>/dev/null; then

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 command [arguments...]" >&2
+    exit 2
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+test_root=/tmp/ghosthub-tmux-tests
+sh "$script_dir/purge_test_tmux.sh" --stale
+mkdir -p "$test_root"
+tmux_tmpdir=$(mktemp -d "$test_root/run.XXXXXX")
+printf '%s\n' "$$" >"$tmux_tmpdir/owner.pid"
+run_id=${tmux_tmpdir##*.}
+
+cleanup() {
+    status=$1
+    trap - EXIT INT TERM HUP
+    sh "$script_dir/purge_test_tmux.sh" "$tmux_tmpdir" || true
+    exit "$status"
+}
+trap 'cleanup $?' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+export TMUX_TMPDIR="$tmux_tmpdir"
+export GHOSTHUB_TEST_TMUX_RUN_ID="$run_id"
+"$@"

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -33,7 +33,9 @@ start_kill_deadline() {
 
     set -m
     (
-        sleep 5
+        # Leave ample time for run_with_timeout.sh to reap this wrapper and
+        # purge its tmux directory before that outer guard escalates at 5s.
+        sleep 2
         : > "$deadline_marker"
         kill -KILL -- -"$child_pid" 2>/dev/null ||
             kill -KILL "$child_pid" 2>/dev/null || true

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -84,14 +84,21 @@ group_has_live_processes() {
 stop_child_group() {
     [ -n "$child_pid" ] || return 0
 
-    if group_has_live_processes; then
-        kill -TERM -- -"$child_pid" 2>/dev/null || true
-    elif kill -0 "$child_pid" 2>/dev/null; then
-        kill -TERM "$child_pid" 2>/dev/null || true
-    else
+    if ! group_has_live_processes && ! kill -0 "$child_pid" 2>/dev/null; then
         cancel_kill_deadline
         wait "$child_pid" 2>/dev/null || true
         return 0
+    fi
+
+    # A forwarded cancellation signal already reached the whole group, and a
+    # second signal would defeat the grace for tools that quit hard when
+    # signalled twice. TERM is only for helpers that outlive a normal exit.
+    if [ -z "$pending_signal" ]; then
+        if group_has_live_processes; then
+            kill -TERM -- -"$child_pid" 2>/dev/null || true
+        else
+            kill -TERM "$child_pid" 2>/dev/null || true
+        fi
     fi
 
     start_kill_deadline

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -22,6 +22,14 @@ sh "$script_dir/purge_test_tmux.sh" --stale
 # concurrent stale sweeps distinguish active runs without a marker-file race.
 tmux_tmpdir=$(mktemp -d "$test_root/run.$$.XXXXXX")
 run_id=${tmux_tmpdir##*.}
+# Seconds a cancelled test group gets to unwind before it is force-killed.
+# run_with_timeout.sh lowers this so the inner KILL lands before that outer
+# guard escalates; interactive cancellation keeps the longer default so
+# SwiftPM can finish its own teardown.
+stop_grace=${GHOSTHUB_TEST_STOP_GRACE:-20}
+case "$stop_grace" in
+    '' | *[!0-9]*) stop_grace=20 ;;
+esac
 child_pid=
 deadline_marker="$tmux_tmpdir/stop-deadline"
 deadline_pid=
@@ -33,10 +41,10 @@ start_kill_deadline() {
 
     set -m
     (
-        # Leave ample time for run_with_timeout.sh to reap this wrapper and
-        # purge its tmux directory before that outer guard escalates at 5s.
-        sleep 2
-        : > "$deadline_marker"
+        sleep "$stop_grace"
+        # The run directory may already be gone. The KILL must still fire so
+        # stop_child_group's wait ends through group exit, not the marker.
+        : > "$deadline_marker" 2>/dev/null || true
         kill -KILL -- -"$child_pid" 2>/dev/null ||
             kill -KILL "$child_pid" 2>/dev/null || true
     ) &
@@ -100,6 +108,7 @@ stop_child_group() {
     wait "$child_pid" 2>/dev/null || true
 }
 
+# shellcheck disable=SC2329  # invoked via the EXIT trap below
 cleanup() {
     status=$1
     trap - EXIT INT TERM HUP

--- a/tools/run_with_timeout.sh
+++ b/tools/run_with_timeout.sh
@@ -17,6 +17,12 @@ set -u
 seconds="$1"
 shift
 
+# The watchdog KILLs the command group 5 seconds after its TERM, so a nested
+# run_swift_tests.sh must force-kill its test group and purge its tmux
+# directory sooner than that.
+GHOSTHUB_TEST_STOP_GRACE="${GHOSTHUB_TEST_STOP_GRACE:-2}"
+export GHOSTHUB_TEST_STOP_GRACE
+
 # Forward INT/TERM/HUP to the child's process group so cancelling the
 # caller (e.g. Ctrl-C on make) does not orphan a detached swift-test
 # group, then re-raise to preserve the signal exit status.

--- a/tools/run_with_timeout.sh
+++ b/tools/run_with_timeout.sh
@@ -19,8 +19,9 @@ shift
 
 # The watchdog KILLs the command group 5 seconds after its TERM, so a nested
 # run_swift_tests.sh must force-kill its test group and purge its tmux
-# directory sooner than that.
-GHOSTHUB_TEST_STOP_GRACE="${GHOSTHUB_TEST_STOP_GRACE:-2}"
+# directory sooner than that. Force the value: an inherited larger grace
+# would let the watchdog reap the wrapper before it can clean up.
+GHOSTHUB_TEST_STOP_GRACE=2
 export GHOSTHUB_TEST_STOP_GRACE
 
 # Forward INT/TERM/HUP to the child's process group so cancelling the


### PR DESCRIPTION
Swift test runs could strand tmux servers and wedged `new-session` clients after a hard kill, eventually exhausting the host PTY pool and making unrelated terminal tests fail. Per-test defers were insufficient because runner termination skips them, and a removed socket does not prove its tmux process exited.

This gives every Make and CI Swift test invocation a pre-created per-run `TMUX_TMPDIR` and short run identity, then reaps only processes carrying that exact identity. The recovery target is confined to isolated run directories and the two canonical UUID-suffixed legacy test socket patterns; it never addresses tmux’s default socket, and every purge mode skips run directories whose owning test process is still alive. Cancellation now grants the test group a twenty-second grace before force-kill, tightened to two seconds under the outer timeout guard so CI escalation ordering is unchanged.

The full suite passed with 153 XCTest cases (5 expected headless skips) and 710 Swift Testing cases. Essential tmux workflows, 120 Python tests, formatting, the app build, shell syntax, a direct orphan-process audit, and a before/after default tmux inventory comparison also passed. Tracks kata wjrk.
