### PR TITLE
Start new tmux sessions from saved launch profiles

### DIFF
--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -12,12 +12,16 @@ struct BorrowedTmuxSessionView: View {
     var attachmentClosure: BorrowedTmuxAttachmentClosure?
     var sessionClosed: Bool
     var defersTerminalResize: Bool
+    var retryRequiresConfirmation: Bool
+    var retryCommand: String?
     var surface: () -> TerminalSurfaceView?
     var onCloseRequest: () -> Void
     var onRetryRequest: () -> Void
+    var onConfirmedRetryRequest: () -> Void
     var onReconnectNow: () -> Void
     var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
+    @State private var isRetryConfirmationPresented = false
 
     init(
         handle: BorrowedTmuxSessionHandle,
@@ -29,9 +33,12 @@ struct BorrowedTmuxSessionView: View {
         attachmentClosure: BorrowedTmuxAttachmentClosure? = nil,
         sessionClosed: Bool = false,
         defersTerminalResize: Bool = false,
+        retryRequiresConfirmation: Bool = false,
+        retryCommand: String? = nil,
         surface: @escaping () -> TerminalSurfaceView?,
         onCloseRequest: @escaping () -> Void,
         onRetryRequest: @escaping () -> Void,
+        onConfirmedRetryRequest: @escaping () -> Void = {},
         onReconnectNow: @escaping () -> Void = {},
         onReviewConnection: @escaping () -> Void = {},
         onHostSettingsRequest: @escaping () -> Void
@@ -45,65 +52,99 @@ struct BorrowedTmuxSessionView: View {
         self.attachmentClosure = attachmentClosure
         self.sessionClosed = sessionClosed
         self.defersTerminalResize = defersTerminalResize
+        self.retryRequiresConfirmation = retryRequiresConfirmation
+        self.retryCommand = retryCommand
         self.surface = surface
         self.onCloseRequest = onCloseRequest
         self.onRetryRequest = onRetryRequest
+        self.onConfirmedRetryRequest = onConfirmedRetryRequest
         self.onReconnectNow = onReconnectNow
         self.onReviewConnection = onReviewConnection
         self.onHostSettingsRequest = onHostSettingsRequest
     }
 
     var body: some View {
-        if let surfaceView = surface() {
-            NativeTmuxTerminalView(
-                surfaceView: surfaceView,
-                defersTerminalResize: defersTerminalResize,
-                onCloseRequest: onCloseRequest
-            )
-        } else if recoveryState != nil {
-            ContentUnavailableView {
-                Label(recoveryTitle, systemImage: "network.slash")
-            } description: {
-                VStack(spacing: 10) {
-                    if showsReconnectProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                    Text(recoveryMessage)
-                        .multilineTextAlignment(.center)
-                }
-            } actions: {
-                if primaryRecoveryActionTitle != nil {
-                    Button("Reconnect Now", action: onReconnectNow)
-                }
-                if showsReviewConnection {
-                    Button("Review Connection", action: onReviewConnection)
-                }
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
-                }
-            }
-        } else if let disconnectionReason {
-            ContentUnavailableView {
-                Label(
-                    disconnectionTitle,
-                    systemImage: sessionClosed
-                        ? "rectangle.portrait.and.arrow.right"
-                        : attachmentClosure == .detached
-                        ? "rectangle.portrait.and.arrow.right"
-                        : "network.slash"
+        Group {
+            if let surfaceView = surface() {
+                NativeTmuxTerminalView(
+                    surfaceView: surfaceView,
+                    defersTerminalResize: defersTerminalResize,
+                    onCloseRequest: onCloseRequest
                 )
-            } description: {
-                Text(disconnectionReason)
-            } actions: {
-                Button(recoveryActionTitle, action: onRetryRequest)
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
+            } else if recoveryState != nil {
+                ContentUnavailableView {
+                    Label(recoveryTitle, systemImage: "network.slash")
+                } description: {
+                    VStack(spacing: 10) {
+                        if showsReconnectProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(recoveryMessage)
+                            .multilineTextAlignment(.center)
+                    }
+                } actions: {
+                    if primaryRecoveryActionTitle != nil {
+                        Button("Reconnect Now", action: onReconnectNow)
+                    }
+                    if showsReviewConnection {
+                        Button("Review Connection", action: onReviewConnection)
+                    }
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else if let disconnectionReason {
+                ContentUnavailableView {
+                    Label(
+                        disconnectionTitle,
+                        systemImage: sessionClosed
+                            ? "rectangle.portrait.and.arrow.right"
+                            : attachmentClosure == .detached
+                            ? "rectangle.portrait.and.arrow.right"
+                            : "network.slash"
+                    )
+                } description: {
+                    Text(disconnectionReason)
+                } actions: {
+                    Button(recoveryActionTitle) {
+                        if retryRequiresConfirmation {
+                            isRetryConfirmationPresented = true
+                        } else {
+                            onRetryRequest()
+                        }
+                    }
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else {
+                ProgressView("Opening \(displayTitle ?? handle.name)…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .confirmationDialog(
+            "Run the launch command again?",
+            isPresented: $isRetryConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Run Command Again", role: .destructive) {
+                onConfirmedRetryRequest()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "The command may have started before the connection "
+                        + "dropped. Running it again could repeat its side "
+                        + "effects."
+                )
+                if let retryConfirmationCommand {
+                    Text(retryConfirmationCommand)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
                 }
             }
-        } else {
-            ProgressView("Opening \(displayTitle ?? handle.name)…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
@@ -165,7 +206,14 @@ struct BorrowedTmuxSessionView: View {
         if sessionClosed {
             return "Reopen"
         }
+        if retryRequiresConfirmation {
+            return "Retry Command"
+        }
         return attachmentClosure == .detached ? "Reconnect" : "Retry"
+    }
+
+    var retryConfirmationCommand: String? {
+        retryRequiresConfirmation ? retryCommand : nil
     }
 
     var showsHostSettingsAction: Bool {

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -100,6 +100,7 @@ private struct NativeTmuxAttachment {
     var socketName: String?
     var protectedWorkspacePath: String?
     var launchMode: TmuxAttachmentLaunchMode
+    var initialCommand: String?
     var workingDirectory: String?
     var openWorkspace: Bool
     var sshConnectionArguments: [String]
@@ -201,6 +202,7 @@ final class NativeTmuxSessionCoordinator {
         host: TmuxHost,
         socketName: String? = nil,
         launchMode: TmuxAttachmentLaunchMode = .attach,
+        initialCommand: String? = nil,
         workingDirectory: String? = nil,
         openWorkspace: Bool = false
     ) -> BorrowedTmuxSessionHandle {
@@ -270,6 +272,7 @@ final class NativeTmuxSessionCoordinator {
                 host: host,
                 socketName: socketName,
                 launchMode: launchMode,
+                initialCommand: launchMode == .create ? initialCommand : nil,
                 workingDirectory: workingDirectory,
                 openWorkspace: openWorkspace,
                 sshConnectionArguments: sshConnectionArguments,
@@ -284,6 +287,7 @@ final class NativeTmuxSessionCoordinator {
         host: TmuxHost,
         socketName: String?,
         launchMode: TmuxAttachmentLaunchMode,
+        initialCommand: String?,
         workingDirectory: String?,
         openWorkspace: Bool,
         sshConnectionArguments: [String],
@@ -315,6 +319,7 @@ final class NativeTmuxSessionCoordinator {
                 socketName: socketName,
                 protectedWorkspacePath: protectedWorkspacePath,
                 launchMode: launchMode,
+                initialCommand: launchMode == .create ? initialCommand : nil,
                 workingDirectory: workingDirectory,
                 openWorkspace: openWorkspace,
                 sshConnectionArguments: sshConnectionArguments,
@@ -425,7 +430,8 @@ final class NativeTmuxSessionCoordinator {
                 : nil,
             protectedWorkspacePath: attachment.protectedWorkspacePath,
             presentationStyle: presentationStyle,
-            launchMode: attachment.launchMode
+            launchMode: attachment.launchMode,
+            initialCommand: attachment.initialCommand
         )
         let surface = terminalCoordinator.paneSurface(
             for: surfaceKey(handle),

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -4168,7 +4168,8 @@ final class WorkspaceSceneModel: ObservableObject {
                     handleID: handle.id,
                     immediately: true
                 )
-            } else if pending.initialCommand == nil {
+            } else if recordsExplicitDismissal
+                || pending.initialCommand == nil {
                 discardPendingTmuxSession(handleID: handle.id)
             }
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -319,8 +319,20 @@ final class WorkspaceSceneModel: ObservableObject {
     @Published var preferredActiveSurfaceTarget: WorkspaceTerminalSurfaceTarget?
     @Published private var borrowedTmuxConnectionStates:
         [UUID: ConnectionState] = [:]
+    private struct PendingTmuxSessionCreation: Equatable {
+        var request: WorkspaceTmuxSessionCreationRequest
+        var commandReplayAuthorized: Bool
+
+        var selection: WorkspaceTmuxSessionSelection {
+            request.selection
+        }
+
+        var initialCommand: String? {
+            request.initialCommand
+        }
+    }
     private var pendingCreatedTmuxSessions:
-        [UUID: WorkspaceTmuxSessionSelection] = [:]
+        [UUID: PendingTmuxSessionCreation] = [:]
     var pendingCreatedTmuxSessionCount: Int {
         pendingCreatedTmuxSessions.count
     }
@@ -338,6 +350,7 @@ final class WorkspaceSceneModel: ObservableObject {
         TmuxConnectionRecoveryRequest?
     private enum RemoteTmuxEstablishmentPhase: Equatable {
         case establishingWorkspace
+        case establishingProfile(initialCommand: String)
         case attachOnly
     }
     private struct TmuxReconnectContext: Equatable {
@@ -443,6 +456,34 @@ final class WorkspaceSceneModel: ObservableObject {
     var activeBorrowedTmuxSessionIsConfirmedEnded: Bool {
         guard let handle = activeBorrowedTmuxHandle else { return false }
         return confirmedEndedTmuxSessionHandles.contains(handle.id)
+    }
+    var activeBorrowedTmuxRetryRequiresConfirmation: Bool {
+        guard let handle = activeBorrowedTmuxHandle,
+              case .disconnected = borrowedTmuxConnectionStates[handle.id],
+              let pending = activePendingTmuxCreation?.pending,
+              pending.initialCommand != nil,
+              !pending.commandReplayAuthorized
+        else { return false }
+        return true
+    }
+
+    var activeBorrowedTmuxRetryCommand: String? {
+        guard activeBorrowedTmuxRetryRequiresConfirmation else { return nil }
+        return activePendingTmuxCreation?.pending.initialCommand
+    }
+
+    private var activePendingTmuxCreation:
+        (handleID: UUID, pending: PendingTmuxSessionCreation)? {
+        guard let selection = activeBorrowedTmuxSelection else { return nil }
+        if let handle = activeBorrowedTmuxHandle,
+           let pending = pendingCreatedTmuxSessions[handle.id] {
+            return (handle.id, pending)
+        }
+        return pendingCreatedTmuxSessions.first {
+            Self.sameTmuxSession($0.value.selection, selection)
+        }.map {
+            ($0.key, $0.value)
+        }
     }
 
     var activityReferenceDate: Date {
@@ -2787,7 +2828,7 @@ final class WorkspaceSceneModel: ObservableObject {
             pendingRemovalPresentationRestorations.removeValue(forKey: scope)
         }
         let pendingForInvalidatedHosts = pendingCreatedTmuxSessions.filter {
-            hostIDs.contains($0.value.hostID)
+            hostIDs.contains($0.value.selection.hostID)
         }
         for (handleID, pending) in pendingForInvalidatedHosts {
             createdSessionDiscoveryTasks.removeValue(
@@ -2797,7 +2838,7 @@ final class WorkspaceSceneModel: ObservableObject {
             endedCreatedTmuxSessionHandles.remove(handleID)
             pendingCreatedTmuxSessions.removeValue(forKey: handleID)
             borrowedTmuxConnectionStates.removeValue(forKey: handleID)
-            removeOptimisticTmuxSession(pending)
+            removeOptimisticTmuxSession(pending.selection)
         }
         for hostID in hostIDs {
             let handles = nativeTmuxSessionCoordinator.detachAll(
@@ -3589,6 +3630,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 sessionClosed:
                 confirmedEndedTmuxSessionHandles.contains(handle.id),
                 defersTerminalResize: defersTerminalResize,
+                retryRequiresConfirmation:
+                activeBorrowedTmuxRetryRequiresConfirmation,
+                retryCommand: activeBorrowedTmuxRetryCommand,
                 surface: { [weak self] in
                     self?.nativeTmuxSessionCoordinator.surface(handle: handle)
                 },
@@ -3599,6 +3643,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 },
                 onRetryRequest: { [weak self] in
                     self?.retryBorrowedTmuxSession(selection)
+                },
+                onConfirmedRetryRequest: { [weak self] in
+                    self?
+                        .retryBorrowedTmuxSessionAfterProfileCommandConfirmation(
+                            selection
+                        )
                 },
                 onReconnectNow: onReconnectNow,
                 onReviewConnection: onReviewConnection,
@@ -3624,25 +3674,54 @@ final class WorkspaceSceneModel: ObservableObject {
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
-        let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
-            Self.sameTmuxSession($0, selection)
+        let pendingCreation = pendingCreatedTmuxSessions.values.first {
+            Self.sameTmuxSession($0.selection, selection)
+        }
+        if pendingCreation?.initialCommand != nil,
+           pendingCreation?.commandReplayAuthorized != true {
+            presentTmuxSession(selection, launchMode: .attachOnly)
+            return
         }
         presentTmuxSession(
             selection,
-            launchMode: selection.socketName == nil && hasPendingCreation
+            launchMode: selection.socketName == nil && pendingCreation != nil
                 ? .create
-                : .attach
+                : .attach,
+            initialCommand: pendingCreation?.initialCommand,
+            commandReplayAuthorized:
+            pendingCreation?.commandReplayAuthorized == true
         )
     }
 
     func createTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection
+        ))
+    }
+
+    func createTmuxSession(_ request: WorkspaceTmuxSessionCreationRequest) {
+        let isPendingCommandReplay = request.initialCommand != nil
+            && pendingCreatedTmuxSessions.values.contains {
+                Self.sameTmuxSession($0.selection, request.selection)
+            }
+        createTmuxSession(
+            request,
+            commandReplayAuthorized: !isPendingCommandReplay
+        )
+    }
+
+    private func createTmuxSession(
+        _ request: WorkspaceTmuxSessionCreationRequest,
+        commandReplayAuthorized: Bool
+    ) {
         cancelPendingRestoration()
+        let selection = request.selection
         userNavigationRevision &+= 1
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
         let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
-            Self.sameTmuxSession($0, selection)
+            Self.sameTmuxSession($0.selection, selection)
         }
         let knownSessions = tmuxSessionsByHost[selection.hostID]
             ?? snapshot.host(id: selection.hostID)?.tmuxSessions
@@ -3659,10 +3738,18 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         guard let handle = presentTmuxSession(
             selection,
-            launchMode: launchMode
+            launchMode: launchMode,
+            initialCommand: launchMode == .create
+                ? request.initialCommand
+                : nil,
+            commandReplayAuthorized: commandReplayAuthorized
         ) else { return }
         if launchMode == .create {
-            pendingCreatedTmuxSessions[handle.id] = selection
+            pendingCreatedTmuxSessions[handle.id] =
+                PendingTmuxSessionCreation(
+                    request: request,
+                    commandReplayAuthorized: false
+                )
             _ = publishCreatedTmuxSession(selection)
         }
     }
@@ -3676,6 +3763,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private func presentTmuxSession(
         _ selection: WorkspaceTmuxSessionSelection,
         launchMode: TmuxAttachmentLaunchMode,
+        initialCommand: String? = nil,
+        commandReplayAuthorized: Bool = false,
         intent: TmuxPresentationIntent = .userInitiated,
         activatesPresentation: Bool = true
     ) -> BorrowedTmuxSessionHandle? {
@@ -3691,6 +3780,10 @@ final class WorkspaceSceneModel: ObservableObject {
             selection.socketName != nil && launchMode == .create
                 ? .attach
                 : launchMode
+        guard effectiveLaunchMode != .create
+            || initialCommand == nil
+            || commandReplayAuthorized
+        else { return nil }
         if let worktreeID = selection.worktreeID {
             let replacedSelections: [WorkspaceTmuxSessionSelection] =
                 retainedTmuxPresentations.values.compactMap { presentation in
@@ -3769,9 +3862,22 @@ final class WorkspaceSceneModel: ObservableObject {
             host: attachmentHost,
             socketName: selection.socketName,
             launchMode: effectiveLaunchMode,
+            initialCommand: effectiveLaunchMode == .create
+                ? initialCommand
+                : nil,
             workingDirectory: selection.worktreePath,
             openWorkspace: openWorkspace
         )
+        let phase: RemoteTmuxEstablishmentPhase
+        if openWorkspace || protectedSessionNeedsEstablishment {
+            phase = .establishingWorkspace
+        } else if effectiveLaunchMode == .create,
+                  let initialCommand,
+                  !initialCommand.isEmpty {
+            phase = .establishingProfile(initialCommand: initialCommand)
+        } else {
+            phase = .attachOnly
+        }
         let reconnectContext = attachmentHost.isRemote
             || openWorkspace
             || protectedSessionNeedsEstablishment
@@ -3779,9 +3885,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 selection: selection,
                 handleID: handle.id,
                 host: attachmentHost,
-                phase: openWorkspace || protectedSessionNeedsEstablishment
-                    ? .establishingWorkspace
-                    : .attachOnly,
+                phase: phase,
                 surfaceExitCode: nil
             )
             : nil
@@ -3802,7 +3906,16 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         borrowedTmuxConnectionStates[handle.id] = .connecting
         if effectiveLaunchMode == .create {
-            transferPendingCreation(for: selection, to: handle)
+            transferPendingCreation(
+                for: PendingTmuxSessionCreation(
+                    request: WorkspaceTmuxSessionCreationRequest(
+                        selection: selection,
+                        initialCommand: initialCommand
+                    ),
+                    commandReplayAuthorized: false
+                ),
+                to: handle
+            )
         }
         return handle
     }
@@ -3974,15 +4087,22 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func transferPendingCreation(
-        for selection: WorkspaceTmuxSessionSelection,
+        for pendingCreation: PendingTmuxSessionCreation,
         to handle: BorrowedTmuxSessionHandle
     ) {
+        let request = pendingCreation.request
         let previousHandleIDs = pendingCreatedTmuxSessions.compactMap {
             handleID, pending in
-            Self.sameTmuxSession(pending, selection) ? handleID : nil
+            Self.sameTmuxSession(pending.selection, request.selection)
+                ? handleID
+                : nil
         }
         guard !previousHandleIDs.isEmpty,
               !previousHandleIDs.contains(handle.id) else { return }
+        let retainedCommand = request.initialCommand
+            ?? previousHandleIDs.lazy.compactMap {
+                self.pendingCreatedTmuxSessions[$0]?.initialCommand
+            }.first
         for handleID in previousHandleIDs {
             createdSessionDiscoveryTasks.removeValue(
                 forKey: handleID
@@ -3992,7 +4112,15 @@ final class WorkspaceSceneModel: ObservableObject {
             pendingCreatedTmuxSessions.removeValue(forKey: handleID)
             borrowedTmuxConnectionStates.removeValue(forKey: handleID)
         }
-        pendingCreatedTmuxSessions[handle.id] = selection
+        pendingCreatedTmuxSessions[handle.id] =
+            PendingTmuxSessionCreation(
+                request: WorkspaceTmuxSessionCreationRequest(
+                    selection: request.selection,
+                    initialCommand: retainedCommand
+                ),
+                commandReplayAuthorized:
+                pendingCreation.commandReplayAuthorized
+            )
     }
 
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
@@ -4031,15 +4159,18 @@ final class WorkspaceSceneModel: ObservableObject {
         cancelTmuxPresentationTasks(handleID: handle.id)
         confirmedEndedTmuxSessionHandles.remove(handle.id)
         borrowedTmuxConnectionStates.removeValue(forKey: handle.id)
-        if pendingCreatedTmuxSessions[handle.id] != nil,
-           nativeTmuxSessionCoordinator.hasLaunched(handle) {
-            endedCreatedTmuxSessionHandles.insert(handle.id)
-            reconcileCreatedTmuxSession(
-                handleID: handle.id,
-                immediately: true
-            )
-        } else if pendingCreatedTmuxSessions[handle.id] != nil {
-            discardPendingTmuxSession(handleID: handle.id)
+        if var pending = pendingCreatedTmuxSessions[handle.id] {
+            if nativeTmuxSessionCoordinator.hasLaunched(handle) {
+                pending.commandReplayAuthorized = false
+                pendingCreatedTmuxSessions[handle.id] = pending
+                endedCreatedTmuxSessionHandles.insert(handle.id)
+                reconcileCreatedTmuxSession(
+                    handleID: handle.id,
+                    immediately: true
+                )
+            } else if pending.initialCommand == nil {
+                discardPendingTmuxSession(handleID: handle.id)
+            }
         }
         if activeBorrowedTmuxHandle == handle {
             activeBorrowedTmuxSelection = nil
@@ -4307,7 +4438,7 @@ final class WorkspaceSceneModel: ObservableObject {
             }
             scheduleTmuxSessionDiscovery()
         }
-        guard pendingCreatedTmuxSessions[handle.id] != nil else {
+        guard var pending = pendingCreatedTmuxSessions[handle.id] else {
             return
         }
         switch state {
@@ -4315,9 +4446,16 @@ final class WorkspaceSceneModel: ObservableObject {
             reconcileCreatedTmuxSession(handleID: handle.id)
         case .disconnected:
             guard nativeTmuxSessionCoordinator.hasLaunched(handle) else {
-                discardPendingTmuxSession(handleID: handle.id)
+                if pending.initialCommand != nil {
+                    pending.commandReplayAuthorized = true
+                    pendingCreatedTmuxSessions[handle.id] = pending
+                } else {
+                    discardPendingTmuxSession(handleID: handle.id)
+                }
                 return
             }
+            pending.commandReplayAuthorized = false
+            pendingCreatedTmuxSessions[handle.id] = pending
             endedCreatedTmuxSessionHandles.insert(handle.id)
             reconcileCreatedTmuxSession(
                 handleID: handle.id,
@@ -4370,14 +4508,14 @@ final class WorkspaceSceneModel: ObservableObject {
         guard let currentContext = presentation.reconnectContext else {
             return .stop
         }
-        let confirmedEstablishment =
-            context.phase == .establishingWorkspace
+        let advancedToAttachOnly =
+            context.phase != .attachOnly
                 && currentContext.phase == .attachOnly
                 && currentContext.selection == context.selection
                 && currentContext.handleID == context.handleID
                 && currentContext.host == context.host
                 && currentContext.surfaceExitCode == context.surfaceExitCode
-        guard currentContext == context || confirmedEstablishment,
+        guard currentContext == context || advancedToAttachOnly,
               presentation.handle.id == context.handleID,
               retainedTmuxPresentation(for: presentation.handle)
               === presentation
@@ -4468,7 +4606,7 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             return .stop
         case .absent:
-            guard context.phase == .establishingWorkspace else {
+            guard context.phase != .attachOnly else {
                 confirmedEndedTmuxSessionHandles.insert(context.handleID)
                 presentation.recoveryState = nil
                 presentation.recoveryRequest = nil
@@ -4482,11 +4620,23 @@ final class WorkspaceSceneModel: ObservableObject {
                 )
                 return .stop
             }
-            relaunchTmuxSession(
-                presentation,
-                launchMode: .attach,
-                intent: .userInitiated
-            )
+            switch context.phase {
+            case .establishingWorkspace:
+                relaunchTmuxSession(
+                    presentation,
+                    launchMode: .attach,
+                    intent: .userInitiated
+                )
+            case .establishingProfile:
+                stopTmuxReconnectWithUnableToAttach(
+                    presentation,
+                    "The session was not found after the connection dropped. "
+                        + "The launch command may have already run. Review the"
+                        + " command before trying it again."
+                )
+            case .attachOnly:
+                break
+            }
             return .stop
         case .failure(.probeCancelled), .failure(.probeTimedOut):
             return .retry
@@ -4537,6 +4687,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private func relaunchTmuxSession(
         _ presentation: RetainedTmuxPresentation,
         launchMode: TmuxAttachmentLaunchMode,
+        initialCommand: String? = nil,
         intent: TmuxPresentationIntent
     ) {
         let selection = presentation.selection
@@ -4572,6 +4723,7 @@ final class WorkspaceSceneModel: ObservableObject {
             host: attachmentHost,
             socketName: selection.socketName,
             launchMode: launchMode,
+            initialCommand: launchMode == .create ? initialCommand : nil,
             workingDirectory: selection.worktreePath,
             openWorkspace: openWorkspace
         )
@@ -4584,13 +4736,21 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         presentation.handle = handle
         presentation.launchMode = launchMode
+        let phase: RemoteTmuxEstablishmentPhase
+        if openWorkspace || protectedSessionNeedsEstablishment {
+            phase = .establishingWorkspace
+        } else if launchMode == .create,
+                  let initialCommand,
+                  !initialCommand.isEmpty {
+            phase = .establishingProfile(initialCommand: initialCommand)
+        } else {
+            phase = .attachOnly
+        }
         presentation.reconnectContext = TmuxReconnectContext(
             selection: selection,
             handleID: handle.id,
             host: attachmentHost,
-            phase: openWorkspace || protectedSessionNeedsEstablishment
-                ? .establishingWorkspace
-                : .attachOnly,
+            phase: phase,
             surfaceExitCode: nil
         )
         borrowedTmuxConnectionStates[handle.id] = .connecting
@@ -4671,7 +4831,7 @@ final class WorkspaceSceneModel: ObservableObject {
         let handle = presentation.handle
         guard let context = presentation.reconnectContext,
               context.handleID == handle.id,
-              context.phase == .establishingWorkspace
+              context.phase != .attachOnly
         else { return }
         presentation.establishmentConfirmationTask?.cancel()
         let delays = [.zero] + createdSessionDiscoveryDelays
@@ -4710,14 +4870,14 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func discardPendingTmuxSession(handleID: UUID) {
-        guard let selection = pendingCreatedTmuxSessions[handleID] else {
+        guard let request = pendingCreatedTmuxSessions[handleID] else {
             return
         }
         createdSessionDiscoveryTasks.removeValue(forKey: handleID)?.cancel()
         pendingCreatedTmuxSessions.removeValue(forKey: handleID)
         exhaustedCreatedTmuxSessionHandles.remove(handleID)
         endedCreatedTmuxSessionHandles.remove(handleID)
-        removeOptimisticTmuxSession(selection)
+        removeOptimisticTmuxSession(request.selection)
     }
 
     /// True once no deferred or draining styling work remains. Tests wait on
@@ -4878,8 +5038,8 @@ final class WorkspaceSceneModel: ObservableObject {
         immediately: Bool = false
     ) {
         guard let pending = pendingCreatedTmuxSessions[handleID],
-              let host = inventoryHosts[pending.hostID]
-              ?? snapshot.host(id: pending.hostID).flatMap(
+              let host = inventoryHosts[pending.selection.hostID]
+              ?? snapshot.host(id: pending.selection.hostID).flatMap(
                   TmuxHostResolver.resolve
               )
         else { return }
@@ -4916,10 +5076,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 case let .success(discovered):
                     fenceTmuxDiscoveryForCreationReconciliation(host: host)
                     tmuxDiscoveryFailuresByHost.removeValue(
-                        forKey: pending.hostID
+                        forKey: pending.selection.hostID
                     )
                     let found = discovered.contains {
-                        $0.name == pending.name
+                        $0.name == pending.selection.name
                     }
                     let isLastAttempt = index == delays.indices.last
                     if !found, isLastAttempt {
@@ -4927,10 +5087,10 @@ final class WorkspaceSceneModel: ObservableObject {
                             handleID
                         )
                     }
-                    tmuxSessionsByHost[pending.hostID] =
+                    tmuxSessionsByHost[pending.selection.hostID] =
                         reconciledTmuxSessions(
                             discovered,
-                            hostID: pending.hostID
+                            hostID: pending.selection.hostID
                         )
                     applyInventoryOverlayIfNeeded()
                     updateWorkspaceInventoryState()
@@ -4945,9 +5105,9 @@ final class WorkspaceSceneModel: ObservableObject {
                     }
                 case let .failure(error):
                     let hostName = snapshot.host(
-                        id: pending.hostID
+                        id: pending.selection.hostID
                     )?.name ?? "Unknown host"
-                    tmuxDiscoveryFailuresByHost[pending.hostID] =
+                    tmuxDiscoveryFailuresByHost[pending.selection.hostID] =
                         "\(hostName): \(error.localizedDescription)"
                     updateWorkspaceInventoryState()
                 }
@@ -4983,14 +5143,24 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         let discoveredNames = Set(summaries.map(\.name))
         let pendingForHost = pendingCreatedTmuxSessions.filter {
-            $0.value.hostID == hostID
+            $0.value.selection.hostID == hostID
         }
         for (handleID, pending) in pendingForHost {
-            if discoveredNames.contains(pending.name) {
+            if discoveredNames.contains(pending.selection.name) {
                 if let key = retainedTmuxPresentationKeysByHandle[handleID],
                    let presentation = retainedTmuxPresentations[key],
-                   Self.sameTmuxSession(presentation.selection, pending) {
+                   Self.sameTmuxSession(
+                       presentation.selection,
+                       pending.selection
+                   ) {
                     presentation.launchMode = .attach
+                    if let context = presentation.reconnectContext,
+                       context.handleID == handleID,
+                       case .establishingProfile = context.phase {
+                        presentation.reconnectContext?.phase = .attachOnly
+                        presentation.establishmentConfirmationTask?.cancel()
+                        presentation.establishmentConfirmationTask = nil
+                    }
                     publishActiveState(for: presentation)
                 }
                 pendingCreatedTmuxSessions.removeValue(forKey: handleID)
@@ -4999,7 +5169,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 )?.cancel()
                 exhaustedCreatedTmuxSessionHandles.remove(handleID)
                 endedCreatedTmuxSessionHandles.remove(handleID)
-            } else if exhaustedCreatedTmuxSessionHandles.contains(handleID),
+            } else if pending.initialCommand == nil,
+                      exhaustedCreatedTmuxSessionHandles.contains(handleID),
                       endedCreatedTmuxSessionHandles.contains(handleID) {
                 pendingCreatedTmuxSessions.removeValue(forKey: handleID)
                 createdSessionDiscoveryTasks.removeValue(
@@ -5009,7 +5180,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 endedCreatedTmuxSessionHandles.remove(handleID)
             } else {
                 summaries.append(TmuxSessionSummary(
-                    name: pending.name,
+                    name: pending.selection.name,
                     managed: false,
                     windows: []
                 ))
@@ -5056,33 +5227,97 @@ final class WorkspaceSceneModel: ObservableObject {
     func retryBorrowedTmuxSession(
         _ selection: WorkspaceTmuxSessionSelection
     ) {
+        guard !activeBorrowedTmuxRetryRequiresConfirmation else { return }
+        retryBorrowedTmuxSession(
+            selection,
+            confirmedPendingCreation: nil
+        )
+    }
+
+    func retryBorrowedTmuxSessionAfterProfileCommandConfirmation(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) {
+        guard activeBorrowedTmuxRetryRequiresConfirmation,
+              let activePending = activePendingTmuxCreation,
+              Self.sameTmuxSession(
+                  activePending.pending.selection,
+                  selection
+              )
+        else { return }
+        var pendingCreation = activePending.pending
+        pendingCreation.commandReplayAuthorized = true
+        pendingCreatedTmuxSessions[activePending.handleID] = pendingCreation
+        retryBorrowedTmuxSession(
+            selection,
+            confirmedPendingCreation: pendingCreation
+        )
+    }
+
+    private func retryBorrowedTmuxSession(
+        _ selection: WorkspaceTmuxSessionSelection,
+        confirmedPendingCreation: PendingTmuxSessionCreation?
+    ) {
         guard activeBorrowedTmuxSelection == selection else { return }
+        if let confirmedPendingCreation,
+           let activePending = activePendingTmuxCreation,
+           activePending.pending == confirmedPendingCreation {
+            var consumedPendingCreation = confirmedPendingCreation
+            consumedPendingCreation.commandReplayAuthorized = false
+            pendingCreatedTmuxSessions[activePending.handleID] =
+                consumedPendingCreation
+        }
         let sessionConfirmedEnded = activeBorrowedTmuxHandle.map {
             confirmedEndedTmuxSessionHandles.contains($0.id)
         } == true
+        let pendingCreation = confirmedPendingCreation
+            ?? activeBorrowedTmuxHandle.flatMap {
+                pendingCreatedTmuxSessions[$0.id]
+            } ?? pendingCreatedTmuxSessions.values.first {
+                Self.sameTmuxSession($0.selection, selection)
+            }
         let recreateEndedNamedSession =
             sessionConfirmedEnded
                 && selection.socketName == nil
                 && selection.worktreeID == nil
                 && selection.worktreePath == nil
-        let launchMode = Self.retryLaunchMode(
-            for: selection,
-            current: activeBorrowedTmuxLaunchMode,
-            sessionConfirmedEnded: sessionConfirmedEnded
-        )
+        let launchMode: TmuxAttachmentLaunchMode =
+            confirmedPendingCreation == nil
+                ? Self.retryLaunchMode(
+                    for: selection,
+                    current: activeBorrowedTmuxLaunchMode,
+                    sessionConfirmedEnded: sessionConfirmedEnded
+                )
+                : .create
         invalidateBorrowedTmuxSession(selection)
         if recreateEndedNamedSession {
             guard let handle = presentTmuxSession(
                 selection,
-                launchMode: .create
+                launchMode: .create,
+                initialCommand: pendingCreation?.initialCommand,
+                commandReplayAuthorized:
+                pendingCreation?.commandReplayAuthorized == true
             ) else { return }
-            pendingCreatedTmuxSessions[handle.id] = selection
+            pendingCreatedTmuxSessions[handle.id] =
+                PendingTmuxSessionCreation(
+                    request: pendingCreation?.request
+                        ?? WorkspaceTmuxSessionCreationRequest(
+                            selection: selection
+                        ),
+                    commandReplayAuthorized: false
+                )
             _ = publishCreatedTmuxSession(selection)
             return
         }
         switch launchMode {
         case .create:
-            createTmuxSession(selection)
+            createTmuxSession(
+                pendingCreation?.request
+                    ?? WorkspaceTmuxSessionCreationRequest(
+                        selection: selection
+                    ),
+                commandReplayAuthorized:
+                pendingCreation?.commandReplayAuthorized == true
+            )
         case .attach, .attachOnly:
             presentTmuxSession(selection, launchMode: launchMode)
         }

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -817,8 +817,8 @@ struct WorkspaceWindow: View {
                 applyTmuxSessionTheme: { [sceneModel] selection in
                     try await sceneModel.applyTheme(to: selection)
                 },
-                createTmuxSession: { [sceneModel] selection in
-                    sceneModel.createTmuxSession(selection)
+                createTmuxSession: { [sceneModel] request in
+                    sceneModel.createTmuxSession(request)
                 },
                 refreshWorkspaceInventory: { [sceneModel] in
                     sceneModel.refreshWorkspaceInventory()

--- a/Sources/Settings/SSHHost.swift
+++ b/Sources/Settings/SSHHost.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GhosthubWorkspace
 
 public struct SSHHost: Codable, Equatable, Sendable, Identifiable {
@@ -5,6 +6,7 @@ public struct SSHHost: Codable, Equatable, Sendable, Identifiable {
     public var name: String
     public var platform: HostPlatform
     public var sshDestination: String
+    public var launchProfiles: [TmuxLaunchProfile]
 
     public var id: String { configKey }
 
@@ -12,11 +14,36 @@ public struct SSHHost: Codable, Equatable, Sendable, Identifiable {
         configKey: String,
         name: String,
         platform: HostPlatform,
-        sshDestination: String
+        sshDestination: String,
+        launchProfiles: [TmuxLaunchProfile] = []
     ) {
         self.configKey = configKey
         self.name = name
         self.platform = platform
         self.sshDestination = sshDestination
+        self.launchProfiles = launchProfiles
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case configKey
+        case name
+        case platform
+        case sshDestination
+        case launchProfiles
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        configKey = try container.decode(String.self, forKey: .configKey)
+        name = try container.decode(String.self, forKey: .name)
+        platform = try container.decode(HostPlatform.self, forKey: .platform)
+        sshDestination = try container.decode(
+            String.self,
+            forKey: .sshDestination
+        )
+        launchProfiles = try container.decodeIfPresent(
+            [TmuxLaunchProfile].self,
+            forKey: .launchProfiles
+        ) ?? []
     }
 }

--- a/Sources/Settings/SSHHostDraft.swift
+++ b/Sources/Settings/SSHHostDraft.swift
@@ -7,19 +7,22 @@ public struct SSHHostDraft: Identifiable, Equatable, Sendable {
     public var name: String
     public var platform: HostPlatform
     public var sshDestination: String
+    public var launchProfiles: [TmuxLaunchProfile]
 
     public init(
         id: UUID = UUID(),
         configKey: String,
         name: String,
         platform: HostPlatform,
-        sshDestination: String
+        sshDestination: String,
+        launchProfiles: [TmuxLaunchProfile] = []
     ) {
         self.id = id
         self.configKey = configKey
         self.name = name
         self.platform = platform
         self.sshDestination = sshDestination
+        self.launchProfiles = launchProfiles
     }
 
     public init(_ host: SSHHost) {
@@ -27,7 +30,8 @@ public struct SSHHostDraft: Identifiable, Equatable, Sendable {
             configKey: host.configKey,
             name: host.name,
             platform: host.platform,
-            sshDestination: host.sshDestination
+            sshDestination: host.sshDestination,
+            launchProfiles: host.launchProfiles
         )
     }
 
@@ -36,7 +40,8 @@ public struct SSHHostDraft: Identifiable, Equatable, Sendable {
             configKey: configKey,
             name: name,
             platform: platform,
-            sshDestination: sshDestination
+            sshDestination: sshDestination,
+            launchProfiles: launchProfiles
         )
     }
 

--- a/Sources/Settings/SSHHostSanitizer.swift
+++ b/Sources/Settings/SSHHostSanitizer.swift
@@ -2,6 +2,33 @@ import Foundation
 import GhosthubWorkspace
 
 public enum SSHHostSanitizer {
+    public static func launchProfiles(
+        _ profiles: [TmuxLaunchProfile]
+    ) -> [TmuxLaunchProfile] {
+        var seenNames = Set<String>()
+
+        return profiles.compactMap { profile in
+            let name = profile.name.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            let command = profile.command.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            let normalizedName = name.lowercased()
+            guard !name.isEmpty,
+                  !command.isEmpty,
+                  seenNames.insert(normalizedName).inserted
+            else {
+                return nil
+            }
+            return TmuxLaunchProfile(
+                id: profile.id,
+                name: name,
+                command: command
+            )
+        }
+    }
+
     public static func sshHosts(
         _ hosts: [SSHHost]
     ) -> [SSHHost] {
@@ -29,7 +56,8 @@ public enum SSHHostSanitizer {
                 configKey: configKey,
                 name: name,
                 platform: host.platform,
-                sshDestination: sshDestination
+                sshDestination: sshDestination,
+                launchProfiles: launchProfiles(host.launchProfiles)
             )
         }
     }

--- a/Sources/Settings/TmuxLaunchProfile.swift
+++ b/Sources/Settings/TmuxLaunchProfile.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct TmuxLaunchProfile:
+    Codable, Equatable, Identifiable, Sendable {
+    public var id: UUID
+    public var name: String
+    public var command: String
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        command: String
+    ) {
+        self.id = id
+        self.name = name
+        self.command = command
+    }
+}

--- a/Sources/Settings/TmuxLaunchProfileValidation.swift
+++ b/Sources/Settings/TmuxLaunchProfileValidation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum TmuxLaunchProfileValidation {
+    public static func message(
+        for profile: TmuxLaunchProfile,
+        in profiles: [TmuxLaunchProfile]
+    ) -> String? {
+        let name = profile.name.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !name.isEmpty else { return "Name is required." }
+        guard !profile.command.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty else {
+            return "Command is required."
+        }
+        let normalizedName = name.lowercased()
+        let duplicates = profiles.filter {
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() == normalizedName
+        }
+        guard duplicates.count < 2 else {
+            return "Profile names must be unique."
+        }
+        return nil
+    }
+}

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -186,6 +186,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     public let protectedWorkspacePath: String?
     public let presentationStyle: TmuxPresentationStyle?
     public var launchMode: TmuxAttachmentLaunchMode
+    public let initialCommand: String?
 
     public init(
         sessionName: String,
@@ -194,7 +195,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         workspacePath: String? = nil,
         protectedWorkspacePath: String? = nil,
         presentationStyle: TmuxPresentationStyle? = nil,
-        launchMode: TmuxAttachmentLaunchMode = .attach
+        launchMode: TmuxAttachmentLaunchMode = .attach,
+        initialCommand: String? = nil
     ) {
         self.sessionName = sessionName
         self.host = host
@@ -203,6 +205,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         self.protectedWorkspacePath = protectedWorkspacePath
         self.presentationStyle = presentationStyle
         self.launchMode = launchMode
+        self.initialCommand = initialCommand
     }
 
     public func attachCommand(
@@ -249,12 +252,22 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     )
                 }
             } else if launchMode == .create {
-                command = remoteCreateThenAttachCommand(
-                    info: info,
-                    tmuxPath: tmuxPath,
-                    workingDirectory: workingDirectory,
-                    sshConnectionArguments: sshConnectionArguments
-                )
+                if let initialCommand, !initialCommand.isEmpty {
+                    command = remoteInitialCommandAttachCommand(
+                        info: info,
+                        tmuxPath: tmuxPath,
+                        workingDirectory: workingDirectory,
+                        initialCommand: initialCommand,
+                        sshConnectionArguments: sshConnectionArguments
+                    )
+                } else {
+                    command = remoteCreateThenAttachCommand(
+                        info: info,
+                        tmuxPath: tmuxPath,
+                        workingDirectory: workingDirectory,
+                        sshConnectionArguments: sshConnectionArguments
+                    )
+                }
             } else if launchMode != .attachOnly,
                       protectedWorkspacePath == nil,
                       workspacePath != nil {
@@ -392,6 +405,9 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             tmuxPath,
             "new-session", "-A", "-E", "-s", sessionName
         ) + (workingDirectory.map { ["-c", $0] } ?? [])
+        if let initialCommand, !initialCommand.isEmpty {
+            arguments.append(initialCommand)
+        }
         if let presentationCommand {
             arguments = presentationCommand.appendingOptions(to: arguments)
         }
@@ -714,6 +730,41 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             "/bin/sh", "-c", Self.remoteCreateThenAttachScript,
             "ghosthub-ssh-tmux-create-once", createOnce, attach,
         ])
+    }
+
+    /// Profile-backed creation must allocate the SSH PTY before tmux starts so
+    /// interactive commands such as sudo and docker exec inherit the terminal
+    /// that remains attached to the outer host session. Native recovery probes
+    /// the exact session before deciding whether creation may run again.
+    private func remoteInitialCommandAttachCommand(
+        info: SSHHostInfo,
+        tmuxPath: String,
+        workingDirectory: String?,
+        initialCommand: String,
+        sshConnectionArguments: [String]
+    ) -> String {
+        var createArguments = tmuxArguments(
+            tmuxPath,
+            "new-session", "-A", "-E", "-s", sessionName
+        ) + (workingDirectory.map { ["-c", $0] } ?? [])
+        createArguments.append(initialCommand)
+        if let presentationCommand {
+            createArguments = presentationCommand.appendingOptions(
+                to: createArguments
+            )
+        }
+        let createAndAttach = createArguments
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let initialBody = "unset TMUX TMUX_PANE; exec \(createAndAttach)"
+        return shellCommand(
+            sshArguments(
+                info: info,
+                allocateTTY: true,
+                remoteCommand: accountLoginShellCommand(initialBody),
+                sshConnectionArguments: sshConnectionArguments
+            )
+        )
     }
 
     private func createIfAbsentCommand(

--- a/Sources/UI/HostsSettingsView.swift
+++ b/Sources/UI/HostsSettingsView.swift
@@ -1,6 +1,7 @@
-import SwiftUI
+import AppKit
 import GhosthubSettings
 import GhosthubWorkspace
+import SwiftUI
 
 enum HostConnectionField: Hashable {
     case displayName
@@ -59,6 +60,118 @@ struct PendingSSHHostTrust: Identifiable {
             confirmation.algorithm,
             confirmation.fingerprint,
         ].joined(separator: ":")
+    }
+}
+
+private struct ShellCommandEditor: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return scrollView
+        }
+        textView.delegate = context.coordinator
+        textView.string = text
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.allowsUndo = true
+        configureTextChecking(for: textView)
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return
+        }
+        context.coordinator.text = $text
+        if textView.string != text {
+            textView.string = text
+        }
+        configureTextChecking(for: textView)
+    }
+
+    private func configureTextChecking(for textView: NSTextView) {
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView,
+                  text.wrappedValue != textView.string
+            else {
+                return
+            }
+            text.wrappedValue = textView.string
+        }
+    }
+}
+
+private struct TmuxLaunchProfileEditorRow: View {
+    @Binding var profile: TmuxLaunchProfile
+    let profiles: [TmuxLaunchProfile]
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                TextField("Profile name", text: $profile.name)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier(
+                        "launch-profile-name-\(profile.id.uuidString)"
+                    )
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .help("Remove Launch Profile")
+                .accessibilityLabel("Remove \(profile.name) launch profile")
+            }
+
+            ShellCommandEditor(text: $profile.command)
+                .frame(minHeight: 58)
+                .padding(4)
+                .background(.background)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(.separator, lineWidth: 1)
+                }
+                .accessibilityLabel("Command for \(profile.name)")
+                .accessibilityIdentifier(
+                    "launch-profile-command-\(profile.id.uuidString)"
+                )
+
+            if let message = TmuxLaunchProfileValidation.message(
+                for: profile,
+                in: profiles
+            ) {
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(10)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }
 
@@ -469,6 +582,40 @@ public struct HostsSettingsView: View {
                         }
                     }
 
+                    if draft.platform != .windows,
+                       let profilesBinding = selectedLaunchProfilesBinding() {
+                        settingsSection("Launch Profiles") {
+                            Text(
+                                "Saved commands run as trusted user code only"
+                                    + " when you explicitly create a new tmux"
+                                    + " session with that profile. Commands are"
+                                    + " stored in local Ghosthub settings; do"
+                                    + " not put passwords or other secrets here."
+                            )
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                            ForEach(profilesBinding) { $profile in
+                                TmuxLaunchProfileEditorRow(
+                                    profile: $profile,
+                                    profiles: profilesBinding.wrappedValue,
+                                    onRemove: {
+                                        removeLaunchProfile(profile.id)
+                                    }
+                                )
+                            }
+
+                            Button {
+                                addLaunchProfile()
+                            } label: {
+                                Label("Add Launch Profile", systemImage: "plus")
+                            }
+                            .accessibilityIdentifier("add-launch-profile")
+                        }
+                        .accessibilityIdentifier("launch-profiles-section")
+                    }
+
                     if isRemoteKwtReady, draft.platform != .windows {
                         settingsSection("Projects") {
                             Text(
@@ -659,6 +806,15 @@ public struct HostsSettingsView: View {
         )
     }
 
+    private func selectedLaunchProfilesBinding()
+        -> Binding<[TmuxLaunchProfile]>? {
+        guard let index = selectedSSHHostDraftIndex else { return nil }
+        return Binding(
+            get: { sshHosts[index].launchProfiles },
+            set: { sshHosts[index].launchProfiles = $0 }
+        )
+    }
+
     // MARK: - Actions
 
     private func addSSHHost() {
@@ -671,6 +827,18 @@ public struct HostsSettingsView: View {
         Task { @MainActor in
             focusedConnectionField = .displayName
         }
+    }
+
+    private func addLaunchProfile() {
+        guard let index = selectedSSHHostDraftIndex else { return }
+        sshHosts[index].launchProfiles.append(
+            TmuxLaunchProfile(name: "New Profile", command: "")
+        )
+    }
+
+    private func removeLaunchProfile(_ id: UUID) {
+        guard let index = selectedSSHHostDraftIndex else { return }
+        sshHosts[index].launchProfiles.removeAll { $0.id == id }
     }
 
     private func removeSelectedSSHHost() {

--- a/Sources/UI/NewTmuxSessionSheet.swift
+++ b/Sources/UI/NewTmuxSessionSheet.swift
@@ -1,3 +1,5 @@
+import Foundation
+import GhosthubSettings
 import GhosthubWorkspace
 import SwiftUI
 
@@ -17,23 +19,90 @@ enum TmuxSessionName {
     }
 }
 
+struct NewTmuxSessionLaunchSelection: Equatable, Sendable {
+    private(set) var hostConfigKey: String
+    private(set) var hostKind: HostKind
+    private(set) var selectedProfileID: UUID?
+
+    init(
+        hostConfigKey: String,
+        hostKind: HostKind,
+        selectedProfileID: UUID? = nil
+    ) {
+        self.hostConfigKey = hostConfigKey
+        self.hostKind = hostKind
+        self.selectedProfileID = selectedProfileID
+    }
+
+    mutating func selectHost(configKey: String, kind: HostKind) {
+        guard configKey != hostConfigKey || kind != hostKind else { return }
+        hostConfigKey = configKey
+        hostKind = kind
+        selectedProfileID = nil
+    }
+
+    mutating func selectProfile(_ id: UUID?) {
+        selectedProfileID = id
+    }
+
+    func availableProfiles(
+        in configuredHosts: [SSHHost]
+    ) -> [TmuxLaunchProfile] {
+        // Configured SSH hosts describe remote machines, so the local host
+        // never resolves profiles, even against a colliding config key.
+        guard hostKind == .remote, let host = configuredHosts.first(where: {
+            $0.configKey == hostConfigKey
+        }), host.platform != .windows else {
+            return []
+        }
+        return host.launchProfiles
+    }
+
+    func selectedCommand(in configuredHosts: [SSHHost]) -> String? {
+        selectedProfile(in: configuredHosts)?.command
+    }
+
+    func selectedProfileName(in configuredHosts: [SSHHost]) -> String? {
+        selectedProfile(in: configuredHosts)?.name
+    }
+
+    private func selectedProfile(
+        in configuredHosts: [SSHHost]
+    ) -> TmuxLaunchProfile? {
+        guard let selectedProfileID else { return nil }
+        return availableProfiles(in: configuredHosts).first {
+            $0.id == selectedProfileID
+        }
+    }
+}
+
 struct NewTmuxSessionSheet: View {
     let hosts: [HostSummary]
-    let onCreate: (HostSummary, String) -> Void
+    let configuredHosts: [SSHHost]
+    let onCreate: (HostSummary, String, String?) -> Void
     let onCancel: () -> Void
 
     @State private var selectedHost: HostSummary
+    @State private var launchSelection: NewTmuxSessionLaunchSelection
     @State private var sessionName = ""
     @FocusState private var isNameFieldFocused: Bool
 
     init(
         host: HostSummary,
         hosts: [HostSummary],
-        onCreate: @escaping (HostSummary, String) -> Void,
+        configuredHosts: [SSHHost],
+        selectedProfileID: UUID? = nil,
+        onCreate: @escaping (HostSummary, String, String?) -> Void,
         onCancel: @escaping () -> Void
     ) {
         _selectedHost = State(initialValue: host)
+        _launchSelection = State(initialValue: NewTmuxSessionLaunchSelection(
+            hostConfigKey: host.configKey,
+            hostKind: host.kind,
+            selectedProfileID: selectedProfileID
+        ))
         self.hosts = hosts
+        self.configuredHosts = configuredHosts
         self.onCreate = onCreate
         self.onCancel = onCancel
     }
@@ -62,6 +131,10 @@ struct NewTmuxSessionSheet: View {
                         hosts.map { host in
                             NativePopupMenuAction(host.sidebarTitle) {
                                 selectedHost = host
+                                launchSelection.selectHost(
+                                    configKey: host.configKey,
+                                    kind: host.kind
+                                )
                             }
                         },
                     ]
@@ -93,6 +166,31 @@ struct NewTmuxSessionSheet: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 13)
+
+            if !availableProfiles.isEmpty {
+                Divider()
+
+                HStack(spacing: 12) {
+                    Text("Start with")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Picker(
+                        "Start with",
+                        selection: selectedProfileBinding
+                    ) {
+                        Text("Login shell").tag(nil as UUID?)
+                        ForEach(availableProfiles) { profile in
+                            Text(profile.name).tag(profile.id as UUID?)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .accessibilityIdentifier("tmux-session-launch-profile")
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 11)
+            }
 
             Text(validationMessage)
                 .font(.caption)
@@ -133,6 +231,11 @@ struct NewTmuxSessionSheet: View {
         if !TmuxSessionName.isValid(normalizedName) {
             return "Use 1–100 characters without periods, colons, or line breaks."
         }
+        if let profileName = launchSelection.selectedProfileName(
+            in: configuredHosts
+        ) {
+            return "Create and attach on \(selectedHost.sidebarTitle) with \(profileName)."
+        }
         return "Create and attach on \(selectedHost.sidebarTitle)."
     }
 
@@ -142,6 +245,21 @@ struct NewTmuxSessionSheet: View {
 
     private func create() {
         guard canCreate else { return }
-        onCreate(selectedHost, normalizedName)
+        onCreate(
+            selectedHost,
+            normalizedName,
+            launchSelection.selectedCommand(in: configuredHosts)
+        )
+    }
+
+    private var availableProfiles: [TmuxLaunchProfile] {
+        launchSelection.availableProfiles(in: configuredHosts)
+    }
+
+    private var selectedProfileBinding: Binding<UUID?> {
+        Binding(
+            get: { launchSelection.selectedProfileID },
+            set: { launchSelection.selectProfile($0) }
+        )
     }
 }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -174,8 +174,13 @@ public struct RootView: View {
                 NewTmuxSessionSheet(
                     host: host,
                     hosts: snapshot.hosts,
-                    onCreate: { selectedHost, name in
-                        createTmuxSession(on: selectedHost, name: name)
+                    configuredHosts: settingsStore.sshHosts,
+                    onCreate: { selectedHost, name, initialCommand in
+                        createTmuxSession(
+                            on: selectedHost,
+                            name: name,
+                            initialCommand: initialCommand
+                        )
                         newTmuxSessionHost = nil
                     },
                     onCancel: { newTmuxSessionHost = nil }
@@ -678,7 +683,11 @@ public struct RootView: View {
         tmuxSelectionBaseline = selection
     }
 
-    private func createTmuxSession(on host: HostSummary, name: String) {
+    private func createTmuxSession(
+        on host: HostSummary,
+        name: String,
+        initialCommand: String?
+    ) {
         let session = WorkspaceTmuxSessionSelection(
             hostID: host.id,
             name: name
@@ -690,7 +699,10 @@ public struct RootView: View {
             visibility: worktreeVisibility
         ))
         tmuxSelectionBaseline = selection
-        handlers.createTmuxSession?(session)
+        handlers.createTmuxSession?(WorkspaceTmuxSessionCreationRequest(
+            selection: session,
+            initialCommand: initialCommand
+        ))
     }
 
     private func requestSessionKill(

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -239,6 +239,19 @@ struct TmuxConnectionRecoveryRequestRouter {
     }
 }
 
+public struct WorkspaceTmuxSessionCreationRequest: Equatable, Sendable {
+    public let selection: WorkspaceTmuxSessionSelection
+    public let initialCommand: String?
+
+    public init(
+        selection: WorkspaceTmuxSessionSelection,
+        initialCommand: String? = nil
+    ) {
+        self.selection = selection
+        self.initialCommand = initialCommand
+    }
+}
+
 public struct InteractionHandlers {
     public let closeWindow: (() -> Void)?
     public let dismissLogViewer: (() -> Void)?
@@ -254,7 +267,8 @@ public struct InteractionHandlers {
         ((TmuxSessionKillRequest) async throws -> Void)?
     public let applyTmuxSessionTheme:
         ((WorkspaceTmuxSessionSelection) async throws -> Void)?
-    public let createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
+    public let createTmuxSession:
+        ((WorkspaceTmuxSessionCreationRequest) -> Void)?
     public let refreshWorkspaceInventory: (() -> Void)?
     public let reconnectActiveTmuxSessionNow: (() -> Void)?
     public let resumeTmuxReconnectAfterSSHRecovery:
@@ -298,7 +312,8 @@ public struct InteractionHandlers {
         ((TmuxSessionKillRequest) async throws -> Void)? = nil,
         applyTmuxSessionTheme:
         ((WorkspaceTmuxSessionSelection) async throws -> Void)? = nil,
-        createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
+        createTmuxSession:
+        ((WorkspaceTmuxSessionCreationRequest) -> Void)? = nil,
         refreshWorkspaceInventory: (() -> Void)? = nil,
         reconnectActiveTmuxSessionNow: (() -> Void)? = nil,
         resumeTmuxReconnectAfterSSHRecovery:

--- a/Tests/App/BorrowedTmuxSessionViewTests.swift
+++ b/Tests/App/BorrowedTmuxSessionViewTests.swift
@@ -76,6 +76,35 @@ struct BorrowedTmuxSessionViewTests {
         #expect(settingsCount == 1)
     }
 
+    @Test("a profile command retry requires explicit confirmation")
+    func profileCommandRetryRequiresConfirmation() {
+        var confirmedRetryCount = 0
+        let retainedCommand = "printf '%s\\n' 'retained command' -- --literal"
+        let view = BorrowedTmuxSessionView(
+            handle: BorrowedTmuxSessionHandle(
+                id: UUID(), hostID: UUID(), name: "editor", surfaceID: UUID()
+            ),
+            hostName: "build-box",
+            isRemoteHost: true,
+            connectionState: .disconnected(
+                reason: "The launch command may have already run."
+            ),
+            retryRequiresConfirmation: true,
+            retryCommand: retainedCommand,
+            surface: { nil },
+            onCloseRequest: {},
+            onRetryRequest: {},
+            onConfirmedRetryRequest: { confirmedRetryCount += 1 },
+            onHostSettingsRequest: {}
+        )
+
+        #expect(view.retryRequiresConfirmation)
+        #expect(view.recoveryActionTitle == "Retry Command")
+        #expect(view.retryConfirmationCommand == retainedCommand)
+        view.onConfirmedRetryRequest()
+        #expect(confirmedRetryCount == 1)
+    }
+
     @Test("an exited tmux client is presented as a closed session")
     func endedSessionPresentation() {
         let view = BorrowedTmuxSessionView(

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -8,6 +8,48 @@ import Testing
 @Suite("Native tmux connection identity", .serialized)
 @MainActor
 struct NativeTmuxSessionCoordinatorTests {
+    @Test("creation carries a launch command but attachment drops it")
+    func launchCommandIsCreationOnly() async throws {
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+        )
+        var readyHandles = Set<UUID>()
+        coordinator.onSurfaceReady = { readyHandles.insert($0.id) }
+        let hostID = UUID()
+        let created = coordinator.attach(
+            hostID: hostID,
+            name: "created",
+            host: .local,
+            launchMode: .create,
+            initialCommand: "exec codex"
+        )
+        let attached = coordinator.attach(
+            hostID: hostID,
+            name: "attached",
+            host: .local,
+            launchMode: .attach,
+            initialCommand: "never-run-this"
+        )
+
+        await waitUntilMainActor {
+            readyHandles == Set([created.id, attached.id])
+        }
+        _ = coordinator.surface(handle: created)
+        let createCommand = try #require(
+            store.requestedConfigurations.last?.command
+        )
+        _ = coordinator.surface(handle: attached)
+        let attachCommand = try #require(
+            store.requestedConfigurations.last?.command
+        )
+
+        #expect(createCommand.contains("exec codex"))
+        #expect(!attachCommand.contains("never-run-this"))
+        #expect(attachCommand.contains("attach-session"))
+    }
+
     @Test("new named sessions use tmux create-or-attach mode")
     func namedSessionUsesCreateMode() async throws {
         let store = RecordingTmuxSurfaceStore()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -656,6 +656,71 @@ struct WorkspaceTmuxDiscoveryTests {
         }
     }
 
+    private final class ProfileReconciliationDiscoveryState:
+        @unchecked Sendable {
+        private let lock = NSLock()
+        private let sessionName: String
+        private var calls = 0
+        private var firstStarted = false
+        private var firstCancelled = false
+
+        init(sessionName: String) {
+            self.sessionName = sessionName
+        }
+
+        func discover(
+            _ host: TmuxHost
+        ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+            lock.lock()
+            calls += 1
+            let call = calls
+            if call == 1 {
+                firstStarted = true
+            }
+            lock.unlock()
+
+            switch call {
+            case 1:
+                while !Task.isCancelled {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                lock.lock()
+                firstCancelled = true
+                lock.unlock()
+                return .failure(.probeCancelled(shell: host.displayName))
+            case 2:
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: sessionName,
+                        windowCount: 1,
+                        createdAt: "1721552400",
+                        managed: false
+                    ),
+                ])
+            default:
+                return .success([])
+            }
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return calls
+        }
+
+        var didStartFirst: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return firstStarted
+        }
+
+        var didCancelFirst: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return firstCancelled
+        }
+    }
+
     @MainActor
     @Test("created sessions publish into host inventory immediately")
     func createdSessionPublishesImmediately() throws {
@@ -1733,7 +1798,10 @@ struct WorkspaceTmuxDiscoveryTests {
             name: "release-work"
         )
 
-        model.createTmuxSession(selection)
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "never-run-this"
+        ))
         await launchActiveTmuxSurface(model, store: surfaceStore)
 
         #expect(model.activeBorrowedTmuxLaunchMode == .attach)
@@ -1741,6 +1809,38 @@ struct WorkspaceTmuxDiscoveryTests {
         let command = try #require(surfaceStore.lastConfiguration?.command)
         #expect(command.contains("attach-session"))
         #expect(!command.contains("new-session"))
+        #expect(!command.contains("never-run-this"))
+    }
+
+    @MainActor
+    @Test("new named creation carries its launch profile command")
+    func profileCreationCarriesInitialCommand() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "codex"
+        )
+
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "exec codex"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("new-session"))
+        #expect(command.contains("exec codex"))
+        await model.shutdown()
     }
 
     @MainActor
@@ -2538,6 +2638,286 @@ struct WorkspaceTmuxDiscoveryTests {
         model.prepareActiveBorrowedTmuxSurface()
         #expect(model.activeBorrowedTmuxSessionIsConnected)
         #expect(surfaceStore.requestCount == 3)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("interrupted profile creation never replays its command automatically")
+    func interruptedProfileCreationRequiresExplicitRetry() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            createdSessionDiscoveryDelays: [.seconds(10)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "codex"
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "exec codex"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState == nil
+        }
+
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(surfaceStore.requestCount == 1)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        #expect(model.activeBorrowedTmuxRetryRequiresConfirmation)
+        #expect(model.activeBorrowedTmuxRetryCommand == "exec codex")
+
+        model.retryBorrowedTmuxSession(selection)
+        for _ in 0 ..< 20 {
+            model.prepareActiveBorrowedTmuxSurface()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(surfaceStore.requestCount == 1)
+
+        model.retryBorrowedTmuxSessionAfterProfileCommandConfirmation(
+            selection
+        )
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        #expect(!model.activeBorrowedTmuxRetryRequiresConfirmation)
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("new-session"))
+        #expect(command.contains("exec codex"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("returning to interrupted profile creation preserves confirmation")
+    func returningToInterruptedProfileCreationPreservesConfirmation()
+        async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            createdSessionDiscoveryDelays: [
+                .milliseconds(10),
+                .milliseconds(20),
+            ],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "codex"
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "exec codex"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let interruptedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState == nil
+        }
+        #expect(model.activeBorrowedTmuxRetryRequiresConfirmation)
+
+        let replacement = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(replacement)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: selection)
+                == interruptedHandle
+        )
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        model.prepareActiveBorrowedTmuxSurface()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(surfaceStore.requestCount == 2)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(model.activeBorrowedTmuxRetryRequiresConfirmation)
+        #expect(model.activeBorrowedTmuxRetryCommand == "exec codex")
+
+        model.retryBorrowedTmuxSessionAfterProfileCommandConfirmation(
+            selection
+        )
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 3
+        }
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("new-session"))
+        #expect(command.contains("exec codex"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a pre-launch failure preserves a safe profile command retry")
+    func preLaunchFailurePreservesProfileCommand() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        surfaceStore.returnsSurface = false
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "codex"
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "exec codex"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        try await Task.sleep(for: .milliseconds(30))
+
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(!model.activeBorrowedTmuxRetryRequiresConfirmation)
+
+        surfaceStore.returnsSurface = true
+        model.retryBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("new-session"))
+        #expect(command.contains("exec codex"))
+        #expect(!model.activeBorrowedTmuxRetryRequiresConfirmation)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("reconciled profile creation never reruns its command")
+    func reconciledProfileCreationDoesNotRerunCommand() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "profile-work"
+        )
+        let discovery = ProfileReconciliationDiscoveryState(
+            sessionName: selection.name
+        )
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: discovery.discover,
+            createdSessionDiscoveryDelays: [.milliseconds(20)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "printf ready"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { discovery.didStartFirst }
+        await waitUntilMainActor {
+            discovery.didCancelFirst
+                && model.pendingCreatedTmuxSessionCount == 0
+        }
+
+        #expect(model.activeBorrowedTmuxLaunchMode == .attach)
+        #expect(surfaceStore.requestCount == 1)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            discovery.count == 3
+                && (model.activeBorrowedTmuxSessionIsConfirmedEnded
+                    || surfaceStore.requestCount > 1)
+        }
+
+        #expect(discovery.count == 3)
+        #expect(surfaceStore.requestCount == 1)
+        #expect(model.activeBorrowedTmuxLaunchMode == .attach)
+        #expect(model.activeBorrowedTmuxSessionIsConfirmedEnded)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("interrupted profile creation attaches when its session is present")
+    func interruptedProfileCreationAttachesWhenPresent() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "profile-work"
+        )
+        let discovery = ProfileReconciliationDiscoveryState(
+            sessionName: selection.name
+        )
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: discovery.discover,
+            createdSessionDiscoveryDelays: [.seconds(10)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "printf ready"
+        ))
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { discovery.didStartFirst }
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(discovery.didCancelFirst)
+        #expect(model.pendingCreatedTmuxSessionCount == 0)
+        #expect(model.activeBorrowedTmuxLaunchMode == .attachOnly)
+        #expect(surfaceStore.requestCount == 2)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("attach-session"))
+        #expect(!command.contains("new-session"))
+        #expect(!command.contains("printf ready"))
         await model.shutdown()
     }
 
@@ -4341,10 +4721,10 @@ struct WorkspaceTmuxDiscoveryTests {
         )
 
         let result = await model.probeSSHHost(SSHHost(
-            configKey: "spark",
-            name: "DGX Spark",
+            configKey: "host-a",
+            name: "Host A",
             platform: .linux,
-            sshDestination: "wesm@dgx-spark"
+            sshDestination: "user-a@host-a.example"
         ), protocolNonce: Self.probeNonce)
         let summary = try result.get()
 
@@ -4728,12 +5108,14 @@ private final class SceneTmuxPaneSurfaceStub: TmuxPaneSurfacing {
     var launchError: Error?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
+    private(set) var lastObserverID: UUID?
 
     func registerSurfaceCloseObserver(
         id: UUID,
         onSurfaceClosed: @escaping (Bool, UInt32?) -> Void
     ) {
         closeObservers[id] = onSurfaceClosed
+        lastObserverID = id
     }
 }
 
@@ -4748,6 +5130,7 @@ private enum SceneSurfaceLaunchError: LocalizedError {
 @MainActor
 private final class SceneTmuxSurfaceStoreStub: TmuxSurfaceStoring {
     let surface = SceneTmuxPaneSurfaceStub()
+    var returnsSurface = true
     private(set) var requestCount = 0
     private(set) var lastConfiguration: TerminalSurfaceConfiguration?
     private(set) var requestedKeys: [SurfaceKey] = []
@@ -4763,7 +5146,7 @@ private final class SceneTmuxSurfaceStoreStub: TmuxSurfaceStoring {
         requestCount += 1
         lastConfiguration = configuration
         requestedKeys.append(key)
-        return surface
+        return returnsSurface ? surface : nil
     }
 
     func removeSurface(for key: SurfaceKey) {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1844,6 +1844,46 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("explicit close abandons an unlaunched profile creation")
+    func explicitCloseAbandonsUnlaunchedProfileCreation() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "codex"
+        )
+        model.createTmuxSession(WorkspaceTmuxSessionCreationRequest(
+            selection: selection,
+            initialCommand: "exec codex"
+        ))
+
+        #expect(surfaceStore.requestCount == 0)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxSessions.map(\.name) == [selection.name]
+        )
+
+        model.closeBorrowedTmuxSession(selection)
+
+        #expect(model.pendingCreatedTmuxSessionCount == 0)
+        #expect(
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxSessions.isEmpty == true
+        )
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) == nil)
+        #expect(!model.activeBorrowedTmuxRetryRequiresConfirmation)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("confirmed named creation retries in attach mode")
     func confirmedCreationDemotesToAttachMode() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/Settings/SSHHostDraftTests.swift
+++ b/Tests/Settings/SSHHostDraftTests.swift
@@ -1,8 +1,34 @@
+import Foundation
 import GhosthubWorkspace
 import Testing
 @testable import GhosthubSettings
 
 struct SSHHostDraftTests {
+    @Test("draft preserves launch profiles through host conversion")
+    func preservesLaunchProfiles() throws {
+        let profileID = try #require(
+            UUID(uuidString: "44444444-4444-4444-4444-444444444444")
+        )
+        let host = SSHHost(
+            configKey: "remote",
+            name: "Remote",
+            platform: .linux,
+            sshDestination: "dev.example",
+            launchProfiles: [
+                TmuxLaunchProfile(
+                    id: profileID,
+                    name: "Codex",
+                    command: "docker exec -it codex codex"
+                ),
+            ]
+        )
+
+        let draft = SSHHostDraft(host)
+
+        #expect(draft.launchProfiles == host.launchProfiles)
+        #expect(draft.sshHost == host)
+    }
+
     @Test("SSH host drafts preserve host identity")
     func preservesHostIdentity() {
         let host = SSHHost(

--- a/Tests/Settings/SSHHostLaunchProfileTests.swift
+++ b/Tests/Settings/SSHHostLaunchProfileTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+@testable import GhosthubSettings
+import Testing
+
+@Suite("SSH host launch profiles")
+struct SSHHostLaunchProfileTests {
+    @Test(
+        "profile validation reports empty and duplicate fields",
+        arguments: [
+            ("", "echo ready", "Name is required."),
+            ("Codex", " \n", "Command is required."),
+            (" codex ", "echo ready", "Profile names must be unique."),
+            ("REPL", "echo ready", nil),
+        ] as [(String, String, String?)]
+    )
+    func validation(name: String, command: String, expected: String?) {
+        let profile = TmuxLaunchProfile(name: name, command: command)
+        let profiles = [
+            TmuxLaunchProfile(name: "Codex", command: "exec codex"),
+            profile,
+        ]
+
+        #expect(
+            TmuxLaunchProfileValidation.message(
+                for: profile,
+                in: profiles
+            ) == expected
+        )
+    }
+
+    @Test("legacy hosts decode with no launch profiles")
+    func legacyHostDecoding() throws {
+        let data = Data("""
+        {
+          "configKey": "remote",
+          "name": "Remote",
+          "platform": "linux",
+          "sshDestination": "dev.example"
+        }
+        """.utf8)
+
+        let host = try JSONDecoder().decode(SSHHost.self, from: data)
+
+        #expect(host.launchProfiles.isEmpty)
+    }
+
+    @Test("launch profiles round trip without changing user shell text")
+    func profileRoundTrip() throws {
+        let profileID = try #require(
+            UUID(uuidString: "11111111-2222-3333-4444-555555555555")
+        )
+        let host = SSHHost(
+            configKey: "remote",
+            name: "Remote",
+            platform: .linux,
+            sshDestination: "dev.example",
+            launchProfiles: [
+                TmuxLaunchProfile(
+                    id: profileID,
+                    name: "Codex container",
+                    command: "printf 'ready'\nexec codex"
+                ),
+            ]
+        )
+
+        let encoded = try JSONEncoder().encode(host)
+        let decoded = try JSONDecoder().decode(SSHHost.self, from: encoded)
+
+        #expect(decoded == host)
+        #expect(decoded.launchProfiles.first?.id == profileID)
+        #expect(
+            decoded.launchProfiles.first?.command
+                == "printf 'ready'\nexec codex"
+        )
+    }
+}

--- a/Tests/Settings/SSHHostSanitizerTests.swift
+++ b/Tests/Settings/SSHHostSanitizerTests.swift
@@ -1,8 +1,46 @@
+import Foundation
 import GhosthubWorkspace
 import Testing
 @testable import GhosthubSettings
 
 struct SSHHostSanitizerTests {
+    @Test("sanitizes launch profiles without changing their order")
+    func sanitizesLaunchProfiles() throws {
+        let firstID = try #require(
+            UUID(uuidString: "11111111-1111-1111-1111-111111111111")
+        )
+        let duplicateID = try #require(
+            UUID(uuidString: "22222222-2222-2222-2222-222222222222")
+        )
+        let secondID = try #require(
+            UUID(uuidString: "33333333-3333-3333-3333-333333333333")
+        )
+        let sanitized = SSHHostSanitizer.launchProfiles([
+            TmuxLaunchProfile(
+                id: firstID,
+                name: " Codex ",
+                command: "\n sudo docker exec -it codex codex \n"
+            ),
+            TmuxLaunchProfile(
+                id: duplicateID,
+                name: "codex",
+                command: "should be dropped"
+            ),
+            TmuxLaunchProfile(name: "Blank command", command: " \n"),
+            TmuxLaunchProfile(name: " \n", command: "echo ignored"),
+            TmuxLaunchProfile(
+                id: secondID,
+                name: " REPL ",
+                command: "printf 'one'\nprintf 'two'"
+            ),
+        ])
+
+        #expect(sanitized.map(\.id) == [firstID, secondID])
+        #expect(sanitized.map(\.name) == ["Codex", "REPL"])
+        #expect(sanitized[0].command == "sudo docker exec -it codex codex")
+        #expect(sanitized[1].command == "printf 'one'\nprintf 'two'")
+    }
+
     @Test("SSH hosts trim required fields")
     func trimsRequiredFields() throws {
         let sanitized = SSHHostSanitizer.sshHosts([

--- a/Tests/Settings/SettingsViewDraftTests.swift
+++ b/Tests/Settings/SettingsViewDraftTests.swift
@@ -203,6 +203,34 @@ struct SettingsViewDraftTests {
         #expect(store.exeAccounts == [disabledAccount])
     }
 
+    @Test("persist sanitizes and writes host launch profiles")
+    func persistWritesLaunchProfiles() {
+        let store = makeStore()
+        var draft = SettingsViewDraft(store: store)
+        draft.sshHosts = [
+            SSHHostDraft(
+                configKey: "remote",
+                name: "Remote",
+                platform: .linux,
+                sshDestination: "dev.example",
+                launchProfiles: [
+                    TmuxLaunchProfile(
+                        name: " Codex ",
+                        command: " docker exec -it codex codex "
+                    ),
+                ]
+            ),
+        ]
+
+        _ = draft.persist(to: store)
+
+        #expect(store.sshHosts[0].launchProfiles[0].name == "Codex")
+        #expect(
+            store.sshHosts[0].launchProfiles[0].command
+                == "docker exec -it codex codex"
+        )
+    }
+
     @Test("host sync preserves selection by stable key")
     func hostSyncPreservesSelection() throws {
         let store = makeStore()

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -782,6 +782,100 @@ struct TmuxAttachmentInfoTests {
         )
     }
 
+    @Test("local profile command is one argument before presentation options")
+    func localProfileCommandPrecedesPresentation() {
+        let initialCommand = "printf 'ready'\nexec codex --dangerously-skip"
+        let command = TmuxAttachmentInfo(
+            sessionName: "codex",
+            host: .local,
+            presentationStyle: TmuxPresentationStyle(
+                foreground: "#3B4851",
+                background: "#FFFFFF"
+            ),
+            launchMode: .create,
+            initialCommand: initialCommand
+        ).attachCommand(
+            tmuxPath: "/opt/bin/tmux",
+            workingDirectory: "/code/vault"
+        )
+
+        #expect(command.contains("printf"))
+        #expect(command.contains("exec codex"))
+        #expect(command.contains("/code/vault"))
+        #expect(command.components(separatedBy: "exec codex").count == 2)
+        let commandPosition = command.range(of: "exec codex")?.lowerBound
+        let presentationPosition = command.range(of: "set-option")?.lowerBound
+        #expect(commandPosition != nil)
+        #expect(presentationPosition != nil)
+        if let commandPosition, let presentationPosition {
+            #expect(commandPosition < presentationPosition)
+        }
+    }
+
+    @Test("remote profile creation allocates a TTY before running its command")
+    func remoteProfileCreationUsesInitialTTY() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "codex",
+            host: .ssh(SSHHostInfo(
+                user: "codex", hostname: "build-box", port: nil
+            )),
+            launchMode: .create,
+            initialCommand: "sudo docker exec -it codex codex"
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+
+        #expect(command.contains("sudo docker exec -it codex codex"))
+        #expect(command.components(
+            separatedBy: "sudo docker exec -it codex codex"
+        ).count == 2)
+        #expect(command.contains("'-tt'"))
+        #expect(command.contains("new-session"))
+        #expect(command.contains("'-A'"))
+        #expect(!command.contains("has-session"))
+        #expect(!command.contains("attach-session"))
+        #expect(!command.contains("reconnecting"))
+        #expect(!command.contains("'new-session' '-d'"))
+    }
+
+    @Test("existing attachment never executes a supplied profile command")
+    func attachModeDropsProfileCommand() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "codex",
+            host: .ssh(SSHHostInfo(
+                user: "codex", hostname: "build-box", port: nil
+            )),
+            launchMode: .attach,
+            initialCommand: "never-run-this"
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+
+        #expect(command.contains("attach-session"))
+        #expect(!command.contains("never-run-this"))
+        #expect(!command.contains("new-session"))
+    }
+
+    @Test("Windows creation ignores POSIX launch profile commands")
+    func windowsCreationDropsProfileCommand() {
+        let host = TmuxHost.ssh(SSHHostInfo(
+            user: "codex",
+            hostname: "build-box",
+            port: nil,
+            platform: .windows
+        ))
+        let command = TmuxAttachmentInfo(
+            sessionName: "codex",
+            host: host,
+            launchMode: .create,
+            initialCommand: "never-run-this"
+        ).attachCommand(tmuxPath: #"C:\Tools\psmux\tmux.exe"#)
+        let commandWithoutProfile = TmuxAttachmentInfo(
+            sessionName: "codex",
+            host: host,
+            launchMode: .create
+        ).attachCommand(tmuxPath: #"C:\Tools\psmux\tmux.exe"#)
+
+        #expect(command == commandWithoutProfile)
+        #expect(!command.contains("never-run-this"))
+    }
+
     @Test("remote creation presents before its attachment attempt")
     func remoteCreationPresentsBeforeAttachment() {
         let info = TmuxAttachmentInfo(

--- a/Tests/UI/LaunchProfileScreenshotTests.swift
+++ b/Tests/UI/LaunchProfileScreenshotTests.swift
@@ -1,0 +1,126 @@
+import AppKit
+import Foundation
+import GhosthubSettings
+import GhosthubWorkspace
+import SwiftUI
+import Testing
+import Vision
+@testable import GhosthubUI
+
+@Suite("Launch profile documentation screenshot")
+struct LaunchProfileScreenshotTests {
+    @MainActor
+    @Test("exports the real sheet with a deterministic selected profile")
+    func selectedProfileRenders() throws {
+        guard let outputPath = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_LAUNCH_PROFILE_SCREENSHOT"
+        ] else {
+            return
+        }
+        let hostID = try #require(
+            UUID(uuidString: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+        )
+        let profileID = try #require(
+            UUID(uuidString: "11111111-2222-4333-8444-555555555555")
+        )
+        let host = HostSummary(
+            id: hostID,
+            configKey: "gpu-01",
+            name: "gpu-01",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "ghosthub-demo-remote",
+            preferredTransport: .ssh,
+            lastKnownReachable: true,
+            tmuxSessions: []
+        )
+        let configuredHost = SSHHost(
+            configKey: "gpu-01",
+            name: "gpu-01",
+            platform: .linux,
+            sshDestination: "ghosthub-demo-remote",
+            launchProfiles: [
+                TmuxLaunchProfile(
+                    id: profileID,
+                    name: "Container shell",
+                    command: "docker exec -it app-container /bin/sh"
+                ),
+            ]
+        )
+        let sheet = NewTmuxSessionSheet(
+            host: host,
+            hosts: [host],
+            configuredHosts: [configuredHost],
+            selectedProfileID: profileID,
+            onCreate: { _, _, _ in },
+            onCancel: {}
+        )
+        .background(Color(nsColor: .windowBackgroundColor))
+        .preferredColorScheme(.dark)
+        let hostingView = hostView(AnyView(sheet), size: CGSize(
+            width: 500,
+            height: 260
+        ))
+        let fittingHeight = ceil(hostingView.fittingSize.height)
+        let renderSize = CGSize(width: 500, height: fittingHeight)
+        hostingView.frame = NSRect(
+            origin: .zero,
+            size: renderSize
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: renderSize),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFrontRegardless()
+        defer { window.close() }
+        hostingView.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+        hostingView.displayIfNeeded()
+
+        let size = hostingView.bounds.size
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(size.width * 2),
+            pixelsHigh: Int(size.height * 2),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        bitmap.size = size
+        let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        hostingView.displayIgnoringOpacity(hostingView.bounds, in: context)
+        NSGraphicsContext.restoreGraphicsState()
+        let png = try #require(bitmap.representation(
+            using: NSBitmapImageRep.FileType.png,
+            properties: [:]
+        ))
+        #expect(bitmap.pixelsWide == 1000)
+        #expect(bitmap.pixelsHigh > 0)
+        #expect(!png.isEmpty)
+
+        let image = try #require(bitmap.cgImage)
+        let textRequest = VNRecognizeTextRequest()
+        textRequest.recognitionLevel = .accurate
+        try VNImageRequestHandler(cgImage: image).perform([textRequest])
+        let recognizedText = (textRequest.results ?? []).compactMap {
+            $0.topCandidates(1).first?.string
+        }
+        #expect(recognizedText.contains {
+            $0.localizedCaseInsensitiveContains("Container shell")
+        })
+        try png.write(
+            to: URL(fileURLWithPath: outputPath),
+            options: Data.WritingOptions.atomic
+        )
+    }
+}

--- a/Tests/UI/NewTmuxSessionSheetTests.swift
+++ b/Tests/UI/NewTmuxSessionSheetTests.swift
@@ -1,8 +1,126 @@
+import Foundation
+import GhosthubSettings
+import GhosthubWorkspace
 import Testing
 @testable import GhosthubUI
 
 @Suite("Tmux session names")
 struct NewTmuxSessionSheetTests {
+    @Test("launch selection defaults to login and resets with its host")
+    func launchSelectionLifecycle() throws {
+        let codexID = try #require(
+            UUID(uuidString: "55555555-5555-5555-5555-555555555555")
+        )
+        let replID = try #require(
+            UUID(uuidString: "66666666-6666-6666-6666-666666666666")
+        )
+        let configuredHosts = [
+            SSHHost(
+                configKey: "remote",
+                name: "Remote",
+                platform: .linux,
+                sshDestination: "dev.example",
+                launchProfiles: [
+                    TmuxLaunchProfile(
+                        id: codexID,
+                        name: "Codex",
+                        command: "exec codex"
+                    ),
+                    TmuxLaunchProfile(
+                        id: replID,
+                        name: "REPL",
+                        command: "exec python"
+                    ),
+                ]
+            ),
+            SSHHost(
+                configKey: "windows",
+                name: "Windows",
+                platform: .windows,
+                sshDestination: "windows",
+                launchProfiles: [
+                    TmuxLaunchProfile(name: "Hidden", command: "ignored"),
+                ]
+            ),
+        ]
+        var selection = NewTmuxSessionLaunchSelection(
+            hostConfigKey: "remote",
+            hostKind: .remote
+        )
+
+        #expect(selection.selectedProfileID == nil)
+        #expect(
+            selection.availableProfiles(in: configuredHosts).map(\.id)
+                == [codexID, replID]
+        )
+        #expect(selection.selectedCommand(in: configuredHosts) == nil)
+
+        selection.selectProfile(codexID)
+        #expect(selection.selectedCommand(in: configuredHosts) == "exec codex")
+        #expect(selection.selectedProfileName(in: configuredHosts) == "Codex")
+
+        selection.selectHost(configKey: "windows", kind: .remote)
+        #expect(selection.selectedProfileID == nil)
+        #expect(selection.availableProfiles(in: configuredHosts).isEmpty)
+        #expect(selection.selectedCommand(in: configuredHosts) == nil)
+    }
+
+    @Test("local host never resolves a colliding remote profile")
+    func localHostIgnoresCollidingConfigKey() {
+        let profile = TmuxLaunchProfile(
+            name: "Codex",
+            command: "exec codex"
+        )
+        let configuredHosts = [
+            SSHHost(
+                configKey: "local",
+                name: "Local",
+                platform: .linux,
+                sshDestination: "host-a.example",
+                launchProfiles: [profile]
+            ),
+        ]
+        var selection = NewTmuxSessionLaunchSelection(
+            hostConfigKey: "local",
+            hostKind: .selfHost
+        )
+
+        #expect(selection.availableProfiles(in: configuredHosts).isEmpty)
+        selection.selectProfile(profile.id)
+        #expect(selection.selectedCommand(in: configuredHosts) == nil)
+
+        selection.selectHost(configKey: "local", kind: .remote)
+        #expect(
+            selection.availableProfiles(in: configuredHosts).map(\.id)
+                == [profile.id]
+        )
+
+        selection.selectHost(configKey: "local", kind: .selfHost)
+        #expect(selection.selectedProfileID == nil)
+        #expect(selection.availableProfiles(in: configuredHosts).isEmpty)
+    }
+
+    @Test("creation requests keep command intent out of session identity")
+    func creationRequestIdentity() {
+        let session = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "codex"
+        )
+        let request = WorkspaceTmuxSessionCreationRequest(
+            selection: session,
+            initialCommand: "exec codex"
+        )
+
+        #expect(request.selection == session)
+        #expect(request.initialCommand == "exec codex")
+        #expect(
+            request != WorkspaceTmuxSessionCreationRequest(
+                selection: session,
+                initialCommand: nil
+            )
+        )
+    }
+
     @Test(
         "validates tmux session names",
         arguments: [

--- a/Tests/UI/SettingsViewTests.swift
+++ b/Tests/UI/SettingsViewTests.swift
@@ -108,6 +108,38 @@ final class SettingsViewTests: XCTestCase {
         assertStableSize(fittingSize(for: store))
     }
 
+    func testLaunchProfileCommandEditorDisablesAutomaticTextChanges() throws {
+        let command = #"runner --mode "safe""#
+        let store = makeSettingsStore()
+        store.selectedDomain = .hosts
+        store.setSSHHosts([
+            SSHHost(
+                configKey: "host-a",
+                name: "Host A",
+                platform: .linux,
+                sshDestination: "user-a@host-a.example",
+                launchProfiles: [
+                    TmuxLaunchProfile(name: "Runner", command: command),
+                ]
+            ),
+        ])
+        let hostingView = hostView(
+            SettingsView(store: store),
+            size: stableMinimumSize
+        )
+        let editor = try XCTUnwrap(
+            descendants(of: hostingView)
+                .compactMap { $0 as? NSTextView }
+                .first { $0.string == command }
+        )
+
+        XCTAssertFalse(editor.isAutomaticQuoteSubstitutionEnabled)
+        XCTAssertFalse(editor.isAutomaticDashSubstitutionEnabled)
+        XCTAssertFalse(editor.isAutomaticTextReplacementEnabled)
+        XCTAssertFalse(editor.isAutomaticSpellingCorrectionEnabled)
+        XCTAssertFalse(editor.isContinuousSpellCheckingEnabled)
+    }
+
     func testAppearanceDomainUsesStableMinimumSize() {
         let store = makeSettingsStore()
         store.selectedDomain = .appearance

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ publication at [ghosthub.ai/docs](https://ghosthub.ai/docs/).
 
 - [`index.md`](index.md) - internal engineering overview
 - [`quickstart.md`](quickstart.md) - prerequisites and first build
+- [`launch-profiles.md`](launch-profiles.md) - configure and use saved tmux launch commands
 - [`architecture.md`](architecture.md) - product and architecture source of truth
 - [`threat-model.md`](threat-model.md) - security boundaries and trusted-peer assumptions
 - [`terminal-sessions.md`](terminal-sessions.md) - terminal ownership, shell startup, and restart semantics

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -450,6 +450,16 @@ remove a newly created session before the client arrives. Remote presentation
 performs one idempotent, detached create-if-absent phase before ordinary
 attachment. Once established, its native reconnect supervisor permanently
 limits all later replacements to attach-only clients.
+Configured POSIX SSH hosts may also persist ordered launch profiles, each with
+a stable identifier, display name, and trusted user-authored shell command.
+The selected profile becomes an optional field on the creation request; it is
+not part of session identity, discovery, navigation, or restoration. Profile
+creation replaces the detached remote phase with one PTY-backed atomic
+`new-session -A` invocation whose initial pane runs the command. If that SSH
+transport fails, Ghosthub probes the exact session: presence advances to the
+ordinary attach-only loop, absence retries the initial invocation, and every
+other result exits. Existing or discovered same-named sessions always attach
+without the profile command.
 Before opening an ordinary worktree, Ghosthub asks kwt to establish or repair
 that exact path's canonical session without attaching. Kwt inventory includes
 worktrees whose sessions are not currently running, so inventory membership is
@@ -498,6 +508,7 @@ Ghosthub local persistence stores app-owned state:
 - terminal presentation state
 - selected worktree/window state
 - settings that are explicitly native-app concerns
+- configured SSH hosts and their launch profiles
 - the anonymous telemetry installation UUID and last attempted activity day
 
 Do not add database migrations before the first production release. Edit the

--- a/docs/launch-profiles.md
+++ b/docs/launch-profiles.md
@@ -1,0 +1,82 @@
+# Launch Profiles
+
+Launch profiles save the command that should become the first process in a new
+tmux session. They are available for the local Mac and for macOS or Linux hosts
+reached through SSH. Windows hosts ignore POSIX launch profiles.
+
+![A new tmux session sheet with the Container shell launch profile selected](https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/docs-launch-profiles.png?asset=docs-launch-profiles)
+
+## Configure a profile
+
+1. Open **Settings → Hosts**.
+2. Select the host and find **Launch Profiles**.
+3. Add a profile with a nonempty name and command. Profile names must be unique
+   for that host.
+4. Arrange profiles in the order you want them to appear in session creation.
+
+For example, a profile named **Container shell** can run:
+
+```sh
+docker exec -it app-container /bin/sh
+```
+
+!!! warning "Keep secrets out of commands"
+    Ghosthub stores profile commands in local app settings, and the host's
+    process list may expose a running command. Do not include passwords, tokens,
+    or other credentials.
+
+## Start a session with a profile
+
+1. Choose **New tmux session** for the target host.
+2. Enter the new session name.
+3. Under **Start with**, select the saved profile. **Login shell** remains the
+   default.
+4. Choose **Create**.
+
+For an SSH host, Ghosthub allocates the remote PTY before it starts the command,
+so interactive programs can use the terminal normally. The selected command is
+run only while establishing that new tmux session.
+
+After Ghosthub discovers or reconciles the created session, every later
+connection is attach-only. Reconnects never run the saved command again, and
+existing sessions are always attach-only even when profiles are configured.
+
+If SSH drops while Ghosthub is still establishing a profile-backed session, it
+probes the host before recovering. When the session is present, Ghosthub
+replaces the interrupted presentation with an attach-only connection. When the
+session is absent, Ghosthub does not repeat the saved command automatically
+because the first attempt may already have produced side effects. The
+confirmation shows the exact command retained from the interrupted attempt,
+even if the profile has since changed. Review that command and explicitly
+confirm before running it again.
+
+If Ghosthub cannot create the terminal presentation before the command starts,
+**Retry** preserves the selected profile and runs its command without an extra
+confirmation. The destructive confirmation appears only after a launch attempt
+may have produced side effects.
+
+Switching to another host, worktree, or session hides the profile-backed
+terminal without detaching it. Ghosthub keeps its presentation and recovery
+supervisor alive, and returning to it reuses the same client. If an interrupted
+command needs confirmation, navigating elsewhere does not discard the retained
+command or its confirmation state.
+
+Pressing **Command-W** detaches the active presentation. Closing its workspace
+window or quitting Ghosthub detaches every presentation that workspace owns.
+Tmux still owns the session and its processes, so none of these actions stops
+the session or the command running inside it.
+
+## Reproduce the screenshot
+
+The checked-in renderer hosts the real SwiftUI sheet with a deterministic
+**Container shell** profile and captures it without launching or activating the
+app:
+
+```sh
+website/demo/render-launch-profile.sh
+```
+
+The generated image defaults to
+`/private/tmp/ghosthub-doc-assets/docs-launch-profiles.png`. The published copy
+lives on the orphan `website-assets` branch so the documentation does not add
+large binaries to the application history.

--- a/docs/launch-profiles.md
+++ b/docs/launch-profiles.md
@@ -64,7 +64,10 @@ command or its confirmation state.
 Pressing **Command-W** detaches the active presentation. Closing its workspace
 window or quitting Ghosthub detaches every presentation that workspace owns.
 Tmux still owns the session and its processes, so none of these actions stops
-the session or the command running inside it.
+the session or the command running inside it. If **Command-W** closes a pending
+profile-backed creation before its command starts, Ghosthub abandons that
+creation and removes its optimistic session entry; use **New tmux session** to
+start it again.
 
 ## Reproduce the screenshot
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -9,6 +9,7 @@ use_directory_urls = true
 nav = [
   {"Overview" = "index.md"},
   {"Quick Start" = "quickstart.md"},
+  {"Launch Profiles" = "launch-profiles.md"},
   {"Architecture" = "architecture.md"},
   {"Threat Model" = "threat-model.md"},
   {"Terminal Sessions" = "terminal-sessions.md"},

--- a/website/demo/render-launch-profile.sh
+++ b/website/demo/render-launch-profile.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Renders the real launch-profile sheet offscreen through the UI test target.
+# Unlike the full marketing capture workflow, this never launches or activates
+# Ghosthub and cannot steal focus from another desktop application.
+set -euo pipefail
+
+demo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$demo_root/../.." && pwd)"
+output="${1:-/private/tmp/ghosthub-doc-assets/docs-launch-profiles.png}"
+output_dir="$(dirname "$output")"
+
+case "$output" in
+  "" | / | */ | */. | */..)
+    echo "error: output must name a PNG file" >&2
+    exit 2
+    ;;
+esac
+[[ "${output##*.}" == "png" ]] || {
+  echo "error: output must end in .png" >&2
+  exit 2
+}
+if [[ -e "$output" && ! -f "$output" ]]; then
+  echo "error: output exists and is not a regular file: $output" >&2
+  exit 2
+fi
+
+umask 077
+mkdir -p "$output_dir"
+temporary="$(mktemp "$output_dir/.docs-launch-profiles.XXXXXX.png")"
+cleanup() {
+  rm -f "$temporary"
+}
+trap cleanup EXIT HUP INT TERM
+
+GHOSTHUB_LAUNCH_PROFILE_SCREENSHOT="$temporary" \
+  sh "$repo_root/tools/run_swift_tests.sh" \
+  swift test --package-path "$repo_root" \
+  --filter LaunchProfileScreenshotTests
+mv -f "$temporary" "$output"
+trap - EXIT HUP INT TERM
+
+sips -g pixelWidth -g pixelHeight "$output" | tail -2
+echo "rendered launch profile documentation asset -> $output"

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -136,6 +136,16 @@ const imageAlt = {
             VMs as SSH hosts. Add your account under{' '}
             <strong>Settings → Integrations</strong> to connect them.
           </p>
+          <p>
+            For a macOS or Linux host, add reusable <strong>Launch Profiles</strong>{' '}
+            in the same settings pane, then choose one under{' '}
+            <strong>Start with</strong> when creating a session. The command runs
+            only for that new session; reconnecting and opening existing sessions
+            are always attach-only. If creation is interrupted and the session is
+            absent, Ghosthub requires confirmation before running the command
+            again. See <a href="/docs/launch-profiles/">Launch Profiles</a>{' '}
+            for setup, lifecycle, and security guidance.
+          </p>
           <aside class="reconnect">
             <span aria-hidden="true">↻</span>
             <p>


### PR DESCRIPTION
## What changed

- Added optional launch profiles to configured POSIX hosts: an ordered per-host list of named commands with stable identifiers, persisted alongside the existing SSH host settings.
- Added a **Start with** picker to the new tmux session sheet that runs the selected profile command as the first process of the session's initial pane, defaulting to **Login shell**.
- Replaced the detached remote create phase with a single PTY-backed atomic `new-session -A` when a profile is selected, so interactive commands can prompt in the terminal.
- Added a `has-session` probe after a transport failure: attach when the session is present, retry the initial invocation with bounded backoff when it is absent, and exit otherwise.
- Carried the selection on the creation request alone, so it never enters session identity, discovery, navigation, or restoration; attach and reconnect never rerun the command.
- Normalized profiles on both save and load: names and commands trimmed, unique by name, empty entries dropped, order and identifiers preserved.
- Decoded hosts written before this change with an empty profile list.
- Excluded Windows hosts, where profiles are neither offered nor applied and session creation is byte-identical with and without one.
- Documented the feature in `docs/architecture.md` and the website guide.

## Why

Ghosthub always starts a new tmux session in the account login shell. When the environment you actually work in sits one level deeper, inside a container or behind `sudo` or in a language runtime, the same entry command has to be retyped on every new session.

The existing remote create path detaches before it attaches, so a command that needs to prompt has no terminal to prompt on. Profile-backed creation therefore uses one PTY-backed `new-session -A` instead, which keeps creation atomic and gives interactive commands a real TTY.

The command is deliberately treated as trusted user code rather than sanitized input, at the same trust level as a shell alias. It is quoted as a single argument so it cannot alter Ghosthub's own SSH or tmux arguments, it runs only when explicitly selected during creation, and both the settings pane and the guide warn against storing secrets in it.

## Usage

1. Open **Settings → Hosts**, select a macOS or Linux host, and add an entry under **Launch Profiles** with a name and a command, for example `docker exec -it app-container /bin/sh`.
2. Create a new tmux session, choose that host, and select the profile under **Start with**.
3. Leave **Start with** on **Login shell** for the previous behavior. Reconnecting to an existing session attaches without rerunning the command.
