### PR TITLE
Smooth terminal resizing with sidebar transitions

### DIFF
--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -10,6 +10,7 @@ struct BorrowedTmuxSessionView: View {
     var connectionState: ConnectionState?
     var attachmentClosure: BorrowedTmuxAttachmentClosure?
     var sessionClosed: Bool
+    var defersTerminalResize: Bool
     var surface: () -> TerminalSurfaceView?
     var onCloseRequest: () -> Void
     var onRetryRequest: () -> Void
@@ -23,6 +24,7 @@ struct BorrowedTmuxSessionView: View {
         connectionState: ConnectionState?,
         attachmentClosure: BorrowedTmuxAttachmentClosure? = nil,
         sessionClosed: Bool = false,
+        defersTerminalResize: Bool = false,
         surface: @escaping () -> TerminalSurfaceView?,
         onCloseRequest: @escaping () -> Void,
         onRetryRequest: @escaping () -> Void,
@@ -35,6 +37,7 @@ struct BorrowedTmuxSessionView: View {
         self.connectionState = connectionState
         self.attachmentClosure = attachmentClosure
         self.sessionClosed = sessionClosed
+        self.defersTerminalResize = defersTerminalResize
         self.surface = surface
         self.onCloseRequest = onCloseRequest
         self.onRetryRequest = onRetryRequest
@@ -45,6 +48,7 @@ struct BorrowedTmuxSessionView: View {
         if let surfaceView = surface() {
             NativeTmuxTerminalView(
                 surfaceView: surfaceView,
+                defersTerminalResize: defersTerminalResize,
                 onCloseRequest: onCloseRequest
             )
         } else if let disconnectionReason {
@@ -105,25 +109,29 @@ struct BorrowedTmuxSessionView: View {
 
 private struct NativeTmuxTerminalView: View {
     @ObservedObject var surfaceView: TerminalSurfaceView
+    var defersTerminalResize: Bool
     var onCloseRequest: () -> Void
     @State private var observerID = UUID()
 
     var body: some View {
-        TerminalSurfaceSwiftUIView(surfaceView: surfaceView)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(nsColor: .textBackgroundColor))
-            .onAppear {
-                surfaceView.registerPaneCloseRequestObserver(
-                    id: observerID,
-                    onCloseRequest: onCloseRequest
-                )
-                surfaceView.suppressAutoFocus = false
-                DispatchQueue.main.async { [surfaceView] in
-                    surfaceView.requestKeyboardFocus()
-                }
+        TerminalSurfaceSwiftUIView(
+            surfaceView: surfaceView,
+            defersSurfaceResize: defersTerminalResize
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+        .onAppear {
+            surfaceView.registerPaneCloseRequestObserver(
+                id: observerID,
+                onCloseRequest: onCloseRequest
+            )
+            surfaceView.suppressAutoFocus = false
+            DispatchQueue.main.async { [surfaceView] in
+                surfaceView.requestKeyboardFocus()
             }
-            .onDisappear {
-                surfaceView.unregisterPaneFocusObserver(id: observerID)
-            }
+        }
+        .onDisappear {
+            surfaceView.unregisterPaneFocusObserver(id: observerID)
+        }
     }
 }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3094,7 +3094,8 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func borrowedTmuxSessionView(
         host: HostSummary,
-        sessionName: String
+        sessionName: String,
+        defersTerminalResize: Bool
     ) -> AnyView? {
         guard TmuxHostResolver.resolve(host) != nil else {
             return AnyView(
@@ -3128,6 +3129,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 nativeTmuxSessionCoordinator.attachmentClosure(handle),
                 sessionClosed:
                 confirmedEndedTmuxSessionHandles.contains(handle.id),
+                defersTerminalResize: defersTerminalResize,
                 surface: { [weak self] in
                     self?.nativeTmuxSessionCoordinator.surface(handle: handle)
                 },

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -647,10 +647,11 @@ struct WorkspaceWindow: View {
             ),
             content: ContentBuilders(
                 tmuxSessionContentBuilder: {
-                    [sceneModel] host, sessionName in
+                    [sceneModel] host, sessionName, defersTerminalResize in
                     sceneModel.borrowedTmuxSessionView(
                         host: host,
-                        sessionName: sessionName
+                        sessionName: sessionName,
+                        defersTerminalResize: defersTerminalResize
                     )
                 },
                 settingsSheetBuilder: { settingsStore in

--- a/Sources/Terminal/TerminalSurfaceRepresentable.swift
+++ b/Sources/Terminal/TerminalSurfaceRepresentable.swift
@@ -3,16 +3,24 @@ import SwiftUI
 
 public struct TerminalSurfaceRepresentable: NSViewRepresentable {
     public let surfaceView: TerminalSurfaceView
+    public let defersSurfaceResize: Bool
 
-    public init(surfaceView: TerminalSurfaceView) {
+    public init(
+        surfaceView: TerminalSurfaceView,
+        defersSurfaceResize: Bool = false
+    ) {
         self.surfaceView = surfaceView
+        self.defersSurfaceResize = defersSurfaceResize
     }
 
     public func makeNSView(context _: Context) -> TerminalSurfaceView {
-        surfaceView
+        surfaceView.setPresentationResizeDeferred(defersSurfaceResize)
+        return surfaceView
     }
 
     public func updateNSView(
-        _: TerminalSurfaceView, context _: Context
-    ) {}
+        _ nsView: TerminalSurfaceView, context _: Context
+    ) {
+        nsView.setPresentationResizeDeferred(defersSurfaceResize)
+    }
 }

--- a/Sources/Terminal/TerminalSurfaceSwiftUIView.swift
+++ b/Sources/Terminal/TerminalSurfaceSwiftUIView.swift
@@ -2,15 +2,23 @@ import SwiftUI
 
 public struct TerminalSurfaceSwiftUIView: View {
     let surfaceView: TerminalSurfaceView
+    let defersSurfaceResize: Bool
     @FocusState private var surfaceFocus: Bool
 
-    public init(surfaceView: TerminalSurfaceView) {
+    public init(
+        surfaceView: TerminalSurfaceView,
+        defersSurfaceResize: Bool = false
+    ) {
         self.surfaceView = surfaceView
+        self.defersSurfaceResize = defersSurfaceResize
     }
 
     public var body: some View {
-        TerminalSurfaceRepresentable(surfaceView: surfaceView)
-            .id(ObjectIdentifier(surfaceView))
-            .focused($surfaceFocus)
+        TerminalSurfaceRepresentable(
+            surfaceView: surfaceView,
+            defersSurfaceResize: defersSurfaceResize
+        )
+        .id(ObjectIdentifier(surfaceView))
+        .focused($surfaceFocus)
     }
 }

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -136,6 +136,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     private var consumedCommandKeyCodes: Set<UInt16> = []
     private var surfaceResizeState = SurfaceResizeState()
     private var isDeferringLiveResize = false
+    private var isDeferringPresentationResize = false
+    private var isDeferringSurfaceResize: Bool {
+        isDeferringLiveResize || isDeferringPresentationResize
+    }
     private var hasSyncedFocusState = false
     private let keyEventInterpreter: (([NSEvent]) -> Void)?
     let textInputObserver: ((String) -> Void)?
@@ -410,6 +414,14 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         handleSizeChange(size)
     }
 
+    func setPresentationResizeDeferred(_ deferred: Bool) {
+        guard isDeferringPresentationResize != deferred else { return }
+        isDeferringPresentationResize = deferred
+        if !isDeferringSurfaceResize {
+            flushPendingSurfaceResize()
+        }
+    }
+
     private func handleSizeChange(_ size: CGSize) {
         let scaledSize = convertToBacking(size)
         guard scaledSize.width >= 1, scaledSize.height >= 1
@@ -422,7 +434,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         ) else { return }
 
         switch SurfaceResizePolicy.decision(
-            isLiveResize: isDeferringLiveResize
+            isLiveResize: isDeferringSurfaceResize
         ) {
         case .immediate:
             applySurfaceSize(width: width, height: height)
@@ -922,7 +934,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     override public func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
         isDeferringLiveResize = false
-        flushPendingSurfaceResize()
+        if !isDeferringSurfaceResize {
+            flushPendingSurfaceResize()
+        }
     }
 
     // MARK: - Mouse Events

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -144,6 +144,9 @@ public final class TerminalSurfaceView: ObservableObject {
     public func sizeDidChange(_ size: CGSize) {
         _ = size
     }
+    func setPresentationResizeDeferred(_ deferred: Bool) {
+        _ = deferred
+    }
     public func registerPaneFocusObserver(
         id: UUID,
         onFocusChange: @escaping (Bool) -> Void,
@@ -297,8 +300,12 @@ struct SurfaceResizeState: Equatable {
 }
 
 public struct TerminalSurfaceSwiftUIView: View {
-    public init(surfaceView: TerminalSurfaceView) {
+    public init(
+        surfaceView: TerminalSurfaceView,
+        defersSurfaceResize: Bool = false
+    ) {
         _ = surfaceView
+        _ = defersSurfaceResize
     }
 
     public var body: some View {
@@ -309,9 +316,14 @@ public struct TerminalSurfaceSwiftUIView: View {
 
 public struct TerminalSurfaceRepresentable: NSViewRepresentable {
     public let surfaceView: TerminalSurfaceView
+    public let defersSurfaceResize: Bool
 
-    public init(surfaceView: TerminalSurfaceView) {
+    public init(
+        surfaceView: TerminalSurfaceView,
+        defersSurfaceResize: Bool = false
+    ) {
         self.surfaceView = surfaceView
+        self.defersSurfaceResize = defersSurfaceResize
     }
 
     public func makeNSView(context _: Context) -> NSView {

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -19,6 +19,9 @@ public struct RootView: View {
     /// Tracks whether the sidebar was auto-collapsed due to narrow
     /// window width so we can auto-expand it when the window grows.
     @State private var sidebarAutoCollapsed = false
+    @State private var sidebarVisibilityProgress: CGFloat
+    @State private var isSidebarTransitioning = false
+    @State private var sidebarTransitionID = UUID()
     @Environment(\.controlActiveState) private var controlActiveState
     @State private var lastKnownWindowWidth: CGFloat = 0
     @State private var sidePanelAutoCollapsed = false
@@ -62,6 +65,9 @@ public struct RootView: View {
         _isCommandPalettePresented = isCommandPalettePresented
         _isLogViewerPresented = isLogViewerPresented
         _isSettingsPresented = isSettingsPresented
+        _sidebarVisibilityProgress = State(
+            initialValue: columnVisibility.wrappedValue == .detailOnly ? 0 : 1
+        )
     }
 
     // MARK: - Convenience accessors
@@ -318,6 +324,7 @@ public struct RootView: View {
     private static let dividerHit =
         WorkspaceSidebarWidthPolicy.dividerHitWidth
     private static let columnSpace = "workspaceColumns"
+    private static let sidebarAnimationDuration = 0.2
 
     private var workspaceContent: some View {
         workspaceColumns
@@ -330,9 +337,8 @@ public struct RootView: View {
                 HStack(spacing: 0) {
                     Color.clear
                         .frame(
-                            width: isSidebarVisible
-                                ? sidebarWidth + Self.dividerHit
-                                : 0
+                            width: (sidebarWidth + Self.dividerHit)
+                                * sidebarVisibilityProgress
                         )
 
                     terminalWorkspaceContent
@@ -341,10 +347,6 @@ public struct RootView: View {
                             maxHeight: .infinity
                         )
                 }
-                .transaction { transaction in
-                    transaction.animation = nil
-                }
-
                 HStack(spacing: 0) {
                     workspaceSidebarColumn
                         .frame(width: sidebarWidth)
@@ -353,18 +355,32 @@ public struct RootView: View {
                         .gesture(sidebarDragGesture)
                 }
                 .offset(
-                    x: isSidebarVisible
-                        ? 0 : -(sidebarWidth + Self.dividerHit)
+                    x: -(sidebarWidth + Self.dividerHit)
+                        * (1 - sidebarVisibilityProgress)
                 )
-                .opacity(isSidebarVisible ? 1 : 0)
+                .opacity(sidebarVisibilityProgress)
                 .allowsHitTesting(isSidebarVisible)
                 .accessibilityHidden(!isSidebarVisible)
-                .animation(
-                    .easeInOut(duration: 0.2),
-                    value: isSidebarVisible
-                )
             }
             .coordinateSpace(name: Self.columnSpace)
+            .onChange(of: isSidebarVisible) { _, visible in
+                animateSidebarVisibility(visible)
+            }
+        }
+    }
+
+    private func animateSidebarVisibility(_ visible: Bool) {
+        let transitionID = UUID()
+        sidebarTransitionID = transitionID
+        isSidebarTransitioning = true
+        withAnimation(
+            .easeInOut(duration: Self.sidebarAnimationDuration),
+            completionCriteria: .logicallyComplete
+        ) {
+            sidebarVisibilityProgress = visible ? 1 : 0
+        } completion: {
+            guard sidebarTransitionID == transitionID else { return }
+            isSidebarTransitioning = false
         }
     }
 
@@ -841,7 +857,8 @@ public struct RootView: View {
             activeTmuxSession == presentedSession,
             let view = content.tmuxSessionContentBuilder?(
                 host,
-                presentedSession.name
+                presentedSession.name,
+                isSidebarTransitioning
             ) {
             view
         } else if display.suppressesAutomaticWorktreeSessionOpen,

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -80,14 +80,14 @@ public struct WorkspaceDisplayState {
 /// View factory closures and providers consumed by RootView.
 public struct ContentBuilders {
     public let tmuxSessionContentBuilder:
-        ((HostSummary, String) -> AnyView?)?
+        ((HostSummary, String, Bool) -> AnyView?)?
     public let settingsSheetBuilder: ((SettingsStore) -> AnyView)?
     public let logViewerBuilder: (() -> AnyView?)?
     public let sshAuthenticationBuilder: ((UUID) -> AnyView?)?
 
     public init(
         tmuxSessionContentBuilder:
-        ((HostSummary, String) -> AnyView?)? = nil,
+        ((HostSummary, String, Bool) -> AnyView?)? = nil,
         settingsSheetBuilder: ((SettingsStore) -> AnyView)? = nil,
         logViewerBuilder: (() -> AnyView?)? = nil,
         sshAuthenticationBuilder: ((UUID) -> AnyView?)? = nil

--- a/Tests/App/ConfiguredHostOverlayTests.swift
+++ b/Tests/App/ConfiguredHostOverlayTests.swift
@@ -285,7 +285,8 @@ struct ConfiguredHostOverlayTests {
         #expect(
             secondWindow.borrowedTmuxSessionView(
                 host: oldHost,
-                sessionName: activeSelection.name
+                sessionName: activeSelection.name,
+                defersTerminalResize: false
             ) != nil
         )
 
@@ -310,7 +311,8 @@ struct ConfiguredHostOverlayTests {
         #expect(
             secondWindow.borrowedTmuxSessionView(
                 host: updatedHost,
-                sessionName: activeSelection.name
+                sessionName: activeSelection.name,
+                defersTerminalResize: false
             ) == nil
         )
 
@@ -321,7 +323,8 @@ struct ConfiguredHostOverlayTests {
         #expect(
             secondWindow.borrowedTmuxSessionView(
                 host: updatedHost,
-                sessionName: activeSelection.name
+                sessionName: activeSelection.name,
+                defersTerminalResize: false
             ) != nil
         )
         configuredHosts.send([])
@@ -330,7 +333,8 @@ struct ConfiguredHostOverlayTests {
         #expect(
             secondWindow.borrowedTmuxSessionView(
                 host: updatedHost,
-                sessionName: activeSelection.name
+                sessionName: activeSelection.name,
+                defersTerminalResize: false
             ) == nil
         )
     }

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -392,7 +392,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 activeTmuxSession: activeTmuxSession
             ),
             content: ContentBuilders(
-                tmuxSessionContentBuilder: { _, _ in
+                tmuxSessionContentBuilder: { _, _, _ in
                     tmuxContentBuilder()
                 }
             ),
@@ -1569,7 +1569,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                         activeTmuxSession: model.activeTmuxSession
                     ),
                     content: ContentBuilders(
-                        tmuxSessionContentBuilder: { _, sessionName in
+                        tmuxSessionContentBuilder: { _, sessionName, _ in
                             guard let surfaceView =
                                 surfacesBySession[sessionName]
                             else { return nil }
@@ -1882,6 +1882,82 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         )
         XCTAssertEqual(appliedSizes.last?.width, UInt32(expectedSize.width))
         XCTAssertEqual(appliedSizes.last?.height, UInt32(expectedSize.height))
+    }
+
+    func testPresentationResizeAppliesOnlyTheFinalSurfaceSize() throws {
+        let appHandle = try requireAppHandle()
+        let previousSetter = TerminalSurfaceView.sizeSetter
+        var appliedSizes: [(width: UInt32, height: UInt32)] = []
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            appliedSizes.append((width, height))
+            ghostty_surface_set_size(surface, width, height)
+        }
+        defer {
+            TerminalSurfaceView.sizeSetter = previousSetter
+        }
+
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        appliedSizes.removeAll()
+
+        view.setPresentationResizeDeferred(true)
+        view.setFrameSize(NSSize(width: 700, height: 450))
+        view.setFrameSize(NSSize(width: 760, height: 480))
+
+        XCTAssertTrue(
+            appliedSizes.isEmpty,
+            "A presentation transition must keep the terminal grid stable."
+        )
+
+        view.setPresentationResizeDeferred(false)
+
+        let expectedSize = view.convertToBacking(view.bounds.size)
+        XCTAssertEqual(
+            appliedSizes.count,
+            1,
+            "Ending a presentation transition must apply only its final size."
+        )
+        XCTAssertEqual(appliedSizes.last?.width, UInt32(expectedSize.width))
+        XCTAssertEqual(appliedSizes.last?.height, UInt32(expectedSize.height))
+    }
+
+    func testPresentationResizeWaitsForOverlappingLiveResize() throws {
+        let appHandle = try requireAppHandle()
+        let previousSetter = TerminalSurfaceView.sizeSetter
+        var appliedSizes: [(width: UInt32, height: UInt32)] = []
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            appliedSizes.append((width, height))
+            ghostty_surface_set_size(surface, width, height)
+        }
+        defer {
+            TerminalSurfaceView.sizeSetter = previousSetter
+        }
+
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        appliedSizes.removeAll()
+
+        view.viewWillStartLiveResize()
+        view.setPresentationResizeDeferred(true)
+        view.setFrameSize(NSSize(width: 760, height: 480))
+        view.setPresentationResizeDeferred(false)
+
+        XCTAssertTrue(
+            appliedSizes.isEmpty,
+            "Ending one resize transition must not flush another active transition."
+        )
+
+        view.viewDidEndLiveResize()
+
+        XCTAssertEqual(appliedSizes.count, 1)
     }
 
     func testDetachingViewMarksSurfaceOccluded() throws {

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -39,8 +39,15 @@ struct SidebarToggleStabilityTests {
         let viewBefore = env.findStableContent()
         #expect(viewBefore != nil, "stable content should exist initially")
 
+        env.clearTerminalResizeDeferrals()
         env.isSidebarVisible = false
-        env.settle()
+        env.settle(for: 0.05)
+
+        #expect(env.terminalResizeDeferrals.last == true)
+
+        env.settle(for: 0.25)
+
+        #expect(env.terminalResizeDeferrals.last == false)
 
         let viewAfter = env.findStableContent()
         #expect(viewAfter != nil, "stable content should exist after hiding sidebar")
@@ -58,6 +65,43 @@ struct SidebarToggleStabilityTests {
             viewBefore === viewRestored,
             "terminal content view must be the same instance after sidebar restore"
         )
+    }
+
+    @Test("rapid sidebar toggles defer terminal resize through the latest transition")
+    func rapidSidebarTogglesKeepTerminalResizeDeferred() {
+        let env = StabilityTestEnvironment()
+        defer { env.close() }
+
+        env.clearTerminalResizeDeferrals()
+        env.isSidebarVisible = false
+        env.settle(for: 0.05)
+        env.isSidebarVisible = true
+        env.settle(for: 0.17)
+
+        #expect(env.terminalResizeDeferrals.last == true)
+
+        env.settle(for: 0.1)
+
+        #expect(env.terminalResizeDeferrals.last == false)
+    }
+
+    @Test("sidebar toggle animates the terminal viewport width")
+    func sidebarToggleAnimatesTerminalViewportWidth() throws {
+        let env = StabilityTestEnvironment()
+        defer { env.close() }
+
+        let terminal = try #require(env.findStableContent())
+        let startingWidth = terminal.frame.width
+
+        env.isSidebarVisible = false
+        env.settle(for: 0.1)
+        let transitionWidth = terminal.frame.width
+
+        env.settle(for: 0.15)
+        let finalWidth = terminal.frame.width
+
+        #expect(transitionWidth > startingWidth)
+        #expect(transitionWidth < finalWidth)
     }
 
     @Test("sidebar command toggles only its targeted window")
@@ -161,6 +205,10 @@ private final class StabilityTestEnvironment {
 
     var columnVisibility: NavigationSplitViewVisibility {
         model.columnVisibility
+    }
+
+    var terminalResizeDeferrals: [Bool] {
+        model.terminalResizeDeferrals
     }
 
     init(sidebarToggleTarget: AnyObject = SidebarToggleTarget()) {
@@ -267,15 +315,20 @@ private final class StabilityTestEnvironment {
         )
     }
 
+    func clearTerminalResizeDeferrals() {
+        model.clearTerminalResizeDeferrals()
+    }
+
     func close() {
         window.orderOut(nil)
         defaults.removePersistentDomain(forName: defaultsSuiteName)
         try? FileManager.default.removeItem(at: tempRoot)
     }
 
-    func settle() {
+    func settle(for duration: TimeInterval = 0.05) {
         hostingView.layoutSubtreeIfNeeded()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        RunLoop.main.run(until: Date().addingTimeInterval(duration))
+        hostingView.layoutSubtreeIfNeeded()
     }
 }
 
@@ -285,6 +338,7 @@ private final class StabilityTestModel: ObservableObject {
     @Published var selection: WorkspaceSelection
     @Published var activeSession: WorkspaceTmuxSessionSelection?
     @Published var columnVisibility: NavigationSplitViewVisibility = .all
+    private(set) var terminalResizeDeferrals: [Bool] = []
 
     init(
         snapshot: WorkspaceSnapshot,
@@ -294,6 +348,14 @@ private final class StabilityTestModel: ObservableObject {
         self.snapshot = snapshot
         self.selection = selection
         self.activeSession = activeSession
+    }
+
+    func recordTerminalResizeDeferral(_ deferred: Bool) {
+        terminalResizeDeferrals.append(deferred)
+    }
+
+    func clearTerminalResizeDeferrals() {
+        terminalResizeDeferrals.removeAll()
     }
 }
 
@@ -310,8 +372,12 @@ private struct StabilityTestHarness: View {
                 activeTmuxSession: model.activeSession
             ),
             content: ContentBuilders(
-                tmuxSessionContentBuilder: { _, sessionName in
-                    AnyView(
+                tmuxSessionContentBuilder: {
+                    _, sessionName, defersTerminalResize in
+                    model.recordTerminalResizeDeferral(
+                        defersTerminalResize
+                    )
+                    return AnyView(
                         PresentedTmuxSessionMarker(sessionName: sessionName)
                     )
                 }

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -361,7 +361,7 @@ private struct EndpointChangePresentationHarness: View {
         RootView(
             display: model.display,
             content: ContentBuilders(
-                tmuxSessionContentBuilder: { _, _ in
+                tmuxSessionContentBuilder: { _, _, _ in
                     AnyView(
                         ActiveTmuxPresentationMarker()
                     )


### PR DESCRIPTION
The sidebar already animated, but the terminal viewport jumped directly to its final width. Resizing libghostty throughout the animation would reintroduce the SIGWINCH redraw storms previously removed for terminal-based agent interfaces.

This keeps the sidebar and terminal viewport in one visual transition while deferring terminal grid reflow until the motion settles. Rapid toggles and overlapping window resizes retain only the latest pending size, preserving terminal identity and producing one final resize.

Accepted in the development app after interactive testing. Formatting is clean, the full Swift suite passes with 908 Swift Testing cases plus XCTest coverage, and `make build` passes.