### PR TITLE
Prepare Ghosthub 0.5.0 release documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: Version for the notarized candidate artifact
         required: true
-        default: 0.1.0
+        default: 0.5.0
 
 permissions:
   # The build job only checks out source and uploads an Actions artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ as subject to direct iteration.
 - Commit every turn when you make changes.
 - Commit before responding without asking whether to commit; committing is the
   expected default after every change.
+- Never commit directly to `main` or `master`. When a task starts on the
+  default branch, create a task-specific branch before the first commit. If a
+  local commit lands on the default branch accidentally, move it to a task
+  branch and restore the local default branch to its upstream before pushing.
 - Never amend commits.
 - Do not leave the app build broken at the end of a turn.
 - If a turn touches Swift app code, terminal integration, `Package.swift`, or bootstrap logic, `make build` must pass before the turn is done.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ test, and documentation-only changes are omitted.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-02
+
+### Added
+
+- Standalone tmux sessions can be hidden from navigation with case-sensitive
+  wildcard patterns managed in **Settings → Worktrees**.
+- **Apply Theme to Current Session** immediately updates the active tmux
+  session without enabling the persistent shared-session theme override.
+- Quit confirmation can be disabled in Terminal Settings.
+
+### Changed
+
+- Closing the final workspace window leaves Ghosthub running so a new window
+  can be opened without relaunching the app.
+- Sparkle-authorized relaunches preserve native window restoration and reopen
+  each exact prior tmux attachment that can be confirmed, including reconnects
+  to temporarily offline SSH hosts.
+- The **Follow ghostty.conf** tmux theme now uses libghostty's effective light
+  or dark foreground and background colors when styling sessions.
+
+### Fixed
+
+- Remote tmux attachment again follows the account login-shell environment,
+  honors OpenSSH authentication and connection sharing, and allows remote
+  copy-mode to write to the Mac clipboard through OSC 52.
+- HTTPS pull-request imports can use the host's configured Git credential
+  helpers, and removing an already-missing worktree still reconciles its exact
+  live tmux session.
+- Tailscale host discovery works in packaged builds.
+- Large sidebars and live terminal resizing no longer trigger SwiftUI layout
+  stalls or excessive resize churn.
+- Terminal configuration notices no longer replay after a successful reload,
+  and cursors stop blinking when their window is in the background.
+
 ## [0.4.0] - 2026-07-30
 
 ### Added
@@ -102,7 +136,8 @@ test, and documentation-only changes are omitted.
   and SSH tmux session discovery, automatic reconnect, and kwt-backed project
   and worktree navigation.
 
-[Unreleased]: https://github.com/kenn-io/ghosthub/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/kenn-io/ghosthub/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/kenn-io/ghosthub/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/kenn-io/ghosthub/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/kenn-io/ghosthub/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/kenn-io/ghosthub/compare/v0.2.0...v0.2.1

--- a/Makefile
+++ b/Makefile
@@ -361,10 +361,12 @@ run-release-app: release-app
 
 release-dmg: LIBGHOSTTY_OPTIMIZE = ReleaseFast
 release-dmg:
-	@./tools/build_release_dmg.sh
+	@RELEASE_APP_VERSION="$(RELEASE_APP_VERSION)" \
+		./tools/build_release_dmg.sh
 
 release-appcast:
-	@./tools/generate_update_appcast.sh
+	@RELEASE_APP_VERSION="$(RELEASE_APP_VERSION)" \
+		./tools/generate_update_appcast.sh
 
 run-app: debug-app
 	@set -euo pipefail; \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DEBUG_APP_PATH ?= $(DEBUG_ROOT)/$(GHOSTHUB_APP).app
 RELEASE_APP_PATH ?= $(RELEASE_ROOT)/$(GHOSTHUB_APP).app
 RELEASE_BUNDLE_ID ?= com.ghosthub
 DEBUG_BUNDLE_ID ?= $(RELEASE_BUNDLE_ID).debug
