### PR TITLE
Track activity for warm tmux sessions

### DIFF
--- a/Sources/App/TmuxSessionActivityController.swift
+++ b/Sources/App/TmuxSessionActivityController.swift
@@ -35,6 +35,7 @@ final class TmuxSessionActivityController: ObservableObject {
     private let workingSampleInterval: TimeInterval
     private let quietSampleInterval: TimeInterval
     private let failureSampleInterval: TimeInterval
+    private let now: @Sendable () -> Date
     private let automaticallyPolls: Bool
     private var entries: [String: Entry] = [:]
     private var inFlightSamples: [String: InFlightSample] = [:]
@@ -46,6 +47,7 @@ final class TmuxSessionActivityController: ObservableObject {
         workingSampleInterval: TimeInterval = 5,
         quietSampleInterval: TimeInterval = 20,
         failureSampleInterval: TimeInterval = 30,
+        now: @escaping @Sendable () -> Date = { .now },
         automaticallyPolls: Bool = true
     ) {
         let probe = TmuxSessionActivityProbe()
@@ -60,6 +62,7 @@ final class TmuxSessionActivityController: ObservableObject {
         self.workingSampleInterval = workingSampleInterval
         self.quietSampleInterval = quietSampleInterval
         self.failureSampleInterval = failureSampleInterval
+        self.now = now
         self.automaticallyPolls = automaticallyPolls
     }
 
@@ -115,7 +118,7 @@ final class TmuxSessionActivityController: ObservableObject {
     private func scheduleWarmSessionSamples(
         at date: Date? = nil
     ) -> [Task<Void, Never>] {
-        let startedAt = date ?? .now
+        let startedAt = date ?? now()
         for (id, entry) in entries {
             if !isWorking(entry, at: startedAt) {
                 setWorking(false, sessionID: id)
@@ -126,6 +129,7 @@ final class TmuxSessionActivityController: ObservableObject {
                 && inFlightSamples[id] == nil ? (id, entry) : nil
         }
         let sampler = sampler
+        let now = now
         return dueEntries.map { id, entry in
             let requestID = UUID()
             let task = Task { [weak self] in
@@ -142,7 +146,7 @@ final class TmuxSessionActivityController: ObservableObject {
                     host: entry.host,
                     requestID: requestID,
                     startedAt: startedAt,
-                    completedAt: date ?? .now
+                    completedAt: date ?? now()
                 )
             }
             inFlightSamples[id] = InFlightSample(

--- a/Sources/App/TmuxSessionActivityController.swift
+++ b/Sources/App/TmuxSessionActivityController.swift
@@ -141,6 +141,7 @@ final class TmuxSessionActivityController: ObservableObject {
                     identity: entry.identity,
                     host: entry.host,
                     requestID: requestID,
+                    startedAt: startedAt,
                     completedAt: date ?? .now
                 )
             }
@@ -158,6 +159,7 @@ final class TmuxSessionActivityController: ObservableObject {
         identity: TmuxSessionIdentity,
         host: TmuxHost,
         requestID: UUID,
+        startedAt: Date,
         completedAt: Date
     ) {
         guard inFlightSamples[id]?.requestID == requestID else { return }
@@ -169,7 +171,7 @@ final class TmuxSessionActivityController: ObservableObject {
         switch result {
         case let .sample(paneID, dimensions, fingerprint):
             let previousIsRecent = entry.lastSampledAt.map { sampledAt in
-                completedAt.timeIntervalSince(sampledAt) < activityDuration
+                startedAt.timeIntervalSince(sampledAt) < activityDuration
             } ?? false
             if entry.paneID == paneID,
                entry.dimensions == dimensions,

--- a/Sources/App/TmuxSessionActivityController.swift
+++ b/Sources/App/TmuxSessionActivityController.swift
@@ -1,0 +1,252 @@
+@preconcurrency import Combine
+import Foundation
+import GhosthubTmux
+import GhosthubUI
+
+@MainActor
+final class TmuxSessionActivityController: ObservableObject {
+    typealias Sampler = @Sendable (
+        WorkspaceTmuxSessionSelection,
+        TmuxSessionIdentity,
+        TmuxHost
+    ) async -> TmuxSessionActivityProbeResult
+
+    private struct Entry: Sendable {
+        var selection: WorkspaceTmuxSessionSelection
+        var identity: TmuxSessionIdentity
+        var host: TmuxHost
+        var paneID: String?
+        var dimensions: String?
+        var fingerprint: String?
+        var lastSampledAt: Date?
+        var lastChangedAt: Date?
+        var nextSampleAt: Date
+    }
+
+    private struct InFlightSample {
+        let requestID: UUID
+        let task: Task<Void, Never>
+    }
+
+    @Published private(set) var workingSessionIDs: Set<String> = []
+
+    private let sampler: Sampler
+    private let activityDuration: TimeInterval
+    private let workingSampleInterval: TimeInterval
+    private let quietSampleInterval: TimeInterval
+    private let failureSampleInterval: TimeInterval
+    private let automaticallyPolls: Bool
+    private var entries: [String: Entry] = [:]
+    private var inFlightSamples: [String: InFlightSample] = [:]
+    private var pollingTask: Task<Void, Never>?
+
+    init(
+        sampler: Sampler? = nil,
+        activityDuration: TimeInterval = 30,
+        workingSampleInterval: TimeInterval = 5,
+        quietSampleInterval: TimeInterval = 20,
+        failureSampleInterval: TimeInterval = 30,
+        automaticallyPolls: Bool = true
+    ) {
+        let probe = TmuxSessionActivityProbe()
+        self.sampler = sampler ?? { selection, identity, host in
+            await probe.sample(
+                selection,
+                expectedIdentity: identity,
+                on: host
+            )
+        }
+        self.activityDuration = activityDuration
+        self.workingSampleInterval = workingSampleInterval
+        self.quietSampleInterval = quietSampleInterval
+        self.failureSampleInterval = failureSampleInterval
+        self.automaticallyPolls = automaticallyPolls
+    }
+
+    deinit {
+        pollingTask?.cancel()
+        inFlightSamples.values.forEach { $0.task.cancel() }
+    }
+
+    func warm(
+        _ selection: WorkspaceTmuxSessionSelection,
+        identity: TmuxSessionIdentity,
+        on host: TmuxHost,
+        at date: Date = .now
+    ) {
+        let id = selection.id
+        if var entry = entries[id],
+           entry.identity == identity,
+           entry.host == host {
+            entry.selection = selection
+            entry.host = host
+            entry.nextSampleAt = min(entry.nextSampleAt, date)
+            entries[id] = entry
+        } else {
+            inFlightSamples.removeValue(forKey: id)?.task.cancel()
+            setWorking(false, sessionID: id)
+            entries[id] = Entry(
+                selection: selection,
+                identity: identity,
+                host: host,
+                paneID: nil,
+                nextSampleAt: date
+            )
+        }
+        startPollingIfNeeded()
+    }
+
+    func reconcile(endpointsByHostID: [UUID: TmuxHost]) {
+        let sessionIDs = entries.compactMap { id, entry in
+            endpointsByHostID[entry.selection.hostID] != entry.host
+                ? id
+                : nil
+        }
+        invalidate(sessionIDs: sessionIDs)
+    }
+
+    func sampleWarmSessions(at date: Date? = nil) async {
+        let tasks = scheduleWarmSessionSamples(at: date)
+        for task in tasks {
+            await task.value
+        }
+    }
+
+    private func scheduleWarmSessionSamples(
+        at date: Date? = nil
+    ) -> [Task<Void, Never>] {
+        let startedAt = date ?? .now
+        for (id, entry) in entries {
+            if !isWorking(entry, at: startedAt) {
+                setWorking(false, sessionID: id)
+            }
+        }
+        let dueEntries = entries.compactMap { id, entry in
+            entry.nextSampleAt <= startedAt
+                && inFlightSamples[id] == nil ? (id, entry) : nil
+        }
+        let sampler = sampler
+        return dueEntries.map { id, entry in
+            let requestID = UUID()
+            let task = Task { [weak self] in
+                let result = await sampler(
+                    entry.selection,
+                    entry.identity,
+                    entry.host
+                )
+                guard let self else { return }
+                applySample(
+                    result,
+                    sessionID: id,
+                    identity: entry.identity,
+                    host: entry.host,
+                    requestID: requestID,
+                    completedAt: date ?? .now
+                )
+            }
+            inFlightSamples[id] = InFlightSample(
+                requestID: requestID,
+                task: task
+            )
+            return task
+        }
+    }
+
+    private func applySample(
+        _ result: TmuxSessionActivityProbeResult,
+        sessionID id: String,
+        identity: TmuxSessionIdentity,
+        host: TmuxHost,
+        requestID: UUID,
+        completedAt: Date
+    ) {
+        guard inFlightSamples[id]?.requestID == requestID else { return }
+        inFlightSamples.removeValue(forKey: id)
+        guard var entry = entries[id],
+              entry.identity == identity,
+              entry.host == host
+        else { return }
+        switch result {
+        case let .sample(paneID, dimensions, fingerprint):
+            let previousIsRecent = entry.lastSampledAt.map { sampledAt in
+                completedAt.timeIntervalSince(sampledAt) < activityDuration
+            } ?? false
+            if entry.paneID == paneID,
+               entry.dimensions == dimensions,
+               previousIsRecent,
+               let previous = entry.fingerprint,
+               previous != fingerprint {
+                entry.lastChangedAt = completedAt
+            }
+            entry.paneID = paneID
+            entry.dimensions = dimensions
+            entry.fingerprint = fingerprint
+            entry.lastSampledAt = completedAt
+            let isWorking = isWorking(entry, at: completedAt)
+            setWorking(isWorking, sessionID: id)
+            entry.nextSampleAt = completedAt.addingTimeInterval(
+                isWorking
+                    ? workingSampleInterval
+                    : quietSampleInterval
+            )
+            entries[id] = entry
+        case .ended:
+            entries.removeValue(forKey: id)
+            setWorking(false, sessionID: id)
+        case .unavailable:
+            let isWorking = isWorking(entry, at: completedAt)
+            setWorking(isWorking, sessionID: id)
+            let retryAt = completedAt.addingTimeInterval(
+                failureSampleInterval
+            )
+            if let lastChangedAt = entry.lastChangedAt,
+               isWorking {
+                entry.nextSampleAt = min(
+                    retryAt,
+                    lastChangedAt.addingTimeInterval(activityDuration)
+                )
+            } else {
+                entry.nextSampleAt = retryAt
+            }
+            entries[id] = entry
+        }
+    }
+
+    private func isWorking(_ entry: Entry, at date: Date) -> Bool {
+        guard let lastChangedAt = entry.lastChangedAt else { return false }
+        return date.timeIntervalSince(lastChangedAt) < activityDuration
+    }
+
+    private func invalidate(sessionIDs: [String]) {
+        for id in sessionIDs {
+            inFlightSamples.removeValue(forKey: id)?.task.cancel()
+            entries.removeValue(forKey: id)
+            setWorking(false, sessionID: id)
+        }
+    }
+
+    private func setWorking(_ isWorking: Bool, sessionID: String) {
+        if isWorking {
+            guard !workingSessionIDs.contains(sessionID) else { return }
+            workingSessionIDs.insert(sessionID)
+        } else {
+            guard workingSessionIDs.contains(sessionID) else { return }
+            workingSessionIDs.remove(sessionID)
+        }
+    }
+
+    private func startPollingIfNeeded() {
+        guard automaticallyPolls, pollingTask == nil else { return }
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                guard let self else { return }
+                _ = scheduleWarmSessionSamples()
+            }
+        }
+    }
+}

--- a/Sources/App/TmuxSessionActivityProbe.swift
+++ b/Sources/App/TmuxSessionActivityProbe.swift
@@ -1,0 +1,547 @@
+import Foundation
+import GhosthubTmux
+import GhosthubUI
+
+enum TmuxSessionActivityProbeResult: Equatable, Sendable {
+    case sample(paneID: String, dimensions: String, fingerprint: String)
+    case ended
+    case unavailable
+}
+
+struct TmuxSessionActivityProbe: Sendable {
+    typealias PathResolver = @Sendable (TmuxHost)
+        -> Result<String, TmuxBinaryError>
+    typealias Runner = @Sendable (TmuxHost, String)
+        -> (status: Int32, stdout: String)
+
+    private static let identityMarker =
+        "GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t"
+    private static let checksumMarker =
+        "GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t"
+    private static let endedMarker =
+        "GHOSTHUB_TMUX_ACTIVITY_ENDED"
+    private static let mismatchMarker =
+        "GHOSTHUB_TMUX_ACTIVITY_MISMATCH"
+    private static let supportMarker =
+        "GHOSTHUB_TMUX_ACTIVITY_SUPPORTED"
+
+    private let pathResolver: PathResolver
+    private let runner: Runner
+
+    init(
+        pathResolver: PathResolver? = nil,
+        runner: Runner? = nil
+    ) {
+        let cache = TmuxSessionActivityPathCache(
+            resolve: pathResolver ?? Self.resolveTmuxPath
+        )
+        self.pathResolver = { host in
+            cache.resolve(on: host)
+        }
+        self.runner = runner ?? { host, command in
+            switch host {
+            case .local:
+                TmuxBinaryResolver.runLoginShell(
+                    shell: TmuxBinaryResolver.loginShell(),
+                    command: command,
+                    timeout: 10
+                )
+            case let .ssh(info):
+                TmuxBinaryResolver.runRemoteLoginShell(
+                    host: info,
+                    command: command,
+                    timeout: 10
+                )
+            }
+        }
+    }
+
+    func sample(
+        _ selection: WorkspaceTmuxSessionSelection,
+        expectedIdentity: TmuxSessionIdentity,
+        on host: TmuxHost
+    ) async -> TmuxSessionActivityProbeResult {
+        let pathResolver = pathResolver
+        let runner = runner
+        let sampleTask = Task.detached(
+            priority: .utility
+        ) { () -> TmuxSessionActivityProbeResult in
+            guard !Task.isCancelled,
+                  TmuxSessionKiller.isNumericIdentity(
+                      expectedIdentity.serverPID
+                  ),
+                  TmuxSessionKiller.isSessionID(expectedIdentity.sessionID),
+                  TmuxSessionKiller.isSessionCreatedAt(
+                      expectedIdentity.createdAt
+                  ),
+                  let tmuxPath = try? pathResolver(host).get()
+            else {
+                return .unavailable
+            }
+            let command = Self.command(
+                tmuxPath: tmuxPath,
+                selection: selection,
+                expectedIdentity: expectedIdentity,
+                platform: Self.platform(for: host)
+            )
+            guard !Task.isCancelled else {
+                return .unavailable
+            }
+            let result = runner(host, command)
+            guard result.status == 0 else {
+                return .unavailable
+            }
+            return Self.parse(
+                result.stdout,
+                expectedIdentity: expectedIdentity
+            )
+        }
+        return await withTaskCancellationHandler {
+            await sampleTask.value
+        } onCancel: {
+            sampleTask.cancel()
+        }
+    }
+
+    static func command(
+        tmuxPath: String,
+        selection: WorkspaceTmuxSessionSelection,
+        expectedIdentity: TmuxSessionIdentity,
+        platform: SSHHostInfo.Platform = .posix
+    ) -> String {
+        if platform == .windows {
+            return windowsCommand(
+                tmuxPath: tmuxPath,
+                selection: selection,
+                expectedIdentity: expectedIdentity
+            )
+        }
+        var baseArguments = [tmuxPath]
+        if let socketName = selection.socketName {
+            baseArguments.append(contentsOf: ["-L", socketName])
+        }
+        let base = baseArguments
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let target = shellQuotedCommandArgument("=\(selection.name):")
+        let format = shellQuotedCommandArgument(
+            identityMarker
+                + "#{pid}\t#{session_id}\t#{session_created}\t#{pane_id}"
+                + "\t#{pane_width}x#{pane_height}"
+        )
+        let identity = base
+            + " display-message -p -t " + target + " " + format
+        let predicate = Self.identityPredicate(expectedIdentity)
+        let historySize = base
+            + " display-message -p -t \"$ghosthub_activity_pane\" "
+            + shellQuotedCommandArgument(
+                "#{?\(predicate),#{history_size},\(mismatchMarker)}"
+            )
+        let checkedIdentity = """
+        ghosthub_activity_identity=$(\(identity) 2>&1)
+        ghosthub_activity_status=$?
+        if [ "$ghosthub_activity_status" -ne 0 ]; then
+            case "$ghosthub_activity_identity" in
+                *"can't find session:"*|*"no server running on "*)
+                    printf '\(endedMarker)\n'
+                    exit 0
+                    ;;
+                *"error connecting to "*"(No such file or directory)"*)
+                    printf '\(endedMarker)\n'
+                    exit 0
+                    ;;
+                *"failed to connect to server: No such file or directory"*)
+                    printf '\(endedMarker)\n'
+                    exit 0
+                    ;;
+            esac
+            printf '%s\n' "$ghosthub_activity_identity" >&2
+            exit "$ghosthub_activity_status"
+        fi
+        printf '%s\n' "$ghosthub_activity_identity"
+        """
+        let capture = base
+            + " if-shell -F -t \"$ghosthub_activity_pane\" "
+            + shellQuotedCommandArgument(predicate)
+            + " \"capture-pane -p -t $ghosthub_activity_pane -S -160 -E -1\" "
+            + shellQuotedCommandArgument(
+                "display-message -p \(mismatchMarker)"
+            )
+        let expectedPrefix = shellQuotedCommandArgument(
+            Self.expectedIdentityPrefix(expectedIdentity)
+        )
+        return """
+        \(checkedIdentity)
+        ghosthub_activity_expected=\(expectedPrefix)
+        case "$ghosthub_activity_identity" in
+            "$ghosthub_activity_expected"*) ;;
+            *)
+                printf '\(endedMarker)\n'
+                exit 0
+                ;;
+        esac
+        ghosthub_activity_pane=${ghosthub_activity_identity#"$ghosthub_activity_expected"}
+        ghosthub_activity_pane=${ghosthub_activity_pane%%\(tabLiteral)*}
+        case "$ghosthub_activity_pane" in
+            %*[!0-9]*|%) exit 65 ;;
+            %[0-9]*) ;;
+            *) exit 65 ;;
+        esac
+        ghosthub_activity_history_size=$(\(historySize)) || exit $?
+        case "$ghosthub_activity_history_size" in
+            '\(mismatchMarker)')
+                printf '\(endedMarker)\n'
+                exit 0
+                ;;
+            ''|*[!0-9]*) exit 65 ;;
+        esac
+        if [ "$ghosthub_activity_history_size" -eq 0 ]; then
+            ghosthub_activity_capture=
+        else
+            ghosthub_activity_capture=$(
+                \(capture) || exit $?
+                printf '%s' 'GHOSTHUB_TMUX_ACTIVITY_CAPTURE_END'
+            ) || exit $?
+            ghosthub_activity_capture=${ghosthub_activity_capture%GHOSTHUB_TMUX_ACTIVITY_CAPTURE_END}
+        fi
+        ghosthub_activity_checksum=$(printf '%s' "$ghosthub_activity_capture" | cksum) || exit $?
+        set -- $ghosthub_activity_checksum
+        [ "$#" -ge 2 ] || exit 65
+        printf '\(checksumMarker)%s\t%s\t%s\n' \
+            "$1" "$2" "$ghosthub_activity_history_size"
+        \(checkedIdentity)
+        """
+    }
+
+    private static let tabLiteral = "\t"
+
+    private static func identityPredicate(
+        _ identity: TmuxSessionIdentity
+    ) -> String {
+        "#{&&:#{==:#{pid},\(identity.serverPID)},"
+            + "#{&&:#{==:#{session_id},\(identity.sessionID)},"
+            + "#{==:#{session_created},\(identity.createdAt)}}}"
+    }
+
+    private static func expectedIdentityPrefix(
+        _ identity: TmuxSessionIdentity
+    ) -> String {
+        identityMarker
+            + identity.serverPID + "\t"
+            + identity.sessionID + "\t"
+            + identity.createdAt + "\t"
+    }
+
+    private static func windowsCommand(
+        tmuxPath: String,
+        selection: WorkspaceTmuxSessionSelection,
+        expectedIdentity: TmuxSessionIdentity
+    ) -> String {
+        var baseArguments: [String] = []
+        if let socketName = selection.socketName {
+            baseArguments.append(contentsOf: ["-L", socketName])
+        }
+        let target = "=\(selection.name):"
+        let format = identityMarker
+            + "#{pid}\t#{session_id}\t#{session_created}\t#{pane_id}"
+            + "\t#{pane_width}x#{pane_height}"
+        let identity = powerShellInvocation(
+            tmuxPath: tmuxPath,
+            arguments: baseArguments + [
+                "display-message", "-p", "-t", target, format,
+            ]
+        )
+        let version = powerShellInvocation(
+            tmuxPath: tmuxPath,
+            arguments: ["-V"]
+        )
+        let predicate = identityPredicate(expectedIdentity)
+        let displayPrefix = ([tmuxPath] + baseArguments + [
+            "display-message", "-p",
+        ]).map(powerShellEncodedArgument).joined(separator: " ")
+        let formatProbe = "& " + displayPrefix + " "
+            + powerShellEncodedArgument(
+                "#{?#{&&:#{==:1,1},#{==:2,2}},\(supportMarker),unsupported}"
+            )
+        let ifShellPrefix = ([tmuxPath] + baseArguments + ["if-shell", "-F"])
+            .map(powerShellEncodedArgument).joined(separator: " ")
+        let ifShellProbe = "& " + ifShellPrefix + " "
+            + powerShellEncodedArgument("1") + " "
+            + powerShellEncodedArgument("display-message -p \(supportMarker)")
+            + " "
+            + powerShellEncodedArgument("display-message -p unsupported")
+        let historySize = "& " + displayPrefix + " "
+            + powerShellEncodedArgument("-t") + " $ghosthubActivityPane "
+            + powerShellEncodedArgument(
+                "#{?\(predicate),#{history_size},\(mismatchMarker)}"
+            )
+        let checkedIdentity = """
+        $ghosthubActivityIdentity = (\(identity) 2>&1 | Out-String).TrimEnd()
+        $ghosthubActivityStatus = $LASTEXITCODE
+        if ($ghosthubActivityStatus -ne 0) {
+            if ($ghosthubActivityIdentity -match "(?i)can't find session:|no server running on |error connecting to .*\\(No such file or directory\\)|failed to connect to server: No such file or directory") {
+                Write-Output '\(endedMarker)'
+                exit 0
+            }
+            [Console]::Error.WriteLine($ghosthubActivityIdentity)
+            exit $ghosthubActivityStatus
+        }
+        Write-Output $ghosthubActivityIdentity
+        """
+        let capture = "& " + ifShellPrefix + " "
+            + powerShellEncodedArgument("-t") + " $ghosthubActivityPane "
+            + powerShellEncodedArgument(predicate)
+            + " (\"capture-pane -p -t \" + $ghosthubActivityPane"
+            + " + \" -S -160 -E -1\") "
+            + powerShellEncodedArgument(
+                "display-message -p \(mismatchMarker)"
+            )
+        return """
+        $ErrorActionPreference = 'Stop'
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $OutputEncoding = [Console]::OutputEncoding
+        $ghosthubActivityVersionOutput = (\(version) 2>&1 | Out-String).Trim()
+        if (($LASTEXITCODE -ne 0) -or ($ghosthubActivityVersionOutput -notmatch '^tmux\\s+(\\d+)\\.(\\d+)(?:\\.(\\d+))?')) {
+            exit 69
+        }
+        $ghosthubActivityPatch = if ($Matches[3]) { [int]$Matches[3] } else { 0 }
+        $ghosthubActivityVersion = [Version]::new(
+            [int]$Matches[1],
+            [int]$Matches[2],
+            $ghosthubActivityPatch
+        )
+        if ($ghosthubActivityVersion -lt [Version]'3.3.4') { exit 69 }
+        \(checkedIdentity)
+        $ghosthubActivityExpected = \(
+            powerShellEncodedArgument(
+                expectedIdentityPrefix(expectedIdentity)
+            )
+        )
+        if (-not $ghosthubActivityIdentity.StartsWith($ghosthubActivityExpected)) {
+            Write-Output '\(endedMarker)'
+            exit 0
+        }
+        $ghosthubActivityFields = $ghosthubActivityIdentity -split "`t"
+        if (($ghosthubActivityFields.Count -lt 6) -or ($ghosthubActivityFields[4] -notmatch '^%\\d+$')) {
+            exit 65
+        }
+        $ghosthubActivityPane = $ghosthubActivityFields[4]
+        $ghosthubActivityFormatProbe = (\(formatProbe) 2>&1 | Out-String).Trim()
+        if (($LASTEXITCODE -ne 0) -or ($ghosthubActivityFormatProbe -ne '\(supportMarker)')) {
+            exit 69
+        }
+        $ghosthubActivityIfShellProbe = (\(ifShellProbe) 2>&1 | Out-String).Trim()
+        if (($LASTEXITCODE -ne 0) -or ($ghosthubActivityIfShellProbe -ne '\(supportMarker)')) {
+            exit 69
+        }
+        $ghosthubActivityHistorySize = (\(historySize) | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0) { exit 65 }
+        if ($ghosthubActivityHistorySize -eq '\(mismatchMarker)') {
+            Write-Output '\(endedMarker)'
+            exit 0
+        }
+        if ($ghosthubActivityHistorySize -notmatch '^\\d+$') {
+            exit 65
+        }
+        if ([int64]$ghosthubActivityHistorySize -eq 0) {
+            $ghosthubActivityCapture = ''
+        } else {
+            $ghosthubActivityCapture = (\(capture) | Out-String)
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        }
+        $ghosthubActivityBytes = [System.Text.Encoding]::UTF8.GetBytes($ghosthubActivityCapture)
+        $ghosthubActivitySHA = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $ghosthubActivityHashBytes = $ghosthubActivitySHA.ComputeHash($ghosthubActivityBytes)
+        } finally {
+            $ghosthubActivitySHA.Dispose()
+        }
+        $ghosthubActivityHash = -join ($ghosthubActivityHashBytes | ForEach-Object { $_.ToString('x2') })
+        Write-Output (\(
+            powerShellEncodedArgument(checksumMarker)
+        ) + $ghosthubActivityHash + "`t" + $ghosthubActivityBytes.Length + "`t" + $ghosthubActivityHistorySize)
+        \(checkedIdentity)
+        """
+    }
+
+    private static func powerShellInvocation(
+        tmuxPath: String,
+        arguments: [String]
+    ) -> String {
+        "& " + ([tmuxPath] + arguments)
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
+    }
+
+    static func parse(
+        _ output: String,
+        expectedIdentity: TmuxSessionIdentity
+    ) -> TmuxSessionActivityProbeResult {
+        let lines = output.split(whereSeparator: \.isNewline).map(String.init)
+        if lines.last == endedMarker {
+            return .ended
+        }
+        let identities = lines.enumerated().compactMap { index, line in
+            parseIdentityLine(line).map { (index, $0) }
+        }
+        guard identities.count >= 2 else {
+            return .unavailable
+        }
+        let first = identities[identities.count - 2]
+        let last = identities[identities.count - 1]
+        guard first.1.identity == expectedIdentity,
+              last.1.identity == expectedIdentity
+        else {
+            return .ended
+        }
+        guard first.1.paneID == last.1.paneID,
+              first.1.dimensions == last.1.dimensions
+        else {
+            return .unavailable
+        }
+        let fencedLines = lines[(first.0 + 1) ..< last.0]
+        guard let checksum = fencedLines
+            .reversed()
+            .compactMap(parseChecksumLine)
+            .first
+        else {
+            return .unavailable
+        }
+        return .sample(
+            paneID: first.1.paneID,
+            dimensions: first.1.dimensions,
+            fingerprint: [
+                checksum.checksum,
+                checksum.byteCount,
+                checksum.historySize,
+            ]
+            .joined(separator: ":")
+        )
+    }
+
+    private static func parseIdentityLine(
+        _ line: String
+    ) -> (
+        identity: TmuxSessionIdentity,
+        paneID: String,
+        dimensions: String
+    )? {
+        guard line.hasPrefix(identityMarker) else { return nil }
+        let fields = line.dropFirst(identityMarker.count).split(
+            separator: "\t",
+            maxSplits: 4,
+            omittingEmptySubsequences: false
+        )
+        guard fields.count == 5 else { return nil }
+        let identity = TmuxSessionIdentity(
+            serverPID: String(fields[0]),
+            sessionID: String(fields[1]),
+            createdAt: String(fields[2])
+        )
+        let paneID = String(fields[3])
+        let dimensions = String(fields[4])
+        guard TmuxSessionKiller.isNumericIdentity(identity.serverPID),
+              TmuxSessionKiller.isSessionID(identity.sessionID),
+              TmuxSessionKiller.isSessionCreatedAt(identity.createdAt),
+              paneID.utf8.first == 37,
+              paneID.utf8.dropFirst().allSatisfy({ byte in
+                  byte >= 48 && byte <= 57
+              }),
+              isDimensions(dimensions)
+        else { return nil }
+        return (identity, paneID, dimensions)
+    }
+
+    private static func parseChecksumLine(
+        _ line: String
+    ) -> (checksum: String, byteCount: String, historySize: String)? {
+        guard line.hasPrefix(checksumMarker) else { return nil }
+        let fields = line.dropFirst(checksumMarker.count).split(
+            separator: "\t",
+            maxSplits: 2,
+            omittingEmptySubsequences: false
+        )
+        guard fields.count == 3,
+              isChecksum(String(fields[0])),
+              isNumeric(String(fields[1])),
+              isNumeric(String(fields[2]))
+        else { return nil }
+        return (
+            String(fields[0]),
+            String(fields[1]),
+            String(fields[2])
+        )
+    }
+
+    private static func isDimensions(_ value: String) -> Bool {
+        let sides = value.split(
+            separator: "x",
+            omittingEmptySubsequences: false
+        )
+        return sides.count == 2 && sides.allSatisfy { side in
+            isNumeric(String(side))
+        }
+    }
+
+    private static func isChecksum(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { byte in
+            (byte >= 48 && byte <= 57)
+                || (byte >= 97 && byte <= 102)
+        }
+    }
+
+    private static func isNumeric(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { byte in
+            byte >= 48 && byte <= 57
+        }
+    }
+
+    private static func platform(
+        for host: TmuxHost
+    ) -> SSHHostInfo.Platform {
+        switch host {
+        case .local:
+            .posix
+        case let .ssh(info):
+            info.platform
+        }
+    }
+
+    private static func resolveTmuxPath(
+        on host: TmuxHost
+    ) -> Result<String, TmuxBinaryError> {
+        let resolver = TmuxBinaryResolver()
+        return switch host {
+        case .local:
+            resolver.resolveTmuxPath()
+        case let .ssh(info):
+            resolver.resolveTmuxPath(on: info)
+        }
+    }
+}
+
+private final class TmuxSessionActivityPathCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [TmuxHost: String] = [:]
+    private let resolve: TmuxSessionActivityProbe.PathResolver
+
+    init(resolve: @escaping TmuxSessionActivityProbe.PathResolver) {
+        self.resolve = resolve
+    }
+
+    func resolve(on host: TmuxHost) -> Result<String, TmuxBinaryError> {
+        lock.lock()
+        if let path = paths[host] {
+            lock.unlock()
+            return .success(path)
+        }
+        lock.unlock()
+        let result = resolve(host)
+        if case let .success(path) = result {
+            lock.lock()
+            paths[host] = path
+            lock.unlock()
+        }
+        return result
+    }
+}

--- a/Sources/App/WorkspaceSceneBootstrap.swift
+++ b/Sources/App/WorkspaceSceneBootstrap.swift
@@ -9,6 +9,7 @@ enum WorkspaceSceneBootstrap {
         let database: WorkspaceDatabase
         let workspaceConfiguration: WorkspaceConfiguration
         let notificationService: NotificationService
+        let tmuxSessionActivityController: TmuxSessionActivityController
         let localHostID: UUID
     }
 
@@ -38,6 +39,8 @@ enum WorkspaceSceneBootstrap {
                 existing.workspaceConfiguration,
                 notificationService:
                 existing.notificationService,
+                tmuxSessionActivityController:
+                existing.tmuxSessionActivityController,
                 localHostID: existing.localHostID
             )
         }
@@ -63,6 +66,8 @@ enum WorkspaceSceneBootstrap {
             database: database,
             workspaceConfiguration: workspaceConfiguration,
             notificationService: notificationService,
+            tmuxSessionActivityController:
+            TmuxSessionActivityController(),
             localHostID: fallbackLocalHostID
         )
         sharedResources = result

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -4942,9 +4942,9 @@ final class WorkspaceSceneModel: ObservableObject {
         handle: BorrowedTmuxSessionHandle
     ) {
         guard let activityController = tmuxSessionActivityController,
-              activeBorrowedTmuxHandle == handle,
+              let selection = retainedTmuxPresentation(for: handle)?
+              .selection,
               !nativeTmuxSessionCoordinator.hasClosedAttachment(handle),
-              let selection = activeBorrowedTmuxSelection,
               let hostSummary = snapshot.host(id: selection.hostID),
               let host = TmuxHostResolver.resolve(hostSummary)
         else { return }
@@ -4970,9 +4970,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
                 guard let self,
                       !Task.isCancelled,
-                      activeBorrowedTmuxHandle == handle,
                       borrowedTmuxConnectionStates[handle.id] == .connected,
-                      let currentSelection = activeBorrowedTmuxSelection,
+                      let currentSelection = retainedTmuxPresentation(
+                          for: handle
+                      )?.selection,
                       Self.sameTmuxEndpoint(currentSelection, selection),
                       let currentHostSummary = snapshot.host(
                           id: currentSelection.hostID
@@ -4989,13 +4990,15 @@ final class WorkspaceSceneModel: ObservableObject {
                     continue
                 }
                 guard !Task.isCancelled,
-                      activeBorrowedTmuxHandle == handle,
                       !nativeTmuxSessionCoordinator.hasClosedAttachment(
                           handle
                       ),
                       borrowedTmuxConnectionStates[handle.id] == .connected,
-                      activeBorrowedTmuxSelection.map({
-                          Self.sameTmuxEndpoint($0, currentSelection)
+                      retainedTmuxPresentation(for: handle).map({
+                          Self.sameTmuxEndpoint(
+                              $0.selection,
+                              currentSelection
+                          )
                       }) == true
                 else { return }
                 activityController.warm(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -582,6 +582,8 @@ final class WorkspaceSceneModel: ObservableObject {
     let terminalCoordinator: TerminalSurfaceCoordinator
     let localHostID: UUID
     private let notificationService: NotificationService
+    private let tmuxSessionActivityController:
+        TmuxSessionActivityController?
     private let kwtInventoryLoader: KwtInventoryLoader
     private let kwtRemoteProvisioner: KwtRemoteProvisioner
     private let kwtWorktreeCreator: KwtWorktreeCreator
@@ -615,6 +617,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private var deferredTmuxPresentationTasks: [UUID: Task<Void, Never>] = [:]
     private var drainingDeferredTmuxPresentationTasks:
         [UUID: Task<Void, Never>] = [:]
+    private var tmuxActivityEnrollmentTasks:
+        [UUID: Task<Void, Never>] = [:]
     private let deferredTmuxPresentationRetryDelays: [Duration]
     private var worktreeMutationCancellable: AnyCancellable?
     private var activityControllerBacking: ActivityMonitoringController?
@@ -637,6 +641,7 @@ final class WorkspaceSceneModel: ObservableObject {
         return nativeTmuxSessionCoordinatorBacking
     }
     private var activityCancellable: AnyCancellable?
+    private var tmuxSessionActivityCancellable: AnyCancellable?
     private var panelRoutingCancellable: AnyCancellable?
     var isAppActive = true
     var childExitCancellable: AnyCancellable?
@@ -662,6 +667,9 @@ final class WorkspaceSceneModel: ObservableObject {
     }
     var defaultIdleThresholdSeconds: Int {
         workspaceConfiguration.notifications.idleThresholdSeconds
+    }
+    var workingTmuxSessionIDs: Set<String> {
+        tmuxSessionActivityController?.workingSessionIDs ?? []
     }
     convenience init(
         terminalRuntime: LibghosttyRuntime = .shared,
@@ -692,6 +700,8 @@ final class WorkspaceSceneModel: ObservableObject {
                         .appliesThemeToTmuxSessions
                 },
                 sshAuthenticationCoordinator: sshAuthenticationCoordinator,
+                tmuxSessionActivityController:
+                boot.tmuxSessionActivityController,
                 localHostID: boot.localHostID,
                 startServices: true
             )
@@ -844,6 +854,8 @@ final class WorkspaceSceneModel: ObservableObject {
         },
         terminalColorsPublisher:
         AnyPublisher<[UInt: TerminalResolvedColors], Never>? = nil,
+        tmuxSessionActivityController:
+        TmuxSessionActivityController? = nil,
         sceneSettings: WorkspaceSceneSettings = .live(),
         localHostID: UUID? = nil,
         overrideSnapshot: WorkspaceSnapshot? = nil,
@@ -924,6 +936,8 @@ final class WorkspaceSceneModel: ObservableObject {
         self.startExeHostInventory = startExeHostInventory
         terminalCoordinator = TerminalSurfaceCoordinator(runtime: terminalRuntime)
         self.notificationService = notificationService
+        self.tmuxSessionActivityController =
+            tmuxSessionActivityController
 
         var snapshot = try overrideSnapshot ?? database.fetchSessionSnapshot()
         let resolvedLocalHostID = localHostID
@@ -949,6 +963,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 configuredSSHHostsProvider(),
                 exeHosts: configuredExeHostsProvider(),
                 to: snapshot
+            )
+            tmuxSessionActivityController?.reconcile(
+                endpointsByHostID: Self.resolvedEndpoints(of: snapshot)
             )
         }
         self.snapshot = snapshot
@@ -1100,6 +1117,10 @@ final class WorkspaceSceneModel: ObservableObject {
         activityCancellable = activityController.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
+        tmuxSessionActivityCancellable = tmuxSessionActivityController?
+            .objectWillChange.sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
         terminalColorsCancellable = (terminalColorsPublisher
             ?? terminalRuntime.$resolvedTerminalColorsBySurface
             .eraseToAnyPublisher())
@@ -1176,6 +1197,7 @@ final class WorkspaceSceneModel: ObservableObject {
         // Cancel Combine subscriptions first so no new events
         // arrive from child controllers during teardown.
         activityCancellable?.cancel()
+        tmuxSessionActivityCancellable?.cancel()
         panelRoutingCancellable?.cancel()
         configuredSSHHostsCancellable?.cancel()
         configuredExeHostsCancellable?.cancel()
@@ -1185,6 +1207,7 @@ final class WorkspaceSceneModel: ObservableObject {
         tmuxDiscoveryTask?.cancel()
         createdSessionDiscoveryTasks.values.forEach { $0.cancel() }
         deferredTmuxPresentationTasks.values.forEach { $0.cancel() }
+        tmuxActivityEnrollmentTasks.values.forEach { $0.cancel() }
         childExitCancellable?.cancel()
         appDidBecomeActiveCancellable?.cancel()
         appDidResignActiveCancellable?.cancel()
@@ -1405,6 +1428,8 @@ final class WorkspaceSceneModel: ObservableObject {
         createdSessionDiscoveryTasks.removeAll()
         deferredTmuxPresentationTasks.values.forEach { $0.cancel() }
         deferredTmuxPresentationTasks.removeAll()
+        tmuxActivityEnrollmentTasks.values.forEach { $0.cancel() }
+        tmuxActivityEnrollmentTasks.removeAll()
         drainingDeferredTmuxPresentationTasks.removeAll()
         exhaustedCreatedTmuxSessionHandles.removeAll()
         endedCreatedTmuxSessionHandles.removeAll()
@@ -2830,21 +2855,26 @@ final class WorkspaceSceneModel: ObservableObject {
             exeHosts: exeHosts,
             to: source
         )
-        let previousTargets = Dictionary(
-            uniqueKeysWithValues: source.hosts.compactMap { host in
-                TmuxHostResolver.resolve(host).map { (host.id, $0) }
-            }
-        )
-        let updatedTargets = Dictionary(
-            uniqueKeysWithValues: updated.hosts.compactMap { host in
-                TmuxHostResolver.resolve(host).map { (host.id, $0) }
-            }
-        )
+        let previousTargets = Self.resolvedEndpoints(of: source)
+        let updatedTargets = Self.resolvedEndpoints(of: updated)
         let invalidatedHostIDs = Set(previousTargets.keys.filter { hostID in
             previousTargets[hostID] != updatedTargets[hostID]
         })
+        tmuxSessionActivityController?.reconcile(
+            endpointsByHostID: updatedTargets
+        )
         invalidateTmuxAttachments(for: invalidatedHostIDs)
         return updated
+    }
+
+    private static func resolvedEndpoints(
+        of snapshot: WorkspaceSnapshot
+    ) -> [UUID: TmuxHost] {
+        Dictionary(
+            uniqueKeysWithValues: snapshot.hosts.compactMap { host in
+                TmuxHostResolver.resolve(host).map { (host.id, $0) }
+            }
+        )
     }
 
     private func invalidateTmuxAttachments(for hostIDs: Set<UUID>) {
@@ -4187,6 +4217,9 @@ final class WorkspaceSceneModel: ObservableObject {
         retainedTmuxPresentationKeysByHandle.removeValue(forKey: handle.id)
         cancelTmuxReconnect(presentation)
         cancelTmuxPresentationTasks(handleID: handle.id)
+        tmuxActivityEnrollmentTasks.removeValue(
+            forKey: handle.id
+        )?.cancel()
         confirmedEndedTmuxSessionHandles.remove(handle.id)
         borrowedTmuxConnectionStates.removeValue(forKey: handle.id)
         if var pending = pendingCreatedTmuxSessions[handle.id] {
@@ -4442,8 +4475,13 @@ final class WorkspaceSceneModel: ObservableObject {
                     presentation: presentation
                 )
             }
+            warmConnectedTmuxSession(handle: handle)
             publishActiveState(for: presentation)
             applyDeferredTmuxPresentationIfReady(presentation)
+        } else {
+            tmuxActivityEnrollmentTasks.removeValue(
+                forKey: handle.id
+            )?.cancel()
         }
         if case .disconnected = state,
            presentation.recoveryState != nil,
@@ -4897,6 +4935,79 @@ final class WorkspaceSceneModel: ObservableObject {
                   presentation.reconnectContext == context
             else { return }
             presentation.establishmentConfirmationTask = nil
+        }
+    }
+
+    private func warmConnectedTmuxSession(
+        handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let activityController = tmuxSessionActivityController,
+              activeBorrowedTmuxHandle == handle,
+              !nativeTmuxSessionCoordinator.hasClosedAttachment(handle),
+              let selection = activeBorrowedTmuxSelection,
+              let hostSummary = snapshot.host(id: selection.hostID),
+              let host = TmuxHostResolver.resolve(hostSummary)
+        else { return }
+        tmuxActivityEnrollmentTasks.removeValue(
+            forKey: handle.id
+        )?.cancel()
+        let retryDelays: [Duration] = [.zero]
+            + createdSessionDiscoveryDelays
+        let settledRetryDelay = createdSessionDiscoveryDelays.last(where: {
+            $0 > .zero
+        }) ?? .seconds(4)
+        tmuxActivityEnrollmentTasks[handle.id] = Task { [weak self] in
+            var retryIndex = 0
+            while true {
+                let delay = retryIndex < retryDelays.count
+                    ? retryDelays[retryIndex]
+                    : settledRetryDelay
+                retryIndex += 1
+                do {
+                    try await Task.sleep(for: delay)
+                } catch {
+                    return
+                }
+                guard let self,
+                      !Task.isCancelled,
+                      activeBorrowedTmuxHandle == handle,
+                      borrowedTmuxConnectionStates[handle.id] == .connected,
+                      let currentSelection = activeBorrowedTmuxSelection,
+                      Self.sameTmuxEndpoint(currentSelection, selection),
+                      let currentHostSummary = snapshot.host(
+                          id: currentSelection.hostID
+                      ),
+                      TmuxHostResolver.resolve(currentHostSummary) == host
+                else { return }
+                let identity: TmuxSessionIdentity
+                do {
+                    identity = try await tmuxSessionIdentityReader(
+                        currentSelection,
+                        host
+                    )
+                } catch {
+                    continue
+                }
+                guard !Task.isCancelled,
+                      activeBorrowedTmuxHandle == handle,
+                      !nativeTmuxSessionCoordinator.hasClosedAttachment(
+                          handle
+                      ),
+                      borrowedTmuxConnectionStates[handle.id] == .connected,
+                      activeBorrowedTmuxSelection.map({
+                          Self.sameTmuxEndpoint($0, currentSelection)
+                      }) == true
+                else { return }
+                activityController.warm(
+                    currentSelection,
+                    identity: identity,
+                    on: host
+                )
+                tmuxActivityEnrollmentTasks.removeValue(
+                    forKey: handle.id
+                )
+                return
+            }
         }
     }
 

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -655,7 +655,9 @@ struct WorkspaceWindow: View {
                 activeTmuxSessionCanApplyTheme:
                 sceneModel.canApplyThemeToActiveTmuxSession,
                 tmuxConnectionRecoveryRequest:
-                sceneModel.tmuxConnectionRecoveryRequest
+                sceneModel.tmuxConnectionRecoveryRequest,
+                workingTmuxSessionIDs:
+                sceneModel.workingTmuxSessionIDs
             ),
             content: ContentBuilders(
                 tmuxSessionContentBuilder: {

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -472,6 +472,8 @@ public struct RootView: View {
             activeTmuxSession: activeTmuxSession,
             activeTmuxSessionIsConnected:
             display.activeTmuxSessionIsConnected,
+            workingTmuxSessionIDs:
+            display.workingTmuxSessionIDs,
             onOpenTmuxSession: { session in
                 activateTmuxSession(session)
             },

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -27,6 +27,7 @@ public struct WorkspaceDisplayState {
     public let activeTmuxSessionCanApplyTheme: Bool
     public let tmuxConnectionRecoveryRequest:
         TmuxConnectionRecoveryRequest?
+    public let workingTmuxSessionIDs: Set<String>
 
     public init(
         snapshot: WorkspaceSnapshot,
@@ -50,7 +51,8 @@ public struct WorkspaceDisplayState {
         activeTmuxSessionIsConnected: Bool = false,
         activeTmuxSessionCanApplyTheme: Bool = false,
         tmuxConnectionRecoveryRequest:
-        TmuxConnectionRecoveryRequest? = nil
+        TmuxConnectionRecoveryRequest? = nil,
+        workingTmuxSessionIDs: Set<String> = []
     ) {
         self.snapshot = snapshot
         self.workspaceResourceSummary = workspaceResourceSummary
@@ -80,6 +82,7 @@ public struct WorkspaceDisplayState {
             activeTmuxSessionCanApplyTheme
         self.tmuxConnectionRecoveryRequest =
             tmuxConnectionRecoveryRequest
+        self.workingTmuxSessionIDs = workingTmuxSessionIDs
     }
 }
 

--- a/Sources/UI/WorkspaceAccessibilityModel.swift
+++ b/Sources/UI/WorkspaceAccessibilityModel.swift
@@ -36,7 +36,8 @@ enum WorkspaceAccessibilityModel {
 
     static func descriptor(
         for row: WorkspaceSidebarRow,
-        isSelected: Bool
+        isSelected: Bool,
+        hasRecentTmuxOutput: Bool = false
     ) -> WorkspaceAccessibilityDescriptor {
         var values: [String] = []
         if let subtitle = row.subtitle, !subtitle.isEmpty {
@@ -44,6 +45,9 @@ enum WorkspaceAccessibilityModel {
         }
         if let status = row.worktreeStatus {
             values.append(contentsOf: worktreeStatusValues(status))
+        }
+        if hasRecentTmuxOutput {
+            values.append("Recent tmux output")
         }
         if isSelected {
             values.append("Selected")

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -118,6 +118,7 @@ struct WorkspaceSidebarView: View {
     let onOpen: (WorktreeSummary) -> Void
     let activeTmuxSession: WorkspaceTmuxSessionSelection?
     let activeTmuxSessionIsConnected: Bool
+    let workingTmuxSessionIDs: Set<String>
     let onOpenTmuxSession: (WorkspaceTmuxSessionSelection) -> Void
     let onNavigateAwayFromTmuxSession: () -> Void
     let onRequestKillTmuxSession: (WorkspaceTmuxSessionSelection) -> Void
@@ -157,6 +158,7 @@ struct WorkspaceSidebarView: View {
         tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
         activeTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeTmuxSessionIsConnected: Bool = false,
+        workingTmuxSessionIDs: Set<String> = [],
         onOpenTmuxSession: @escaping (
             WorkspaceTmuxSessionSelection
         ) -> Void = { _ in },
@@ -187,6 +189,7 @@ struct WorkspaceSidebarView: View {
         self.tmuxSessionVisibility = tmuxSessionVisibility
         self.activeTmuxSession = activeTmuxSession
         self.activeTmuxSessionIsConnected = activeTmuxSessionIsConnected
+        self.workingTmuxSessionIDs = workingTmuxSessionIDs
         self.onOpenTmuxSession = onOpenTmuxSession
         self.onNavigateAwayFromTmuxSession = onNavigateAwayFromTmuxSession
         self.onRequestKillTmuxSession = onRequestKillTmuxSession
@@ -631,6 +634,9 @@ struct WorkspaceSidebarView: View {
             } ?? false,
             isActionHovered: isActionHovered
         )
+        let isTmuxSessionWorking = tmuxSession.map {
+            workingTmuxSessionIDs.contains($0.id)
+        } ?? false
         let usesDirectKillAction: Bool
         if case .tmuxSession = row.target {
             usesDirectKillAction = true
@@ -685,6 +691,9 @@ struct WorkspaceSidebarView: View {
                         )
                     }
                     Spacer(minLength: 0)
+                    if isTmuxSessionWorking {
+                        tmuxSessionActivityIndicator
+                    }
                     if isSelected, differentiateWithoutColor {
                         Image(systemName: "checkmark")
                             .font(.system(size: 10, weight: .bold))
@@ -735,7 +744,8 @@ struct WorkspaceSidebarView: View {
             .workspaceAccessibility(
                 WorkspaceAccessibilityModel.descriptor(
                     for: row,
-                    isSelected: isSelected
+                    isSelected: isSelected,
+                    hasRecentTmuxOutput: isTmuxSessionWorking
                 )
             )
             .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -1604,6 +1614,17 @@ struct WorkspaceSidebarView: View {
                     .lineLimit(1)
             }
         }
+    }
+
+    private var tmuxSessionActivityIndicator: some View {
+        Image(
+            systemName: differentiateWithoutColor
+                ? "waveform" : "circle.fill"
+        )
+        .font(.system(size: 8, weight: .semibold))
+        .foregroundStyle(Color.accentColor)
+        .help("Recent tmux output")
+        .accessibilityLabel("Recent tmux output")
     }
 }
 

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -403,6 +403,8 @@ func makeModel(
     refreshExeHosts: @escaping () -> Void = {},
     terminalColorsPublisher:
     AnyPublisher<[UInt: TerminalResolvedColors], Never>? = nil,
+    tmuxSessionActivityController:
+    TmuxSessionActivityController? = nil,
     sceneSettings: WorkspaceSceneSettings = .live(),
     createdSessionDiscoveryDelays: [Duration] = [
         .milliseconds(500),
@@ -454,6 +456,7 @@ func makeModel(
         configuredExeHostsPublisher: configuredExeHostsPublisher,
         refreshExeHosts: refreshExeHosts,
         terminalColorsPublisher: terminalColorsPublisher,
+        tmuxSessionActivityController: tmuxSessionActivityController,
         sceneSettings: sceneSettings,
         localHostID: localHostID,
         overrideSnapshot: snapshot,

--- a/Tests/App/TmuxSessionActivityTests.swift
+++ b/Tests/App/TmuxSessionActivityTests.swift
@@ -1159,6 +1159,48 @@ struct TmuxSessionActivityControllerTests {
         await secondRound.value
     }
 
+    @Test("a slow quiet probe still reports fresh activity")
+    func slowProbeCountsChangesFromItsStart() async {
+        let sampleCount = LockedValue(0)
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                var current = 0
+                sampleCount.withLock { count in
+                    count += 1
+                    current = count
+                }
+                if current == 1 {
+                    return .sample(
+                        paneID: "%2",
+                        dimensions: "120x30",
+                        fingerprint: "baseline"
+                    )
+                }
+                try? await Task.sleep(for: .milliseconds(700))
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: "changed"
+                )
+            },
+            activityDuration: 0.5,
+            workingSampleInterval: 0,
+            quietSampleInterval: 0,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        controller.warm(selection, identity: activityIdentity, on: .local)
+        await controller.sampleWarmSessions()
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        await controller.sampleWarmSessions()
+
+        #expect(controller.workingSessionIDs == [selection.id])
+    }
+
     @Test("a blocked probe expires activity at completion")
     func blockedProbeUsesCompletionTime() async {
         let sampleCount = LockedValue(0)

--- a/Tests/App/TmuxSessionActivityTests.swift
+++ b/Tests/App/TmuxSessionActivityTests.swift
@@ -1,0 +1,1214 @@
+import Combine
+import Foundation
+import GhosthubTmux
+import GhosthubUI
+import Testing
+@testable import GhosthubApp
+
+private let activityIdentity = TmuxSessionIdentity(
+    serverPID: "1234",
+    sessionID: "$7",
+    createdAt: "1720000000"
+)
+
+@Suite("Tmux session activity probe")
+struct TmuxSessionActivityProbeTests {
+    @Test("samples only the exact selected session")
+    func exactSessionCommand() {
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "review session",
+            socketName: "private socket"
+        )
+
+        let command = TmuxSessionActivityProbe.command(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            selection: selection,
+            expectedIdentity: activityIdentity
+        )
+
+        #expect(command.contains("capture-pane"))
+        #expect(command.contains("-S -160"))
+        #expect(command.contains("'private socket'"))
+        #expect(command.contains("'=review session:'"))
+        #expect(command.contains("if-shell -F"))
+        #expect(command.contains("#{==:#{pid},1234}"))
+        #expect(command.contains("GHOSTHUB_TMUX_ACTIVITY_ENDED"))
+        #expect(!command.contains("list-sessions"))
+    }
+
+    @Test("Windows probes hash the bounded capture on the host")
+    func windowsCommand() {
+        let command = TmuxSessionActivityProbe.command(
+            tmuxPath: "C:\\Program Files\\tmux\\tmux.exe",
+            selection: WorkspaceTmuxSessionSelection(
+                hostID: UUID(),
+                name: "review"
+            ),
+            expectedIdentity: activityIdentity,
+            platform: .windows
+        )
+
+        #expect(command.contains("System.Security.Cryptography.SHA256"))
+        #expect(command.contains("ghosthubActivityCapture"))
+        #expect(command.contains("ghosthubActivityVersion"))
+        #expect(command.contains("3.3.4"))
+        #expect(command.contains("GHOSTHUB_TMUX_ACTIVITY_SUPPORTED"))
+        #expect(command.contains("ghosthubActivityFormatProbe"))
+        #expect(command.contains("ghosthubActivityIfShellProbe"))
+        #expect(command.contains("$ghosthubActivityPane"))
+        #expect(command.contains("GHOSTHUB_TMUX_ACTIVITY_MISMATCH"))
+        #expect(command.contains("GHOSTHUB_TMUX_ACTIVITY_ENDED"))
+        #expect(!command.contains("cksum"))
+    }
+
+    @Test("accepts a checksum only between matching identity reads")
+    func parsesIdentityFencedSample() {
+        let output = """
+        noisy shell startup
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t8f41a2\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .sample(
+                paneID: "%2",
+                dimensions: "120x30",
+                fingerprint: "8f41a2:412:161"
+            )
+        )
+    }
+
+    @Test("ends tracking when the exact session identity changes")
+    func rejectsReplacementSession() {
+        let output = """
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t9981\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$8\t1720000010\t%3\t120x30
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .ended
+        )
+    }
+
+    @Test("rejects a sample spanning an active pane switch")
+    func rejectsPaneSwitchDuringSample() {
+        let output = """
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t9981\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%3\t120x30
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .unavailable
+        )
+    }
+
+    @Test("rejects a sample spanning a pane resize")
+    func rejectsPaneResizeDuringSample() {
+        let output = """
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t9981\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t80x30
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .unavailable
+        )
+    }
+
+    @Test("rejects malformed pane dimensions")
+    func rejectsMalformedDimensions() {
+        let output = """
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t9981\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .unavailable
+        )
+    }
+
+    @Test("rejects checksum metadata outside the identity fence")
+    func rejectsUnfencedChecksum() {
+        let output = """
+        GHOSTHUB_TMUX_ACTIVITY_CHECKSUM\t9981\t412\t161
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        GHOSTHUB_TMUX_ACTIVITY_IDENTITY\t1234\t$7\t1720000000\t%2\t120x30
+        """
+
+        #expect(
+            TmuxSessionActivityProbe.parse(
+                output,
+                expectedIdentity: activityIdentity
+            ) == .unavailable
+        )
+    }
+
+    @Test("treats an unmarked status one as unavailable")
+    func genericStatusOneIsUnavailable() async {
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in (status: 1, stdout: "") }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(result == .unavailable)
+    }
+
+    @Test("ends tracking only for an explicit absence marker")
+    func explicitAbsenceEndsTracking() async {
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in
+                (
+                    status: 0,
+                    stdout: "GHOSTHUB_TMUX_ACTIVITY_ENDED\n"
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(result == .ended)
+    }
+
+    @Test(
+        "only confirmed absence diagnostics emit an ended probe",
+        arguments: [
+            (
+                "can't find session: build",
+                TmuxSessionActivityProbeResult.ended
+            ),
+            (
+                "no server running on /private/tmp/tmux-501/default",
+                TmuxSessionActivityProbeResult.ended
+            ),
+            (
+                "error connecting to /private/tmp/tmux-501/default "
+                    + "(No such file or directory)",
+                TmuxSessionActivityProbeResult.ended
+            ),
+            (
+                "failed to connect to server: No such file or directory",
+                TmuxSessionActivityProbeResult.ended
+            ),
+            (
+                "error connecting to socket (Permission denied)",
+                TmuxSessionActivityProbeResult.unavailable
+            ),
+            (
+                "error connecting to /private/tmp/tmux-501/default "
+                    + "(Socket operation on non-socket)",
+                TmuxSessionActivityProbeResult.unavailable
+            ),
+        ]
+    )
+    func confirmsAbsenceBeforeEnding(
+        diagnostic: String,
+        expected: TmuxSessionActivityProbeResult
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        try """
+        #!/bin/sh
+        printf '%s\\n' \(shellQuotedCommandArgument(diagnostic)) >&2
+        exit 1
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(result == expected)
+    }
+
+    @Test("a same-named replacement session is never captured")
+    func replacementSessionIsNotCaptured() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        let counter = directory.appendingPathComponent("capture-count")
+        try """
+        #!/bin/sh
+        case " $* " in
+            *" display-message "*"GHOSTHUB_TMUX_ACTIVITY_IDENTITY"*)
+                printf 'GHOSTHUB_TMUX_ACTIVITY_IDENTITY\\t9999\\t$8\\t1720000099\\t%%2\\t120x30\\n'
+                ;;
+            *" display-message "*)
+                printf '5\\n'
+                ;;
+            *" capture-pane "*)
+                printf '1\\n' > \(shellQuotedCommandArgument(counter.path))
+                printf 'replacement scrollback\\n'
+                ;;
+        esac
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(result == .ended)
+        #expect(!FileManager.default.fileExists(atPath: counter.path))
+    }
+
+    @Test("a replacement racing the verified identity read is not captured")
+    func replacementAfterIdentityReadIsNotCaptured() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        let leak = directory.appendingPathComponent("captured-leak")
+        try statefulFakeTmux(
+            directory: directory,
+            replacesAfterFirstIdentityRead: true,
+            capture: "printf 'replacement scrollback\\n'"
+        ).write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(result == .ended)
+        #expect(!FileManager.default.fileExists(atPath: leak.path))
+    }
+
+    @Test("live scrollback resembling probe markers stays a valid sample")
+    func markerLookalikeContentIsNotReplacement() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        try statefulFakeTmux(
+            directory: directory,
+            replacesAfterFirstIdentityRead: false,
+            capture: "printf 'GHOSTHUB_TMUX_ACTIVITY_MISMATCH is discussed here\\n'"
+        ).write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let result = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        guard case .sample = result else {
+            Issue.record("expected a valid sample, got \(result)")
+            return
+        }
+    }
+
+    @Test("a cancelled sample never contacts the host")
+    func cancelledSampleSkipsRunner() async {
+        let resolverEntered = LockedFlag()
+        let resolverGate = DispatchSemaphore(value: 0)
+        let runnerInvoked = LockedFlag()
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in
+                resolverEntered.set()
+                resolverGate.wait()
+                return .success("/usr/bin/tmux")
+            },
+            runner: { _, _ in
+                runnerInvoked.set()
+                return (status: 0, stdout: "")
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let sample = Task {
+            await probe.sample(
+                selection,
+                expectedIdentity: activityIdentity,
+                on: .local
+            )
+        }
+        while !resolverEntered.isSet {
+            await Task.yield()
+        }
+        sample.cancel()
+        resolverGate.signal()
+        let result = await sample.value
+
+        #expect(result == .unavailable)
+        #expect(!runnerInvoked.isSet)
+    }
+
+    @Test("visible pane redraws do not change activity samples")
+    func ignoresVisiblePaneRedraws() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        let counter = directory.appendingPathComponent("capture-count")
+        try """
+        #!/bin/sh
+        case " $* " in
+            *" display-message "*"GHOSTHUB_TMUX_ACTIVITY_IDENTITY"*)
+                printf 'GHOSTHUB_TMUX_ACTIVITY_IDENTITY\\t1234\\t$7\\t1720000000\\t%%2\\t120x30\\n'
+                ;;
+            *" display-message "*)
+                printf '0\\n'
+                ;;
+            *" capture-pane "*)
+                count=0
+                if [ -f \(shellQuotedCommandArgument(counter.path)) ]; then
+                    count=$(cat \(shellQuotedCommandArgument(counter.path)))
+                fi
+                count=$((count + 1))
+                printf '%s\\n' "$count" > \(shellQuotedCommandArgument(counter.path))
+                printf 'visible redraw %s\\n' "$count"
+                ;;
+        esac
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let first = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+        let second = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        let emptyCapture = TmuxSessionActivityProbeResult.sample(
+            paneID: "%2",
+            dimensions: "120x30",
+            fingerprint: "4294967295:0:0"
+        )
+        #expect(first == emptyCapture)
+        #expect(second == emptyCapture)
+        #expect(!FileManager.default.fileExists(atPath: counter.path))
+    }
+
+    @Test("trailing blank output changes the activity fingerprint")
+    func preservesTrailingBlankOutput() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        let counter = directory.appendingPathComponent("capture-count")
+        try """
+        #!/bin/sh
+        case " $* " in
+            *" display-message "*"GHOSTHUB_TMUX_ACTIVITY_IDENTITY"*)
+                printf 'GHOSTHUB_TMUX_ACTIVITY_IDENTITY\\t1234\\t$7\\t1720000000\\t%%2\\t120x30\\n'
+                ;;
+            *" if-shell "*)
+                count=0
+                if [ -f \(shellQuotedCommandArgument(counter.path)) ]; then
+                    count=$(cat \(shellQuotedCommandArgument(counter.path)))
+                fi
+                count=$((count + 1))
+                printf '%s\\n' "$count" > \(shellQuotedCommandArgument(counter.path))
+                if [ "$count" -eq 1 ]; then
+                    printf 'same\\n'
+                else
+                    printf 'same\\n\\n'
+                fi
+                ;;
+            *" display-message "*)
+                printf '1\\n'
+                ;;
+        esac
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let first = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+        let second = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(first != second)
+    }
+
+    @Test("repeated output advances the activity fingerprint")
+    func tracksRepeatedOutputProgress() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        let counter = directory.appendingPathComponent("history-count")
+        try """
+        #!/bin/sh
+        case " $* " in
+            *" display-message "*"GHOSTHUB_TMUX_ACTIVITY_IDENTITY"*)
+                printf 'GHOSTHUB_TMUX_ACTIVITY_IDENTITY\\t1234\\t$7\\t1720000000\\t%%2\\t120x30\\n'
+                ;;
+            *" display-message "*)
+                count=160
+                if [ -f \(shellQuotedCommandArgument(counter.path)) ]; then
+                    count=$(cat \(shellQuotedCommandArgument(counter.path)))
+                fi
+                count=$((count + 1))
+                printf '%s\\n' "$count" > \(shellQuotedCommandArgument(counter.path))
+                printf '%s\\n' "$count"
+                ;;
+            *" if-shell "*)
+                printf 'repeat\\nrepeat\\n'
+                ;;
+        esac
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let probe = TmuxSessionActivityProbe(
+            pathResolver: { _ in .success(tmux.path) },
+            runner: { _, command in
+                TmuxBinaryResolver.runLoginShell(
+                    shell: "/bin/sh",
+                    command: command,
+                    timeout: 2
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+
+        let first = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+        let second = await probe.sample(
+            selection,
+            expectedIdentity: activityIdentity,
+            on: .local
+        )
+
+        #expect(first != second)
+    }
+}
+
+/// A fake tmux that tracks the current session identity in a state file,
+/// answers identity reads from it, and evaluates the probe's embedded
+/// identity predicates against it, so replacement races exercise the same
+/// compare-and-act contract as a real server. A bare capture-pane call,
+/// which bypasses that predicate, records a leak file.
+private func statefulFakeTmux(
+    directory: URL,
+    replacesAfterFirstIdentityRead: Bool,
+    capture: String
+) -> String {
+    let state = shellQuotedCommandArgument(
+        directory.appendingPathComponent("identity-state").path
+    )
+    let flipped = shellQuotedCommandArgument(
+        directory.appendingPathComponent("identity-flipped").path
+    )
+    let leak = shellQuotedCommandArgument(
+        directory.appendingPathComponent("captured-leak").path
+    )
+    return """
+    #!/bin/sh
+    ghosthub_args=" $* "
+    if [ ! -f \(state) ]; then
+        printf '1234 $7 1720000000' > \(state)
+    fi
+    ghosthub_state=$(cat \(state))
+    set -- $ghosthub_state
+    ghosthub_pid=$1
+    ghosthub_sid=$2
+    ghosthub_created=$3
+    ghosthub_match=0
+    case "$ghosthub_args" in
+        *"#{==:#{pid},$ghosthub_pid}"*)
+            case "$ghosthub_args" in
+                *"#{==:#{session_id},$ghosthub_sid}"*)
+                    case "$ghosthub_args" in
+                        *"#{==:#{session_created},$ghosthub_created}"*)
+                            ghosthub_match=1
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+    esac
+    case "$ghosthub_args" in
+        *"GHOSTHUB_TMUX_ACTIVITY_IDENTITY"*)
+            printf 'GHOSTHUB_TMUX_ACTIVITY_IDENTITY\\t%s\\t%s\\t%s\\t%%2\\t120x30\\n' \\
+                "$ghosthub_pid" "$ghosthub_sid" "$ghosthub_created"
+            if \(replacesAfterFirstIdentityRead ? "true" : "false") \\
+                && [ ! -f \(flipped) ]; then
+                touch \(flipped)
+                printf '9999 $8 1720000099' > \(state)
+            fi
+            ;;
+        *" if-shell "*)
+            if [ "$ghosthub_match" -eq 1 ]; then
+                \(capture)
+            else
+                printf 'GHOSTHUB_TMUX_ACTIVITY_MISMATCH\\n'
+            fi
+            ;;
+        *"#{?"*)
+            if [ "$ghosthub_match" -eq 1 ]; then
+                printf '5\\n'
+            else
+                printf 'GHOSTHUB_TMUX_ACTIVITY_MISMATCH\\n'
+            fi
+            ;;
+        *" capture-pane "*)
+            printf '1\\n' > \(leak)
+            printf 'directly captured scrollback\\n'
+            ;;
+    esac
+    """
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    func set() {
+        lock.lock()
+        defer { lock.unlock() }
+        value = true
+    }
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+private actor ActivitySampleQueue {
+    private var samples: [TmuxSessionActivityProbeResult]
+
+    init(_ samples: [TmuxSessionActivityProbeResult]) {
+        self.samples = samples
+    }
+
+    func next() -> TmuxSessionActivityProbeResult {
+        samples.removeFirst()
+    }
+}
+
+@Suite("Warm tmux session activity")
+@MainActor
+struct TmuxSessionActivityControllerTests {
+    @Test("a baseline is quiet and later output becomes temporarily active")
+    func outputTransitionLifecycle() async {
+        let queue = ActivitySampleQueue([
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "baseline"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed"),
+        ])
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in await queue.next() },
+            activityDuration: 30,
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+        await controller.sampleWarmSessions(at: start)
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(controller.workingSessionIDs == [selection.id])
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(50)
+        )
+        #expect(controller.workingSessionIDs.isEmpty)
+    }
+
+    @Test("switching active panes establishes a quiet baseline")
+    func paneSwitchIsQuiet() async {
+        let queue = ActivitySampleQueue([
+            .sample(paneID: "%1", dimensions: "120x30", fingerprint: "baseline:100"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "baseline:200"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed:220"),
+        ])
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in await queue.next() },
+            activityDuration: 30,
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+
+        await controller.sampleWarmSessions(at: start)
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(40)
+        )
+        #expect(controller.workingSessionIDs == [selection.id])
+    }
+
+    @Test("a pane resize establishes a quiet baseline")
+    func paneResizeIsQuiet() async {
+        let queue = ActivitySampleQueue([
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "wide"),
+            .sample(paneID: "%2", dimensions: "80x30", fingerprint: "narrow"),
+            .sample(paneID: "%2", dimensions: "80x30", fingerprint: "output"),
+        ])
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in await queue.next() },
+            activityDuration: 30,
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+
+        await controller.sampleWarmSessions(at: start)
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(40)
+        )
+        #expect(controller.workingSessionIDs == [selection.id])
+    }
+
+    @Test("recovery after a sampling outage establishes a quiet baseline")
+    func outageRecoveryIsQuiet() async {
+        let queue = ActivitySampleQueue([
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "baseline"),
+            .unavailable,
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "outage"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "fresh"),
+        ])
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in await queue.next() },
+            activityDuration: 30,
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            failureSampleInterval: 30,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+
+        await controller.sampleWarmSessions(at: start)
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(50)
+        )
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(70)
+        )
+        #expect(controller.workingSessionIDs == [selection.id])
+    }
+
+    @Test("reconciling endpoints retires changed and removed hosts only")
+    func reconcileRetiresStaleEndpoints() async {
+        let sampled = LockedValue<[String]>([])
+        let fingerprints = LockedValue(0)
+        let controller = TmuxSessionActivityController(
+            sampler: { selection, _, _ in
+                sampled.withLock { $0.append(selection.name) }
+                var fingerprint = 0
+                fingerprints.withLock { count in
+                    count += 1
+                    fingerprint = count
+                }
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: "output-\(fingerprint)"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let keptHostID = UUID()
+        let movedHostID = UUID()
+        let removedHostID = UUID()
+        let oldEndpoint = TmuxHost.ssh(SSHHostInfo(
+            user: "wes",
+            hostname: "old-box",
+            port: nil,
+            platform: .posix
+        ))
+        let newEndpoint = TmuxHost.ssh(SSHHostInfo(
+            user: "wes",
+            hostname: "new-box",
+            port: nil,
+            platform: .posix
+        ))
+        let kept = WorkspaceTmuxSessionSelection(
+            hostID: keptHostID,
+            name: "kept"
+        )
+        let moved = WorkspaceTmuxSessionSelection(
+            hostID: movedHostID,
+            name: "moved"
+        )
+        let removed = WorkspaceTmuxSessionSelection(
+            hostID: removedHostID,
+            name: "removed"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(kept, identity: activityIdentity, on: .local, at: start)
+        controller.warm(
+            moved,
+            identity: activityIdentity,
+            on: oldEndpoint,
+            at: start
+        )
+        controller.warm(
+            removed,
+            identity: activityIdentity,
+            on: oldEndpoint,
+            at: start
+        )
+        await controller.sampleWarmSessions(at: start)
+        #expect(controller.workingSessionIDs.isEmpty)
+
+        controller.reconcile(endpointsByHostID: [
+            keptHostID: .local,
+            movedHostID: newEndpoint,
+        ])
+        sampled.withLock { $0.removeAll() }
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+
+        #expect(sampled.load() == ["kept"])
+        #expect(controller.workingSessionIDs == [kept.id])
+    }
+
+    @Test("polling publishes only changed working membership")
+    func pollingPublishesOnlyChangedMembership() async {
+        let queue = ActivitySampleQueue([
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "baseline"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed"),
+            .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed"),
+        ])
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in await queue.next() },
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "quiet"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+        await controller.sampleWarmSessions(at: start)
+        var updateCount = 0
+        let updates = controller.objectWillChange.sink {
+            updateCount += 1
+        }
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(1)
+        )
+        #expect(updateCount == 0)
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(controller.workingSessionIDs == [selection.id])
+        updateCount = 0
+
+        await controller.sampleWarmSessions(
+            at: start.addingTimeInterval(25)
+        )
+        #expect(updateCount == 0)
+        withExtendedLifetime(updates) {}
+    }
+
+    @Test("a blocked probe does not delay another session result")
+    func probesDueSessionsConcurrently() async {
+        let hostID = UUID()
+        let slow = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "slow"
+        )
+        let fast = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "fast"
+        )
+        let sampleCounts = LockedValue<[String: Int]>([:])
+        let secondStarts = LockedValue<Set<String>>([])
+        let bothStarted = AsyncStream<Void>.makeStream()
+        let releaseSlow = AsyncStream<Void>.makeStream()
+        let controller = TmuxSessionActivityController(
+            sampler: { selection, _, _ in
+                var sampleCount = 0
+                sampleCounts.withLock { counts in
+                    counts[selection.id, default: 0] += 1
+                    sampleCount = counts[selection.id] ?? 0
+                }
+                guard sampleCount > 1 else {
+                    return .sample(
+                        paneID: "%2",
+                        dimensions: "120x30",
+                        fingerprint: "baseline"
+                    )
+                }
+                secondStarts.withLock { starts in
+                    _ = starts.insert(selection.id)
+                }
+                if secondStarts.load().count == 2 {
+                    bothStarted.continuation.yield()
+                }
+                if selection.id == slow.id {
+                    for await _ in releaseSlow.stream {
+                        break
+                    }
+                    return .unavailable
+                }
+                for await _ in bothStarted.stream {
+                    break
+                }
+                return .sample(paneID: "%2", dimensions: "120x30", fingerprint: "changed")
+            },
+            automaticallyPolls: false
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        controller.warm(
+            slow,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+        controller.warm(
+            fast,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+        await controller.sampleWarmSessions(at: start)
+
+        let secondRound = Task { @MainActor in
+            await controller.sampleWarmSessions(
+                at: start.addingTimeInterval(20)
+            )
+        }
+        await waitUntilMainActor(timeout: .milliseconds(250)) {
+            controller.workingSessionIDs.contains(fast.id)
+        }
+        #expect(controller.workingSessionIDs.contains(fast.id))
+
+        let thirdTickFinished = LockedValue(false)
+        let thirdTick = Task { @MainActor in
+            await controller.sampleWarmSessions(
+                at: start.addingTimeInterval(25)
+            )
+            thirdTickFinished.store(true)
+        }
+        await waitUntilMainActor(timeout: .milliseconds(250)) {
+            thirdTickFinished.load()
+        }
+        #expect(thirdTickFinished.load())
+        #expect(sampleCounts.load()[fast.id] == 3)
+
+        bothStarted.continuation.yield()
+        releaseSlow.continuation.yield()
+        releaseSlow.continuation.yield()
+        await thirdTick.value
+        await secondRound.value
+    }
+
+    @Test("a blocked probe expires activity at completion")
+    func blockedProbeUsesCompletionTime() async {
+        let sampleCount = LockedValue(0)
+        let controller = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                var current = 0
+                sampleCount.withLock { count in
+                    count += 1
+                    current = count
+                }
+                switch current {
+                case 1:
+                    return .sample(
+                        paneID: "%2",
+                        dimensions: "120x30",
+                        fingerprint: "baseline"
+                    )
+                case 2:
+                    return .sample(
+                        paneID: "%2",
+                        dimensions: "120x30",
+                        fingerprint: "changed"
+                    )
+                default:
+                    try? await Task.sleep(for: .milliseconds(300))
+                    return .unavailable
+                }
+            },
+            activityDuration: 0.15,
+            workingSampleInterval: 0,
+            quietSampleInterval: 0,
+            automaticallyPolls: false
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "build"
+        )
+        let start = Date.now
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
+        await controller.sampleWarmSessions(at: start)
+        await controller.sampleWarmSessions(at: start)
+        #expect(controller.workingSessionIDs == [selection.id])
+
+        await controller.sampleWarmSessions()
+
+        #expect(controller.workingSessionIDs.isEmpty)
+    }
+}

--- a/Tests/App/TmuxSessionActivityTests.swift
+++ b/Tests/App/TmuxSessionActivityTests.swift
@@ -1161,6 +1161,8 @@ struct TmuxSessionActivityControllerTests {
 
     @Test("a slow quiet probe still reports fresh activity")
     func slowProbeCountsChangesFromItsStart() async {
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        let clock = LockedValue(start)
         let sampleCount = LockedValue(0)
         let controller = TmuxSessionActivityController(
             sampler: { _, _, _ in
@@ -1176,26 +1178,33 @@ struct TmuxSessionActivityControllerTests {
                         fingerprint: "baseline"
                     )
                 }
-                try? await Task.sleep(for: .milliseconds(700))
+                clock.withLock { $0 = $0.addingTimeInterval(40) }
                 return .sample(
                     paneID: "%2",
                     dimensions: "120x30",
                     fingerprint: "changed"
                 )
             },
-            activityDuration: 0.5,
-            workingSampleInterval: 0,
-            quietSampleInterval: 0,
+            activityDuration: 30,
+            workingSampleInterval: 5,
+            quietSampleInterval: 20,
+            now: { clock.load() },
             automaticallyPolls: false
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: UUID(),
             name: "build"
         )
-        controller.warm(selection, identity: activityIdentity, on: .local)
+        controller.warm(
+            selection,
+            identity: activityIdentity,
+            on: .local,
+            at: start
+        )
         await controller.sampleWarmSessions()
         #expect(controller.workingSessionIDs.isEmpty)
 
+        clock.store(start.addingTimeInterval(25))
         await controller.sampleWarmSessions()
 
         #expect(controller.workingSessionIDs == [selection.id])

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1475,6 +1475,290 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("connected attachment keeps retrying activity enrollment")
+    func connectedAttachmentKeepsRetryingActivityEnrollment() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let activitySamples = Counter()
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                let sample = activitySamples.increment()
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: sample == 1 ? "baseline" : "changed"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { selection, host in
+                guard identityReads.increment() > 2 else {
+                    throw TmuxSessionKillError.sessionNotRunning(
+                        host: host.displayName,
+                        session: selection.name
+                    )
+                }
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            },
+            tmuxSessionActivityController: activityController,
+            createdSessionDiscoveryDelays: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            socketName: "protected"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        await waitUntilMainActor(timeout: .milliseconds(250)) {
+            identityReads.count == 3
+        }
+        let start = Date.now
+        await activityController.sampleWarmSessions(at: start)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+
+        #expect(model.workingTmuxSessionIDs == [selection.id])
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("connected attachment validates stale discovered activity identity")
+    func connectedAttachmentValidatesStaleActivityIdentity() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: selection.name,
+                managed: false,
+                windows: [],
+                serverPID: "1111",
+                sessionID: "$1",
+                createdAt: "1721552300"
+            ),
+        ]
+        let liveIdentity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$42",
+            createdAt: "1721552400"
+        )
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let sampledIdentities = LockedValue<[TmuxSessionIdentity]>([])
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, identity, _ in
+                sampledIdentities.withLock { $0.append(identity) }
+                return identity == liveIdentity
+                    ? .sample(
+                        paneID: "%2",
+                        dimensions: "120x30",
+                        fingerprint: "baseline"
+                    )
+                    : .ended
+            },
+            automaticallyPolls: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { _, _ in
+                _ = identityReads.increment()
+                return liveIdentity
+            },
+            tmuxSessionActivityController: activityController,
+            createdSessionDiscoveryDelays: [.milliseconds(1)]
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        await waitUntilMainActor(timeout: .milliseconds(250)) {
+            identityReads.count == 1
+        }
+        await activityController.sampleWarmSessions()
+
+        #expect(identityReads.count == 1)
+        #expect(sampledIdentities.load() == [liveIdentity])
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("closing one attachment preserves shared warm activity")
+    func closingOneAttachmentPreservesSharedWarmActivity() async throws {
+        let environment = try setupStandardEnvironment()
+        let firstSurfaceStore = SceneTmuxSurfaceStoreStub()
+        let secondSurfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let activitySamples = Counter()
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                let sample = activitySamples.increment()
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: sample == 1 ? "baseline" : "changed"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let firstModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: firstSurfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { _, _ in
+                _ = identityReads.increment()
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            },
+            tmuxSessionActivityController: activityController
+        )
+        let secondModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: secondSurfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { _, _ in
+                _ = identityReads.increment()
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            },
+            tmuxSessionActivityController: activityController
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        firstModel.openBorrowedTmuxSession(selection)
+        secondModel.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(
+            firstModel,
+            store: firstSurfaceStore
+        )
+        await launchActiveTmuxSurface(
+            secondModel,
+            store: secondSurfaceStore
+        )
+        await waitUntilMainActor { identityReads.count == 2 }
+        let start = Date.now
+        await activityController.sampleWarmSessions(at: start)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(firstModel.workingTmuxSessionIDs == [selection.id])
+        #expect(secondModel.workingTmuxSessionIDs == [selection.id])
+
+        let close = try #require(
+            firstSurfaceStore.surface.closeObservers.values.first
+        )
+        close(false, 1)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(25)
+        )
+
+        #expect(firstModel.workingTmuxSessionIDs == [selection.id])
+        #expect(secondModel.workingTmuxSessionIDs == [selection.id])
+        #expect(activitySamples.count == 3)
+        await firstModel.shutdown()
+        await secondModel.shutdown()
+    }
+
+    @MainActor
+    @Test("reopening an attachment preserves its warm activity baseline")
+    func reopeningAttachmentPreservesWarmActivityBaseline() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let activitySamples = Counter()
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                let sample = activitySamples.increment()
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: sample == 1 ? "baseline" : "changed"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { _, _ in
+                _ = identityReads.increment()
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            },
+            tmuxSessionActivityController: activityController
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { identityReads.count == 1 }
+        let start = Date.now
+        await activityController.sampleWarmSessions(at: start)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(model.workingTmuxSessionIDs == [selection.id])
+
+        let close = try #require(
+            surfaceStore.surface.closeObservers.values.first
+        )
+        close(false, 1)
+        model.closeBorrowedTmuxSession(selection)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        await waitUntilMainActor { identityReads.count == 2 }
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(25)
+        )
+
+        #expect(model.workingTmuxSessionIDs == [selection.id])
+        #expect(activitySamples.count == 3)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("protected kill availability survives a generation change")
     func protectedKillSurvivesGenerationChange() async throws {
         let environment = try setupStandardEnvironment()
@@ -2461,6 +2745,158 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(surfaceStore.removedKeys.count == 1)
         await model.shutdown()
+    }
+
+    @MainActor
+    @Test("endpoint changes retire warm activity on the former host")
+    func endpointChangeRetiresWarmActivity() async throws {
+        let environment = try setupStandardEnvironment()
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@old.example.com"
+            ),
+        ])
+        let activitySamples = Counter()
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                let sample = activitySamples.increment()
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: sample == 1 ? "baseline" : "changed"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            configuredSSHHostsProvider: { configuredHosts.value },
+            tmuxSessionActivityController: activityController
+        )
+        model.refreshHosts()
+        let remoteHost = try #require(
+            model.snapshot.hosts.first { $0.configKey == "laptop" }
+        )
+        let oldEndpoint = try #require(TmuxHostResolver.resolve(remoteHost))
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: remoteHost.id,
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        activityController.warm(
+            selection,
+            identity: TmuxSessionIdentity(
+                serverPID: "31415",
+                sessionID: "$42",
+                createdAt: "1721552400"
+            ),
+            on: oldEndpoint,
+            at: start
+        )
+        await activityController.sampleWarmSessions(at: start)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
+        #expect(model.workingTmuxSessionIDs == [selection.id])
+
+        configuredHosts.value = [
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@new.example.com"
+            ),
+        ]
+        model.refreshHosts()
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(40)
+        )
+
+        #expect(model.workingTmuxSessionIDs.isEmpty)
+        #expect(activitySamples.count == 2)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a new scene retires warm activity for reconfigured endpoints")
+    func newSceneRetiresWarmActivityForReconfiguredEndpoints() async throws {
+        let environment = try setupStandardEnvironment()
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@old.example.com"
+            ),
+        ])
+        let activitySamples = Counter()
+        let activityController = TmuxSessionActivityController(
+            sampler: { _, _, _ in
+                _ = activitySamples.increment()
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: "baseline"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let firstScene = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            configuredSSHHostsProvider: { configuredHosts.value },
+            tmuxSessionActivityController: activityController
+        )
+        firstScene.refreshHosts()
+        let remoteHost = try #require(
+            firstScene.snapshot.hosts.first { $0.configKey == "laptop" }
+        )
+        let oldEndpoint = try #require(TmuxHostResolver.resolve(remoteHost))
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: remoteHost.id,
+            name: "build"
+        )
+        let start = Date(timeIntervalSince1970: 1_720_000_000)
+        activityController.warm(
+            selection,
+            identity: TmuxSessionIdentity(
+                serverPID: "31415",
+                sessionID: "$42",
+                createdAt: "1721552400"
+            ),
+            on: oldEndpoint,
+            at: start
+        )
+        await activityController.sampleWarmSessions(at: start)
+        #expect(activitySamples.count == 1)
+        await firstScene.shutdown()
+
+        configuredHosts.value = [
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@new.example.com"
+            ),
+        ]
+        let secondScene = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            tmuxSessionActivityController: activityController,
+            startServices: true
+        )
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(40)
+        )
+
+        #expect(activitySamples.count == 1)
+        await secondScene.shutdown()
     }
 
     @MainActor

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1536,6 +1536,85 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("an occluded connected attachment still enrolls warm activity")
+    func occludedConnectedAttachmentEnrollsWarmActivity() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let identityAvailable = LockedValue(false)
+        let sampleCounts = LockedValue<[String: Int]>([:])
+        let activityController = TmuxSessionActivityController(
+            sampler: { selection, _, _ in
+                var count = 0
+                sampleCounts.withLock { counts in
+                    count = (counts[selection.name] ?? 0) + 1
+                    counts[selection.name] = count
+                }
+                return .sample(
+                    paneID: "%2",
+                    dimensions: "120x30",
+                    fingerprint: "\(selection.name)-\(count)"
+                )
+            },
+            automaticallyPolls: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            tmuxSessionIdentityReader: { selection, host in
+                _ = identityReads.increment()
+                guard identityAvailable.load() else {
+                    throw TmuxSessionKillError.sessionNotRunning(
+                        host: host.displayName,
+                        session: selection.name
+                    )
+                }
+                return TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1721552400"
+                )
+            },
+            tmuxSessionActivityController: activityController,
+            createdSessionDiscoveryDelays: [.milliseconds(1)]
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            socketName: "protected"
+        )
+        model.openBorrowedTmuxSession(first)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { identityReads.count >= 1 }
+
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        identityAvailable.store(true)
+
+        let start = Date.now
+        for tick in 1 ... 400
+            where !model.workingTmuxSessionIDs.contains(first.id) {
+            await activityController.sampleWarmSessions(
+                at: start.addingTimeInterval(Double(tick))
+            )
+            try await Task.sleep(for: .milliseconds(2))
+        }
+
+        #expect(model.workingTmuxSessionIDs.contains(first.id))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("connected attachment validates stale discovered activity identity")
     func connectedAttachmentValidatesStaleActivityIdentity() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -65,15 +65,19 @@ struct WorkspaceTmuxDiscoveryTests {
         )
 
         await kwtGate.waitUntilStarted()
