### PR TITLE
Fix macOS CI test state isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      - name: Configure isolated macOS test state
+        shell: bash
+        run: |
+          test -n "${HOME:-}"
+          test -n "${RUNNER_TEMP:-}"
+          mkdir -p "$HOME/Library/Caches" "$RUNNER_TEMP/ghosthub-tmp"
+          chmod 700 "$HOME/Library" "$HOME/Library/Caches" "$RUNNER_TEMP/ghosthub-tmp"
+          echo "CFFIXED_USER_HOME=$HOME" >> "$GITHUB_ENV"
+          echo "TMPDIR=$RUNNER_TEMP/ghosthub-tmp" >> "$GITHUB_ENV"
+
       - name: Install Zig 0.15.2
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,14 @@ jobs:
       - name: Configure isolated macOS test state
         shell: bash
         run: |
-          test -n "${HOME:-}"
           test -n "${RUNNER_TEMP:-}"
-          mkdir -p "$HOME/Library/Caches" "$RUNNER_TEMP/ghosthub-tmp"
-          chmod 700 "$HOME/Library" "$HOME/Library/Caches" "$RUNNER_TEMP/ghosthub-tmp"
-          echo "CFFIXED_USER_HOME=$HOME" >> "$GITHUB_ENV"
-          echo "TMPDIR=$RUNNER_TEMP/ghosthub-tmp" >> "$GITHUB_ENV"
+          foundation_home="$RUNNER_TEMP/ghosthub-home"
+          foundation_tmp="$RUNNER_TEMP/ghosthub-tmp"
+          mkdir -p "$foundation_home/Library/Caches" "$foundation_tmp"
+          chmod 700 "$foundation_home" "$foundation_home/Library" \
+            "$foundation_home/Library/Caches" "$foundation_tmp"
+          echo "CFFIXED_USER_HOME=$foundation_home" >> "$GITHUB_ENV"
+          echo "TMPDIR=$foundation_tmp" >> "$GITHUB_ENV"
 
       - name: Install Zig 0.15.2
         shell: bash


### PR DESCRIPTION
CI tests currently inherit platform defaults for temporary files and Foundation home-directory state. On some macOS environments, those defaults point to shared or non-writable locations, causing secure scratch-path checks and Sparkle tooling to fail before testing application behavior.

Establish private job-scoped temporary and Foundation-home state so the tests use disposable, writable paths consistently across macOS environments.