-RELEASE_APP_VERSION ?= 0.1.0
+RELEASE_APP_VERSION ?= 0.5.0
 ifeq ($(origin DEVELOPMENT_APP_VERSION),undefined)
 DEVELOPMENT_APP_VERSION := $(shell $(PYTHON) tools/development_version.py --component short)
 endif
@@ -127,8 +127,8 @@ help:
 		'  RELEASE_ROOT=dist/release' \
 		'  DEVELOPMENT_APP_VERSION=0.3.0' \
 		'  DEVELOPMENT_VERSION_DESCRIPTION=0.3.0-1-gabcdef0' \
-		'  RELEASE_APP_VERSION=0.1.0' \
-		'  RELEASE_BUILD_VERSION=0.1.0' \
+		'  RELEASE_APP_VERSION=0.5.0' \
+		'  RELEASE_BUILD_VERSION=0.5.0' \
 		'  KWT_BINARY_PATH=/absolute/path/to/kwt' \
 		'  SWIFT_TEST_FILTER=WorkspaceDatabaseTests' \
 		'  HOST_KEY=local' \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://ghosthub.io">
+  <a href="https://ghosthub.ai">
     <img src="Resources/AppIcon/Ghosthub.svg" width="112" alt="Ghosthub app icon">
   </a>
 </p>
@@ -22,11 +22,11 @@
 </p>
 
 <p align="center">
-  <a href="https://ghosthub.io"><strong>Website</strong></a>
+  <a href="https://ghosthub.ai"><strong>Website</strong></a>
   ·
   <a href="https://github.com/kenn-io/ghosthub/releases"><strong>Download</strong></a>
   ·
-  <a href="https://ghosthub.io/guide/"><strong>Guide</strong></a>
+  <a href="https://ghosthub.ai/guide/"><strong>Guide</strong></a>
   ·
   <a href="CHANGELOG.md"><strong>Changelog</strong></a>
   ·
@@ -35,7 +35,7 @@
 
 <p align="center">
   <img
-    src="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets/hero.png"
+    src="https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/hero.png?release=0.5.0"
     width="960"
     alt="Ghosthub showing local and remote tmux sessions and kwt worktrees in its sidebar"
   >
@@ -47,6 +47,11 @@ history, and process lifetime; Ghosthub provides the native macOS interface,
 terminal presentation, and SSH reconnect supervision.
 
 There is no proprietary session format, background daemon, or migration.