-        await waitUntilMainActor { tmuxGate.didStart }
+        await waitUntilMainActor(timeout: .seconds(15)) {
+            tmuxGate.didStart
+        }
         #expect(!model.isWorkspaceInventoryRefreshComplete)
 
         await kwtGate.release()
-        await waitUntilMainActor { kwtCompletions.count == 1 }
+        await waitUntilMainActor(timeout: .seconds(15)) {
+            kwtCompletions.count == 1
+        }
         #expect(!model.isWorkspaceInventoryRefreshComplete)
 
         tmuxGate.release()
-        await waitUntilMainActor {
+        await waitUntilMainActor(timeout: .seconds(15)) {
             model.isWorkspaceInventoryRefreshComplete
         }
         #expect(model.isWorkspaceInventoryRefreshComplete)

--- a/Tests/UI/WorkspaceAccessibilityModelTests.swift
+++ b/Tests/UI/WorkspaceAccessibilityModelTests.swift
@@ -44,10 +44,11 @@ struct WorkspaceAccessibilityModelTests {
         expectAccessibilityDescriptor(
             WorkspaceAccessibilityModel.descriptor(
                 for: row,
-                isSelected: true
+                isSelected: true,
+                hasRecentTmuxOutput: true
             ),
             label: "docbank",
-            value: "2 windows, Selected",
+            value: "2 windows, Recent tmux output, Selected",
             hint: "Attach to this tmux session."
         )
     }

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -21,6 +21,7 @@ DEMO = ROOT / "website" / "demo"
 WEBSITE_ASSET_NAMES = (
     "hero.png",
     "guide-sessions.png",
+    "guide-session-activity.png",
     "guide-hosts.png",
     "guide-exe-dev.png",
     "guide-worktree.png",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,21 @@ entries.
 General tmux sessions are presented as one ordinary native tmux client; tmux
 alone owns and renders their layout.
 
+After an attachment reaches the connected state, Ghosthub keeps that exact
+session warm for the remainder of the app launch. One app-scoped, in-memory
+activity controller serves every workspace window. It samples only warm
+endpoints, never the complete discovered fleet, and binds each target to its
+tmux server PID, session ID, and creation time. A bounded tail of the active
+pane's scrollback, excluding its visible screen, is checksummed on the host
+without discarding trailing blank output. Only the checksum, byte count,
+scrollback line count, pane identity, and session identity return to the app.
+The first sample for each active pane, and the first after a pane resize,
+establishes a quiet baseline. A later scrollback change on that pane at
+unchanged dimensions publishes a short-lived passive activity state to both
+worktree and standalone session rows. Warm state is not
+persisted, and a missing or same-named replacement session stops sampling that
+identity.
+
 ## Window Model
 
 Each Ghosthub workspace is an independent SwiftUI scene with its own scene
@@ -350,6 +365,9 @@ through encoded, noninteractive PowerShell commands, then creates and attaches
 to sessions using the same exact-target and attach-only reconnect model as
 POSIX tmux hosts. Windows 11 build 22523 or newer is the initial interactive
 target because its ConPTY path supports ordinary OpenSSH TTY allocation.
+Passive activity sampling additionally requires psmux 3.3.4 or newer; earlier
+versions remain attachable but cannot provide the scrollback-only capture
+contract.
 
 When Ghosthub creates a native Windows session, it passes the SSH account
 process's `PATH` through psmux's session-environment argument so the initial

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -356,6 +356,47 @@ sidebar and command palette. Settings → Worktrees edits the same list, one
 pattern per line. Filtering occurs after discovery and never suppresses a kwt
 worktree, its running state, duplicate-name checks, or session identity.
 
+Tmux activity indicators do not extend inventory polling. Once an ordinary
+client has connected during the current app launch, Ghosthub samples only that
+exact session as a warm target. Active warm sessions are sampled every five
+seconds, quiet targets every twenty seconds, and unavailable targets back off
+to thirty seconds. Each probe captures at most the active pane's latest 160
+scrollback lines, excluding its visible screen, and computes a checksum on the
+local or remote host without discarding trailing blank output, so terminal
+text is not returned to Ghosthub. The fingerprint also carries the pane's
+scrollback line count so blank or repeated output records progression until
+the pane's history limit is reached. Once history is full, output that leaves
+the bounded tail byte-identical reads as quiet: tmux exposes no cumulative
+output counter, and its activity timestamps also advance on redraws, so this
+keeps the deliberate bias toward quiet false negatives over misleading
+attention signals.
+The probe verifies the expected server PID, session ID, and creation time on
+the host before any capture runs, targets the scrollback and capture reads at
+the exact pane ID from that verified read, and re-evaluates the identity
+predicate inside the same tmux server dispatch as each read, so a same-named
+replacement session is never read even when it races the probe. Identity,
+pane, and pane-dimension reads before and after the capture must also match.
+Native Windows sampling verifies at runtime that psmux supports the format
+predicate and if-shell contract, then uses the same atomic reads; when the
+capability probe fails, the sample is refused rather than taken without the
+predicate. The first sample after a pane switch or a pane resize establishes a
+quiet baseline; later scrollback progression on that pane at unchanged
+dimensions marks the session active for thirty seconds. In-place prompt,
+spinner, and status redraws do not count as activity, and neither do client
+resizes, which reflow scrollback without representing new work.
+Windows activity sampling requires psmux 3.3.4 or newer because earlier
+versions do not expose negative scrollback ranges. Older supported psmux
+versions remain available for discovery and attachment but publish no passive
+activity state.
+Closing a presentation does not remove warm state, while app termination,
+session disappearance, or identity replacement does. Every host refresh and
+every new scene reconciles warm entries against the currently configured
+endpoints, so a reconfigured or removed host stops being sampled even when the
+change happened while no window observed it. Retiring a warm entry cancels its
+in-flight probe; a probe cancelled after its host command launched drains
+within the probe's ten-second timeout and its result is discarded. This state
+is not saved to the database.
+
 Pull-request imports are the one alternate-socket case. Kwt returns the named
 socket reserved for the workspace-specific server, and Ghosthub carries that
 identity with the worktree selection. Import does not start tmux or execute a

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -379,9 +379,12 @@ pane, and pane-dimension reads before and after the capture must also match.
 Native Windows sampling verifies at runtime that psmux supports the format
 predicate and if-shell contract, then uses the same atomic reads; when the
 capability probe fails, the sample is refused rather than taken without the
-predicate. The first sample after a pane switch or a pane resize establishes a
-quiet baseline; later scrollback progression on that pane at unchanged
-dimensions marks the session active for thirty seconds. In-place prompt,
+predicate. The first sample after a pane switch, a pane resize, or a sampling gap
+longer than the activity window establishes a quiet baseline; later
+scrollback progression on that pane at unchanged dimensions marks the session
+active for thirty seconds. Sample continuity is measured from each probe's
+start, so a slow probe on a laggy host cannot stretch the gap past the window
+and demote real changes to baselines. In-place prompt,
 spinner, and status redraws do not count as activity, and neither do client
 resizes, which reflow scrollback without representing new work.
 Windows activity sampling requires psmux 3.3.4 or newer because earlier

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -288,6 +288,17 @@ retained inventory cannot authorize killing a same-named replacement,
 including one created during the same timestamp second or after a rapid tmux
 server restart. An active client is detached only after the kill succeeds.
 
+Passive activity sampling receives no authority to mutate a warm session. Its
+bounded `capture-pane` reads only recent scrollback, excluding the visible
+screen, from an endpoint connected during the current app launch. Identity
+reads on both sides of the capture must match the enrolled server PID, session
+ID, creation time, and active pane; a session mismatch retires the target and
+a pane mismatch discards the sample. The host computes the capture checksum
+over the exact captured text, including trailing blank output, and adds only
+its byte count and scrollback line count. That fixed-size fingerprint and the
+identity metadata are all that cross SSH or enter application state. Ghosthub
+does not log or persist captured terminal text or warm-session state.
+
 Ghosthub applies the selected Tmux Theme when it creates a new bare session.
 Attachment to an existing session does not add a client-local palette or modify
 tmux visual styles by default. The explicit shared-session override may reset

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -338,4 +338,21 @@ prepare_command_tab "release-watch"
 prepare_command_tab "test-matrix"
 capture_state guide-native-tabs.png
 
+echo "==> guide: passive session activity indicator"
+# Every session above is warm from its earlier attachment. Drive fresh
+# scrollback into the unselected scratch session on the demo socket only,
+# then wait out one quiet-interval resample (20s) so its sidebar row shows
+# the accent activity indicator while add-session-filters stays selected.
+demo_input new-window
+sleep 2
+demo_input frame
+sleep 1
+palette "add-session-filters"
+sleep 3
+demo_tmux_socket="$scratch/tmux/tmux-$(id -u)/default"
+tmux -S "$demo_tmux_socket" send-keys -t '=scratch:' \
+  'clear; for f in vault index threads search; do printf "compacting %s… done\n" "$f"; done; seq 1 40 | sed "s/^/segment /"' Enter
+sleep 24
+capture_state guide-session-activity.png
+
 echo "captured website asset set -> $out_dir"

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -129,3 +129,7 @@ for development machines and power users and is never run automatically.
 Automatic provisioning will remain disabled until the kwt executables are
 Authenticode-signed. Adding a new project from Ghosthub is not yet supported on
 Windows, although already registered project inventory can be shown.
+
+[Session activity indicators](sessions.md#activity-indicators) require psmux
+3.3.4 or newer; older supported versions remain attachable but publish no
+passive activity state.

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -33,6 +33,25 @@ tab or window detaches every presentation it owns, and quitting Ghosthub
 detaches them all. None of these actions ends a tmux session; tmux keeps the
 session and its processes alive.
 
+## Activity indicators
+
+After a session connects, Ghosthub remembers it for the rest of the app
+launch. A small accent indicator appears beside its worktree or standalone
+session row when Ghosthub observes recent tmux scrollback progress, then
+clears about thirty seconds after output stops.
+
+![Ghosthub sidebar showing an accent activity indicator beside a standalone session that is producing output while another session is selected](assets/guide-session-activity.png)
+
+Only genuine output counts. Switching panes, resizing the window, or a
+full-screen tool redrawing its prompt, spinner, or status display does not
+light the indicator. Closing the window still only detaches; the warm session
+stays visible across your other Ghosthub windows.
+
+This activity state resets when Ghosthub quits. Ghosthub never scans sessions
+you have not opened, and terminal text never leaves the host: the probe
+returns only a checksum and size counters. On native Windows hosts, activity
+indicators require psmux 3.3.4 or newer.
+
 ## Reopen an exited standalone session
 
 If a standalone session exits while its presentation is still open, Ghosthub

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -17,6 +17,7 @@ mkdir -p src/assets
 assets=(
   hero.png
   guide-sessions.png
+  guide-session-activity.png
   guide-hosts.png
   guide-exe-dev.png
   guide-worktree.png

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -95,8 +95,11 @@ const imageAlt = {
             Switching between hosts, worktrees, and sessions keeps each opened
             terminal connected, so returning picks up where you left off. Press
             <kbd>⌘W</kbd> to detach only the active terminal; your work keeps
-            running in tmux. See <a href="/docs/sessions/">Sessions</a> for
-            session lifecycle and confirmed kill controls.
+            running in tmux. After a session connects, a small accent
+            indicator appears beside its row when Ghosthub observes recent
+            tmux scrollback progress. See <a href="/docs/sessions/">Sessions</a>{' '}
+            for session lifecycle, activity indicators, and confirmed kill
+            controls.
           </p>
           <p>
             With tmux 3.4+, use <kbd>⌘D</kbd> to split right or{' '}


### PR DESCRIPTION
Ghosthub currently loses visibility into a tmux session as soon as its presentation is not frontmost. Polling every discovered fleet session would scale poorly and unnecessarily move terminal output across SSH.

This keeps only sessions connected during the current app launch warm, fences every sample to the exact tmux identity, and computes a bounded fingerprint on the host. The resulting short-lived recent-output signal is shared across windows and shown for worktree and standalone rows without persistence or session authority; same-named replacements are deliberately not followed.

The full Swift and Python suites, essential tmux workflows, app/docs/website builds, and guarded synthetic screenshot workflow pass.