### PR TITLE
Stop hosted CI from deleting Xcode mounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,11 @@ jobs:
 
       - name: Run essential kwt and tmux workflows
         run: make test-essential-workflows
+
+      - name: Remove isolated macOS test state
+        if: ${{ always() && runner.environment == 'self-hosted' }}
+        shell: bash
+        run: |
+          case "${GHOSTHUB_CI_STATE_ROOT:-}" in
+            /tmp/ghosthub-ci.*) rm -rf -- "$GHOSTHUB_CI_STATE_ROOT" ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,3 @@ jobs:
 
       - name: Run essential kwt and tmux workflows
         run: make test-essential-workflows
-
-      - name: Remove isolated macOS test state
-        if: always()
-        shell: bash
-        run: |
-          case "${GHOSTHUB_CI_STATE_ROOT:-}" in
-            /tmp/ghosthub-ci.*) rm -rf -- "$GHOSTHUB_CI_STATE_ROOT" ;;
-          esac


### PR DESCRIPTION
Every build and test in the 0.6.0 main run passed, but the job still reported failure after Xcode mounted its downloaded Metal toolchain read-only inside the isolated Foundation home. The unconditional final cleanup could not delete that live mount.

Cleanup is necessary on persistent self-hosted runners, but the current `macos-26` runner is GitHub-hosted and discards its filesystem after every job. Gate cleanup on `runner.environment == self-hosted` so hosted jobs avoid the Xcode mount race while preserving state isolation when Ghosthub returns to self-hosted CI.

The workflow parses as YAML, passes its commit hooks, and passes `actionlint` apart from a pre-existing unrelated SC2129 style advisory. The hosted macOS job is the behavioral verification for the current runner path.