### PR TITLE
Cancel superseded pull request CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ghosthub-ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   run:
     uses: kenn-io/ghosthub/.github/workflows/ci.yml@main


### PR DESCRIPTION
When a new commit is pushed to an open pull request, the previous CI run should stop so it does not continue consuming runner capacity or report stale results. The PR caller workflow had no concurrency group; the reusable workflow’s existing group was not keyed to the pull request itself.

This gives each pull request caller a stable concurrency group and cancels its prior run when a newer commit arrives. Separate pull requests remain independent.