### PR TITLE
Present Ghosthub's two workflows equally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@ Deeper dev workflows, layout configuration, and end-to-end harnesses are in
 
 Two files govern day-to-day workflow:
 
-- [`CLAUDE.md`](CLAUDE.md) — quality gates, commit conventions, test
+- [`CLAUDE.md`](CLAUDE.md): quality gates, commit conventions, test
   and build commands, shell safety rules.
-- [`AGENTS.md`](AGENTS.md) — the source-of-truth hierarchy, test
+- [`AGENTS.md`](AGENTS.md): the source-of-truth hierarchy, test
   framework policy (Swift Testing preferred over XCTest for new
   tests), terminal-parity rules, and directory map.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <strong>A native power terminal for your tmux fleet.</strong>
   <br>
   Create or attach to any session, or manage worktree-bound sessions from Git
-  branches and GitHub pull requests—locally or over SSH.
+  branches and GitHub pull requests, locally or over SSH.
 </p>
 
 <p align="center">
@@ -71,7 +71,7 @@ we will do our best to fix them.
 - **Managed worktree sessions.** Register an existing checkout, continue a
   local or remote branch, create a branch, import a GitHub pull request, and
   remove a linked worktree through the bundled [kwt](https://kwt.sh)
-  helper—no system kwt installation required.
+  helper. No system kwt installation is required.
 - **Resilient SSH.** Keepalives and automatic reconnect preserve remote
   presentations through ordinary network interruptions.
 - **Deliberate tmux lifecycle.** Closing a presentation detaches. Confirmed
@@ -87,7 +87,7 @@ we will do our best to fix them.
   `ghostty.conf`. Existing sessions keep their appearance unless you apply the
   theme to the active session or opt into shared-session styling.
 - **Fast terminal rendering.** Ghosthub embeds libghostty with an isolated,
-  Ghostty-compatible configuration—no Electron and no Ghostty.app dependency.
+  Ghostty-compatible configuration. No Electron and no Ghostty.app dependency.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 <h1 align="center">Ghosthub</h1>
 
 <p align="center">
-  <strong>A power terminal for your fleet of tmux sessions.</strong>
+  <strong>A native terminal for your tmux fleet.</strong>
   <br>
-  Find and enter the sessions behind your projects and coding agents,
-  on your Mac or over SSH.
+  Create or attach to any session, or manage worktree-bound sessions from Git
+  branches and GitHub pull requests—locally or over SSH.
 </p>
 
 <p align="center">
@@ -41,10 +41,20 @@
   >
 </p>
 
-Ghosthub discovers the tmux sessions you already have and organizes them by
-host, project, and worktree. Tmux continues to own windows, panes, layout,
-history, and process lifetime; Ghosthub provides the native macOS interface,
-terminal presentation, and SSH reconnect supervision.
+Ghosthub creates and attaches to ordinary tmux sessions across your Mac and SSH
+hosts, including sessions started outside Ghosthub. They need no Git project or
+worktree setup: create a named session, pick up an existing one, and manage the
+whole fleet from one native sidebar.
+
+Ghosthub also manages tmux sessions bound to Git worktrees. Register a
+repository, then continue a local or remote branch, create a branch, or import
+a GitHub pull request without leaving the app. Its bundled [kwt](https://kwt.sh)
+helper manages the linked worktree lifecycle while Ghosthub opens the canonical
+tmux session for that workspace.
+
+In both modes, tmux continues to own windows, panes, layout, history, and
+process lifetime. Ghosthub provides the native, libghostty-powered terminal and
+supervises SSH keepalives and reconnects.
 
 There is no proprietary session format, background daemon, or migration.
 
@@ -55,14 +65,15 @@ we will do our best to fix them.
 
 ## Highlights
 
-- **One fleet sidebar.** Navigate local sessions, remote sessions, projects,
-  and worktrees—even when their tmux sessions were created outside Ghosthub.
-- **Resilient SSH.** Keepalives and automatic reconnect preserve remote
-  presentations through ordinary network interruptions.
-- **Complete worktree workflows.** Register an existing checkout, continue a
+- **Any tmux session.** Create or attach to sessions on local and remote hosts,
+  including sessions created outside Ghosthub. No Git project or worktree is
+  required.
+- **Managed worktree sessions.** Register an existing checkout, continue a
   local or remote branch, create a branch, import a GitHub pull request, and
   remove a linked worktree through the bundled [kwt](https://kwt.sh)
   helper—no system kwt installation required.
+- **Resilient SSH.** Keepalives and automatic reconnect preserve remote
+  presentations through ordinary network interruptions.
 - **Deliberate tmux lifecycle.** Closing a presentation detaches. Confirmed
   controls end standalone or worktree-backed sessions, and a bare session that
   exits can be reopened under its exact previous name.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Ghosthub</h1>
 
 <p align="center">
-  <strong>A native terminal for your tmux fleet.</strong>
+  <strong>A native power terminal for your tmux fleet.</strong>
   <br>
   Create or attach to any session, or manage worktree-bound sessions from Git
   branches and GitHub pull requests—locally or over SSH.

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -7,15 +7,15 @@ interface Feature {
 
 const features: Feature[] = [
   {
-    title: 'tmux-native',
-    body: 'Works with the tmux sessions you already have, local or over SSH with keepalives '
-      + 'and automatic reconnect. Nothing to migrate.',
+    title: 'Any tmux session',
+    body: 'Create or attach to sessions on your Mac or over SSH, including sessions started '
+      + 'outside Ghosthub. No Git project or worktree required.',
     icon: 'M4 5h24v22H4Z M4 13h24 M16 13v14',
   },
   {
-    title: 'Worktree-first',
-    body: 'Add projects, create Git worktrees, and import GitHub pull requests without leaving '
-      + 'Ghosthub, then drop straight into their tmux sessions.',
+    title: 'Managed worktree sessions',
+    body: 'Create Git worktrees from new or existing branches, import GitHub pull requests, '
+      + 'and manage their tmux sessions without leaving Ghosthub.',
     icon: 'M9 6v14a6 6 0 0 0 6 6h4 M9 6a3 3 0 1 0 0-1 '
       + 'M23 26a3 3 0 1 0 0 1 M23 9h-6 M23 9a3 3 0 1 0 0-1',
   },

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -16,11 +16,11 @@ const heroAlt =
       <AppIcon prefix="gh-ic-hero" />
       <span class="wordmark">Ghosthub</span>
     </p>
-    <h1>A power terminal for your fleet of tmux sessions</h1>
+    <h1>A native power terminal for your tmux fleet</h1>
     <p class="sub">
-      A native, libghostty-powered home for the tmux sessions behind your
-      projects and coding agents—local or over SSH—with keepalives, automatic
-      reconnect, and built-in worktree workflows.
+      Create or attach to any tmux session on your Mac or over SSH, or manage
+      worktree-bound sessions from Git branches and GitHub pull requests—with
+      keepalives and automatic reconnect.
     </p>
     <div class="actions">
       <a class="cta" data-download href={RELEASES_URL}>Download for Apple Silicon</a>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -19,7 +19,7 @@ const heroAlt =
     <h1>A native power terminal for your tmux fleet</h1>
     <p class="sub">
       Create or attach to any tmux session on your Mac or over SSH, or manage
-      worktree-bound sessions from Git branches and GitHub pull requests—with
+      worktree-bound sessions from Git branches and GitHub pull requests, with
       keepalives and automatic reconnect.
     </p>
     <div class="actions">

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -40,10 +40,10 @@ const imageAlt = {
       <p class="eyebrow">Five-minute guide</p>
       <h1>How to use Ghosthub</h1>
       <p class="lead">
-        Ghosthub keeps the tmux sessions behind your projects and coding
-        agents connected in one native macOS workspace. If SSH drops, it
-        retries and reattaches to the same exact session automatically.
-        Tmux keeps owning the windows, panes, history, and process state.
+        Ghosthub creates and attaches to any tmux session across your Mac and
+        SSH hosts, with no Git setup required. It also manages worktree-bound
+        sessions created from branches and GitHub pull requests. If SSH drops,
+        it retries and reattaches to the same exact session automatically.
       </p>
       <p class="promise" aria-label="Automatic SSH reconnect plus tmux reattach">
         <span class="promise-icon" aria-hidden="true">↻</span>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -96,7 +96,7 @@ const imageAlt = {
             remain visible under their projects.
           </p>
           <p>
-            Closing the Ghosthub window only detaches—your work keeps running
+            Closing the Ghosthub window only detaches. Your work keeps running
             in tmux. To end a standalone session Ghosthub knows is running,
             hover its row and click the subtle <strong>×</strong>. A
             worktree-backed session keeps <strong>Kill Session…</strong> in

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,11 +4,10 @@ import GuideCTA from '../components/GuideCTA.astro';
 import Hero from '../components/Hero.astro';
 import SiteLayout from '../layouts/SiteLayout.astro';
 
-const title = 'Ghosthub: a power terminal for your fleet of tmux sessions';
+const title = 'Ghosthub: a native power terminal for your tmux fleet';
 const description =
-  'Ghosthub is a free and open source macOS power terminal for the tmux sessions '
-  + 'behind your projects and coding agents, local or over SSH. Worktree-native, '
-  + 'built on libghostty.';
+  'Ghosthub is a free and open source macOS power terminal for any local or SSH tmux '
+  + 'session, with built-in Git worktree management and GitHub pull request import.';
 ---
 
 <SiteLayout title={title} description={description} path="/">


### PR DESCRIPTION
Ghosthub’s public copy alternated between describing the app as a session navigator and calling it worktree-first. Neither framing matched the product: creating or attaching to arbitrary tmux sessions and managing worktree-bound sessions are independent, first-class workflows, and users never need to configure Git to use the former.\n\nThis gives the README, landing page, metadata, feature cards, and guide one concrete promise: any tmux session across the local and SSH fleet, or a managed worktree session created from a branch or GitHub pull request. The worktree capability is now visible without making it sound mandatory.\n\nThe website production build passes.