+
+Ghosthub is alpha software. It likely has more bugs than more mature terminal
+applications like Ghostty, but please open
+[GitHub issues](https://github.com/kenn-io/ghosthub/issues) to report bugs and
+we will do our best to fix them.
 
 ## Highlights
 
@@ -67,8 +72,9 @@ There is no proprietary session format, background daemon, or migration.
 - **Native workspaces.** Open independent windows or macOS tabs, and search
   sessions and common actions from the Command Palette.
 - **Predictable tmux theming.** New sessions created by Ghosthub use the
-  selected Tmux Theme. Existing sessions keep their appearance unless you
-  explicitly opt into shared-session styling.
+  selected Tmux Theme, including resolved light and dark colors from
+  `ghostty.conf`. Existing sessions keep their appearance unless you apply the
+  theme to the active session or opt into shared-session styling.
 - **Fast terminal rendering.** Ghosthub embeds libghostty with an isolated,
   Ghostty-compatible configuration—no Electron and no Ghostty.app dependency.
 
@@ -136,7 +142,9 @@ machine.
 Pull-request import requires the
 [GitHub CLI (`gh`)](https://cli.github.com/) on the host containing the project:
 your Mac for a local project or the SSH machine for a remote one. Install it
-there and run `gh auth login` on that same host before importing.
+there and run `gh auth login` on that same host before importing. For an HTTPS
+Git remote, ordinary Git authentication must also work there; `gh auth
+setup-git` configures GitHub CLI as a Git credential helper.
 
 Select a project and press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> to create a Git
 worktree or import a GitHub pull request. The branch picker searches available
@@ -153,6 +161,9 @@ session if needed and asks kwt to remove the checkout. The Git branch is kept.
 
 Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> to open the **Command Palette** and
 search across hosts, projects, worktrees, sessions, settings, and actions.
+Use **Settings → Worktrees** to hide tool-owned standalone tmux sessions with
+case-sensitive `*` and `?` patterns. Kwt workspaces always remain visible under
+their projects.
 
 | Shortcut | Action |
 | --- | --- |
@@ -179,9 +190,13 @@ reloads the active configuration when the base file, an included file, or a
 project override changes. The **Tmux Theme** setting supplies colors for new
 sessions created by Ghosthub. Existing sessions keep their own appearance by
 default; **Apply theme to shared tmux sessions** explicitly applies the
-selected colors to the session's existing windows and chrome for every
-attached terminal. Use **Ghosthub → Reload Configuration** for an explicit
-reload and diagnostic result.
+selected colors before future attachments. Use **Session → Apply Theme to
+Current Session** to update only the connected active session immediately.
+Both choices update the session's existing windows and chrome for every
+attached terminal. Quit confirmation is on by default and can be disabled in
+Terminal Settings; closing the final workspace leaves Ghosthub running, while
+Command-Q detaches every presentation and quits. Use **Ghosthub → Reload
+Configuration** for an explicit reload and diagnostic result.
 
 ## How the pieces fit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -132,8 +132,8 @@ A full local release-app build:
 
 ```bash
 make release-app \
-  RELEASE_APP_VERSION=0.1.0 \
-  RELEASE_BUILD_VERSION=0.1.0
+  RELEASE_APP_VERSION=0.5.0 \
+  RELEASE_BUILD_VERSION=0.5.0
 ```
 
 Ghosthub bundles kwt CLI helpers but no daemon. A clean `make release-app`
@@ -145,8 +145,8 @@ DMG build:
 
 ```bash
 make release-dmg \
-  RELEASE_APP_VERSION=0.1.0 \
-  RELEASE_BUILD_VERSION=0.1.0
+  RELEASE_APP_VERSION=0.5.0 \
+  RELEASE_BUILD_VERSION=0.5.0
 ```
 
 If Apple signing and notary environment variables are present, this

--- a/docs/release.md
+++ b/docs/release.md
@@ -205,7 +205,7 @@ workflow before creating a tag:
 gh workflow run release.yml \
   --repo kenn-io/ghosthub \
   --ref main \
-  -f version=0.1.0
+  -f version=0.5.0
 ```
 
 The manual path imports the signing certificate into an ephemeral keychain,
@@ -226,7 +226,7 @@ Download the candidate and verify either checksum from the directory that
 contains the three artifact files:
 
 ```bash
-shasum -a 256 -c Ghosthub_0.1.0_macos_arm64.dmg.sha256
+shasum -a 256 -c Ghosthub_0.5.0_macos_arm64.dmg.sha256
 shasum -a 256 -c SHA256SUMS
 ```
 
@@ -234,7 +234,7 @@ Inspect the run and install the candidate on a Mac where Ghosthub has not been
 locally built. Verify at minimum:
 
 - Gatekeeper opens the app without a quarantine override.
-- About Ghosthub reports version 0.1.0, Kenn Software LLC copyright, and the
+- About Ghosthub reports version 0.5.0, Kenn Software LLC copyright, and the
   GNU AGPL v3.0-or-later license notice.
 - Local kwt projects and worktrees load without a system kwt on `PATH`.
 - Existing local tmux sessions remain discoverable and attach normally.
@@ -248,21 +248,21 @@ locally built. Verify at minimum:
   signature error. A complete end-to-end installation requires a later release
   than the first version that embeds Sparkle.
 
-## Publishing 0.1.0
+## Publishing 0.5.0
 
 Only publish after the candidate succeeds. From a clean `main` checkout:
 
 ```bash
-./scripts/release.sh 0.1.0
+./scripts/release.sh 0.5.0
 ```
 
-The script creates and pushes annotated tag `v0.1.0`. The tag workflow rebuilds
+The script creates and pushes annotated tag `v0.5.0`. The tag workflow rebuilds
 from source, repeats signing and notarization, generates the production-signed
 appcast, and creates
-`https://github.com/kenn-io/ghosthub/releases/tag/v0.1.0` with:
+`https://github.com/kenn-io/ghosthub/releases/tag/v0.5.0` with:
 
-- `Ghosthub_0.1.0_macos_arm64.dmg`
-- `Ghosthub_0.1.0_macos_arm64.dmg.sha256`
+- `Ghosthub_0.5.0_macos_arm64.dmg`
+- `Ghosthub_0.5.0_macos_arm64.dmg.sha256`
 - `SHA256SUMS`
 - `appcast.xml`
 
@@ -300,7 +300,7 @@ executable only when deliberately packaging a separately prepared build:
 
 ```bash
 make release-app \
-  RELEASE_APP_VERSION=0.1.0 \
+  RELEASE_APP_VERSION=0.5.0 \
   KWT_BINARY_PATH=/absolute/path/to/kwt \
   KWT_VERSION=development \
   KWT_SOURCE_REVISION=local
@@ -324,7 +324,7 @@ Unsigned DMG:
 
 ```bash
 make release-dmg \
-  RELEASE_APP_VERSION=0.1.0 \
+  RELEASE_APP_VERSION=0.5.0 \
   KWT_BINARY_PATH=/absolute/path/to/kwt
 ```
 
@@ -336,7 +336,7 @@ APPLE_NOTARY_KEY_FILE=/path/to/AuthKey_XXXXXXXXXX.p8 \
 APPLE_NOTARY_KEY_ID=XXXXXXXXXX \
 APPLE_NOTARY_ISSUER=issuer-uuid \
 KWT_BINARY_PATH=/absolute/path/to/kwt \
-make release-dmg RELEASE_APP_VERSION=0.1.0
+make release-dmg RELEASE_APP_VERSION=0.5.0
 ```
 
 After the DMG is notarized, generate a local signed appcast with an exported
@@ -345,7 +345,7 @@ working copy of the Sparkle key supplied through the environment:
 ```bash
 SPARKLE_PUBLIC_ED_KEY='<reviewed public key>' \
 SPARKLE_ED_PRIVATE_KEY='<temporary private seed>' \
-make release-appcast RELEASE_APP_VERSION=0.1.0
+make release-appcast RELEASE_APP_VERSION=0.5.0
 ```
 
 Do not place the private seed directly in shell history in real operations;

--- a/docs/release.md
+++ b/docs/release.md
@@ -198,6 +198,13 @@ No cross-repository token is required. The workflow uses its short-lived
 
 ## Candidate run
 
+Release preparation updates the default `RELEASE_APP_VERSION` used by the
+Makefile, the standalone DMG and appcast scripts, and the manual workflow
+input. The Makefile passes its resolved version explicitly to both scripts, so
+bare `make release-dmg` and `make release-appcast` invocations cannot fall back
+to an older script default. Keep the direct-script fallbacks and workflow
+dispatch default on the same release while it is current.
+
 After release workflow changes reach the default branch, run the manual
 workflow before creating a tag:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,7 @@ TAG_BODY="${2:-}"
 
 if [[ -z "$VERSION" ]]; then
   echo "Usage: $0 <version> [tag_body]"
-  echo "Example: $0 0.1.0"
+  echo "Example: $0 0.5.0"
   exit 1
 fi
 

--- a/tools/build_release_dmg.sh
+++ b/tools/build_release_dmg.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 
 APP_NAME="${GHOSTHUB_APP:-Ghosthub}"
 RELEASE_ROOT="${RELEASE_ROOT:-dist/release}"
-RELEASE_APP_VERSION="${RELEASE_APP_VERSION:-0.1.0}"
+RELEASE_APP_VERSION="${RELEASE_APP_VERSION:-0.5.0}"
 RELEASE_BUILD_VERSION="${RELEASE_BUILD_VERSION:-$(git rev-list --count HEAD 2>/dev/null || echo 0)}"
 RELEASE_BUNDLE_ID="${RELEASE_BUNDLE_ID:-com.ghosthub}"
 # `hdiutil create` fails here when the mounted volume name matches the staged

--- a/tools/generate_update_appcast.sh
+++ b/tools/generate_update_appcast.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 
 APP_NAME="${GHOSTHUB_APP:-Ghosthub}"
 RELEASE_ROOT="${RELEASE_ROOT:-dist/release}"
-RELEASE_APP_VERSION="${RELEASE_APP_VERSION:-0.1.0}"
+RELEASE_APP_VERSION="${RELEASE_APP_VERSION:-0.5.0}"
 RELEASE_ARCH="${RELEASE_ARCH:-$(uname -m)}"
 RELEASE_DMG_NAME="${RELEASE_DMG_NAME:-${APP_NAME}_${RELEASE_APP_VERSION}_macos_${RELEASE_ARCH}.dmg}"
 RELEASE_APP_PATH="${RELEASE_APP_PATH:-$RELEASE_ROOT/${APP_NAME}.app}"
@@ -94,7 +94,7 @@ printf '%s' "$SPARKLE_ED_PRIVATE_KEY" \
   | "$SPARKLE_GENERATE_APPCAST" \
       --ed-key-file - \
       --download-url-prefix "$DOWNLOAD_PREFIX" \
-      --link "https://ghosthub.io" \
+      --link "https://ghosthub.ai" \
       --embed-release-notes \
       --maximum-versions 1 \
       --maximum-deltas 0 \

--- a/website/demo/bin/kwt
+++ b/website/demo/bin/kwt
@@ -81,8 +81,8 @@ branches_json() {
    "source": "feature/session-search", "is_remote": false},
   {"name": "feature/sidebar-groups",
    "source": "origin/feature/sidebar-groups", "is_remote": true},
-  {"name": "release/0.4.0",
-   "source": "origin/release/0.4.0", "is_remote": true}
+  {"name": "release/0.5.0",
+   "source": "origin/release/0.5.0", "is_remote": true}
 ]
 EOF
       ;;

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -75,7 +75,7 @@ notifications.post(
         "expectKind": environment["GHOSTHUB_DEMO_EXPECT_KIND"] ?? "",
     ]
 )
