### PR TITLE
Scope sidebar toggles to the focused window

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -309,12 +309,14 @@ struct GhosthubApp: App {
             Divider()
 
             Button("Toggle Sidebar") {
+                guard let focusedSceneModel else { return }
                 NotificationCenter.default.post(
                     name: .ghosthubToggleSidebar,
-                    object: nil
+                    object: focusedSceneModel
                 )
             }
             .keyboardShortcut("b")
+            .disabled(focusedSceneModel == nil)
         }
     }
 }

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -695,6 +695,7 @@ struct WorkspaceWindow: View {
                     try await sceneModel.removeWorktree(request)
                 }
             ),
+            sidebarToggleTarget: sceneModel,
             settingsStore: settingsStore,
             selection: Binding(
                 get: { sceneModel.selection },
@@ -761,7 +762,7 @@ struct WorkspaceWindow: View {
                 onToggleSidebar: {
                     NotificationCenter.default.post(
                         name: .ghosthubToggleSidebar,
-                        object: nil
+                        object: sceneModel
                     )
                 },
                 onQuickLaunch: {

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -7,6 +7,7 @@ public struct RootView: View {
     private let display: WorkspaceDisplayState
     private let content: ContentBuilders
     private let handlers: InteractionHandlers
+    private let sidebarToggleTarget: AnyObject
     @Binding private var selection: WorkspaceSelection
     @Binding private var isSidePanelVisible: Bool
     @Binding private var columnVisibility: NavigationSplitViewVisibility
@@ -32,6 +33,7 @@ public struct RootView: View {
         display: WorkspaceDisplayState,
         content: ContentBuilders = ContentBuilders(),
         handlers: InteractionHandlers = InteractionHandlers(),
+        sidebarToggleTarget: AnyObject = NSObject(),
         settingsStore: SettingsStore = .shared,
         selection: Binding<WorkspaceSelection>,
         isSidePanelVisible: Binding<Bool> = .constant(false),
@@ -43,6 +45,7 @@ public struct RootView: View {
         self.display = display
         self.content = content
         self.handlers = handlers
+        self.sidebarToggleTarget = sidebarToggleTarget
         self.settingsStore = settingsStore
         _selection = selection
         _isSidePanelVisible = isSidePanelVisible
@@ -216,7 +219,8 @@ public struct RootView: View {
             ) { _ in handleCommandPalette() }
             .onReceive(
                 NotificationCenter.default.publisher(
-                    for: .ghosthubToggleSidebar
+                    for: .ghosthubToggleSidebar,
+                    object: sidebarToggleTarget
                 )
             ) { _ in handleToggleSidebar() }
             .onReceive(

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -60,6 +60,35 @@ struct SidebarToggleStabilityTests {
         )
     }
 
+    @Test("sidebar command toggles only its targeted window")
+    func sidebarCommandTogglesOnlyTargetedWindow() {
+        let firstTarget = SidebarToggleTarget()
+        let secondTarget = SidebarToggleTarget()
+        let first = StabilityTestEnvironment(
+            sidebarToggleTarget: firstTarget
+        )
+        let second = StabilityTestEnvironment(
+            sidebarToggleTarget: secondTarget
+        )
+        defer {
+            first.close()
+            second.close()
+        }
+
+        #expect(first.columnVisibility == .all)
+        #expect(second.columnVisibility == .all)
+
+        NotificationCenter.default.post(
+            name: .ghosthubToggleSidebar,
+            object: firstTarget
+        )
+        first.settle()
+        second.settle()
+
+        #expect(first.columnVisibility == .detailOnly)
+        #expect(second.columnVisibility == .all)
+    }
+
     @Test("right side panel toggle preserves main column view identity")
     func rightSidePanelTogglePreservesMainColumn() {
         let env = SidePanelStabilityTestEnvironment()
@@ -91,6 +120,8 @@ struct SidebarToggleStabilityTests {
 
 // MARK: - Test Helpers
 
+private final class SidebarToggleTarget {}
+
 @MainActor
 private final class StabilityTestEnvironment {
     let firstSession: WorkspaceTmuxSessionSelection
@@ -103,6 +134,7 @@ private final class StabilityTestEnvironment {
     private let tempRoot: URL
     private let defaults: UserDefaults
     private let defaultsSuiteName: String
+    private let sidebarToggleTarget: AnyObject
 
     var isSidebarVisible: Bool {
         get { model.columnVisibility != .detailOnly }
@@ -131,7 +163,8 @@ private final class StabilityTestEnvironment {
         model.columnVisibility
     }
 
-    init() {
+    init(sidebarToggleTarget: AnyObject = SidebarToggleTarget()) {
+        self.sidebarToggleTarget = sidebarToggleTarget
         let hostID = UUID()
         firstSession = WorkspaceTmuxSessionSelection(
             hostID: hostID,
@@ -193,7 +226,8 @@ private final class StabilityTestEnvironment {
             rootView: StabilityTestHarness(
                 model: model,
                 settingsStore: settingsStore,
-                defaults: defaults
+                defaults: defaults,
+                sidebarToggleTarget: sidebarToggleTarget
             )
         )
         window = NSWindow(
@@ -267,6 +301,7 @@ private struct StabilityTestHarness: View {
     @ObservedObject var model: StabilityTestModel
     let settingsStore: SettingsStore
     let defaults: UserDefaults
+    let sidebarToggleTarget: AnyObject
 
     var body: some View {
         RootView(
@@ -281,11 +316,13 @@ private struct StabilityTestHarness: View {
                     )
                 }
             ),
+            sidebarToggleTarget: sidebarToggleTarget,
             settingsStore: settingsStore,
             selection: $model.selection,
             columnVisibility: $model.columnVisibility
         )
         .defaultAppStorage(defaults)
+        .environment(\.controlActiveState, .key)
     }
 }
 


### PR DESCRIPTION
Command-B currently broadcasts a process-wide notification and trusts each SwiftUI scene to reject it using control-active state. Multiple live windows can report key state simultaneously, allowing one shortcut to invert sidebars in more than one window; the same problem affects the compact titlebar control.\n\nThis binds sidebar commands to the focused scene identity, so each workspace receives only its own toggle while preserving the existing sidebar and auto-collapse behavior. A two-window regression forces both hosted views into key control state and confirms only the addressed window changes.\n\nThe targeted regression, full Swift suite, formatting, and app build pass.