### PR TITLE
CI: stabilize macOS workflow routing

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,6 +1,8 @@
 name: CI
 
-# Keep pull requests on the canonical workflow definition.
+# The PR dispatcher always calls the main-pinned workflow. That workflow
+# independently routes same-repository macOS jobs to the managed public runner
+# and fork jobs to GitHub-hosted runners.
 on:
   pull_request:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,11 @@
+name: CI
+
+# Keep pull requests on the canonical workflow definition.
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  run:
+    uses: kenn-io/ghosthub/.github/workflows/ci.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,9 @@ jobs:
     runs-on: >-
       ${{
         github.repository == 'kenn-io/ghosthub' &&
-        (
-          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.base.repo.full_name == github.repository
-          )
-        ) && 'kenn-macos-arm64-public' || 'macos-26'
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        'kenn-macos-arm64-public' || 'macos-26'
       }}
     timeout-minutes: 90
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,14 @@ jobs:
     runs-on: >-
       ${{
         github.repository == 'kenn-io/ghosthub' &&
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/main' &&
-        'kenn-macos-arm64-public' || 'macos-26'
+        (
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.base.repo.full_name == github.repository
+          )
+        ) && 'kenn-macos-arm64-public' || 'macos-26'
       }}
     timeout-minutes: 90
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  workflow_call:
   push:
     branches: [main]
 
@@ -15,7 +15,18 @@ concurrency:
 jobs:
   macos-arm64:
     name: macOS (Apple Silicon)
-    runs-on: macos-26
+    runs-on: >-
+      ${{
+        github.repository == 'kenn-io/ghosthub' &&
+        (
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.base.repo.full_name == github.repository
+          )
+        ) && 'kenn-macos-arm64-public' || 'macos-26'
+      }}
     timeout-minutes: 90
     env:
       # The bootstrap default is intentionally arm64 for developer Macs.
@@ -25,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Verify Apple Silicon runner
@@ -43,7 +55,9 @@ jobs:
           # Ghosthub intentionally follows the account shell from getpwuid,
           # just like a normal terminal. Hosted runner accounts still default
           # to bash, while supported macOS user accounts default to zsh.
-          sudo chsh -s /bin/zsh "$USER"
+          if [[ "${RUNNER_ENVIRONMENT:-}" == "github-hosted" ]]; then
+            sudo chsh -s /bin/zsh "$USER"
+          fi
           user_shell="$(dscl . -read "/Users/$USER" UserShell | awk '{print $2}')"
           if [[ "$user_shell" != "/bin/zsh" ]]; then
             echo "Expected /bin/zsh as the test account shell; found $user_shell." >&2
@@ -51,14 +65,15 @@ jobs:
           fi
           echo "SHELL=/bin/zsh" >> "$GITHUB_ENV"
 
-      - name: Select Xcode 26.0.1
+      - name: Select an Xcode with the Ghosthub toolchain
         shell: bash
         run: |
-          # Zig 0.15.2 cannot link Ghostty's build runner against newer
-          # Xcode 26 SDK stubs. The hosted image retains this baseline.
-          XCODE_APP=/Applications/Xcode_26.0.1.app
-          if [[ ! -d "$XCODE_APP" ]]; then
-            echo "Xcode 26.0.1 is not installed on the hosted runner." >&2
+          if [[ -d /Applications/Xcode.app ]]; then
+            XCODE_APP=/Applications/Xcode.app
+          elif [[ -d /Applications/Xcode_26.0.1.app ]]; then
+            XCODE_APP=/Applications/Xcode_26.0.1.app
+          else
+            echo "No supported Xcode installation found." >&2
             ls -1 /Applications >&2
             exit 1
           fi
@@ -100,7 +115,7 @@ jobs:
       # had drifted from them. Checked before the build so a formatting-only
       # failure does not wait on a full compile.
       - name: Install SwiftFormat
-        run: brew install swiftformat
+        run: command -v swiftformat >/dev/null || brew install swiftformat
 
       - name: Check Swift formatting
         run: make format-check

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -7,6 +7,15 @@ Threat model:
   Ghosthub may inspect that checkout with ordinary Git commands and may use its
   repository-local terminal configuration. Do not report those expected actions
   as untrusted-workspace or credential-exposure vulnerabilities.
