### PR TITLE
Add opt-in macOS validation lane

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# The PR dispatcher always calls the main-pinned workflow. That workflow
-# independently routes same-repository macOS jobs to the managed public runner
-# and fork jobs to GitHub-hosted runners.
+# The PR dispatcher always calls the main-pinned workflow. Repository admins
+# can opt same-repository PRs into the additional validation lane, while the
+# called workflow keeps fork jobs on GitHub-hosted runners.
 on:
   pull_request:
 
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   run:
     uses: kenn-io/ghosthub/.github/workflows/ci.yml@main
+    with:
+      self_hosted_validation: ${{ vars.GHOSTHUB_SELF_HOSTED_VALIDATION == 'true' }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,5 +15,3 @@ concurrency:
 jobs:
   run:
     uses: kenn-io/ghosthub/.github/workflows/ci.yml@main
-    with:
-      self_hosted_validation: ${{ vars.GHOSTHUB_SELF_HOSTED_VALIDATION == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: CI
 
 on:
   workflow_call:
-    inputs:
-      self_hosted_validation:
-        description: Run the additional macOS validation lane
-        required: false
-        type: boolean
-        default: false
   push:
     branches: [main]
 
@@ -26,7 +20,7 @@ jobs:
       matrix:
         include: >-
           ${{ fromJSON(
-            inputs.self_hosted_validation &&
+            vars.GHOSTHUB_SELF_HOSTED_VALIDATION == 'true' &&
             github.repository == 'kenn-io/ghosthub' &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      self_hosted_validation:
+        description: Run the additional macOS validation lane
+        required: false
+        type: boolean
+        default: false
   push:
     branches: [main]
 
@@ -14,12 +20,25 @@ concurrency:
 
 jobs:
   macos-arm64:
-    name: macOS (Apple Silicon)
-    runs-on: macos-26
+    name: macOS (Apple Silicon, ${{ matrix.lane }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include: >-
+          ${{ fromJSON(
+            inputs.self_hosted_validation &&
+            github.repository == 'kenn-io/ghosthub' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.base.repo.full_name == github.repository &&
+            '[{"lane":"hosted","runner":"macos-26"},{"lane":"self-hosted","runner":"kenn-macos-arm64-public"}]' ||
+            '[{"lane":"hosted","runner":"macos-26"}]'
+          ) }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     env:
       # The bootstrap default is intentionally arm64 for developer Macs.
-      # `native` builds the arm64 libghostty slice on the hosted runner.
+      # `native` builds the arm64 libghostty slice on each validation runner.
       LIBGHOSTTY_XCFRAMEWORK_TARGET: native
 
     steps:
@@ -86,9 +105,11 @@ jobs:
           mkdir -p "$foundation_home/Library/Caches" "$foundation_tmp"
           chmod 700 "$state_root" "$foundation_home" "$foundation_home/Library" \
             "$foundation_home/Library/Caches" "$foundation_tmp"
-          echo "GHOSTHUB_CI_STATE_ROOT=$state_root" >> "$GITHUB_ENV"
-          echo "CFFIXED_USER_HOME=$foundation_home" >> "$GITHUB_ENV"
-          echo "TMPDIR=$foundation_tmp" >> "$GITHUB_ENV"
+          {
+            echo "GHOSTHUB_CI_STATE_ROOT=$state_root"
+            echo "CFFIXED_USER_HOME=$foundation_home"
+            echo "TMPDIR=$foundation_tmp"
+          } >> "$GITHUB_ENV"
 
       - name: Install Zig 0.15.2
         shell: bash
@@ -142,6 +163,8 @@ jobs:
         # NSPasteboard.general, which is shared across worker processes.
         shell: bash
         run: |
+          windowserver_log="$RUNNER_TEMP/windowserver-tests.log"
+          : > "$windowserver_log"
           test_workers=2
           if [[ "${RUNNER_ENVIRONMENT:-}" == "self-hosted" ]]; then
             test_workers=8
@@ -151,13 +174,28 @@ jobs:
             swift test --skip-build --disable-swift-testing \
             --filter GhosthubTerminalSmokeTests \
             --skip 'Clipboard|Paste' \
-            --parallel --num-workers "$test_workers"
+            --parallel --num-workers "$test_workers" \
+            2>&1 | tee -a "$windowserver_log"
 
       - name: Run pasteboard terminal smoke tests
-        run: >-
-          sh tools/run_swift_tests.sh
-          swift test --skip-build --disable-swift-testing
-          --filter 'Clipboard|Paste' --no-parallel
+        shell: bash
+        run: |
+          sh tools/run_swift_tests.sh \
+            swift test --skip-build --disable-swift-testing \
+            --filter 'Clipboard|Paste' --no-parallel \
+            2>&1 | tee -a "$RUNNER_TEMP/windowserver-tests.log"
+
+      - name: Verify WindowServer coverage
+        shell: bash
+        run: |
+          windowserver_log="$RUNNER_TEMP/windowserver-tests.log"
+          skip_count="$(grep -c \
+            'Test skipped - Test requires window server' \
+            "$windowserver_log" || true)"
+          if [[ "$skip_count" -ne 2 ]]; then
+            echo "Expected 2 WindowServer skips; found $skip_count." >&2
+            exit 1
+          fi
 
       - name: Run remaining XCTest suites
         # Keep deadline-sensitive monitor and lifecycle tests serialized.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ layer, as subject to direct iteration.
 - Commit every turn when you make changes.
 - Commit before responding without asking whether to commit; committing is the
   expected default after every change.
+- Push completed task-branch commits to their configured remote before
+  responding. Force-push only when the user explicitly requests a history
+  rewrite.
 - Ending a completed turn with task-related uncommitted work is forbidden. A
   clean task worktree is a precondition for handoff and for any roborev
   interaction.
@@ -97,8 +100,8 @@ layer, as subject to direct iteration.
   navel-gazing sections such as "Changes", "Validation", "Tests", or
   "Verification". Mention unusual validation only inline when it is genuinely
   useful reviewer context.
-- The canonical repository is `https://github.com/kenn-io/ghosthub`. Only push
-  or open pull requests when the user explicitly asks.
+- The canonical repository is `https://github.com/kenn-io/ghosthub`. Open pull
+  requests only when the user explicitly asks.
 - The public repository does not accept unsolicited pull requests. Direct bug
   reports and feature requests to GitHub issues. Prospective code contributors
   must coordinate privately with Kenn Software and sign the CLA before their

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1509,6 +1509,7 @@ struct WorkspaceTmuxDiscoveryTests {
                         session: selection.name
                     )
                 }
+                try await Task.sleep(for: .milliseconds(20))
                 return TmuxSessionIdentity(
                     serverPID: "31415",
                     sessionID: "$42",
@@ -1530,10 +1531,13 @@ struct WorkspaceTmuxDiscoveryTests {
             identityReads.count == 3
         }
         let start = Date.now
-        await activityController.sampleWarmSessions(at: start)
-        await activityController.sampleWarmSessions(
-            at: start.addingTimeInterval(20)
-        )
+        for tick in 1 ... 400
+            where !model.workingTmuxSessionIDs.contains(selection.id) {
+            await activityController.sampleWarmSessions(
+                at: start.addingTimeInterval(Double(tick))
+            )
+            try await Task.sleep(for: .milliseconds(2))
+        }
 
         #expect(model.workingTmuxSessionIDs == [selection.id])
         await model.shutdown()


### PR DESCRIPTION
Canonical CI needs a controlled way to compare an additional macOS execution environment before changing default routing. The comparison remains disabled by default and can be enabled only through repository configuration.

- Run both hosted and additional validation lanes only for same-repository pull requests in the canonical repository; forks and other callers remain hosted.
- Keep routing in the immutable main-pinned workflow and require the canonical repository checks before selecting the additional runner.
- Pin the currently observed WindowServer skip count so coverage changes require an explicit update.
- Make the activity-enrollment retry test wait for observable session activity rather than racing an asynchronous identity read.
- Record the repository workflow preference to push completed task branches while keeping history rewrites explicit.