-let deadline = Date(timeIntervalSinceNow: 15)
+let deadline = Date(timeIntervalSinceNow: 30)
 while acknowledgement.result == nil && Date() < deadline {
     RunLoop.current.run(
         mode: .default,

--- a/website/demo/stage.sh
+++ b/website/demo/stage.sh
@@ -239,7 +239,7 @@ new_session scratch "$scratch/repos/msgvault" \
 new_session docbank-export "$scratch" \
   "clear; echo 'exported 4,812 threads (2.1 GiB) in 96s'; echo done."
 new_session release-watch "$scratch/repos/ghosthub" \
-  "clear; printf 'release v0.4.0\\n\\n  ✓ build\\n  ✓ swift tests\\n  ✓ notarization\\n  ● publish\\n'"
+  "clear; printf 'release v0.5.0\\n\\n  ✓ build\\n  ✓ swift tests\\n  ✓ notarization\\n  ● publish\\n'"
 new_session test-matrix "$scratch/repos/agentsview" \
   "clear; printf 'test matrix\\n\\nmacOS 26 arm64     ✓ 680 passed\\nUbuntu 24.04       ✓ 149 passed\\nSSH integration    ✓  42 passed\\n'"
 


### PR DESCRIPTION
Ghosthub’s now-public repository needs one accurate release story before 0.5.0 ships. The previous README still linked to the old domain and a hero URL that had been cached as missing while the repository was private, while the release playbook and screenshot fixtures still presented earlier versions. That would leave new users with broken first impressions and operators with stale release commands.

This prepares the dated 0.5.0 changelog, brings the README and release guidance in line with the accepted product, and publishes the complete controlled screenshot generation to the separate website-assets branch so main remains free of binary churn. It also makes the branch-before-commit requirement explicit in AGENTS.md so the commit-every-turn rule cannot put future work directly on the default branch.

The 0.5.0 release app, changelog extraction, documentation build, website lint/tests/type checks/production build, and 136 Python tests pass. All eight screenshots were regenerated and inspected at original resolution, and every external README link returns HTTP 200.