+- CI intentionally routes canonical `main` pushes and same-repository pull
+  requests to the managed public macOS runner. Fork pull requests and
+  noncanonical repository copies fall back to GitHub-hosted runners. The managed
+  runner group admits only the reusable `.github/workflows/ci.yml` definition
+  from `main`, and `.github/workflows/ci-pr.yml` invokes that exact main-pinned
+  workflow. Pull-request changes therefore cannot retarget the managed runner by
+  editing or adding a dispatcher. Do not report this routing as PR-controlled
+  self-hosted execution unless the immutable-workflow runner-group restriction
+  or the same-repository checks are removed.
 - Continue to report actual command/argument injection, unsafe interpolation,
   automatic execution that is not a consequence of the user's explicit checkout
   or open action, and violations of an established credential boundary.

--- a/Tests/test_ci_workflow.py
+++ b/Tests/test_ci_workflow.py
@@ -8,7 +8,7 @@ def workflow_text(name: str) -> str:
     return (REPO_ROOT / ".github" / "workflows" / name).read_text()
 
 
-def test_pull_requests_cannot_select_the_self_hosted_runner():
+def test_trusted_refs_select_the_self_hosted_runner():
     caller = workflow_text("ci-pr.yml")
     workflow = workflow_text("ci.yml")
     runner_selection = workflow.split("    runs-on: >-", 1)[1].split(
@@ -16,6 +16,17 @@ def test_pull_requests_cannot_select_the_self_hosted_runner():
     )[0]
 
     assert "kenn-macos-arm64-public" not in caller
+    assert "github.repository == 'kenn-io/ghosthub'" in runner_selection
     assert "github.event_name == 'push'" in runner_selection
     assert "github.ref == 'refs/heads/main'" in runner_selection
-    assert "pull_request" not in runner_selection
+    assert "github.event_name == 'pull_request'" in runner_selection
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in runner_selection
+    )
+    assert (
+        "github.event.pull_request.base.repo.full_name == github.repository"
+        in runner_selection
+    )
+    assert "kenn-macos-arm64-public" in runner_selection
+    assert "macos-26" in runner_selection

--- a/Tests/test_ci_workflow.py
+++ b/Tests/test_ci_workflow.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow_text(name: str) -> str:
+    return (REPO_ROOT / ".github" / "workflows" / name).read_text()
+
+
+def test_pull_requests_cannot_select_the_self_hosted_runner():
+    caller = workflow_text("ci-pr.yml")
+    workflow = workflow_text("ci.yml")
+    runner_selection = workflow.split("    runs-on: >-", 1)[1].split(
+        "    timeout-minutes:", 1
+    )[0]
+
+    assert "kenn-macos-arm64-public" not in caller
+    assert "github.event_name == 'push'" in runner_selection
+    assert "github.ref == 'refs/heads/main'" in runner_selection
+    assert "pull_request" not in runner_selection

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,10 +90,12 @@ tmux attachment contracts.
 
 ## Apple Silicon macOS toolchain
 
-Pull requests and pushes to `main` run `.github/workflows/ci.yml` on GitHub's
-hosted `macos-26` Apple Silicon image. The workflow pins Xcode 26.0.1 and the
-exact Zig toolchain required by the pinned Ghostty source, then runs the
-complete build and test gates in a fresh environment.
+Pull requests invoke the `main`-pinned `.github/workflows/ci.yml`. Canonical
+`main` pushes and same-repository pull requests run on the managed public macOS
+runner; fork pull requests and noncanonical repository copies fall back to
+GitHub's hosted `macos-26` Apple Silicon image. The workflow selects a supported
+Xcode installation and the exact Zig toolchain required by the pinned Ghostty
+source, then runs the complete build and test gates.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig
@@ -105,9 +107,8 @@ If no compatible SDK is installed, bootstrap stops with the searched locations
 and the supported Xcode baseline instead of failing later with linker errors.
 
 CI builds libghostty with `LIBGHOSTTY_XCFRAMEWORK_TARGET=native`, producing the
-arm64 slice for the hosted runner. The project default remains `aarch64` for
-developer Macs. The hosted runner is temporary coverage while the Intel
-`mac-pro-intel` runner is prepared for an eventual architecture matrix.
+arm64 slice required by both runner paths. The project default remains
+`aarch64` for developer Macs.
 
 ## Remote SSH Host Prerequisites
 


### PR DESCRIPTION
Ghosthub needs one canonical CI definition for pull requests and pushes so changes are evaluated consistently with the revision being tested. The previous PR entry point could execute a workflow definition that diverged from the default branch before review.

This keeps pull requests pinned to the canonical workflow while preserving the existing build and test coverage. External pull requests continue to use the existing fallback behavior.