### PR TITLE
Prevent crash while reopening windows after updates

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -86,8 +86,6 @@ struct GhosthubApp: App {
                 AppAppearance.apply(appearance)
                 #endif
             }
-        } defaultValue: {
-            WorkspaceWindowState.fresh()
         }
         .defaultSize(width: 1600, height: 1000)
         .windowStyle(.hiddenTitleBar)

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -790,12 +790,16 @@ struct WorkspaceWindow: View {
             resolvedWindowState.wrappedValue = state
         }
         .onChange(of: windowState) { _, state in
-            windowStateBuffer.absorb(state)
+            if let restoredState = windowStateBuffer.receive(state) {
+                sceneModel.beginRestoration(restoredState)
+            }
         }
         .onAppear {
-            let initialState = resolvedWindowState.wrappedValue
-            resolvedWindowState.wrappedValue = initialState
-            sceneModel.beginRestoration(initialState)
+            if let initialState = windowStateBuffer.beginAppearance(
+                with: windowState
+            ) {
+                sceneModel.beginRestoration(initialState)
+            }
             refreshWindowState()
             registry.register(
                 sceneModel,
@@ -845,7 +849,7 @@ struct WorkspaceWindow: View {
                 windowStateBuffer.resolved(windowState)
             },
             set: { state in
-                windowStateBuffer.absorb(state)
+                windowStateBuffer.prepareToPresent(state)
                 windowState = state
             }
         )

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -520,8 +520,9 @@ private struct CompactToolbarButton: View {
 struct WorkspaceWindow: View {
     #if canImport(AppKit)
     let applicationDelegate: ApplicationDelegate
-    @Binding var windowState: WorkspaceWindowState
+    @Binding var windowState: WorkspaceWindowState?
     #endif
+    @State private var windowStateBuffer = WorkspaceWindowStateBuffer()
     @StateObject private var sceneModel = WorkspaceSceneModel()
     @EnvironmentObject private var terminalRuntime: LibghosttyRuntime
     @ObservedObject private var settingsStore = SettingsStore.shared
@@ -747,7 +748,7 @@ struct WorkspaceWindow: View {
         .background(
             WindowFocusTracker(
                 applicationDelegate: applicationDelegate,
-                requestID: windowState.windowID,
+                requestID: resolvedWindowState.wrappedValue.windowID,
                 isFocused: Binding(
                     get: { sceneModel.isFocusedWindow },
                     set: { sceneModel.isFocusedWindow = $0 }
@@ -784,12 +785,17 @@ struct WorkspaceWindow: View {
         )
         #endif
         .onChange(of: sceneModel.restorationState(
-            windowID: windowState.windowID
+            windowID: resolvedWindowState.wrappedValue.windowID
         )) { _, state in
-            windowState = state
+            resolvedWindowState.wrappedValue = state
+        }
+        .onChange(of: windowState) { _, state in
+            windowStateBuffer.absorb(state)
         }
         .onAppear {
-            sceneModel.beginRestoration(windowState)
+            let initialState = resolvedWindowState.wrappedValue
+            resolvedWindowState.wrappedValue = initialState
+            sceneModel.beginRestoration(initialState)
             refreshWindowState()
             registry.register(
                 sceneModel,
@@ -828,8 +834,20 @@ struct WorkspaceWindow: View {
     }
 
     private func refreshWindowState() {
-        windowState = sceneModel.restorationState(
-            windowID: windowState.windowID
+        resolvedWindowState.wrappedValue = sceneModel.restorationState(
+            windowID: resolvedWindowState.wrappedValue.windowID
+        )
+    }
+
+    private var resolvedWindowState: Binding<WorkspaceWindowState> {
+        Binding(
+            get: {
+                windowStateBuffer.resolved(windowState)
+            },
+            set: { state in
+                windowStateBuffer.absorb(state)
+                windowState = state
+            }
         )
     }
 

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -129,7 +129,7 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
 
 struct WorkspaceWindowStateBuffer {
     private(set) var retained: WorkspaceWindowState
-    private var pendingPresentation: WorkspaceWindowState?
+    private var pendingPresentations: [WorkspaceWindowState] = []
     private var awaitsLateRestoration = false
 
     init(retained: WorkspaceWindowState = .fresh()) {
@@ -147,21 +147,20 @@ struct WorkspaceWindowStateBuffer {
 
     mutating func prepareToPresent(_ state: WorkspaceWindowState) {
         retained = state
-        pendingPresentation = state
+        pendingPresentations.append(state)
     }
 
     mutating func receive(
         _ presented: WorkspaceWindowState?
     ) -> WorkspaceWindowState? {
         guard let presented else { return nil }
-        retained = presented
 
-        if presented == pendingPresentation {
-            pendingPresentation = nil
+        if let index = pendingPresentations.firstIndex(of: presented) {
+            pendingPresentations.remove(at: index)
             return nil
         }
-        pendingPresentation = nil
 
+        retained = presented
         guard awaitsLateRestoration else { return nil }
         awaitsLateRestoration = false
         return presented

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -129,14 +129,42 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
 
 struct WorkspaceWindowStateBuffer {
     private(set) var retained: WorkspaceWindowState
+    private var pendingPresentation: WorkspaceWindowState?
+    private var awaitsLateRestoration = false
 
     init(retained: WorkspaceWindowState = .fresh()) {
         self.retained = retained
     }
 
-    mutating func absorb(_ presented: WorkspaceWindowState?) {
-        guard let presented else { return }
+    mutating func beginAppearance(
+        with presented: WorkspaceWindowState?
+    ) -> WorkspaceWindowState? {
+        awaitsLateRestoration = presented == nil
+        guard let presented else { return nil }
         retained = presented
+        return presented
+    }
+
+    mutating func prepareToPresent(_ state: WorkspaceWindowState) {
+        retained = state
+        pendingPresentation = state
+    }
+
+    mutating func receive(
+        _ presented: WorkspaceWindowState?
+    ) -> WorkspaceWindowState? {
+        guard let presented else { return nil }
+        retained = presented
+
+        if presented == pendingPresentation {
+            pendingPresentation = nil
+            return nil
+        }
+        pendingPresentation = nil
+
+        guard awaitsLateRestoration else { return nil }
+        awaitsLateRestoration = false
+        return presented
     }
 
     func resolved(_ presented: WorkspaceWindowState?) -> WorkspaceWindowState {

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -127,6 +127,23 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
     }
 }
 
+struct WorkspaceWindowStateBuffer {
+    private(set) var retained: WorkspaceWindowState
+
+    init(retained: WorkspaceWindowState = .fresh()) {
+        self.retained = retained
+    }
+
+    mutating func absorb(_ presented: WorkspaceWindowState?) {
+        guard let presented else { return }
+        retained = presented
+    }
+
+    func resolved(_ presented: WorkspaceWindowState?) -> WorkspaceWindowState {
+        presented ?? retained
+    }
+}
+
 enum WorkspaceRestorationResolution: Equatable, Sendable {
     case invalid
     case pending(selection: WorkspaceSelection?)

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -175,6 +175,27 @@ private struct RestorationFixture {
 
 @Suite("Workspace window restoration state")
 struct WorkspaceWindowStateTests {
+    @Test("window state survives a temporarily nil scene binding")
+    func windowStateSurvivesNilSceneBinding() {
+        let fallback = WorkspaceWindowState.fresh()
+        let restored = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "local",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil
+        )
+        var buffer = WorkspaceWindowStateBuffer(retained: fallback)
+
+        #expect(buffer.resolved(nil) == fallback)
+
+        buffer.absorb(restored)
+
+        #expect(buffer.resolved(nil) == restored)
+    }
+
     enum OrdinaryOwnershipDrift: CaseIterable, Sendable {
         case sessionName
         case socket

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -177,7 +177,8 @@ private struct RestorationFixture {
 struct WorkspaceWindowStateTests {
     @Test("window state survives a temporarily nil scene binding")
     func windowStateSurvivesNilSceneBinding() {
-        let fallback = WorkspaceWindowState.fresh()
+        let firstFallback = WorkspaceWindowState.fresh()
+        let secondFallback = WorkspaceWindowState.fresh()
         let restored = WorkspaceWindowState(
             windowID: UUID(),
             navigation: WorkspaceNavigationDescriptor(
@@ -187,13 +188,17 @@ struct WorkspaceWindowStateTests {
             ),
             tmux: nil
         )
-        var buffer = WorkspaceWindowStateBuffer(retained: fallback)
+        var buffer = WorkspaceWindowStateBuffer(retained: firstFallback)
 
-        #expect(buffer.resolved(nil) == fallback)
+        #expect(buffer.resolved(nil) == firstFallback)
 
         #expect(buffer.beginAppearance(with: nil) == nil)
-        buffer.prepareToPresent(fallback)
-        #expect(buffer.receive(fallback) == nil)
+        buffer.prepareToPresent(firstFallback)
+        buffer.prepareToPresent(secondFallback)
+
+        #expect(buffer.receive(firstFallback) == nil)
+        #expect(buffer.resolved(nil) == secondFallback)
+        #expect(buffer.receive(secondFallback) == nil)
 
         #expect(buffer.receive(restored) == restored)
 

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -191,7 +191,11 @@ struct WorkspaceWindowStateTests {
 
         #expect(buffer.resolved(nil) == fallback)
 
-        buffer.absorb(restored)
+        #expect(buffer.beginAppearance(with: nil) == nil)
+        buffer.prepareToPresent(fallback)
+        #expect(buffer.receive(fallback) == nil)
+
+        #expect(buffer.receive(restored) == restored)
 
         #expect(buffer.resolved(nil) == restored)
     }


### PR DESCRIPTION
Ghosthub 0.5.0 installs successfully through Sparkle, but the relaunched process can crash before drawing a window when macOS restores saved scenes. SwiftUI’s typed `WindowGroup` default-value overload force-unwraps a scene binding that can be temporarily nil during this handoff, producing the `BindingOperations.ForceUnwrapping` crash and a repeatable “reopening windows” crash loop.

Use SwiftUI’s optional scene-binding path and keep the last valid `WorkspaceWindowState` available while restoration settles. If the binding is nil at appearance and macOS supplies its decoded value later, Ghosthub now distinguishes its own fallback writes from that external value and begins restoration with the saved workspace and exact tmux identity. This preserves fresh-window initialization without losing native saved-window recovery.

The separate 0.4.0 report is a hang in the synchronous quit-confirmation run loop while Sparkle requests termination, not this SwiftUI crash. The 0.5.0 base already fixes that path by arming a one-shot updater authorization before relaunch, causing AppKit to return `.terminateNow` before presenting the confirmation; its ordering and single-use behavior remain covered here. Because 0.5.0 is already public, the scene-restoration fix should be included in the next patch release.

The app build, formatting check, focused late-restoration regression, updater termination tests, and full Swift suite pass (155 XCTest cases with 5 expected headless skips, plus 794 Swift Testing cases).