### PR TITLE
Bound SSH diagnostic test process cleanup

### DIFF
--- a/Tests/App/SSHAuthenticationSessionTests.swift
+++ b/Tests/App/SSHAuthenticationSessionTests.swift
@@ -101,21 +101,24 @@ struct SSHAuthenticationSessionTests {
 
         let diagnostic = await drain.finish(after: .milliseconds(50))
 
-        if writer.isRunning {
-            writer.terminate()
-        }
-        var exitDeadline = ContinuousClock.now + .seconds(2)
-        while writer.isRunning, ContinuousClock.now < exitDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        if writer.isRunning {
-            Darwin.kill(writer.processIdentifier, SIGKILL)
-            exitDeadline = ContinuousClock.now + .seconds(2)
-            while writer.isRunning, ContinuousClock.now < exitDeadline {
-                try await Task.sleep(for: .milliseconds(20))
+        let writerStopped = await Task.detached {
+            if writer.isRunning {
+                writer.terminate()
             }
-        }
-        try #require(!writer.isRunning)
+            var exitDeadline = ContinuousClock.now + .seconds(2)
+            while writer.isRunning, ContinuousClock.now < exitDeadline {
+                try? await Task.sleep(for: .milliseconds(20))
+            }
+            if writer.isRunning {
+                Darwin.kill(writer.processIdentifier, SIGKILL)
+                exitDeadline = ContinuousClock.now + .seconds(2)
+                while writer.isRunning, ContinuousClock.now < exitDeadline {
+                    try? await Task.sleep(for: .milliseconds(20))
+                }
+            }
+            return !writer.isRunning
+        }.value
+        try #require(writerStopped)
         #expect(!diagnostic.isEmpty)
     }
 

--- a/Tests/App/SSHAuthenticationSessionTests.swift
+++ b/Tests/App/SSHAuthenticationSessionTests.swift
@@ -104,7 +104,18 @@ struct SSHAuthenticationSessionTests {
         if writer.isRunning {
             writer.terminate()
         }
-        writer.waitUntilExit()
+        var exitDeadline = ContinuousClock.now + .seconds(2)
+        while writer.isRunning, ContinuousClock.now < exitDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        if writer.isRunning {
+            Darwin.kill(writer.processIdentifier, SIGKILL)
+            exitDeadline = ContinuousClock.now + .seconds(2)
+            while writer.isRunning, ContinuousClock.now < exitDeadline {
+                try await Task.sleep(for: .milliseconds(20))
+            }
+        }
+        try #require(!writer.isRunning)
         #expect(!diagnostic.isEmpty)
     }
 


### PR DESCRIPTION
Main CI reached the Swift Testing phase after every earlier gate passed, then consumed the remainder of its 90-minute budget. A live local reproduction showed the synthetic SSH diagnostic writer blocked in Foundation `Process.waitUntilExit()` even though its child process had already disappeared.

Bound that test teardown with asynchronous process-state checks and a force-kill fallback. This preserves the real diagnostic-drain assertion while ensuring a cleanup anomaly fails in seconds instead of hanging CI; application code and behavior are unchanged.

The failure reproduced before the change. After rebuilding the test target, two consecutive full Swift Testing runs passed all 906 tests, the focused 18-test SSH authentication suite passed, formatting is clean, `make build` passes, and commit hooks—including warnings-as-errors test compilation—pass.