### PR TITLE
Restore all windows after self-updates

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -64,6 +64,10 @@ struct GhosthubApp: App {
                         value: windowState
                     )
                 }
+                appDelegate.setWindowRestorationFinishedHandler {
+                    updateRelaunchRestorer
+                        .nativeWindowRestorationDidFinish()
+                }
                 appDelegate.needsConfirmQuit = {
                     QuitPolicy.needsConfirmation(
                         confirmBeforeQuitting:

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -64,9 +64,11 @@ struct GhosthubApp: App {
                         value: windowState
                     )
                 }
-                appDelegate.setWindowRestorationFinishedHandler {
+                appDelegate.setWindowRestorationFinishedHandler { count in
                     updateRelaunchRestorer
-                        .nativeWindowRestorationDidFinish()
+                        .nativeWindowRestorationDidFinish(
+                            expectedSceneCount: count
+                        )
                 }
                 appDelegate.needsConfirmQuit = {
                     QuitPolicy.needsConfirmation(

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -21,6 +21,8 @@ struct GhosthubApp: App {
     @StateObject private var settingsStore = SettingsStore.shared
     #if canImport(AppKit)
     private let updateController = UpdateController()
+    private let updateRelaunchStore = UpdateRelaunchManifestStore()
+    private let updateRelaunchRestorer = UpdateRelaunchRestorer()
     #endif
     @FocusedValue(\.sceneModel) private var focusedSceneModel
     @Environment(\.openWindow) private var openWindow
@@ -44,7 +46,11 @@ struct GhosthubApp: App {
         ) { windowState in
             WorkspaceWindow(
                 applicationDelegate: appDelegate,
-                windowState: windowState
+                windowState: windowState,
+                updateRelaunchRestorer: updateRelaunchRestorer,
+                openRelaunchWindow: { state in
+                    openWindow(id: "workspace", value: state)
+                }
             )
             .environmentObject(terminalRuntime)
             .onAppear {
@@ -65,8 +71,25 @@ struct GhosthubApp: App {
                     )
                 }
                 updateController.configureRelaunch(
-                    refreshRestorationState: {
-                        WindowRegistry.shared.refreshRestorationStates()
+                    prepareRelaunch: {
+                        let states = WindowRegistry.shared
+                            .captureRestorationStates()
+                        do {
+                            try updateRelaunchStore.save(states)
+                        } catch {
+                            AppLogger.shared.error(
+                                "update relaunch: could not save windows: \(error)"
+                            )
+                        }
+                    },
+                    cancelRelaunch: {
+                        do {
+                            try updateRelaunchStore.clear()
+                        } catch {
+                            AppLogger.shared.error(
+                                "update relaunch: could not discard saved windows: \(error)"
+                            )
+                        }
                     },
                     authorizeTermination: {
                         appDelegate.authorizeNextUpdaterTermination()

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -46,6 +46,10 @@ enum WorkspaceWindowIdentity {
         window.tabbingIdentifier == tabbingIdentifier
     }
 
+    static func count(in windows: [NSWindow]) -> Int {
+        windows.count(where: matches)
+    }
+
     static func group(containing window: NSWindow) -> [NSWindow] {
         window.tabGroup?.windows ?? [window]
     }
@@ -111,8 +115,8 @@ final class ApplicationDelegate: NSObject,
     var openWorkspaceWindow: (WorkspaceWindowState) -> Void = { _ in }
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
-    private var windowRestorationFinishedHandler: () -> Void = {}
-    private var windowRestorationFinished = false
+    private var windowRestorationFinishedHandler: (Int) -> Void = { _ in }
+    private var restoredWorkspaceWindowCount: Int?
     private(set) var terminationConfirmed = false
     private(set) var terminationConfirmationPending = false
     private var updaterTerminationAuthorized = false
@@ -142,20 +146,23 @@ final class ApplicationDelegate: NSObject,
     }
 
     func setWindowRestorationFinishedHandler(
-        _ handler: @escaping () -> Void
+        _ handler: @escaping (Int) -> Void
     ) {
         windowRestorationFinishedHandler = handler
-        if windowRestorationFinished {
-            handler()
+        if let restoredWorkspaceWindowCount {
+            handler(restoredWorkspaceWindowCount)
         }
     }
 
     @objc func applicationDidFinishRestoringWindows(
         _ notification: Notification
     ) {
-        guard !windowRestorationFinished else { return }
-        windowRestorationFinished = true
-        windowRestorationFinishedHandler()
+        guard restoredWorkspaceWindowCount == nil else { return }
+        let count = WorkspaceWindowIdentity.count(
+            in: NSApplication.shared.windows
+        )
+        restoredWorkspaceWindowCount = count
+        windowRestorationFinishedHandler(count)
     }
 
     func applicationDidFinishLaunching(

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -111,6 +111,8 @@ final class ApplicationDelegate: NSObject,
     var openWorkspaceWindow: (WorkspaceWindowState) -> Void = { _ in }
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
+    private var windowRestorationFinishedHandler: () -> Void = {}
+    private var windowRestorationFinished = false
     private(set) var terminationConfirmed = false
     private(set) var terminationConfirmationPending = false
     private var updaterTerminationAuthorized = false
@@ -118,11 +120,42 @@ final class ApplicationDelegate: NSObject,
     override init() {
         confirmTermination = { false }
         super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidFinishRestoringWindows(_:)),
+            name: NSApplication.didFinishRestoringWindowsNotification,
+            object: nil
+        )
         confirmTermination = { [weak self] in
             guard let self else { return false }
             return presentApplicationAlert(makeTerminationAlert())
                 == .alertFirstButtonReturn
         }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSApplication.didFinishRestoringWindowsNotification,
+            object: nil
+        )
+    }
+
+    func setWindowRestorationFinishedHandler(
+        _ handler: @escaping () -> Void
+    ) {
+        windowRestorationFinishedHandler = handler
+        if windowRestorationFinished {
+            handler()
+        }
+    }
+
+    @objc func applicationDidFinishRestoringWindows(
+        _ notification: Notification
+    ) {
+        guard !windowRestorationFinished else { return }
+        windowRestorationFinished = true
+        windowRestorationFinishedHandler()
     }
 
     func applicationDidFinishLaunching(

--- a/Sources/App/UpdateController.swift
+++ b/Sources/App/UpdateController.swift
@@ -57,40 +57,49 @@ struct UpdateConfiguration: Equatable {
 
 @MainActor
 final class UpdateInstallationDelegate: NSObject, SPUUpdaterDelegate {
-    private var refreshRestorationState: () -> Void
+    private var prepareRelaunch: () -> Void
+    private var cancelRelaunch: () -> Void
     private var authorizeTermination: () -> Void
     private var clearTerminationAuthorization: () -> Void
     private var isRelaunchPending = false
 
     init(
-        refreshRestorationState: @escaping () -> Void = {},
+        prepareRelaunch: @escaping () -> Void = {},
+        cancelRelaunch: @escaping () -> Void = {},
         authorizeTermination: @escaping () -> Void = {},
         clearTerminationAuthorization: @escaping () -> Void = {}
     ) {
-        self.refreshRestorationState = refreshRestorationState
+        self.prepareRelaunch = prepareRelaunch
+        self.cancelRelaunch = cancelRelaunch
         self.authorizeTermination = authorizeTermination
         self.clearTerminationAuthorization = clearTerminationAuthorization
         super.init()
     }
 
     func configure(
-        refreshRestorationState: @escaping () -> Void,
+        prepareRelaunch: @escaping () -> Void,
+        cancelRelaunch: @escaping () -> Void,
         authorizeTermination: @escaping () -> Void,
         clearTerminationAuthorization: @escaping () -> Void
     ) {
-        self.refreshRestorationState = refreshRestorationState
+        self.prepareRelaunch = prepareRelaunch
+        self.cancelRelaunch = cancelRelaunch
         self.authorizeTermination = authorizeTermination
         self.clearTerminationAuthorization = clearTerminationAuthorization
     }
 
     func prepareForRelaunch() {
         isRelaunchPending = true
-        refreshRestorationState()
+        prepareRelaunch()
         authorizeTermination()
     }
 
     func updateSessionDidAbort() {
+        let shouldCancelRelaunch = isRelaunchPending
         isRelaunchPending = false
+        if shouldCancelRelaunch {
+            cancelRelaunch()
+        }
         clearTerminationAuthorization()
     }
 
@@ -99,7 +108,11 @@ final class UpdateInstallationDelegate: NSObject, SPUUpdaterDelegate {
         // termination request; disarming here would resurface the quit
         // confirmation mid-relaunch.
         guard error || !isRelaunchPending else { return }
+        let shouldCancelRelaunch = isRelaunchPending
         isRelaunchPending = false
+        if shouldCancelRelaunch {
+            cancelRelaunch()
+        }
         clearTerminationAuthorization()
     }
 
@@ -154,12 +167,14 @@ final class UpdateController {
     }
 
     func configureRelaunch(
-        refreshRestorationState: @escaping () -> Void,
+        prepareRelaunch: @escaping () -> Void,
+        cancelRelaunch: @escaping () -> Void,
         authorizeTermination: @escaping () -> Void,
         clearTerminationAuthorization: @escaping () -> Void
     ) {
         installationDelegate?.configure(
-            refreshRestorationState: refreshRestorationState,
+            prepareRelaunch: prepareRelaunch,
+            cancelRelaunch: cancelRelaunch,
             authorizeTermination: authorizeTermination,
             clearTerminationAuthorization: clearTerminationAuthorization
         )

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -96,6 +96,7 @@ final class UpdateRelaunchRestorer {
     /// AppKit can finish restoring NSWindows before every corresponding
     /// SwiftUI view reaches onAppear and registers its scene here.
     private var expectedNativeSceneCount: Int?
+    private var sceneBindingSettlementTask: Task<Void, Never>?
 
     init(
         store: UpdateRelaunchManifestStore = .init()
@@ -167,6 +168,28 @@ final class UpdateRelaunchRestorer {
     }
 
     func reconcileIfNativeRestorationFinished() {
+        sceneBindingSettlementTask?.cancel()
+        sceneBindingSettlementTask = nil
+        guard let expectedNativeSceneCount,
+              sceneEntries.count >= expectedNativeSceneCount,
+              !orderedWindowIDs.isEmpty,
+              openWindow != nil
+        else { return }
+
+        // Registration and an optional binding's decoded value can arrive in
+        // separate SwiftUI updates. Wait through the next main-actor turn and
+        // restart this settlement whenever another value arrives.
+        sceneBindingSettlementTask = Task { [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            self?.sceneBindingSettlementTask = nil
+            self?.reconcileAfterSceneBindingsSettled()
+        }
+    }
+
+    func reconcileAfterSceneBindingsSettled() {
+        sceneBindingSettlementTask?.cancel()
+        sceneBindingSettlementTask = nil
         guard let expectedNativeSceneCount,
               sceneEntries.count >= expectedNativeSceneCount,
               !orderedWindowIDs.isEmpty,
@@ -232,6 +255,8 @@ final class UpdateRelaunchRestorer {
         restoringWindowIDs = []
         sceneEntries = [:]
         openWindow = nil
+        sceneBindingSettlementTask?.cancel()
+        sceneBindingSettlementTask = nil
     }
 
     private func observe(

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -111,8 +111,7 @@ final class UpdateRelaunchRestorer {
     private let store: UpdateRelaunchManifestStore
     private var statesByID: [UUID: WorkspaceWindowState]
     private var orderedWindowIDs: [UUID]
-    private var scheduledWindowIDs: Set<UUID> = []
-    private var displacedFallbackByReplayID: [UUID: UUID] = [:]
+    private var replayTargetByRequestID: [UUID: UUID] = [:]
     private var restoringWindowIDs: Set<UUID> = []
     private var sceneEntries: [UUID: SceneEntry] = [:]
     private var nextRegistrationOrder = 0
@@ -156,7 +155,7 @@ final class UpdateRelaunchRestorer {
     ) -> UpdateRelaunchSceneObservation {
         guard !orderedWindowIDs.isEmpty,
               !manifestConsumed || sceneEntries[sceneID] != nil
-              || !scheduledWindowIDs.isEmpty
+              || !replayTargetByRequestID.isEmpty
         else { return .ordinary }
         let registrationOrder = sceneEntries[sceneID]?.registrationOrder
             ?? nextRegistrationOrder
@@ -233,10 +232,10 @@ final class UpdateRelaunchRestorer {
         let claimedWindowIDs = Set(
             sceneEntries.values.compactMap { $0.assignment?.windowID }
         )
+        let scheduledWindowIDs = Set(replayTargetByRequestID.values)
         var missingWindowIDs = orderedWindowIDs.filter {
             !claimedWindowIDs.contains($0)
                 && !scheduledWindowIDs.contains($0)
-                && !restoringWindowIDs.contains($0)
         }
         let availableSceneIDs = sceneEntries
             .filter { $0.value.assignment == nil }
@@ -261,10 +260,10 @@ final class UpdateRelaunchRestorer {
         }
 
         let statesToOpen: [WorkspaceWindowState] = missingWindowIDs
-            .compactMap { windowID in
-                guard let state = statesByID[windowID] else { return nil }
-                scheduledWindowIDs.insert(windowID)
-                return state
+            .map { windowID in
+                let request = WorkspaceWindowState.fresh()
+                replayTargetByRequestID[request.windowID] = windowID
+                return request
             }
         restorations.forEach { restore, state in restore(state) }
         statesToOpen.forEach(openWindow)
@@ -273,8 +272,18 @@ final class UpdateRelaunchRestorer {
     func didBeginRestoring(windowID: UUID) {
         guard statesByID[windowID] != nil else { return }
         restoringWindowIDs.insert(windowID)
+        consumeManifestIfComplete()
+    }
+
+    private func consumeManifestIfComplete() {
+        let assignedWindowIDs = sceneEntries.values.compactMap {
+            $0.assignment?.windowID
+        }
         guard !manifestConsumed,
-              restoringWindowIDs.count == statesByID.count
+              replayTargetByRequestID.isEmpty,
+              restoringWindowIDs == Set(statesByID.keys),
+              assignedWindowIDs.count == statesByID.count,
+              Set(assignedWindowIDs) == Set(statesByID.keys)
         else {
             return
         }
@@ -318,39 +327,38 @@ final class UpdateRelaunchRestorer {
                 otherEntry.assignment = .fallback(assignedWindowID)
                 sceneEntries[sceneID] = entry
                 sceneEntries[otherSceneID] = otherEntry
-                scheduledWindowIDs.remove(saved.windowID)
                 otherEntry.restore(previousState)
                 return .restore(saved)
             }
-            guard scheduledWindowIDs.contains(saved.windowID) else {
+            guard let requestID = replayTargetByRequestID.first(where: {
+                $0.value == saved.windowID
+            })?.key,
+                let openWindow
+            else {
                 return .waitingForNativeRestoration
             }
             entry.assignment = .presented(saved.windowID)
             sceneEntries[sceneID] = entry
-            displacedFallbackByReplayID[saved.windowID] = assignedWindowID
+            replayTargetByRequestID[requestID] = assignedWindowID
+            openWindow(.fresh(windowID: requestID))
             return .restore(saved)
         }
-        guard let presented,
-              let saved = statesByID[presented.windowID]
-        else { return .waitingForNativeRestoration }
+        guard let presented else { return .waitingForNativeRestoration }
 
-        if let displacedWindowID = displacedFallbackByReplayID
-            .removeValue(forKey: saved.windowID),
-            let displacedState = statesByID[displacedWindowID] {
-            entry.assignment = .fallback(displacedWindowID)
+        if let replayTargetID = replayTargetByRequestID.removeValue(
+            forKey: presented.windowID
+        ), let replayState = statesByID[replayTargetID] {
+            entry.assignment = .replay(replayTargetID)
             sceneEntries[sceneID] = entry
-            scheduledWindowIDs.remove(saved.windowID)
-            return .restore(displacedState)
+            return .restore(replayState)
         }
+        guard let saved = statesByID[presented.windowID]
+        else { return .waitingForNativeRestoration }
         guard !sceneEntries.values.contains(where: {
             $0.assignment?.windowID == presented.windowID
         }) else { return .waitingForNativeRestoration }
 
-        if scheduledWindowIDs.remove(saved.windowID) != nil {
-            entry.assignment = .replay(saved.windowID)
-        } else {
-            entry.assignment = .presented(saved.windowID)
-        }
+        entry.assignment = .presented(saved.windowID)
         sceneEntries[sceneID] = entry
         return .restore(saved)
     }

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -71,17 +71,41 @@ struct UpdateRelaunchManifestStore {
     }
 }
 
+enum UpdateRelaunchSceneObservation: Equatable {
+    case ordinary
+    case waitingForNativeRestoration
+    case restore(WorkspaceWindowState)
+}
+
 @MainActor
 final class UpdateRelaunchRestorer {
+    private struct SceneEntry {
+        let registrationOrder: Int
+        var assignedWindowID: UUID?
+        var restore: (WorkspaceWindowState) -> Void
+    }
+
     private let store: UpdateRelaunchManifestStore
+    private let reconciliationDelayNanoseconds: UInt64?
     private var statesByID: [UUID: WorkspaceWindowState]
     private var orderedWindowIDs: [UUID]
     private var scheduledWindowIDs: Set<UUID> = []
     private var restoringWindowIDs: Set<UUID> = []
-    private var replaysMissingWindows = false
+    private var sceneEntries: [UUID: SceneEntry] = [:]
+    private var nextRegistrationOrder = 0
+    private var openWindow: ((WorkspaceWindowState) -> Void)?
+    private var reconciliationTask: Task<Void, Never>?
 
-    init(store: UpdateRelaunchManifestStore = .init()) {
+    init(
+        store: UpdateRelaunchManifestStore = .init(),
+        // SwiftUI can publish decoded scene values after onAppear. Restarting
+        // this short quiet period on every scene update lets native claims
+        // arrive before Ghosthub assigns or opens the remaining manifest IDs.
+        reconciliationDelayNanoseconds: UInt64? = 250_000_000
+    ) {
         self.store = store
+        self.reconciliationDelayNanoseconds =
+            reconciliationDelayNanoseconds
         do {
             let states = try store.load() ?? []
             orderedWindowIDs = states.map(\.windowID)
@@ -103,40 +127,90 @@ final class UpdateRelaunchRestorer {
         }
     }
 
-    func stateForAppearance(
-        presented: WorkspaceWindowState?
-    ) -> WorkspaceWindowState? {
-        guard !orderedWindowIDs.isEmpty else { return presented }
+    func registerScene(
+        id sceneID: UUID,
+        presented: WorkspaceWindowState?,
+        restore: @escaping (WorkspaceWindowState) -> Void,
+        openWindow: @escaping (WorkspaceWindowState) -> Void
+    ) -> UpdateRelaunchSceneObservation {
+        guard !orderedWindowIDs.isEmpty else { return .ordinary }
+        let registrationOrder = sceneEntries[sceneID]?.registrationOrder
+            ?? nextRegistrationOrder
+        if sceneEntries[sceneID] == nil {
+            nextRegistrationOrder += 1
+        }
+        sceneEntries[sceneID] = SceneEntry(
+            registrationOrder: registrationOrder,
+            assignedWindowID: sceneEntries[sceneID]?.assignedWindowID,
+            restore: restore
+        )
+        self.openWindow = openWindow
+        let observation = observe(sceneID: sceneID, presented: presented)
+        scheduleReconciliation()
+        return observation
+    }
 
-        if let presented,
-           let saved = statesByID[presented.windowID] {
-            return saved
+    func receivePresentedState(
+        sceneID: UUID,
+        presented: WorkspaceWindowState?
+    ) -> UpdateRelaunchSceneObservation {
+        guard !orderedWindowIDs.isEmpty,
+              sceneEntries[sceneID] != nil
+        else { return .ordinary }
+        let observation = observe(sceneID: sceneID, presented: presented)
+        scheduleReconciliation()
+        return observation
+    }
+
+    func unregisterScene(id sceneID: UUID) {
+        sceneEntries.removeValue(forKey: sceneID)
+        scheduleReconciliation()
+    }
+
+    func reconcileAfterNativeRestorationSettled() {
+        reconciliationTask?.cancel()
+        reconciliationTask = nil
+        guard !orderedWindowIDs.isEmpty else { return }
+
+        let claimedWindowIDs = Set(
+            sceneEntries.values.compactMap(\.assignedWindowID)
+        )
+        var missingWindowIDs = orderedWindowIDs.filter {
+            !claimedWindowIDs.contains($0)
+                && !scheduledWindowIDs.contains($0)
+                && !restoringWindowIDs.contains($0)
+        }
+        let availableSceneIDs = sceneEntries
+            .filter { $0.value.assignedWindowID == nil }
+            .sorted {
+                $0.value.registrationOrder < $1.value.registrationOrder
+            }
+            .map(\.key)
+
+        var restorations: [(
+            (WorkspaceWindowState) -> Void,
+            WorkspaceWindowState
+        )] = []
+        for sceneID in availableSceneIDs {
+            guard let windowID = missingWindowIDs.first,
+                  let state = statesByID[windowID],
+                  var entry = sceneEntries[sceneID]
+            else { break }
+            missingWindowIDs.removeFirst()
+            entry.assignedWindowID = windowID
+            sceneEntries[sceneID] = entry
+            restorations.append((entry.restore, state))
         }
 
-        guard let windowID = orderedWindowIDs.first(where: {
-            !scheduledWindowIDs.contains($0)
-                && !restoringWindowIDs.contains($0)
-        })
-        else { return presented }
-        replaysMissingWindows = true
-        scheduledWindowIDs.insert(windowID)
-        return statesByID[windowID]
-    }
-
-    func containsSavedState(windowID: UUID) -> Bool {
-        statesByID[windowID] != nil
-    }
-
-    func takeStatesToOpen() -> [WorkspaceWindowState] {
-        guard replaysMissingWindows else { return [] }
-        return orderedWindowIDs.compactMap { windowID ->
-            WorkspaceWindowState? in
-            guard !scheduledWindowIDs.contains(windowID),
-                  !restoringWindowIDs.contains(windowID),
-                  let state = statesByID[windowID]
-            else { return nil }
-            scheduledWindowIDs.insert(windowID)
-            return state
+        let statesToOpen: [WorkspaceWindowState] = missingWindowIDs
+            .compactMap { windowID in
+                guard let state = statesByID[windowID] else { return nil }
+                scheduledWindowIDs.insert(windowID)
+                return state
+            }
+        restorations.forEach { restore, state in restore(state) }
+        if let openWindow {
+            statesToOpen.forEach(openWindow)
         }
     }
 
@@ -157,6 +231,52 @@ final class UpdateRelaunchRestorer {
         statesByID = [:]
         scheduledWindowIDs = []
         restoringWindowIDs = []
-        replaysMissingWindows = false
+        sceneEntries = [:]
+        openWindow = nil
+        reconciliationTask?.cancel()
+        reconciliationTask = nil
+    }
+
+    private func observe(
+        sceneID: UUID,
+        presented: WorkspaceWindowState?
+    ) -> UpdateRelaunchSceneObservation {
+        guard var entry = sceneEntries[sceneID] else { return .ordinary }
+        if let assignedWindowID = entry.assignedWindowID {
+            guard presented?.windowID != assignedWindowID else {
+                return .ordinary
+            }
+            return presented == nil
+                ? .ordinary : .waitingForNativeRestoration
+        }
+        guard let presented,
+              let saved = statesByID[presented.windowID],
+              !sceneEntries.values.contains(where: {
+                  $0.assignedWindowID == presented.windowID
+              })
+        else { return .waitingForNativeRestoration }
+
+        entry.assignedWindowID = saved.windowID
+        sceneEntries[sceneID] = entry
+        scheduledWindowIDs.remove(saved.windowID)
+        return .restore(saved)
+    }
+
+    private func scheduleReconciliation() {
+        guard let reconciliationDelayNanoseconds,
+              !orderedWindowIDs.isEmpty
+        else { return }
+        reconciliationTask?.cancel()
+        reconciliationTask = Task { [weak self] in
+            do {
+                try await Task.sleep(
+                    nanoseconds: reconciliationDelayNanoseconds
+                )
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.reconcileAfterNativeRestorationSettled()
+        }
     }
 }

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -82,19 +82,23 @@ final class UpdateRelaunchRestorer {
     private enum SceneAssignment {
         case presented(UUID)
         case fallback(UUID)
+        case replay(UUID)
 
         var windowID: UUID {
             switch self {
-            case let .presented(windowID), let .fallback(windowID):
+            case let .presented(windowID), let .fallback(windowID),
+                 let .replay(windowID):
                 windowID
             }
         }
 
-        var isFallback: Bool {
-            if case .fallback = self {
-                return true
+        var isProvisional: Bool {
+            switch self {
+            case .fallback, .replay:
+                true
+            case .presented:
+                false
             }
-            return false
         }
     }
 
@@ -108,6 +112,7 @@ final class UpdateRelaunchRestorer {
     private var statesByID: [UUID: WorkspaceWindowState]
     private var orderedWindowIDs: [UUID]
     private var scheduledWindowIDs: Set<UUID> = []
+    private var displacedFallbackByReplayID: [UUID: UUID] = [:]
     private var restoringWindowIDs: Set<UUID> = []
     private var sceneEntries: [UUID: SceneEntry] = [:]
     private var nextRegistrationOrder = 0
@@ -151,6 +156,7 @@ final class UpdateRelaunchRestorer {
     ) -> UpdateRelaunchSceneObservation {
         guard !orderedWindowIDs.isEmpty,
               !manifestConsumed || sceneEntries[sceneID] != nil
+              || !scheduledWindowIDs.isEmpty
         else { return .ordinary }
         let registrationOrder = sceneEntries[sceneID]?.registrationOrder
             ?? nextRegistrationOrder
@@ -280,7 +286,6 @@ final class UpdateRelaunchRestorer {
             )
         }
         manifestConsumed = true
-        scheduledWindowIDs = []
         sceneBindingSettlementTask?.cancel()
         sceneBindingSettlementTask = nil
     }
@@ -297,38 +302,56 @@ final class UpdateRelaunchRestorer {
             }
             guard let presented,
                   let saved = statesByID[presented.windowID],
-                  assignment.isFallback
+                  assignment.isProvisional
             else {
                 return presented == nil
                     ? .ordinary : .waitingForNativeRestoration
             }
-            guard let otherSceneID = sceneEntries.first(where: {
+            if let otherSceneID = sceneEntries.first(where: {
                 $0.key != sceneID
                     && $0.value.assignment?.windowID == saved.windowID
             })?.key,
                 var otherEntry = sceneEntries[otherSceneID],
-                otherEntry.assignment?.isFallback == true,
-                let previousState = statesByID[assignedWindowID]
-            else { return .waitingForNativeRestoration }
-
+                otherEntry.assignment?.isProvisional == true,
+                let previousState = statesByID[assignedWindowID] {
+                entry.assignment = .presented(saved.windowID)
+                otherEntry.assignment = .fallback(assignedWindowID)
+                sceneEntries[sceneID] = entry
+                sceneEntries[otherSceneID] = otherEntry
+                scheduledWindowIDs.remove(saved.windowID)
+                otherEntry.restore(previousState)
+                return .restore(saved)
+            }
+            guard scheduledWindowIDs.contains(saved.windowID) else {
+                return .waitingForNativeRestoration
+            }
             entry.assignment = .presented(saved.windowID)
-            otherEntry.assignment = .fallback(assignedWindowID)
             sceneEntries[sceneID] = entry
-            sceneEntries[otherSceneID] = otherEntry
-            scheduledWindowIDs.remove(saved.windowID)
-            otherEntry.restore(previousState)
+            displacedFallbackByReplayID[saved.windowID] = assignedWindowID
             return .restore(saved)
         }
         guard let presented,
-              let saved = statesByID[presented.windowID],
-              !sceneEntries.values.contains(where: {
-                  $0.assignment?.windowID == presented.windowID
-              })
+              let saved = statesByID[presented.windowID]
         else { return .waitingForNativeRestoration }
 
-        entry.assignment = .presented(saved.windowID)
+        if let displacedWindowID = displacedFallbackByReplayID
+            .removeValue(forKey: saved.windowID),
+            let displacedState = statesByID[displacedWindowID] {
+            entry.assignment = .fallback(displacedWindowID)
+            sceneEntries[sceneID] = entry
+            scheduledWindowIDs.remove(saved.windowID)
+            return .restore(displacedState)
+        }
+        guard !sceneEntries.values.contains(where: {
+            $0.assignment?.windowID == presented.windowID
+        }) else { return .waitingForNativeRestoration }
+
+        if scheduledWindowIDs.remove(saved.windowID) != nil {
+            entry.assignment = .replay(saved.windowID)
+        } else {
+            entry.assignment = .presented(saved.windowID)
+        }
         sceneEntries[sceneID] = entry
-        scheduledWindowIDs.remove(saved.windowID)
         return .restore(saved)
     }
 

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -79,9 +79,28 @@ enum UpdateRelaunchSceneObservation: Equatable {
 
 @MainActor
 final class UpdateRelaunchRestorer {
+    private enum SceneAssignment {
+        case presented(UUID)
+        case fallback(UUID)
+
+        var windowID: UUID {
+            switch self {
+            case let .presented(windowID), let .fallback(windowID):
+                windowID
+            }
+        }
+
+        var isFallback: Bool {
+            if case .fallback = self {
+                return true
+            }
+            return false
+        }
+    }
+
     private struct SceneEntry {
         let registrationOrder: Int
-        var assignedWindowID: UUID?
+        var assignment: SceneAssignment?
         var restore: (WorkspaceWindowState) -> Void
     }
 
@@ -97,6 +116,7 @@ final class UpdateRelaunchRestorer {
     /// SwiftUI view reaches onAppear and registers its scene here.
     private var expectedNativeSceneCount: Int?
     private var sceneBindingSettlementTask: Task<Void, Never>?
+    private var manifestConsumed = false
 
     init(
         store: UpdateRelaunchManifestStore = .init()
@@ -129,7 +149,9 @@ final class UpdateRelaunchRestorer {
         restore: @escaping (WorkspaceWindowState) -> Void,
         openWindow: @escaping (WorkspaceWindowState) -> Void
     ) -> UpdateRelaunchSceneObservation {
-        guard !orderedWindowIDs.isEmpty else { return .ordinary }
+        guard !orderedWindowIDs.isEmpty,
+              !manifestConsumed || sceneEntries[sceneID] != nil
+        else { return .ordinary }
         let registrationOrder = sceneEntries[sceneID]?.registrationOrder
             ?? nextRegistrationOrder
         if sceneEntries[sceneID] == nil {
@@ -137,7 +159,7 @@ final class UpdateRelaunchRestorer {
         }
         sceneEntries[sceneID] = SceneEntry(
             registrationOrder: registrationOrder,
-            assignedWindowID: sceneEntries[sceneID]?.assignedWindowID,
+            assignment: sceneEntries[sceneID]?.assignment,
             restore: restore
         )
         self.openWindow = openWindow
@@ -173,15 +195,20 @@ final class UpdateRelaunchRestorer {
         guard let expectedNativeSceneCount,
               sceneEntries.count >= expectedNativeSceneCount,
               !orderedWindowIDs.isEmpty,
+              !manifestConsumed,
               openWindow != nil
         else { return }
 
         // Registration and an optional binding's decoded value can arrive in
-        // separate SwiftUI updates. Wait through the next main-actor turn and
-        // restart this settlement whenever another value arrives.
+        // separate SwiftUI updates. Require a real quiescence interval and
+        // restart it whenever another value arrives. Fallback assignments stay
+        // provisional so an even later presented ID can still correct them.
         sceneBindingSettlementTask = Task { [weak self] in
-            await Task.yield()
-            guard !Task.isCancelled else { return }
+            do {
+                try await Task.sleep(for: .milliseconds(100))
+            } catch {
+                return
+            }
             self?.sceneBindingSettlementTask = nil
             self?.reconcileAfterSceneBindingsSettled()
         }
@@ -193,11 +220,12 @@ final class UpdateRelaunchRestorer {
         guard let expectedNativeSceneCount,
               sceneEntries.count >= expectedNativeSceneCount,
               !orderedWindowIDs.isEmpty,
+              !manifestConsumed,
               let openWindow
         else { return }
 
         let claimedWindowIDs = Set(
-            sceneEntries.values.compactMap(\.assignedWindowID)
+            sceneEntries.values.compactMap { $0.assignment?.windowID }
         )
         var missingWindowIDs = orderedWindowIDs.filter {
             !claimedWindowIDs.contains($0)
@@ -205,7 +233,7 @@ final class UpdateRelaunchRestorer {
                 && !restoringWindowIDs.contains($0)
         }
         let availableSceneIDs = sceneEntries
-            .filter { $0.value.assignedWindowID == nil }
+            .filter { $0.value.assignment == nil }
             .sorted {
                 $0.value.registrationOrder < $1.value.registrationOrder
             }
@@ -221,7 +249,7 @@ final class UpdateRelaunchRestorer {
                   var entry = sceneEntries[sceneID]
             else { break }
             missingWindowIDs.removeFirst()
-            entry.assignedWindowID = windowID
+            entry.assignment = .fallback(windowID)
             sceneEntries[sceneID] = entry
             restorations.append((entry.restore, state))
         }
@@ -239,7 +267,9 @@ final class UpdateRelaunchRestorer {
     func didBeginRestoring(windowID: UUID) {
         guard statesByID[windowID] != nil else { return }
         restoringWindowIDs.insert(windowID)
-        guard restoringWindowIDs.count == statesByID.count else {
+        guard !manifestConsumed,
+              restoringWindowIDs.count == statesByID.count
+        else {
             return
         }
         do {
@@ -249,12 +279,8 @@ final class UpdateRelaunchRestorer {
                 "update relaunch: could not consume saved windows: \(error)"
             )
         }
-        orderedWindowIDs = []
-        statesByID = [:]
+        manifestConsumed = true
         scheduledWindowIDs = []
-        restoringWindowIDs = []
-        sceneEntries = [:]
-        openWindow = nil
         sceneBindingSettlementTask?.cancel()
         sceneBindingSettlementTask = nil
     }
@@ -264,21 +290,43 @@ final class UpdateRelaunchRestorer {
         presented: WorkspaceWindowState?
     ) -> UpdateRelaunchSceneObservation {
         guard var entry = sceneEntries[sceneID] else { return .ordinary }
-        if let assignedWindowID = entry.assignedWindowID {
+        if let assignment = entry.assignment {
+            let assignedWindowID = assignment.windowID
             guard presented?.windowID != assignedWindowID else {
                 return .ordinary
             }
-            return presented == nil
-                ? .ordinary : .waitingForNativeRestoration
+            guard let presented,
+                  let saved = statesByID[presented.windowID],
+                  assignment.isFallback
+            else {
+                return presented == nil
+                    ? .ordinary : .waitingForNativeRestoration
+            }
+            guard let otherSceneID = sceneEntries.first(where: {
+                $0.key != sceneID
+                    && $0.value.assignment?.windowID == saved.windowID
+            })?.key,
+                var otherEntry = sceneEntries[otherSceneID],
+                otherEntry.assignment?.isFallback == true,
+                let previousState = statesByID[assignedWindowID]
+            else { return .waitingForNativeRestoration }
+
+            entry.assignment = .presented(saved.windowID)
+            otherEntry.assignment = .fallback(assignedWindowID)
+            sceneEntries[sceneID] = entry
+            sceneEntries[otherSceneID] = otherEntry
+            scheduledWindowIDs.remove(saved.windowID)
+            otherEntry.restore(previousState)
+            return .restore(saved)
         }
         guard let presented,
               let saved = statesByID[presented.windowID],
               !sceneEntries.values.contains(where: {
-                  $0.assignedWindowID == presented.windowID
+                  $0.assignment?.windowID == presented.windowID
               })
         else { return .waitingForNativeRestoration }
 
-        entry.assignedWindowID = saved.windowID
+        entry.assignment = .presented(saved.windowID)
         sceneEntries[sceneID] = entry
         scheduledWindowIDs.remove(saved.windowID)
         return .restore(saved)

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -86,7 +86,6 @@ final class UpdateRelaunchRestorer {
     }
 
     private let store: UpdateRelaunchManifestStore
-    private let reconciliationDelayNanoseconds: UInt64?
     private var statesByID: [UUID: WorkspaceWindowState]
     private var orderedWindowIDs: [UUID]
     private var scheduledWindowIDs: Set<UUID> = []
@@ -94,18 +93,12 @@ final class UpdateRelaunchRestorer {
     private var sceneEntries: [UUID: SceneEntry] = [:]
     private var nextRegistrationOrder = 0
     private var openWindow: ((WorkspaceWindowState) -> Void)?
-    private var reconciliationTask: Task<Void, Never>?
+    private var nativeWindowRestorationFinished = false
 
     init(
-        store: UpdateRelaunchManifestStore = .init(),
-        // SwiftUI can publish decoded scene values after onAppear. Restarting
-        // this short quiet period on every scene update lets native claims
-        // arrive before Ghosthub assigns or opens the remaining manifest IDs.
-        reconciliationDelayNanoseconds: UInt64? = 250_000_000
+        store: UpdateRelaunchManifestStore = .init()
     ) {
         self.store = store
-        self.reconciliationDelayNanoseconds =
-            reconciliationDelayNanoseconds
         do {
             let states = try store.load() ?? []
             orderedWindowIDs = states.map(\.windowID)
@@ -145,9 +138,7 @@ final class UpdateRelaunchRestorer {
             restore: restore
         )
         self.openWindow = openWindow
-        let observation = observe(sceneID: sceneID, presented: presented)
-        scheduleReconciliation()
-        return observation
+        return observe(sceneID: sceneID, presented: presented)
     }
 
     func receivePresentedState(
@@ -157,20 +148,25 @@ final class UpdateRelaunchRestorer {
         guard !orderedWindowIDs.isEmpty,
               sceneEntries[sceneID] != nil
         else { return .ordinary }
-        let observation = observe(sceneID: sceneID, presented: presented)
-        scheduleReconciliation()
-        return observation
+        return observe(sceneID: sceneID, presented: presented)
     }
 
     func unregisterScene(id sceneID: UUID) {
         sceneEntries.removeValue(forKey: sceneID)
-        scheduleReconciliation()
+        reconcileIfNativeRestorationFinished()
     }
 
-    func reconcileAfterNativeRestorationSettled() {
-        reconciliationTask?.cancel()
-        reconciliationTask = nil
-        guard !orderedWindowIDs.isEmpty else { return }
+    func nativeWindowRestorationDidFinish() {
+        guard !nativeWindowRestorationFinished else { return }
+        nativeWindowRestorationFinished = true
+        reconcileIfNativeRestorationFinished()
+    }
+
+    func reconcileIfNativeRestorationFinished() {
+        guard nativeWindowRestorationFinished,
+              !orderedWindowIDs.isEmpty,
+              let openWindow
+        else { return }
 
         let claimedWindowIDs = Set(
             sceneEntries.values.compactMap(\.assignedWindowID)
@@ -209,9 +205,7 @@ final class UpdateRelaunchRestorer {
                 return state
             }
         restorations.forEach { restore, state in restore(state) }
-        if let openWindow {
-            statesToOpen.forEach(openWindow)
-        }
+        statesToOpen.forEach(openWindow)
     }
 
     func didBeginRestoring(windowID: UUID) {
@@ -233,8 +227,6 @@ final class UpdateRelaunchRestorer {
         restoringWindowIDs = []
         sceneEntries = [:]
         openWindow = nil
-        reconciliationTask?.cancel()
-        reconciliationTask = nil
     }
 
     private func observe(
@@ -262,21 +254,4 @@ final class UpdateRelaunchRestorer {
         return .restore(saved)
     }
 
-    private func scheduleReconciliation() {
-        guard let reconciliationDelayNanoseconds,
-              !orderedWindowIDs.isEmpty
-        else { return }
-        reconciliationTask?.cancel()
-        reconciliationTask = Task { [weak self] in
-            do {
-                try await Task.sleep(
-                    nanoseconds: reconciliationDelayNanoseconds
-                )
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            self?.reconcileAfterNativeRestorationSettled()
-        }
-    }
 }

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -93,7 +93,9 @@ final class UpdateRelaunchRestorer {
     private var sceneEntries: [UUID: SceneEntry] = [:]
     private var nextRegistrationOrder = 0
     private var openWindow: ((WorkspaceWindowState) -> Void)?
-    private var nativeWindowRestorationFinished = false
+    /// AppKit can finish restoring NSWindows before every corresponding
+    /// SwiftUI view reaches onAppear and registers its scene here.
+    private var expectedNativeSceneCount: Int?
 
     init(
         store: UpdateRelaunchManifestStore = .init()
@@ -156,14 +158,17 @@ final class UpdateRelaunchRestorer {
         reconcileIfNativeRestorationFinished()
     }
 
-    func nativeWindowRestorationDidFinish() {
-        guard !nativeWindowRestorationFinished else { return }
-        nativeWindowRestorationFinished = true
+    func nativeWindowRestorationDidFinish(
+        expectedSceneCount: Int
+    ) {
+        guard expectedNativeSceneCount == nil else { return }
+        expectedNativeSceneCount = expectedSceneCount
         reconcileIfNativeRestorationFinished()
     }
 
     func reconcileIfNativeRestorationFinished() {
-        guard nativeWindowRestorationFinished,
+        guard let expectedNativeSceneCount,
+              sceneEntries.count >= expectedNativeSceneCount,
               !orderedWindowIDs.isEmpty,
               let openWindow
         else { return }

--- a/Sources/App/UpdateRelaunchRestoration.swift
+++ b/Sources/App/UpdateRelaunchRestoration.swift
@@ -1,0 +1,162 @@
+import Foundation
+import GhosthubWorkspace
+
+struct UpdateRelaunchManifest: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var windows: [WorkspaceWindowState]
+
+    init(windows: [WorkspaceWindowState]) {
+        schemaVersion = Self.currentSchemaVersion
+        self.windows = windows
+    }
+}
+
+struct UpdateRelaunchManifestStore {
+    enum StoreError: Error {
+        case unsupportedSchema(Int)
+    }
+
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = StateHome.resolved()
+            .appendingPathComponent("update-relaunch.json"),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func save(_ states: [WorkspaceWindowState]) throws {
+        guard !states.isEmpty else {
+            try clear()
+            return
+        }
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(
+            UpdateRelaunchManifest(windows: states)
+        )
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    func load() throws -> [WorkspaceWindowState]? {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+        let manifest = try JSONDecoder().decode(
+            UpdateRelaunchManifest.self,
+            from: Data(contentsOf: fileURL)
+        )
+        guard manifest.schemaVersion
+            == UpdateRelaunchManifest.currentSchemaVersion
+        else {
+            throw StoreError.unsupportedSchema(manifest.schemaVersion)
+        }
+        return manifest.windows
+    }
+
+    func clear() throws {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return
+        }
+        try fileManager.removeItem(at: fileURL)
+    }
+}
+
+@MainActor
+final class UpdateRelaunchRestorer {
+    private let store: UpdateRelaunchManifestStore
+    private var statesByID: [UUID: WorkspaceWindowState]
+    private var orderedWindowIDs: [UUID]
+    private var scheduledWindowIDs: Set<UUID> = []
+    private var restoringWindowIDs: Set<UUID> = []
+    private var replaysMissingWindows = false
+
+    init(store: UpdateRelaunchManifestStore = .init()) {
+        self.store = store
+        do {
+            let states = try store.load() ?? []
+            orderedWindowIDs = states.map(\.windowID)
+            statesByID = Dictionary(
+                states.map { ($0.windowID, $0) },
+                uniquingKeysWith: { saved, _ in saved }
+            )
+            orderedWindowIDs = orderedWindowIDs.reduce(into: []) {
+                uniqueIDs, windowID in
+                guard !uniqueIDs.contains(windowID) else { return }
+                uniqueIDs.append(windowID)
+            }
+        } catch {
+            orderedWindowIDs = []
+            statesByID = [:]
+            AppLogger.shared.error(
+                "update relaunch: could not load saved windows: \(error)"
+            )
+        }
+    }
+
+    func stateForAppearance(
+        presented: WorkspaceWindowState?
+    ) -> WorkspaceWindowState? {
+        guard !orderedWindowIDs.isEmpty else { return presented }
+
+        if let presented,
+           let saved = statesByID[presented.windowID] {
+            return saved
+        }
+
+        guard let windowID = orderedWindowIDs.first(where: {
+            !scheduledWindowIDs.contains($0)
+                && !restoringWindowIDs.contains($0)
+        })
+        else { return presented }
+        replaysMissingWindows = true
+        scheduledWindowIDs.insert(windowID)
+        return statesByID[windowID]
+    }
+
+    func containsSavedState(windowID: UUID) -> Bool {
+        statesByID[windowID] != nil
+    }
+
+    func takeStatesToOpen() -> [WorkspaceWindowState] {
+        guard replaysMissingWindows else { return [] }
+        return orderedWindowIDs.compactMap { windowID ->
+            WorkspaceWindowState? in
+            guard !scheduledWindowIDs.contains(windowID),
+                  !restoringWindowIDs.contains(windowID),
+                  let state = statesByID[windowID]
+            else { return nil }
+            scheduledWindowIDs.insert(windowID)
+            return state
+        }
+    }
+
+    func didBeginRestoring(windowID: UUID) {
+        guard statesByID[windowID] != nil else { return }
+        restoringWindowIDs.insert(windowID)
+        guard restoringWindowIDs.count == statesByID.count else {
+            return
+        }
+        do {
+            try store.clear()
+        } catch {
+            AppLogger.shared.error(
+                "update relaunch: could not consume saved windows: \(error)"
+            )
+        }
+        orderedWindowIDs = []
+        statesByID = [:]
+        scheduledWindowIDs = []
+        restoringWindowIDs = []
+        replaysMissingWindows = false
+    }
+}

--- a/Sources/App/WindowRegistry.swift
+++ b/Sources/App/WindowRegistry.swift
@@ -9,26 +9,37 @@ final class WindowRegistry: ObservableObject {
 
     private struct Entry {
         let model: WorkspaceSceneModel
-        let refreshRestorationState: () -> Void
+        let registrationOrder: Int
+        let captureRestorationState: () -> WorkspaceWindowState
 
         init(
             model: WorkspaceSceneModel,
-            refreshRestorationState: @escaping () -> Void
+            registrationOrder: Int,
+            captureRestorationState: @escaping () -> WorkspaceWindowState
         ) {
             self.model = model
-            self.refreshRestorationState = refreshRestorationState
+            self.registrationOrder = registrationOrder
+            self.captureRestorationState = captureRestorationState
         }
     }
 
     private var sceneEntries: [ObjectIdentifier: Entry] = [:]
+    private var nextRegistrationOrder = 0
 
     func register(
         _ model: WorkspaceSceneModel,
-        refreshRestorationState: @escaping () -> Void
+        captureRestorationState: @escaping () -> WorkspaceWindowState
     ) {
-        sceneEntries[ObjectIdentifier(model)] = Entry(
+        let identifier = ObjectIdentifier(model)
+        let registrationOrder = sceneEntries[identifier]?.registrationOrder
+            ?? nextRegistrationOrder
+        if sceneEntries[identifier] == nil {
+            nextRegistrationOrder += 1
+        }
+        sceneEntries[identifier] = Entry(
             model: model,
-            refreshRestorationState: refreshRestorationState
+            registrationOrder: registrationOrder,
+            captureRestorationState: captureRestorationState
         )
     }
 
@@ -36,8 +47,10 @@ final class WindowRegistry: ObservableObject {
         sceneEntries.removeValue(forKey: ObjectIdentifier(model))
     }
 
-    func refreshRestorationStates() {
-        sceneEntries.values.forEach { $0.refreshRestorationState() }
+    func captureRestorationStates() -> [WorkspaceWindowState] {
+        sceneEntries.values
+            .sorted { $0.registrationOrder < $1.registrationOrder }
+            .map { $0.captureRestorationState() }
     }
 
     var totalOpenTerminalSurfaceCount: Int {

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -805,11 +805,17 @@ struct WorkspaceWindow: View {
                 if updateRelaunchWindowID != nil {
                     refreshWindowState()
                 }
+                updateRelaunchRestorer
+                    .reconcileIfNativeRestorationFinished()
                 return
             case let .restore(savedState):
                 restoreForUpdateRelaunch(savedState)
+                updateRelaunchRestorer
+                    .reconcileIfNativeRestorationFinished()
                 return
             }
+            updateRelaunchRestorer
+                .reconcileIfNativeRestorationFinished()
             #endif
             if let updateRelaunchWindowID,
                let state,
@@ -837,6 +843,8 @@ struct WorkspaceWindow: View {
             case let .restore(savedState):
                 restoreForUpdateRelaunch(savedState)
             }
+            updateRelaunchRestorer
+                .reconcileIfNativeRestorationFinished()
             #else
             beginPresentedRestoration(nil)
             refreshWindowState()

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -818,9 +818,13 @@ struct WorkspaceWindow: View {
                 .reconcileIfNativeRestorationFinished()
             #endif
             if let updateRelaunchWindowID,
-               let state,
-               state.windowID != updateRelaunchWindowID {
-                refreshWindowState()
+               let replacement = UpdateRelaunchStatePolicy.replacement(
+                   presented: state,
+                   current: sceneModel.restorationState(
+                       windowID: updateRelaunchWindowID
+                   )
+               ) {
+                resolvedWindowState.wrappedValue = replacement
                 return
             }
             if let restoredState = windowStateBuffer.receive(state) {

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -525,6 +525,7 @@ struct WorkspaceWindow: View {
     let openRelaunchWindow: (WorkspaceWindowState) -> Void
     #endif
     @State private var windowStateBuffer = WorkspaceWindowStateBuffer()
+    @State private var updateRelaunchSceneID = UUID()
     @State private var updateRelaunchWindowID: UUID?
     @StateObject private var sceneModel = WorkspaceSceneModel()
     @EnvironmentObject private var terminalRuntime: LibghosttyRuntime
@@ -793,6 +794,23 @@ struct WorkspaceWindow: View {
             resolvedWindowState.wrappedValue = state
         }
         .onChange(of: windowState) { _, state in
+            #if canImport(AppKit)
+            switch updateRelaunchRestorer.receivePresentedState(
+                sceneID: updateRelaunchSceneID,
+                presented: state
+            ) {
+            case .ordinary:
+                break
+            case .waitingForNativeRestoration:
+                if updateRelaunchWindowID != nil {
+                    refreshWindowState()
+                }
+                return
+            case let .restore(savedState):
+                restoreForUpdateRelaunch(savedState)
+                return
+            }
+            #endif
             if let updateRelaunchWindowID,
                let state,
                state.windowID != updateRelaunchWindowID {
@@ -805,42 +823,28 @@ struct WorkspaceWindow: View {
         }
         .onAppear {
             #if canImport(AppKit)
-            let appearanceState = updateRelaunchRestorer.stateForAppearance(
-                presented: windowState
-            )
-            if let appearanceState,
-               updateRelaunchRestorer.containsSavedState(
-                   windowID: appearanceState.windowID
-               ) {
-                updateRelaunchWindowID = appearanceState.windowID
+            switch updateRelaunchRestorer.registerScene(
+                id: updateRelaunchSceneID,
+                presented: windowState,
+                restore: restoreForUpdateRelaunch,
+                openWindow: openRelaunchWindow
+            ) {
+            case .ordinary:
+                beginPresentedRestoration(windowState)
+                refreshWindowState()
+            case .waitingForNativeRestoration:
+                beginPresentedRestoration(nil)
+            case let .restore(savedState):
+                restoreForUpdateRelaunch(savedState)
             }
             #else
-            let appearanceState: WorkspaceWindowState? = nil
-            #endif
-            if let initialState = windowStateBuffer.beginAppearance(
-                with: appearanceState
-            ) {
-                if windowState != appearanceState {
-                    windowStateBuffer.prepareToPresent(initialState)
-                    windowState = initialState
-                }
-                sceneModel.beginRestoration(initialState)
-                #if canImport(AppKit)
-                updateRelaunchRestorer.didBeginRestoring(
-                    windowID: initialState.windowID
-                )
-                #endif
-            }
+            beginPresentedRestoration(nil)
             refreshWindowState()
+            #endif
             registry.register(
                 sceneModel,
                 captureRestorationState: captureWindowState
             )
-            #if canImport(AppKit)
-            updateRelaunchRestorer.takeStatesToOpen().forEach(
-                openRelaunchWindow
-            )
-            #endif
             if terminalRuntime.configReloadNotice?.kind == .error {
                 visibleConfigReloadNotice =
                     terminalRuntime.configReloadNotice
@@ -867,11 +871,42 @@ struct WorkspaceWindow: View {
         .onDisappear {
             sceneModel.cancelPendingRestoration()
             registry.unregister(sceneModel)
+            #if canImport(AppKit)
+            updateRelaunchRestorer.unregisterScene(
+                id: updateRelaunchSceneID
+            )
+            #endif
             Task { [sceneModel] in
                 await sceneModel.shutdown()
             }
         }
     }
+
+    private func beginPresentedRestoration(
+        _ state: WorkspaceWindowState?
+    ) {
+        if let state = windowStateBuffer.beginAppearance(with: state) {
+            sceneModel.beginRestoration(state)
+        }
+    }
+
+    #if canImport(AppKit)
+    private func restoreForUpdateRelaunch(
+        _ state: WorkspaceWindowState
+    ) {
+        updateRelaunchWindowID = state.windowID
+        _ = windowStateBuffer.beginAppearance(with: state)
+        if windowState != state {
+            windowStateBuffer.prepareToPresent(state)
+            windowState = state
+        }
+        sceneModel.beginRestoration(state)
+        updateRelaunchRestorer.didBeginRestoring(
+            windowID: state.windowID
+        )
+        refreshWindowState()
+    }
+    #endif
 
     private func captureWindowState() -> WorkspaceWindowState {
         let state = sceneModel.restorationState(

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -521,8 +521,11 @@ struct WorkspaceWindow: View {
     #if canImport(AppKit)
     let applicationDelegate: ApplicationDelegate
     @Binding var windowState: WorkspaceWindowState?
+    let updateRelaunchRestorer: UpdateRelaunchRestorer
+    let openRelaunchWindow: (WorkspaceWindowState) -> Void
     #endif
     @State private var windowStateBuffer = WorkspaceWindowStateBuffer()
+    @State private var updateRelaunchWindowID: UUID?
     @StateObject private var sceneModel = WorkspaceSceneModel()
     @EnvironmentObject private var terminalRuntime: LibghosttyRuntime
     @ObservedObject private var settingsStore = SettingsStore.shared
@@ -790,21 +793,54 @@ struct WorkspaceWindow: View {
             resolvedWindowState.wrappedValue = state
         }
         .onChange(of: windowState) { _, state in
+            if let updateRelaunchWindowID,
+               let state,
+               state.windowID != updateRelaunchWindowID {
+                refreshWindowState()
+                return
+            }
             if let restoredState = windowStateBuffer.receive(state) {
                 sceneModel.beginRestoration(restoredState)
             }
         }
         .onAppear {
+            #if canImport(AppKit)
+            let appearanceState = updateRelaunchRestorer.stateForAppearance(
+                presented: windowState
+            )
+            if let appearanceState,
+               updateRelaunchRestorer.containsSavedState(
+                   windowID: appearanceState.windowID
+               ) {
+                updateRelaunchWindowID = appearanceState.windowID
+            }
+            #else
+            let appearanceState: WorkspaceWindowState? = nil
+            #endif
             if let initialState = windowStateBuffer.beginAppearance(
-                with: windowState
+                with: appearanceState
             ) {
+                if windowState != appearanceState {
+                    windowStateBuffer.prepareToPresent(initialState)
+                    windowState = initialState
+                }
                 sceneModel.beginRestoration(initialState)
+                #if canImport(AppKit)
+                updateRelaunchRestorer.didBeginRestoring(
+                    windowID: initialState.windowID
+                )
+                #endif
             }
             refreshWindowState()
             registry.register(
                 sceneModel,
-                refreshRestorationState: refreshWindowState
+                captureRestorationState: captureWindowState
             )
+            #if canImport(AppKit)
+            updateRelaunchRestorer.takeStatesToOpen().forEach(
+                openRelaunchWindow
+            )
+            #endif
             if terminalRuntime.configReloadNotice?.kind == .error {
                 visibleConfigReloadNotice =
                     terminalRuntime.configReloadNotice
@@ -837,10 +873,16 @@ struct WorkspaceWindow: View {
         }
     }
 
-    private func refreshWindowState() {
-        resolvedWindowState.wrappedValue = sceneModel.restorationState(
+    private func captureWindowState() -> WorkspaceWindowState {
+        let state = sceneModel.restorationState(
             windowID: resolvedWindowState.wrappedValue.windowID
         )
+        resolvedWindowState.wrappedValue = state
+        return state
+    }
+
+    private func refreshWindowState() {
+        _ = captureWindowState()
     }
 
     private var resolvedWindowState: Binding<WorkspaceWindowState> {

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -127,6 +127,16 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
     }
 }
 
+enum UpdateRelaunchStatePolicy {
+    static func replacement(
+        presented: WorkspaceWindowState?,
+        current: WorkspaceWindowState
+    ) -> WorkspaceWindowState? {
+        guard let presented, presented != current else { return nil }
+        return current
+    }
+}
+
 struct WorkspaceWindowStateBuffer {
     private(set) var retained: WorkspaceWindowState
     private var pendingPresentations: [WorkspaceWindowState] = []

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -127,6 +127,23 @@ final class ApplicationDelegateTests: XCTestCase {
         override var tabbedWindows: [NSWindow]? { nil }
     }
 
+    func testWindowRestorationFinishedHandlerIsLatched() {
+        let delegate = ApplicationDelegate()
+        delegate.applicationDidFinishRestoringWindows(
+            Notification(name: NSApplication.didFinishRestoringWindowsNotification)
+        )
+        var callCount = 0
+
+        delegate.setWindowRestorationFinishedHandler {
+            callCount += 1
+        }
+        delegate.applicationDidFinishRestoringWindows(
+            Notification(name: NSApplication.didFinishRestoringWindowsNotification)
+        )
+
+        XCTAssertEqual(callCount, 1)
+    }
+
     private final class NotificationCenterSpy: UserNotificationCentering {
         private(set) var requestAuthorizationCallCount = 0
         private(set) var addedRequests: [UNNotificationRequest] = []

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -129,19 +129,25 @@ final class ApplicationDelegateTests: XCTestCase {
 
     func testWindowRestorationFinishedHandlerIsLatched() {
         let delegate = ApplicationDelegate()
+        let expectedCount = WorkspaceWindowIdentity.count(
+            in: NSApplication.shared.windows
+        )
         delegate.applicationDidFinishRestoringWindows(
             Notification(name: NSApplication.didFinishRestoringWindowsNotification)
         )
         var callCount = 0
+        var receivedCount: Int?
 
-        delegate.setWindowRestorationFinishedHandler {
+        delegate.setWindowRestorationFinishedHandler { count in
             callCount += 1
+            receivedCount = count
         }
         delegate.applicationDidFinishRestoringWindows(
             Notification(name: NSApplication.didFinishRestoringWindowsNotification)
         )
 
         XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(receivedCount, expectedCount)
     }
 
     private final class NotificationCenterSpy: UserNotificationCentering {

--- a/Tests/App/UpdateControllerTests.swift
+++ b/Tests/App/UpdateControllerTests.swift
@@ -81,22 +81,24 @@ struct UpdateControllerTests {
     func preRelaunchOrdering() {
         var events: [String] = []
         let delegate = UpdateInstallationDelegate(
-            refreshRestorationState: { events.append("refresh") },
+            prepareRelaunch: { events.append("persist") },
             authorizeTermination: { events.append("authorize") },
             clearTerminationAuthorization: { events.append("clear") }
         )
 
         delegate.prepareForRelaunch()
 
-        #expect(events == ["refresh", "authorize"])
+        #expect(events == ["persist", "authorize"])
     }
 
     @MainActor
     @Test("aborted or finished update sessions clear unused authorization")
     func updateSessionCleanup() {
         var clearCount = 0
+        var cancelCount = 0
         let delegate = UpdateInstallationDelegate(
-            refreshRestorationState: {},
+            prepareRelaunch: {},
+            cancelRelaunch: { cancelCount += 1 },
             authorizeTermination: {},
             clearTerminationAuthorization: { clearCount += 1 }
         )
@@ -105,6 +107,7 @@ struct UpdateControllerTests {
         delegate.updateSessionDidFinish(error: false)
 
         #expect(clearCount == 2)
+        #expect(cancelCount == 0)
     }
 
     @MainActor
@@ -112,7 +115,7 @@ struct UpdateControllerTests {
     func pendingRelaunchSurvivesCycleFinish() {
         var clearCount = 0
         let delegate = UpdateInstallationDelegate(
-            refreshRestorationState: {},
+            prepareRelaunch: {},
             authorizeTermination: {},
             clearTerminationAuthorization: { clearCount += 1 }
         )
@@ -130,8 +133,10 @@ struct UpdateControllerTests {
     )
     func failedRelaunchDisarmsTermination(_ aborts: Bool) {
         var clearCount = 0
+        var cancelCount = 0
         let delegate = UpdateInstallationDelegate(
-            refreshRestorationState: {},
+            prepareRelaunch: {},
+            cancelRelaunch: { cancelCount += 1 },
             authorizeTermination: {},
             clearTerminationAuthorization: { clearCount += 1 }
         )
@@ -144,5 +149,6 @@ struct UpdateControllerTests {
         }
 
         #expect(clearCount == 1)
+        #expect(cancelCount == 1)
     }
 }

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -39,7 +39,9 @@ struct UpdateRelaunchRestorationTests {
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
-        restorer.nativeWindowRestorationDidFinish()
+        restorer.nativeWindowRestorationDidFinish(
+            expectedSceneCount: 1
+        )
 
         #expect(restored == [first])
         #expect(opened == [second])
@@ -136,7 +138,9 @@ struct UpdateRelaunchRestorationTests {
             ) == .restore(second)
         )
         restorer.didBeginRestoring(windowID: second.windowID)
-        restorer.nativeWindowRestorationDidFinish()
+        restorer.nativeWindowRestorationDidFinish(
+            expectedSceneCount: 2
+        )
 
         #expect(restored.isEmpty)
         #expect(opened.isEmpty)
@@ -174,7 +178,9 @@ struct UpdateRelaunchRestorationTests {
             ) == .restore(first)
         )
         restorer.didBeginRestoring(windowID: first.windowID)
-        restorer.nativeWindowRestorationDidFinish()
+        restorer.nativeWindowRestorationDidFinish(
+            expectedSceneCount: 1
+        )
 
         #expect(opened == [second])
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
@@ -221,7 +227,9 @@ struct UpdateRelaunchRestorationTests {
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
-        restorer.nativeWindowRestorationDidFinish()
+        restorer.nativeWindowRestorationDidFinish(
+            expectedSceneCount: 2
+        )
 
         #expect(restored == [first, second])
         #expect(opened.isEmpty)
@@ -237,6 +245,57 @@ struct UpdateRelaunchRestorationTests {
                 presented: second
             ) == .ordinary
         )
+        #expect(opened.isEmpty)
+    }
+
+    @Test("native completion waits for every restored scene to register")
+    func completionPrecedesMatchingSceneRegistration() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(store: store)
+        var opened: [WorkspaceWindowState] = []
+
+        restorer.nativeWindowRestorationDidFinish(
+            expectedSceneCount: 2
+        )
+        #expect(
+            restorer.registerScene(
+                id: UUID(),
+                presented: first,
+                restore: { _ in },
+                openWindow: { opened.append($0) }
+            ) == .restore(first)
+        )
+        restorer.didBeginRestoring(windowID: first.windowID)
+        restorer.reconcileIfNativeRestorationFinished()
+        #expect(opened.isEmpty)
+
+        #expect(
+            restorer.registerScene(
+                id: UUID(),
+                presented: second,
+                restore: { _ in },
+                openWindow: { opened.append($0) }
+            ) == .restore(second)
+        )
+        restorer.didBeginRestoring(windowID: second.windowID)
+        restorer.reconcileIfNativeRestorationFinished()
+
         #expect(opened.isEmpty)
     }
 

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -105,14 +105,15 @@ struct UpdateRelaunchRestorationTests {
         let restorer = UpdateRelaunchRestorer(store: store)
         let firstSceneID = UUID()
         let secondSceneID = UUID()
-        var restored: [WorkspaceWindowState] = []
+        var firstRestored: [WorkspaceWindowState] = []
+        var secondRestored: [WorkspaceWindowState] = []
         var opened: [WorkspaceWindowState] = []
 
         #expect(
             restorer.registerScene(
                 id: firstSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { firstRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
@@ -120,7 +121,7 @@ struct UpdateRelaunchRestorationTests {
             restorer.registerScene(
                 id: secondSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { secondRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
@@ -143,7 +144,8 @@ struct UpdateRelaunchRestorationTests {
             expectedSceneCount: 2
         )
 
-        #expect(restored.isEmpty)
+        #expect(firstRestored.isEmpty)
+        #expect(secondRestored.isEmpty)
         #expect(opened.isEmpty)
         #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
     }
@@ -188,8 +190,8 @@ struct UpdateRelaunchRestorationTests {
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
     }
 
-    @Test("native values arriving after reconciliation do not duplicate windows")
-    func nativeValuesArriveAfterReconciliationBegins() throws {
+    @Test("late reversed native values correct provisional fallback assignments")
+    func reversedNativeValuesCorrectFallbackAssignments() throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
@@ -210,14 +212,15 @@ struct UpdateRelaunchRestorationTests {
         let restorer = UpdateRelaunchRestorer(store: store)
         let firstSceneID = UUID()
         let secondSceneID = UUID()
-        var restored: [WorkspaceWindowState] = []
+        var firstRestored: [WorkspaceWindowState] = []
+        var secondRestored: [WorkspaceWindowState] = []
         var opened: [WorkspaceWindowState] = []
 
         #expect(
             restorer.registerScene(
                 id: firstSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { firstRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
@@ -225,7 +228,7 @@ struct UpdateRelaunchRestorationTests {
             restorer.registerScene(
                 id: secondSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { secondRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
@@ -234,25 +237,30 @@ struct UpdateRelaunchRestorationTests {
         )
         restorer.reconcileAfterSceneBindingsSettled()
 
-        #expect(restored == [first, second])
+        #expect(firstRestored == [first])
+        #expect(secondRestored == [second])
         #expect(opened.isEmpty)
+        let secondObservation = restorer.receivePresentedState(
+            sceneID: secondSceneID,
+            presented: first
+        )
+        #expect(secondObservation == .restore(first))
+        if case let .restore(state) = secondObservation {
+            secondRestored.append(state)
+        }
         #expect(
             restorer.receivePresentedState(
                 sceneID: firstSceneID,
-                presented: first
-            ) == .ordinary
-        )
-        #expect(
-            restorer.receivePresentedState(
-                sceneID: secondSceneID,
                 presented: second
             ) == .ordinary
         )
+        #expect(firstRestored.last == second)
+        #expect(secondRestored.last == first)
         #expect(opened.isEmpty)
     }
 
     @Test("late native IDs preserve their restored window association")
-    func completionPrecedesReverseNativeIDs() throws {
+    func completionPrecedesReverseNativeIDs() async throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
@@ -273,7 +281,8 @@ struct UpdateRelaunchRestorationTests {
         let restorer = UpdateRelaunchRestorer(store: store)
         let firstSceneID = UUID()
         let secondSceneID = UUID()
-        var restored: [WorkspaceWindowState] = []
+        var firstRestored: [WorkspaceWindowState] = []
+        var secondRestored: [WorkspaceWindowState] = []
         var opened: [WorkspaceWindowState] = []
 
         restorer.nativeWindowRestorationDidFinish(
@@ -283,7 +292,7 @@ struct UpdateRelaunchRestorationTests {
             restorer.registerScene(
                 id: firstSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { firstRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
@@ -294,31 +303,41 @@ struct UpdateRelaunchRestorationTests {
             restorer.registerScene(
                 id: secondSceneID,
                 presented: nil,
-                restore: { restored.append($0) },
+                restore: { secondRestored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
         restorer.reconcileIfNativeRestorationFinished()
-        #expect(restored.isEmpty)
+        #expect(firstRestored.isEmpty)
+        #expect(secondRestored.isEmpty)
         #expect(opened.isEmpty)
 
-        #expect(
-            restorer.receivePresentedState(
-                sceneID: secondSceneID,
-                presented: first
-            ) == .restore(first)
+        for _ in 0 ..< 3 {
+            await Task.yield()
+        }
+
+        let secondObservation = restorer.receivePresentedState(
+            sceneID: secondSceneID,
+            presented: first
         )
+        #expect(secondObservation == .restore(first))
+        if case let .restore(state) = secondObservation {
+            secondRestored.append(state)
+        }
         restorer.didBeginRestoring(windowID: first.windowID)
-        #expect(
-            restorer.receivePresentedState(
-                sceneID: firstSceneID,
-                presented: second
-            ) == .restore(second)
+        let firstObservation = restorer.receivePresentedState(
+            sceneID: firstSceneID,
+            presented: second
         )
+        #expect(firstObservation != .waitingForNativeRestoration)
+        if case let .restore(state) = firstObservation {
+            firstRestored.append(state)
+        }
         restorer.didBeginRestoring(windowID: second.windowID)
         restorer.reconcileAfterSceneBindingsSettled()
 
-        #expect(restored.isEmpty)
+        #expect(firstRestored.last == second)
+        #expect(secondRestored.last == first)
         #expect(opened.isEmpty)
     }
 

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -27,10 +27,7 @@ struct UpdateRelaunchRestorationTests {
         )
         try store.save([first, second])
 
-        let restorer = UpdateRelaunchRestorer(
-            store: store,
-            reconciliationDelayNanoseconds: nil
-        )
+        let restorer = UpdateRelaunchRestorer(store: store)
         let defaultSceneID = UUID()
         var restored: [WorkspaceWindowState] = []
         var opened: [WorkspaceWindowState] = []
@@ -42,7 +39,7 @@ struct UpdateRelaunchRestorationTests {
                 openWindow: { opened.append($0) }
             ) == .waitingForNativeRestoration
         )
-        restorer.reconcileAfterNativeRestorationSettled()
+        restorer.nativeWindowRestorationDidFinish()
 
         #expect(restored == [first])
         #expect(opened == [second])
@@ -102,10 +99,7 @@ struct UpdateRelaunchRestorationTests {
             owner: .unbound
         )
         try store.save([first, second])
-        let restorer = UpdateRelaunchRestorer(
-            store: store,
-            reconciliationDelayNanoseconds: nil
-        )
+        let restorer = UpdateRelaunchRestorer(store: store)
         let firstSceneID = UUID()
         let secondSceneID = UUID()
         var restored: [WorkspaceWindowState] = []
@@ -142,7 +136,7 @@ struct UpdateRelaunchRestorationTests {
             ) == .restore(second)
         )
         restorer.didBeginRestoring(windowID: second.windowID)
-        restorer.reconcileAfterNativeRestorationSettled()
+        restorer.nativeWindowRestorationDidFinish()
 
         #expect(restored.isEmpty)
         #expect(opened.isEmpty)
@@ -168,10 +162,7 @@ struct UpdateRelaunchRestorationTests {
             owner: .unbound
         )
         try store.save([first, second])
-        let restorer = UpdateRelaunchRestorer(
-            store: store,
-            reconciliationDelayNanoseconds: nil
-        )
+        let restorer = UpdateRelaunchRestorer(store: store)
         var opened: [WorkspaceWindowState] = []
 
         #expect(
@@ -183,10 +174,70 @@ struct UpdateRelaunchRestorationTests {
             ) == .restore(first)
         )
         restorer.didBeginRestoring(windowID: first.windowID)
-        restorer.reconcileAfterNativeRestorationSettled()
+        restorer.nativeWindowRestorationDidFinish()
 
         #expect(opened == [second])
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @Test("native values arriving after reconciliation do not duplicate windows")
+    func nativeValuesArriveAfterReconciliationBegins() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(store: store)
+        let firstSceneID = UUID()
+        let secondSceneID = UUID()
+        var restored: [WorkspaceWindowState] = []
+        var opened: [WorkspaceWindowState] = []
+
+        #expect(
+            restorer.registerScene(
+                id: firstSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        #expect(
+            restorer.registerScene(
+                id: secondSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        restorer.nativeWindowRestorationDidFinish()
+
+        #expect(restored == [first, second])
+        #expect(opened.isEmpty)
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: firstSceneID,
+                presented: first
+            ) == .ordinary
+        )
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: secondSceneID,
+                presented: second
+            ) == .ordinary
+        )
+        #expect(opened.isEmpty)
     }
 
     private func state(

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -45,14 +45,18 @@ struct UpdateRelaunchRestorationTests {
         restorer.reconcileAfterSceneBindingsSettled()
 
         #expect(restored == [first])
-        #expect(opened == [second])
+        #expect(opened.count == 1)
+        let replayRequest = try #require(opened.first)
+        #expect(replayRequest.navigation == nil)
+        #expect(replayRequest.tmux == nil)
+        #expect(replayRequest.windowID != second.windowID)
         restorer.didBeginRestoring(windowID: first.windowID)
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
 
         #expect(
             restorer.registerScene(
                 id: UUID(),
-                presented: second,
+                presented: replayRequest,
                 restore: { restored.append($0) },
                 openWindow: { opened.append($0) }
             ) == .restore(second)
@@ -186,7 +190,10 @@ struct UpdateRelaunchRestorationTests {
         )
         restorer.reconcileAfterSceneBindingsSettled()
 
-        #expect(opened == [second])
+        #expect(opened.count == 1)
+        #expect(opened.first?.navigation == nil)
+        #expect(opened.first?.tmux == nil)
+        #expect(opened.first?.windowID != second.windowID)
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
     }
 
@@ -227,12 +234,12 @@ struct UpdateRelaunchRestorationTests {
         restorer.reconcileAfterSceneBindingsSettled()
 
         #expect(nativeRestored == [first])
-        #expect(opened == [second])
+        let replayRequest = try #require(opened.first)
         restorer.didBeginRestoring(windowID: first.windowID)
 
         let replayObservation = restorer.registerScene(
             id: UUID(),
-            presented: second,
+            presented: replayRequest,
             restore: { replayRestored.append($0) },
             openWindow: { opened.append($0) }
         )
@@ -253,7 +260,70 @@ struct UpdateRelaunchRestorationTests {
 
         #expect(nativeRestored.last == second)
         #expect(replayRestored.last == first)
-        #expect(opened == [second])
+        #expect(opened == [replayRequest])
+        #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @Test("a displaced window stays pending until its replay scene is live")
+    func displacedWindowWaitsForReplayScene() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(store: store)
+        let nativeSceneID = UUID()
+        var nativeRestored: [WorkspaceWindowState] = []
+        var opened: [WorkspaceWindowState] = []
+
+        #expect(
+            restorer.registerScene(
+                id: nativeSceneID,
+                presented: nil,
+                restore: { nativeRestored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        restorer.nativeWindowRestorationDidFinish(expectedSceneCount: 1)
+        restorer.reconcileAfterSceneBindingsSettled()
+        let replayRequest = try #require(opened.first)
+        restorer.didBeginRestoring(windowID: first.windowID)
+
+        let nativeObservation = restorer.receivePresentedState(
+            sceneID: nativeSceneID,
+            presented: second
+        )
+        #expect(nativeObservation == .restore(second))
+        if case let .restore(state) = nativeObservation {
+            nativeRestored.append(state)
+            restorer.didBeginRestoring(windowID: state.windowID)
+        }
+
+        #expect(opened == [replayRequest, replayRequest])
+        #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
+
+        let replayObservation = restorer.registerScene(
+            id: UUID(),
+            presented: replayRequest,
+            restore: { _ in },
+            openWindow: { opened.append($0) }
+        )
+        #expect(replayObservation == .restore(first))
+        restorer.didBeginRestoring(windowID: first.windowID)
+
+        #expect(nativeRestored.last == second)
         #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
     }
 

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+@Suite("Update relaunch restoration")
+struct UpdateRelaunchRestorationTests {
+    @Test("replays every saved window and consumes the manifest")
+    func replaysSavedWindows() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "kwt-ghosthub-fix",
+            socketName: "kwt-0123456789abcdef",
+            owner: .worktree(
+                generation: "0123456789abcdef0123456789abcdef"
+            )
+        )
+        try store.save([first, second])
+
+        let restorer = UpdateRelaunchRestorer(store: store)
+        let defaultState = WorkspaceWindowState.fresh()
+        #expect(
+            restorer.stateForAppearance(presented: defaultState) == first
+        )
+        restorer.didBeginRestoring(windowID: first.windowID)
+        #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
+
+        #expect(restorer.takeStatesToOpen() == [second])
+        #expect(restorer.stateForAppearance(presented: second) == second)
+        restorer.didBeginRestoring(windowID: second.windowID)
+
+        #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+        #expect(restorer.takeStatesToOpen().isEmpty)
+    }
+
+    @Test("an aborted relaunch manifest can be discarded")
+    func discardsAbortedRelaunch() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        try store.save([
+            state(
+                sessionName: "editor",
+                socketName: nil,
+                owner: .unbound
+            ),
+        ])
+
+        try store.clear()
+
+        #expect(try store.load() == nil)
+    }
+
+    @Test("matching native scenes do not open duplicate windows")
+    func matchingNativeScenesAvoidDuplicates() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(store: store)
+
+        #expect(restorer.stateForAppearance(presented: first) == first)
+        restorer.didBeginRestoring(windowID: first.windowID)
+        #expect(restorer.takeStatesToOpen().isEmpty)
+
+        #expect(restorer.stateForAppearance(presented: second) == second)
+        restorer.didBeginRestoring(windowID: second.windowID)
+        #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    private func state(
+        sessionName: String,
+        socketName: String?,
+        owner: WorkspaceTmuxOwnerDescriptor
+    ) -> WorkspaceWindowState {
+        let generation: String? = switch owner {
+        case .unbound:
+            nil
+        case let .worktree(generation):
+            generation
+        }
+        return WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "local",
+                projectKey: generation == nil
+                    ? nil : "github.com/kenn-io/ghosthub",
+                worktreeGeneration: generation
+            ),
+            tmux: WorkspaceTmuxDescriptor(
+                hostKey: "local",
+                sessionName: sessionName,
+                socketName: socketName,
+                owner: owner
+            )
+        )
+    }
+}

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -5,8 +5,8 @@ import Testing
 @MainActor
 @Suite("Update relaunch restoration")
 struct UpdateRelaunchRestorationTests {
-    @Test("replays every saved window and consumes the manifest")
-    func replaysSavedWindows() throws {
+    @Test("missing native scenes are assigned before new windows open")
+    func replaysMissingNativeScenes() throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
@@ -27,20 +27,39 @@ struct UpdateRelaunchRestorationTests {
         )
         try store.save([first, second])
 
-        let restorer = UpdateRelaunchRestorer(store: store)
-        let defaultState = WorkspaceWindowState.fresh()
-        #expect(
-            restorer.stateForAppearance(presented: defaultState) == first
+        let restorer = UpdateRelaunchRestorer(
+            store: store,
+            reconciliationDelayNanoseconds: nil
         )
+        let defaultSceneID = UUID()
+        var restored: [WorkspaceWindowState] = []
+        var opened: [WorkspaceWindowState] = []
+        #expect(
+            restorer.registerScene(
+                id: defaultSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        restorer.reconcileAfterNativeRestorationSettled()
+
+        #expect(restored == [first])
+        #expect(opened == [second])
         restorer.didBeginRestoring(windowID: first.windowID)
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
 
-        #expect(restorer.takeStatesToOpen() == [second])
-        #expect(restorer.stateForAppearance(presented: second) == second)
+        #expect(
+            restorer.registerScene(
+                id: UUID(),
+                presented: second,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .restore(second)
+        )
         restorer.didBeginRestoring(windowID: second.windowID)
 
         #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
-        #expect(restorer.takeStatesToOpen().isEmpty)
     }
 
     @Test("an aborted relaunch manifest can be discarded")
@@ -64,8 +83,8 @@ struct UpdateRelaunchRestorationTests {
         #expect(try store.load() == nil)
     }
 
-    @Test("matching native scenes do not open duplicate windows")
-    func matchingNativeScenesAvoidDuplicates() throws {
+    @Test("late native values claim initially nil scenes without duplicates")
+    func lateNativeValuesClaimNilScenes() throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
@@ -83,15 +102,91 @@ struct UpdateRelaunchRestorationTests {
             owner: .unbound
         )
         try store.save([first, second])
-        let restorer = UpdateRelaunchRestorer(store: store)
+        let restorer = UpdateRelaunchRestorer(
+            store: store,
+            reconciliationDelayNanoseconds: nil
+        )
+        let firstSceneID = UUID()
+        let secondSceneID = UUID()
+        var restored: [WorkspaceWindowState] = []
+        var opened: [WorkspaceWindowState] = []
 
-        #expect(restorer.stateForAppearance(presented: first) == first)
+        #expect(
+            restorer.registerScene(
+                id: firstSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        #expect(
+            restorer.registerScene(
+                id: secondSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: firstSceneID,
+                presented: first
+            ) == .restore(first)
+        )
         restorer.didBeginRestoring(windowID: first.windowID)
-        #expect(restorer.takeStatesToOpen().isEmpty)
-
-        #expect(restorer.stateForAppearance(presented: second) == second)
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: secondSceneID,
+                presented: second
+            ) == .restore(second)
+        )
         restorer.didBeginRestoring(windowID: second.windowID)
+        restorer.reconcileAfterNativeRestorationSettled()
+
+        #expect(restored.isEmpty)
+        #expect(opened.isEmpty)
         #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
+    @Test("partial native restoration opens every unclaimed saved window")
+    func partialNativeRestorationOpensMissingWindows() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(
+            store: store,
+            reconciliationDelayNanoseconds: nil
+        )
+        var opened: [WorkspaceWindowState] = []
+
+        #expect(
+            restorer.registerScene(
+                id: UUID(),
+                presented: first,
+                restore: { _ in },
+                openWindow: { opened.append($0) }
+            ) == .restore(first)
+        )
+        restorer.didBeginRestoring(windowID: first.windowID)
+        restorer.reconcileAfterNativeRestorationSettled()
+
+        #expect(opened == [second])
+        #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
     }
 
     private func state(

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -42,6 +42,7 @@ struct UpdateRelaunchRestorationTests {
         restorer.nativeWindowRestorationDidFinish(
             expectedSceneCount: 1
         )
+        restorer.reconcileAfterSceneBindingsSettled()
 
         #expect(restored == [first])
         #expect(opened == [second])
@@ -181,6 +182,7 @@ struct UpdateRelaunchRestorationTests {
         restorer.nativeWindowRestorationDidFinish(
             expectedSceneCount: 1
         )
+        restorer.reconcileAfterSceneBindingsSettled()
 
         #expect(opened == [second])
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
@@ -230,6 +232,7 @@ struct UpdateRelaunchRestorationTests {
         restorer.nativeWindowRestorationDidFinish(
             expectedSceneCount: 2
         )
+        restorer.reconcileAfterSceneBindingsSettled()
 
         #expect(restored == [first, second])
         #expect(opened.isEmpty)
@@ -248,8 +251,8 @@ struct UpdateRelaunchRestorationTests {
         #expect(opened.isEmpty)
     }
 
-    @Test("native completion waits for every restored scene to register")
-    func completionPrecedesMatchingSceneRegistration() throws {
+    @Test("late native IDs preserve their restored window association")
+    func completionPrecedesReverseNativeIDs() throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
@@ -268,6 +271,9 @@ struct UpdateRelaunchRestorationTests {
         )
         try store.save([first, second])
         let restorer = UpdateRelaunchRestorer(store: store)
+        let firstSceneID = UUID()
+        let secondSceneID = UUID()
+        var restored: [WorkspaceWindowState] = []
         var opened: [WorkspaceWindowState] = []
 
         restorer.nativeWindowRestorationDidFinish(
@@ -275,27 +281,44 @@ struct UpdateRelaunchRestorationTests {
         )
         #expect(
             restorer.registerScene(
-                id: UUID(),
-                presented: first,
-                restore: { _ in },
+                id: firstSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
                 openWindow: { opened.append($0) }
-            ) == .restore(first)
+            ) == .waitingForNativeRestoration
         )
-        restorer.didBeginRestoring(windowID: first.windowID)
         restorer.reconcileIfNativeRestorationFinished()
         #expect(opened.isEmpty)
 
         #expect(
             restorer.registerScene(
-                id: UUID(),
-                presented: second,
-                restore: { _ in },
+                id: secondSceneID,
+                presented: nil,
+                restore: { restored.append($0) },
                 openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        restorer.reconcileIfNativeRestorationFinished()
+        #expect(restored.isEmpty)
+        #expect(opened.isEmpty)
+
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: secondSceneID,
+                presented: first
+            ) == .restore(first)
+        )
+        restorer.didBeginRestoring(windowID: first.windowID)
+        #expect(
+            restorer.receivePresentedState(
+                sceneID: firstSceneID,
+                presented: second
             ) == .restore(second)
         )
         restorer.didBeginRestoring(windowID: second.windowID)
-        restorer.reconcileIfNativeRestorationFinished()
+        restorer.reconcileAfterSceneBindingsSettled()
 
+        #expect(restored.isEmpty)
         #expect(opened.isEmpty)
     }
 

--- a/Tests/App/UpdateRelaunchRestorationTests.swift
+++ b/Tests/App/UpdateRelaunchRestorationTests.swift
@@ -190,6 +190,73 @@ struct UpdateRelaunchRestorationTests {
         #expect(FileManager.default.fileExists(atPath: store.fileURL.path))
     }
 
+    @Test("late native IDs reclaim scheduled replacement windows")
+    func lateNativeIDReclaimsScheduledWindow() throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let store = UpdateRelaunchManifestStore(
+            fileURL: scratch.appendingPathComponent("relaunch.json")
+        )
+        let first = state(
+            sessionName: "editor",
+            socketName: nil,
+            owner: .unbound
+        )
+        let second = state(
+            sessionName: "review",
+            socketName: nil,
+            owner: .unbound
+        )
+        try store.save([first, second])
+        let restorer = UpdateRelaunchRestorer(store: store)
+        let nativeSceneID = UUID()
+        var nativeRestored: [WorkspaceWindowState] = []
+        var replayRestored: [WorkspaceWindowState] = []
+        var opened: [WorkspaceWindowState] = []
+
+        #expect(
+            restorer.registerScene(
+                id: nativeSceneID,
+                presented: nil,
+                restore: { nativeRestored.append($0) },
+                openWindow: { opened.append($0) }
+            ) == .waitingForNativeRestoration
+        )
+        restorer.nativeWindowRestorationDidFinish(expectedSceneCount: 1)
+        restorer.reconcileAfterSceneBindingsSettled()
+
+        #expect(nativeRestored == [first])
+        #expect(opened == [second])
+        restorer.didBeginRestoring(windowID: first.windowID)
+
+        let replayObservation = restorer.registerScene(
+            id: UUID(),
+            presented: second,
+            restore: { replayRestored.append($0) },
+            openWindow: { opened.append($0) }
+        )
+        #expect(replayObservation == .restore(second))
+        if case let .restore(state) = replayObservation {
+            replayRestored.append(state)
+            restorer.didBeginRestoring(windowID: state.windowID)
+        }
+
+        let nativeObservation = restorer.receivePresentedState(
+            sceneID: nativeSceneID,
+            presented: second
+        )
+        #expect(nativeObservation == .restore(second))
+        if case let .restore(state) = nativeObservation {
+            nativeRestored.append(state)
+        }
+
+        #expect(nativeRestored.last == second)
+        #expect(replayRestored.last == first)
+        #expect(opened == [second])
+        #expect(!FileManager.default.fileExists(atPath: store.fileURL.path))
+    }
+
     @Test("late reversed native values correct provisional fallback assignments")
     func reversedNativeValuesCorrectFallbackAssignments() throws {
         let scratch = FileManager.default.temporaryDirectory

--- a/Tests/App/WindowRegistryTests.swift
+++ b/Tests/App/WindowRegistryTests.swift
@@ -4,8 +4,8 @@ import Testing
 @MainActor
 @Suite("Workspace window registry")
 struct WindowRegistryTests {
-    @Test("refreshes each live scene and drops unregistered scenes")
-    func refreshesLiveSceneBindings() throws {
+    @Test("captures live scenes in registration order")
+    func capturesLiveScenesInRegistrationOrder() throws {
         let firstEnvironment = try setupHostEnvironment()
         let secondEnvironment = try setupHostEnvironment()
         let first = try makeModel(
@@ -19,18 +19,17 @@ struct WindowRegistryTests {
             snapshot: secondEnvironment.snapshot
         )
         let registry = WindowRegistry()
-        var firstRefreshes = 0
-        var secondRefreshes = 0
-        registry.register(first) { firstRefreshes += 1 }
-        registry.register(second) { secondRefreshes += 1 }
+        let firstState = WorkspaceWindowState.fresh()
+        let secondState = WorkspaceWindowState.fresh()
+        registry.register(first) { firstState }
+        registry.register(second) { secondState }
 
-        registry.refreshRestorationStates()
-        #expect(firstRefreshes == 1)
-        #expect(secondRefreshes == 1)
+        #expect(
+            registry.captureRestorationStates()
+                == [firstState, secondState]
+        )
 
         registry.unregister(first)
-        registry.refreshRestorationStates()
-        #expect(firstRefreshes == 1)
-        #expect(secondRefreshes == 2)
+        #expect(registry.captureRestorationStates() == [secondState])
     }
 }

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -175,6 +175,46 @@ private struct RestorationFixture {
 
 @Suite("Workspace window restoration state")
 struct WorkspaceWindowStateTests {
+    @Test("same-ID stale update payloads are rewritten")
+    func staleUpdatePayloadRequiresRewrite() {
+        let windowID = UUID()
+        let provisional = WorkspaceWindowState(
+            windowID: windowID,
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "local",
+                projectKey: "github.com/kenn-io/ghosthub",
+                worktreeGeneration: nil
+            ),
+            tmux: WorkspaceTmuxDescriptor(
+                hostKey: "local",
+                sessionName: "editor",
+                socketName: nil,
+                owner: .unbound
+            )
+        )
+        let stale = WorkspaceWindowState(
+            windowID: windowID,
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "remote",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: WorkspaceTmuxDescriptor(
+                hostKey: "remote",
+                sessionName: "review",
+                socketName: nil,
+                owner: .unbound
+            )
+        )
+
+        #expect(
+            UpdateRelaunchStatePolicy.replacement(
+                presented: stale,
+                current: provisional
+            ) == provisional
+        )
+    }
+
     @Test("window state survives a temporarily nil scene binding")
     func windowStateSurvivesNilSceneBinding() {
         let firstFallback = WorkspaceWindowState.fresh()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,9 +41,10 @@ not persist its worktree-owned tmux presentation. SwiftUI and macOS normally
 remain responsible for restoring scene count, native tab groups, and window
 geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
 ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
-app first collects initial and late native scene values. After those values
-settle, unresolved scenes adopt unclaimed descriptors in saved order and
-Ghosthub requests a scene for every descriptor still missing. Native
+app collects initial and late native scene values until AppKit reports that
+native window restoration has finished. Unresolved scenes then adopt unclaimed
+descriptors in saved order, and Ghosthub requests a scene for every descriptor
+still missing. Native
 restoration still owns any geometry and tab grouping it provides.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,9 @@ a late native scene; a displaced request is retargeted and issued again with the
 same token. The manifest remains until every saved descriptor has begun
 restoration in exactly one live assigned scene. Native restoration therefore
 still owns geometry and tab grouping without dropping or duplicating a session.
+After assignment, the scene model owns the complete logical descriptor; delayed
+native payloads that share its window UUID but contain stale navigation or tmux
+data are rewritten before they can become persisted scene state.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,10 +42,11 @@ remain responsible for restoring scene count, native tab groups, and window
 geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
 ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
 app collects initial and late native scene values until AppKit reports that
-native window restoration has finished. Unresolved scenes then adopt unclaimed
-descriptors in saved order, and Ghosthub requests a scene for every descriptor
-still missing. Native
-restoration still owns any geometry and tab grouping it provides.
+native window restoration has finished and every restored workspace window has
+registered its SwiftUI scene. Unresolved scenes then adopt unclaimed descriptors
+in saved order, and Ghosthub requests a scene for every descriptor still
+missing. Native restoration still owns any geometry and tab grouping it
+provides.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,13 @@ kwt worktree generation, and exact tmux session and protected-socket identity.
 Its window UUID exists only for native scene adoption; runtime model UUIDs and
 paths are never persisted as host, project, or worktree identity. A worktree
 without a canonical generation degrades to project-only navigation and does
-not persist its worktree-owned tmux presentation. SwiftUI and macOS remain
-responsible for restoring scene count, native tab groups, and window geometry.
+not persist its worktree-owned tmux presentation. SwiftUI and macOS normally
+remain responsible for restoring scene count, native tab groups, and window
+geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
+ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
+first default scene adopts the first descriptor and Ghosthub requests the
+remaining scenes when macOS does not return them. Native restoration still
+owns any geometry and tab grouping it provides.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete
@@ -92,9 +97,11 @@ native UI and installation flow. Development binaries without the packaged
 feed and public key disable the update command instead of contacting a release
 service.
 
-When the user accepts Sparkle's **Install and Relaunch**, Ghosthub refreshes
-the continuously maintained scene descriptors and authorizes exactly one
-updater-driven AppKit termination request. This one-shot authorization is
+When the user accepts Sparkle's **Install and Relaunch**, Ghosthub captures
+every live scene descriptor into the updater relaunch manifest before it
+authorizes exactly one updater-driven AppKit termination request. The manifest
+is discarded if the update aborts or errors, and consumed only after every
+saved scene has begun restoration in the relaunched app. This authorization is
 separate from ordinary quit confirmation and is cleared when an update cycle
 aborts or finishes with an error. A successful cycle-finish notification that
 arrives after the relaunch was requested does not disarm it, so Sparkle's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,10 +43,10 @@ geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
 ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
 app collects initial and late native scene values until AppKit reports that
 native window restoration has finished and every restored workspace window has
-registered its SwiftUI scene. Unresolved scenes then adopt unclaimed descriptors
-in saved order, and Ghosthub requests a scene for every descriptor still
-missing. Native restoration still owns any geometry and tab grouping it
-provides.
+registered its SwiftUI scene. Ghosthub lets the scenes' optional bindings finish
+publishing decoded values before unresolved scenes adopt unclaimed descriptors
+in saved order, then requests a scene for every descriptor still missing. Native
+restoration still owns any geometry and tab grouping it provides.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,12 @@ in saved order, then requests a scene for every descriptor still missing. A
 later native descriptor remains authoritative and corrects provisional
 assignments. Scenes opened to replay missing descriptors also remain provisional:
 if a late native scene reclaims their descriptor, the replay scene receives the
-native scene's displaced descriptor instead. Native restoration therefore still
-owns geometry and tab grouping without dropping or duplicating a session.
+native scene's displaced descriptor instead. Replay requests use fresh scene
+tokens rather than saved window IDs, preventing SwiftUI from coalescing them with
+a late native scene; a displaced request is retargeted and issued again with the
+same token. The manifest remains until every saved descriptor has begun
+restoration in exactly one live assigned scene. Native restoration therefore
+still owns geometry and tab grouping without dropping or duplicating a session.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,10 @@ registered its SwiftUI scene. Ghosthub requires the scenes' optional bindings to
 be quiescent before unresolved scenes receive provisional unclaimed descriptors
 in saved order, then requests a scene for every descriptor still missing. A
 later native descriptor remains authoritative and corrects provisional
-assignments, so native restoration still owns geometry and tab grouping.
+assignments. Scenes opened to replay missing descriptors also remain provisional:
+if a late native scene reclaims their descriptor, the replay scene receives the
+native scene's displaced descriptor instead. Native restoration therefore still
+owns geometry and tab grouping without dropping or duplicating a session.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,9 +41,10 @@ not persist its worktree-owned tmux presentation. SwiftUI and macOS normally
 remain responsible for restoring scene count, native tab groups, and window
 geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
 ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
-first default scene adopts the first descriptor and Ghosthub requests the
-remaining scenes when macOS does not return them. Native restoration still
-owns any geometry and tab grouping it provides.
+app first collects initial and late native scene values. After those values
+settle, unresolved scenes adopt unclaimed descriptors in saved order and
+Ghosthub requests a scene for every descriptor still missing. Native
+restoration still owns any geometry and tab grouping it provides.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,10 +43,11 @@ geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
 ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
 app collects initial and late native scene values until AppKit reports that
 native window restoration has finished and every restored workspace window has
-registered its SwiftUI scene. Ghosthub lets the scenes' optional bindings finish
-publishing decoded values before unresolved scenes adopt unclaimed descriptors
-in saved order, then requests a scene for every descriptor still missing. Native
-restoration still owns any geometry and tab grouping it provides.
+registered its SwiftUI scene. Ghosthub requires the scenes' optional bindings to
+be quiescent before unresolved scenes receive provisional unclaimed descriptors
+in saved order, then requests a scene for every descriptor still missing. A
+later native descriptor remains authoritative and corrects provisional
+assignments, so native restoration still owns geometry and tab grouping.
 An active tmux presentation retains the worktree generation observed when it
 was established; a later non-nil generation change is a replacement even when
 inventory reuses the same runtime UUID. Scene persistence observes the complete

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -109,11 +109,13 @@ window has registered its SwiftUI scene. Ghosthub waits for binding quiescence
 before unresolved scenes receive provisional unclaimed descriptors, then opens
 every saved window still missing. Later native descriptors correct provisional
 assignments, including by moving a displaced session to a provisionally opened
-replay scene. This covers absent or partial macOS restoration without swapping
-sessions between restored geometry or tab groups.
-The manifest is removed after every saved window has begun attach-only
-restoration; native scene restoration still supplies geometry and tab grouping
-when available.
+replay scene. Replay requests use distinct scene tokens so SwiftUI cannot satisfy
+them with a late native saved window, and displaced requests are explicitly
+reissued. This covers absent or partial macOS restoration without swapping
+sessions between restored geometry or tab groups. The manifest is removed only
+after every saved window has begun attach-only restoration in one live assigned
+scene; native scene restoration still supplies geometry and tab grouping when
+available.
 An ordinary local session must be present in direct discovery before Ghosthub
 runs the exact `attach-session` path. Remote sessions use that same rule and the
 existing SSH keepalive and transport-reconnect loop.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -105,9 +105,10 @@ For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
 launch, Ghosthub collects initial and late native scene values until AppKit
 reports that native window restoration has finished and every restored workspace
-window has registered its SwiftUI scene. Unresolved scenes then adopt unclaimed
-descriptors, and Ghosthub opens every saved window still missing, covering both
-absent and partial macOS restoration.
+window has registered its SwiftUI scene. Ghosthub lets the scenes' optional
+bindings finish publishing decoded values before unresolved scenes adopt
+unclaimed descriptors, then opens every saved window still missing, covering
+both absent and partial macOS restoration.
 The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping
 when available.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -115,7 +115,8 @@ reissued. This covers absent or partial macOS restoration without swapping
 sessions between restored geometry or tab groups. The manifest is removed only
 after every saved window has begun attach-only restoration in one live assigned
 scene; native scene restoration still supplies geometry and tab grouping when
-available.
+available. Once assigned, the scene model's complete logical descriptor replaces
+any delayed same-ID native payload with stale navigation or tmux data.
 An ordinary local session must be present in direct discovery before Ghosthub
 runs the exact `attach-session` path. Remote sessions use that same rule and the
 existing SSH keepalive and transport-reconnect loop.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -108,7 +108,8 @@ reports that native window restoration has finished and every restored workspace
 window has registered its SwiftUI scene. Ghosthub waits for binding quiescence
 before unresolved scenes receive provisional unclaimed descriptors, then opens
 every saved window still missing. Later native descriptors correct provisional
-assignments, covering absent or partial macOS restoration without swapping
+assignments, including by moving a displaced session to a provisionally opened
+replay scene. This covers absent or partial macOS restoration without swapping
 sessions between restored geometry or tab groups.
 The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -104,9 +104,10 @@ attaches the replacement session.
 For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
 launch, Ghosthub collects initial and late native scene values until AppKit
-reports that native window restoration has finished. Unresolved scenes then
-adopt unclaimed descriptors, and Ghosthub opens every saved window still
-missing, covering both absent and partial macOS restoration.
+reports that native window restoration has finished and every restored workspace
+window has registered its SwiftUI scene. Unresolved scenes then adopt unclaimed
+descriptors, and Ghosthub opens every saved window still missing, covering both
+absent and partial macOS restoration.
 The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping
 when available.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -101,6 +101,13 @@ Once a worktree presentation has observed a generation, incomplete inventory
 cannot erase it and a different non-nil generation is treated as a replacement;
 explicitly reselecting the worktree detaches the observed presentation and
 attaches the replacement session.
+For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
+manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
+launch, the default window adopts the first saved descriptor and Ghosthub opens
+the remaining saved windows, covering relaunches where macOS supplies no scene
+values. The manifest is removed after every saved window has begun attach-only
+restoration; native scene restoration still supplies geometry and tab grouping
+when available.
 An ordinary local session must be present in direct discovery before Ghosthub
 runs the exact `attach-session` path. Remote sessions use that same rule and the
 existing SSH keepalive and transport-reconnect loop.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -103,9 +103,10 @@ explicitly reselecting the worktree detaches the observed presentation and
 attaches the replacement session.
 For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
-launch, the default window adopts the first saved descriptor and Ghosthub opens
-the remaining saved windows, covering relaunches where macOS supplies no scene
-values. The manifest is removed after every saved window has begun attach-only
+launch, Ghosthub first collects initial and late native scene values. Once they
+settle, unresolved scenes adopt unclaimed descriptors and Ghosthub opens every
+saved window still missing, covering both absent and partial macOS restoration.
+The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping
 when available.
 An ordinary local session must be present in direct discovery before Ghosthub

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -103,9 +103,10 @@ explicitly reselecting the worktree detaches the observed presentation and
 attaches the replacement session.
 For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
-launch, Ghosthub first collects initial and late native scene values. Once they
-settle, unresolved scenes adopt unclaimed descriptors and Ghosthub opens every
-saved window still missing, covering both absent and partial macOS restoration.
+launch, Ghosthub collects initial and late native scene values until AppKit
+reports that native window restoration has finished. Unresolved scenes then
+adopt unclaimed descriptors, and Ghosthub opens every saved window still
+missing, covering both absent and partial macOS restoration.
 The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping
 when available.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -105,10 +105,11 @@ For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
 launch, Ghosthub collects initial and late native scene values until AppKit
 reports that native window restoration has finished and every restored workspace
-window has registered its SwiftUI scene. Ghosthub lets the scenes' optional
-bindings finish publishing decoded values before unresolved scenes adopt
-unclaimed descriptors, then opens every saved window still missing, covering
-both absent and partial macOS restoration.
+window has registered its SwiftUI scene. Ghosthub waits for binding quiescence
+before unresolved scenes receive provisional unclaimed descriptors, then opens
+every saved window still missing. Later native descriptors correct provisional
+assignments, covering absent or partial macOS restoration without swapping
+sessions between restored geometry or tab groups.
 The manifest is removed after every saved window has begun attach-only
 restoration; native scene restoration still supplies geometry and tab grouping
 when available.

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -414,11 +414,12 @@ const imageAlt = {
       <p>
         Ghosthub never replaces tmux windows, panes, history, or plugins.
         Quit the app or install an update and the sessions remain where you
-        left them. When macOS restores your windows, Ghosthub reopens each
-        exact session it can confirm and keeps retrying offline SSH hosts as
-        inventory refreshes. A window that had no terminal attached restores
-        its navigation without creating a worktree session; select the
-        worktree when you want to attach again.
+        left them. Ghosthub restores each exact session it can confirm and
+        keeps retrying offline SSH hosts as inventory refreshes. During an
+        update relaunch, it also recreates your saved windows if macOS does not
+        return them. A window that had no terminal attached restores its
+        navigation without creating a worktree session; select the worktree
+        when you want to attach again.
       </p>
       <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
     </div>


### PR DESCRIPTION
A real 0.5.0 to 0.5.1 Sparkle update with two attached windows relaunched into one unattached default window. SwiftUI returned no saved scene values, so the existing late-binding recovery had nothing to resolve even though both tmux sessions remained alive.

This adds a one-shot updater manifest containing each live window's stable navigation and exact tmux identity. A default relaunch scene adopts the first saved window and recreates the remainder, while matching native scenes remain authoritative to preserve macOS geometry and tab grouping without duplicates. Missing sessions still fail soft through the existing attach-only restoration path and are never implicitly created or retargeted.

The full Swift suite passes with 796 Swift Testing cases and 155 XCTest cases, including five expected headless window-server skips. The app build, documentation build, website check and production build, formatting, focused relaunch regressions, and commit hooks also pass. Kata x6dx remains open for the signed multi-window update smoke.
