### PR TITLE
Automatically reconnect remote tmux sessions

### DIFF
--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -8,12 +8,15 @@ struct BorrowedTmuxSessionView: View {
     var isRemoteHost: Bool
     var displayTitle: String?
     var connectionState: ConnectionState?
+    var recoveryState: BorrowedTmuxRecoveryState?
     var attachmentClosure: BorrowedTmuxAttachmentClosure?
     var sessionClosed: Bool
     var defersTerminalResize: Bool
     var surface: () -> TerminalSurfaceView?
     var onCloseRequest: () -> Void
     var onRetryRequest: () -> Void
+    var onReconnectNow: () -> Void
+    var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
 
     init(
@@ -22,12 +25,15 @@ struct BorrowedTmuxSessionView: View {
         isRemoteHost: Bool,
         displayTitle: String? = nil,
         connectionState: ConnectionState?,
+        recoveryState: BorrowedTmuxRecoveryState? = nil,
         attachmentClosure: BorrowedTmuxAttachmentClosure? = nil,
         sessionClosed: Bool = false,
         defersTerminalResize: Bool = false,
         surface: @escaping () -> TerminalSurfaceView?,
         onCloseRequest: @escaping () -> Void,
         onRetryRequest: @escaping () -> Void,
+        onReconnectNow: @escaping () -> Void = {},
+        onReviewConnection: @escaping () -> Void = {},
         onHostSettingsRequest: @escaping () -> Void
     ) {
         self.handle = handle
@@ -35,12 +41,15 @@ struct BorrowedTmuxSessionView: View {
         self.isRemoteHost = isRemoteHost
         self.displayTitle = displayTitle
         self.connectionState = connectionState
+        self.recoveryState = recoveryState
         self.attachmentClosure = attachmentClosure
         self.sessionClosed = sessionClosed
         self.defersTerminalResize = defersTerminalResize
         self.surface = surface
         self.onCloseRequest = onCloseRequest
         self.onRetryRequest = onRetryRequest
+        self.onReconnectNow = onReconnectNow
+        self.onReviewConnection = onReviewConnection
         self.onHostSettingsRequest = onHostSettingsRequest
     }
 
@@ -51,6 +60,29 @@ struct BorrowedTmuxSessionView: View {
                 defersTerminalResize: defersTerminalResize,
                 onCloseRequest: onCloseRequest
             )
+        } else if recoveryState != nil {
+            ContentUnavailableView {
+                Label(recoveryTitle, systemImage: "network.slash")
+            } description: {
+                VStack(spacing: 10) {
+                    if showsReconnectProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(recoveryMessage)
+                        .multilineTextAlignment(.center)
+                }
+            } actions: {
+                if primaryRecoveryActionTitle != nil {
+                    Button("Reconnect Now", action: onReconnectNow)
+                }
+                if showsReviewConnection {
+                    Button("Review Connection", action: onReviewConnection)
+                }
+                if showsHostSettingsAction {
+                    Button("Host Settings", action: onHostSettingsRequest)
+                }
+            }
         } else if let disconnectionReason {
             ContentUnavailableView {
                 Label(
@@ -73,6 +105,40 @@ struct BorrowedTmuxSessionView: View {
             ProgressView("Opening \(displayTitle ?? handle.name)…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    var recoveryTitle: String {
+        switch recoveryState {
+        case .reconnecting:
+            "Connection interrupted"
+        case .needsAttention:
+            "Connection needs attention"
+        case nil:
+            disconnectionTitle
+        }
+    }
+
+    var recoveryMessage: String {
+        switch recoveryState {
+        case let .reconnecting(message), let .needsAttention(message, _):
+            message
+        case nil:
+            disconnectionReason ?? "The tmux session disconnected."
+        }
+    }
+
+    var showsReconnectProgress: Bool {
+        recoveryState?.isReconnecting == true
+    }
+
+    var primaryRecoveryActionTitle: String? {
+        showsReconnectProgress ? "Reconnect Now" : nil
+    }
+
+    var showsReviewConnection: Bool {
+        guard case let .needsAttention(_, canReviewConnection) = recoveryState
+        else { return false }
+        return canReviewConnection
     }
 
     var disconnectionReason: String? {

--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -132,7 +132,7 @@ struct BorrowedTmuxSessionView: View {
     }
 
     var primaryRecoveryActionTitle: String? {
-        showsReconnectProgress ? "Reconnect Now" : nil
+        recoveryState?.allowsReconnectNow == true ? "Reconnect Now" : nil
     }
 
     var showsReviewConnection: Bool {

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -80,7 +80,7 @@ struct BorrowedTmuxSessionHandle: Equatable, Sendable {
 
 enum BorrowedTmuxAttachmentClosure: Equatable {
     case detached
-    case processExited
+    case processExited(code: UInt32?)
     case launchFailed
 }
 
@@ -430,18 +430,14 @@ final class NativeTmuxSessionCoordinator {
             )
         )
         guard let surface else {
-            deferredPresentationStyleHandles.remove(handle.id)
+            failSurfaceLaunch(
+                handle,
+                reason: "Ghosthub could not create the terminal surface."
+            )
             return nil
         }
         if let error = surface.launchError {
-            attachmentClosures[handle.id] = .launchFailed
-            attachments.removeValue(forKey: handle.id)
-            deferredPresentationStyleHandles.remove(handle.id)
-            terminalCoordinator.removeSurface(for: surfaceKey(handle))
-            reportSurfaceStateLater(
-                handle,
-                state: .disconnected(reason: error.localizedDescription)
-            )
+            failSurfaceLaunch(handle, reason: error.localizedDescription)
             return nil
         }
         if isFirstLaunch, appliesPresentationStyle,
@@ -459,14 +455,27 @@ final class NativeTmuxSessionCoordinator {
                 )
             }
         )
-        if launchedHandles.insert(handle.id).inserted {
-            reportSurfaceStateLater(
-                handle,
-                state: .connected,
-                requiresLiveSurface: true
-            )
-        }
+        launchedHandles.insert(handle.id)
+        reportSurfaceStateLater(
+            handle,
+            state: .connected,
+            requiresLiveSurface: true
+        )
         return surface as? TerminalSurfaceView
+    }
+
+    private func failSurfaceLaunch(
+        _ handle: BorrowedTmuxSessionHandle,
+        reason: String
+    ) {
+        attachmentClosures[handle.id] = .launchFailed
+        attachments.removeValue(forKey: handle.id)
+        deferredPresentationStyleHandles.remove(handle.id)
+        terminalCoordinator.removeSurface(for: surfaceKey(handle))
+        reportSurfaceStateLater(
+            handle,
+            state: .disconnected(reason: reason)
+        )
     }
 
     func surfaceIdentity(handle: BorrowedTmuxSessionHandle) -> UInt? {
@@ -500,7 +509,7 @@ final class NativeTmuxSessionCoordinator {
         guard handlesByKey[key] == handle else { return }
         attachmentClosures[handle.id] = processAlive || childExitCode == 0
             ? .detached
-            : .processExited
+            : .processExited(code: childExitCode)
         attachments.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -91,6 +91,7 @@ private struct NativeTmuxSessionKey: Hashable {
 }
 
 private struct NativeTmuxAttachment {
+    var id: UUID
     var host: TmuxHost
     var tmuxPath: String
     var kwtPath: String?
@@ -127,6 +128,7 @@ final class NativeTmuxSessionCoordinator {
     private var attachments: [UUID: NativeTmuxAttachment] = [:]
     private var attachmentClosures: [UUID: BorrowedTmuxAttachmentClosure] = [:]
     private var launchedHandles: Set<UUID> = []
+    private var reportedConnectedAttachmentIDs: [UUID: UUID] = [:]
     private var tmuxPathsByHost: [TmuxHost: String] = [:]
     private var provisioningHandles: Set<UUID> = []
     private var provisioningTasks: [UUID: Task<Void, Never>] = [:]
@@ -292,6 +294,7 @@ final class NativeTmuxSessionCoordinator {
                 ? nil
                 : workingDirectory
             attachments[handle.id] = NativeTmuxAttachment(
+                id: UUID(),
                 host: host,
                 tmuxPath: path,
                 kwtPath: host.isRemote ? nil : localKwtPathProvider(),
@@ -352,6 +355,7 @@ final class NativeTmuxSessionCoordinator {
         attachments.removeValue(forKey: handle.id)
         attachmentClosures.removeValue(forKey: handle.id)
         launchedHandles.remove(handle.id)
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
     }
@@ -456,11 +460,14 @@ final class NativeTmuxSessionCoordinator {
             }
         )
         launchedHandles.insert(handle.id)
-        reportSurfaceStateLater(
-            handle,
-            state: .connected,
-            requiresLiveSurface: true
-        )
+        if reportedConnectedAttachmentIDs[handle.id] != attachment.id {
+            reportedConnectedAttachmentIDs[handle.id] = attachment.id
+            reportSurfaceStateLater(
+                handle,
+                state: .connected,
+                requiredAttachmentID: attachment.id
+            )
+        }
         return surface as? TerminalSurfaceView
     }
 
@@ -470,6 +477,7 @@ final class NativeTmuxSessionCoordinator {
     ) {
         attachmentClosures[handle.id] = .launchFailed
         attachments.removeValue(forKey: handle.id)
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
         reportSurfaceStateLater(
@@ -485,14 +493,15 @@ final class NativeTmuxSessionCoordinator {
     private func reportSurfaceStateLater(
         _ handle: BorrowedTmuxSessionHandle,
         state: ConnectionState,
-        requiresLiveSurface: Bool = false
+        requiredAttachmentID: UUID? = nil
     ) {
         Task { [weak self] in
             guard let self, !isShuttingDown else { return }
             let key = sessionKey(handle)
             guard handlesByKey[key] == handle else { return }
-            if requiresLiveSurface {
-                guard launchedHandles.contains(handle.id),
+            if let requiredAttachmentID {
+                guard attachments[handle.id]?.id == requiredAttachmentID,
+                      launchedHandles.contains(handle.id),
                       attachmentClosures[handle.id] == nil
                 else { return }
             }
@@ -511,6 +520,7 @@ final class NativeTmuxSessionCoordinator {
             ? .detached
             : .processExited(code: childExitCode)
         attachments.removeValue(forKey: handle.id)
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
         onStateChanged?(
@@ -532,6 +542,7 @@ final class NativeTmuxSessionCoordinator {
         attachments.removeAll()
         attachmentClosures.removeAll()
         launchedHandles.removeAll()
+        reportedConnectedAttachmentIDs.removeAll()
         deferredPresentationStyleHandles.removeAll()
         for handle in handles {
             terminalCoordinator.removeSurface(for: surfaceKey(handle))

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -103,6 +103,7 @@ private struct NativeTmuxAttachment {
     var workingDirectory: String?
     var openWorkspace: Bool
     var sshConnectionArguments: [String]
+    var remoteExitStatusURL: URL?
 }
 
 /// Hosts ordinary tmux clients for kwt workspaces and unbound sessions.
@@ -123,6 +124,7 @@ final class NativeTmuxSessionCoordinator {
     private let presentationStyleProvider: () -> TmuxPresentationStyle?
     private let appliesPresentationStyleToExistingSessionsProvider:
         () -> Bool
+    private let remoteExitStatusDirectory: URL
     private var handlesByKey: [NativeTmuxSessionKey: BorrowedTmuxSessionHandle] = [:]
     private var targetHostsByHandle: [UUID: TmuxHost] = [:]
     private var attachments: [UUID: NativeTmuxAttachment] = [:]
@@ -170,7 +172,12 @@ final class NativeTmuxSessionCoordinator {
                 + SSHConfigurationResolver.noninteractiveHostKeyArguments(
                     for: $0
                 )
-        }
+        },
+        remoteExitStatusDirectory: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ghosthub-tmux-exit-\(UUID().uuidString)",
+                isDirectory: true
+            )
     ) {
         self.terminalCoordinator = terminalCoordinator
         self.tmuxPathProvider = tmuxPathProvider
@@ -185,6 +192,7 @@ final class NativeTmuxSessionCoordinator {
         self.remoteTmuxPathProvider = remoteTmuxPathProvider
         self.sshConnectionArgumentsProvider =
             sshConnectionArgumentsProvider
+        self.remoteExitStatusDirectory = remoteExitStatusDirectory
     }
 
     func attach(
@@ -309,7 +317,10 @@ final class NativeTmuxSessionCoordinator {
                 launchMode: launchMode,
                 workingDirectory: workingDirectory,
                 openWorkspace: openWorkspace,
-                sshConnectionArguments: sshConnectionArguments
+                sshConnectionArguments: sshConnectionArguments,
+                remoteExitStatusURL: host.isRemote
+                    ? prepareRemoteExitStatusFile()
+                    : nil
             )
             onSurfaceReady?(handle)
         case let .failure(error):
@@ -352,7 +363,7 @@ final class NativeTmuxSessionCoordinator {
         provisioningTasks.removeValue(forKey: handle.id)?.cancel()
         provisioningHandles.remove(handle.id)
         targetHostsByHandle.removeValue(forKey: handle.id)
-        attachments.removeValue(forKey: handle.id)
+        removeRemoteExitStatusFile(attachments.removeValue(forKey: handle.id))
         attachmentClosures.removeValue(forKey: handle.id)
         launchedHandles.remove(handle.id)
         reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
@@ -429,7 +440,9 @@ final class NativeTmuxSessionCoordinator {
                     attachment.windowsKwtRelativePath,
                     workingDirectory: attachment.workingDirectory,
                     sshConnectionArguments: tmuxSSHConnectionArguments()
-                        + attachment.sshConnectionArguments
+                        + attachment.sshConnectionArguments,
+                    remoteExitStatusPath:
+                    attachment.remoteExitStatusURL?.path
                 )
             )
         )
@@ -476,7 +489,7 @@ final class NativeTmuxSessionCoordinator {
         reason: String
     ) {
         attachmentClosures[handle.id] = .launchFailed
-        attachments.removeValue(forKey: handle.id)
+        removeRemoteExitStatusFile(attachments.removeValue(forKey: handle.id))
         reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
@@ -516,10 +529,17 @@ final class NativeTmuxSessionCoordinator {
     ) {
         let key = sessionKey(handle)
         guard handlesByKey[key] == handle else { return }
-        attachmentClosures[handle.id] = processAlive || childExitCode == 0
-            ? .detached
-            : .processExited(code: childExitCode)
-        attachments.removeValue(forKey: handle.id)
+        let attachment = attachments.removeValue(forKey: handle.id)
+        let recordedExitCode = consumeRemoteExitStatus(attachment)
+        if let recordedExitCode {
+            attachmentClosures[handle.id] = recordedExitCode == 0
+                ? .detached
+                : .processExited(code: recordedExitCode)
+        } else {
+            attachmentClosures[handle.id] = processAlive || childExitCode == 0
+                ? .detached
+                : .processExited(code: childExitCode)
+        }
         reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
@@ -539,6 +559,7 @@ final class NativeTmuxSessionCoordinator {
         provisioningHandles.removeAll()
         handlesByKey.removeAll()
         targetHostsByHandle.removeAll()
+        attachments.values.forEach(removeRemoteExitStatusFile)
         attachments.removeAll()
         attachmentClosures.removeAll()
         launchedHandles.removeAll()
@@ -547,6 +568,46 @@ final class NativeTmuxSessionCoordinator {
         for handle in handles {
             terminalCoordinator.removeSurface(for: surfaceKey(handle))
         }
+    }
+
+    private func prepareRemoteExitStatusFile() -> URL? {
+        do {
+            try FileManager.default.createDirectory(
+                at: remoteExitStatusDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let url = remoteExitStatusDirectory.appendingPathComponent(
+                UUID().uuidString,
+                isDirectory: false
+            )
+            guard FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data(),
+                attributes: [.posixPermissions: 0o600]
+            ) else { return nil }
+            return url
+        } catch {
+            return nil
+        }
+    }
+
+    private func consumeRemoteExitStatus(
+        _ attachment: NativeTmuxAttachment?
+    ) -> UInt32? {
+        guard let url = attachment?.remoteExitStatusURL else { return nil }
+        defer { try? FileManager.default.removeItem(at: url) }
+        guard let value = try? String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        return UInt32(value)
+    }
+
+    private func removeRemoteExitStatusFile(
+        _ attachment: NativeTmuxAttachment?
+    ) {
+        guard let url = attachment?.remoteExitStatusURL else { return }
+        try? FileManager.default.removeItem(at: url)
     }
 
     private func surfaceKey(_ handle: BorrowedTmuxSessionHandle) -> SurfaceKey {

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -2,18 +2,57 @@ import Foundation
 import GhosthubWorkspace
 
 enum SSHConnectionFailure {
-    static func diagnostic(
+    struct Classification: Equatable, Sendable {
+        enum Kind: Equatable, Sendable {
+            case transport
+            case authenticationRequired
+            case hostKeyReviewRequired
+            case hostKeyChanged
+        }
+
+        var kind: Kind
+        var diagnostic: RemoteHostDiagnostic
+    }
+
+    static func classify(
         status: Int32,
         output: String
-    ) -> RemoteHostDiagnostic {
+    ) -> Classification {
         let normalized = output.lowercased()
+        if status == 255, hostKeyChanged(normalized) {
+            return Classification(
+                kind: .hostKeyChanged,
+                diagnostic: RemoteHostDiagnostic(
+                    code: .sshConnectionFailed,
+                    severity: .error,
+                    summary: "The SSH host identity changed.",
+                    recoverySuggestion:
+                    "Verify the host outside Ghosthub, then update its known-hosts entry before reconnecting."
+                )
+            )
+        }
+        if status == 255, requiresHostKeyReview(normalized) {
+            return Classification(
+                kind: .hostKeyReviewRequired,
+                diagnostic: RemoteHostDiagnostic(
+                    code: .sshConnectionFailed,
+                    severity: .error,
+                    summary: "The SSH host key needs review.",
+                    recoverySuggestion:
+                    "Review and approve the host identity before reconnecting."
+                )
+            )
+        }
         if status == 255, requiresAuthentication(normalized) {
-            return RemoteHostDiagnostic(
-                code: .sshAuthenticationFailed,
-                severity: .error,
-                summary: "SSH authentication is required.",
-                recoverySuggestion:
-                "Enter the password or verification code requested by OpenSSH."
+            return Classification(
+                kind: .authenticationRequired,
+                diagnostic: RemoteHostDiagnostic(
+                    code: .sshAuthenticationFailed,
+                    severity: .error,
+                    summary: "SSH authentication is required.",
+                    recoverySuggestion:
+                    "Enter the password or verification code requested by OpenSSH."
+                )
             )
         }
 
@@ -33,13 +72,23 @@ enum SSHConnectionFailure {
         } else {
             summary = "SSH could not connect to the host."
         }
-        return RemoteHostDiagnostic(
-            code: .sshConnectionFailed,
-            severity: .error,
-            summary: summary,
-            recoverySuggestion:
-            "Check the destination, network access, and SSH server, then retry."
+        return Classification(
+            kind: .transport,
+            diagnostic: RemoteHostDiagnostic(
+                code: .sshConnectionFailed,
+                severity: .error,
+                summary: summary,
+                recoverySuggestion:
+                "Check the destination, network access, and SSH server, then retry."
+            )
         )
+    }
+
+    static func diagnostic(
+        status: Int32,
+        output: String
+    ) -> RemoteHostDiagnostic {
+        classify(status: status, output: output).diagnostic
     }
 
     private static func requiresAuthentication(_ normalized: String) -> Bool {
@@ -49,5 +98,15 @@ enum SSHConnectionFailure {
                 "no supported authentication methods available"
             )
             || normalized.contains("too many authentication failures")
+    }
+
+    private static func requiresHostKeyReview(_ normalized: String) -> Bool {
+        normalized.contains("host key verification failed")
+    }
+
+    private static func hostKeyChanged(_ normalized: String) -> Bool {
+        normalized.contains("remote host identification has changed")
+            || (normalized.contains("offending ")
+                && normalized.contains(" key in "))
     }
 }

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -38,7 +38,10 @@ private final class TmuxProbeOutputCollector: @unchecked Sendable {
 enum TmuxBinaryError: Error, Equatable, LocalizedError, Sendable {
     case notFound(shell: String)
     case shellFailed(status: Int32)
-    case sshConnectionFailed(host: String)
+    case sshConnectionFailed(
+        host: String,
+        classification: SSHConnectionFailure.Classification
+    )
     case probeTimedOut(shell: String)
     case probeCancelled(shell: String)
     case probeOutputExceeded(shell: String)
@@ -55,10 +58,9 @@ enum TmuxBinaryError: Error, Equatable, LocalizedError, Sendable {
         case let .shellFailed(status):
             return "The login shell exited with status \(status) while"
                 + " locating tmux. Check your shell startup files."
-        case let .sshConnectionFailed(host):
-            return "SSH could not connect to \(host). Open Host Settings and"
-                + " run Test Connection to review an unseen host key or"
-                + " diagnose authentication and network access."
+        case let .sshConnectionFailed(host, classification):
+            return "\(classification.diagnostic.summary) Host: \(host). "
+                + classification.diagnostic.recoverySuggestion
         case let .probeTimedOut(shell):
             return "Timed out while locating tmux through \(shell). Check"
                 + " for commands that block in your shell startup files."
@@ -117,7 +119,7 @@ struct TmuxBinaryResolver: Sendable {
         -> (status: Int32, stdout: String)
     typealias RemoteProcessRunner = @Sendable (
         _ host: SSHHostInfo, _ command: String
-    ) -> (status: Int32, stdout: String)
+    ) -> (status: Int32, stdout: String, stderr: String)
 
     private let processRunner: ProcessRunner
     private let remoteProcessRunner: RemoteProcessRunner
@@ -135,7 +137,7 @@ struct TmuxBinaryResolver: Sendable {
             )
         }
         self.remoteProcessRunner = remoteProcessRunner ?? { host, command in
-            Self.runRemoteLoginShell(
+            Self.runRemoteLoginShellSeparatingStandardError(
                 host: host,
                 command: command,
                 timeout: processTimeout,
@@ -157,9 +159,18 @@ struct TmuxBinaryResolver: Sendable {
             Self.probeCommand(for: host.platform)
         )
         if result.status == 255 {
-            return .failure(.sshConnectionFailed(host: host.displayName))
+            return .failure(.sshConnectionFailed(
+                host: host.displayName,
+                classification: SSHConnectionFailure.classify(
+                    status: result.status,
+                    output: result.stderr
+                )
+            ))
         }
-        return Self.parseProbe(result, shell: host.displayName)
+        return Self.parseProbe(
+            (status: result.status, stdout: result.stdout),
+            shell: host.displayName
+        )
     }
 
     func discoverSessions() -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
@@ -178,30 +189,104 @@ struct TmuxBinaryResolver: Sendable {
             Self.discoveryCommand(for: host.platform)
         )
         if result.status == 255 {
-            return .failure(.sshConnectionFailed(host: host.displayName))
+            return .failure(.sshConnectionFailed(
+                host: host.displayName,
+                classification: SSHConnectionFailure.classify(
+                    status: result.status,
+                    output: result.stderr
+                )
+            ))
         }
         return Self.parseDiscovery(
-            result,
+            (status: result.status, stdout: result.stdout),
             shell: host.displayName
         )
+    }
+
+    func sessionExists(
+        name: String,
+        socketName: String?,
+        on host: SSHHostInfo
+    ) -> Result<Bool, TmuxBinaryError> {
+        let result = remoteProcessRunner(
+            host,
+            Self.sessionProbeCommand(
+                name: name,
+                socketName: socketName,
+                platform: host.platform
+            )
+        )
+        if result.status == 255 {
+            return .failure(.sshConnectionFailed(
+                host: host.displayName,
+                classification: SSHConnectionFailure.classify(
+                    status: result.status,
+                    output: result.stderr
+                )
+            ))
+        }
+        guard result.status == 0 else {
+            switch result.status {
+            case Self.timedOutStatus:
+                return .failure(.probeTimedOut(shell: host.displayName))
+            case Self.cancelledStatus:
+                return .failure(.probeCancelled(shell: host.displayName))
+            case Self.outputExceededStatus:
+                return .failure(.probeOutputExceeded(shell: host.displayName))
+            default:
+                return .failure(.shellFailed(status: result.status))
+            }
+        }
+        switch Self.parseProbe(
+            (status: result.status, stdout: result.stdout),
+            shell: host.displayName
+        ) {
+        case let .failure(error):
+            return .failure(error)
+        case .success:
+            break
+        }
+
+        let outcomes = result.stdout
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> Bool? in
+                switch line {
+                case Substring(Self.sessionPresentMarker): true
+                case Substring(Self.sessionAbsentMarker): false
+                default: nil
+                }
+            }
+        guard outcomes.count == 1, let exists = outcomes.first else {
+            return .failure(.shellFailed(status: result.status))
+        }
+        return .success(exists)
     }
 
     private static let probeCommand =
         "ghosthub_tmux_path=$(command -v tmux) || exit $?; "
             + "printf '%s\\n' \"$ghosthub_tmux_path\"; "
-            + "\"$ghosthub_tmux_path\" -V"
+            + "\"$ghosthub_tmux_path\" -V || exit $?"
 
     private static let discoveryPrefix = "GHOSTHUB_TMUX_SESSION"
+    private static let sessionPresentMarker =
+        "GHOSTHUB_TMUX_SESSION_PRESENT"
+    private static let sessionAbsentMarker =
+        "GHOSTHUB_TMUX_SESSION_ABSENT"
     private static let discoveryFormat = discoveryPrefix
         + "\t#{session_windows}\t#{pid}\t#{session_id}\t#{session_created}"
         + "\t#{@ghosthub_owner}\t#{session_name}"
     private static let discoveryCommand = probeCommand
-        + "; ghosthub_tmux_status=0; "
+        + "; ghosthub_tmux_output=$("
         + "\"$ghosthub_tmux_path\" list-sessions -F "
         + shellQuotedCommandArgument(discoveryFormat)
-        + " 2>/dev/null || ghosthub_tmux_status=$?; "
-        + "[ \"$ghosthub_tmux_status\" -eq 0 ]"
-        + " || [ \"$ghosthub_tmux_status\" -eq 1 ]"
+        + " 2>&1); ghosthub_tmux_status=$?; "
+        + "if [ \"$ghosthub_tmux_status\" -eq 0 ]; then "
+        + "printf '%s\\n' \"$ghosthub_tmux_output\"; else "
+        + "printf '%s\\n' \"$ghosthub_tmux_output\" >&2; "
+        + "case \"$ghosthub_tmux_output\" in "
+        + "*\"no server running on \"*|"
+        + "*\"failed to connect to server: No such file or directory\"*) "
+        + "exit 0 ;; *) exit \"$ghosthub_tmux_status\" ;; esac; fi"
 
     private static func probeCommand(
         for platform: SSHHostInfo.Platform
@@ -233,12 +318,81 @@ struct TmuxBinaryResolver: Sendable {
             if ($LASTEXITCODE -ne 0) {
                 exit $LASTEXITCODE
             }
-            & $ghosthubMux 'list-sessions' '-F' \(powerShellEncodedArgument(discoveryFormat))
+            $ghosthubMuxOutput = (& $ghosthubMux 'list-sessions' '-F' \(
+                powerShellEncodedArgument(discoveryFormat)
+            ) 2>&1 | Out-String)
             $ghosthubMuxStatus = $LASTEXITCODE
-            if (($ghosthubMuxStatus -eq 0) -or ($ghosthubMuxStatus -eq 1)) {
+            if ($ghosthubMuxStatus -eq 0) {
+                Write-Output $ghosthubMuxOutput
+                exit 0
+            }
+            [Console]::Error.Write($ghosthubMuxOutput)
+            if ($ghosthubMuxOutput -match 'no server running on ' -or
+                $ghosthubMuxOutput -match 'failed to connect to server: No such file or directory') {
                 exit 0
             }
             exit $ghosthubMuxStatus
+            """
+        }
+    }
+
+    private static func sessionProbeCommand(
+        name: String,
+        socketName: String?,
+        platform: SSHHostInfo.Platform
+    ) -> String {
+        switch platform {
+        case .posix:
+            var arguments = [String]()
+            if let socketName {
+                arguments.append(contentsOf: ["-L", socketName])
+            }
+            arguments.append(contentsOf: ["has-session", "-t", "=\(name)"])
+            let command = arguments
+                .map(shellQuotedCommandArgument)
+                .joined(separator: " ")
+            return probeCommand
+                + "; ghosthub_probe_error=$("
+                + "\"$ghosthub_tmux_path\" \(command) 2>&1); "
+                + "ghosthub_probe_status=$?; "
+                + "if [ \"$ghosthub_probe_status\" -eq 0 ]; then "
+                + "printf '\(sessionPresentMarker)\\n'; "
+                + "else printf '%s\\n' \"$ghosthub_probe_error\" >&2; "
+                + "case \"$ghosthub_probe_error\" in "
+                + "*\"can't find session:\"*|*\"no server running on \"*|"
+                + "*\"failed to connect to server: No such file or directory\"*) "
+                + "printf '\(sessionAbsentMarker)\\n' ;; "
+                + "*) exit \"$ghosthub_probe_status\" ;; esac; fi"
+        case .windows:
+            var arguments = [String]()
+            if let socketName {
+                arguments.append(contentsOf: ["-L", socketName])
+            }
+            arguments.append(contentsOf: ["has-session", "-t", "=\(name)"])
+            let command = arguments
+                .map(powerShellEncodedArgument)
+                .joined(separator: " ")
+            return windowsProbePrelude + """
+
+            Write-Output $ghosthubMux
+            & $ghosthubMux '-V'
+            if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+            }
+            $ghosthubProbeError = (& $ghosthubMux \(command) 2>&1 | Out-String)
+            $ghosthubProbeStatus = $LASTEXITCODE
+            if ($ghosthubProbeStatus -eq 0) {
+                Write-Output '\(sessionPresentMarker)'
+                exit 0
+            }
+            [Console]::Error.Write($ghosthubProbeError)
+            if ($ghosthubProbeError -match "can't find session:" -or
+                $ghosthubProbeError -match 'no server running on ' -or
+                $ghosthubProbeError -match 'failed to connect to server: No such file or directory') {
+                Write-Output '\(sessionAbsentMarker)'
+                exit 0
+            }
+            exit $ghosthubProbeStatus
             """
         }
     }
@@ -303,6 +457,21 @@ struct TmuxBinaryResolver: Sendable {
         _ result: (status: Int32, stdout: String),
         shell: String
     ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+        if result.status != 0 {
+            switch result.status {
+            case timedOutStatus, cancelledStatus, outputExceededStatus:
+                if case let .failure(error) = parseProbe(result, shell: shell) {
+                    return .failure(error)
+                }
+            default:
+                if case .success = parseProbe(
+                    (status: 0, stdout: result.stdout),
+                    shell: shell
+                ) {
+                    return .failure(.shellFailed(status: result.status))
+                }
+            }
+        }
         switch parseProbe(result, shell: shell) {
         case let .failure(error):
             return .failure(error)

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -285,7 +285,8 @@ struct TmuxBinaryResolver: Sendable {
         + "printf '%s\\n' \"$ghosthub_tmux_output\" >&2; "
         + "case \"$ghosthub_tmux_output\" in "
         + "*\"no server running on \"*|"
-        + "*\"failed to connect to server: No such file or directory\"*) "
+        + "*\"failed to connect to server: No such file or directory\"*|"
+        + "*\"error connecting to \"*\" (No such file or directory)\"*) "
         + "exit 0 ;; *) exit \"$ghosthub_tmux_status\" ;; esac; fi"
 
     private static func probeCommand(
@@ -360,7 +361,8 @@ struct TmuxBinaryResolver: Sendable {
                 + "else printf '%s\\n' \"$ghosthub_probe_error\" >&2; "
                 + "case \"$ghosthub_probe_error\" in "
                 + "*\"can't find session:\"*|*\"no server running on \"*|"
-                + "*\"failed to connect to server: No such file or directory\"*) "
+                + "*\"failed to connect to server: No such file or directory\"*|"
+                + "*\"error connecting to \"*\" (No such file or directory)\"*) "
                 + "printf '\(sessionAbsentMarker)\\n' ;; "
                 + "*) exit \"$ghosthub_probe_status\" ;; esac; fi"
         case .windows:

--- a/Sources/App/TmuxSessionProbeBroker.swift
+++ b/Sources/App/TmuxSessionProbeBroker.swift
@@ -1,0 +1,314 @@
+import Foundation
+import GhosthubTmux
+
+struct TmuxSessionProbeTarget: Hashable, Sendable {
+    var host: SSHHostInfo
+    var name: String
+    var socketName: String?
+}
+
+enum TmuxSessionProbeOutcome: Equatable, Sendable {
+    case present
+    case absent
+    case failure(TmuxBinaryError)
+}
+
+@MainActor
+final class TmuxSessionProbeBroker {
+    typealias Discovery = @Sendable (TmuxHost) async
+        -> Result<[DiscoveredTmuxSession], TmuxBinaryError>
+    typealias ExactProbe = @Sendable (TmuxSessionProbeTarget) async
+        -> Result<Bool, TmuxBinaryError>
+    private typealias DiscoveryResult =
+        Result<[DiscoveredTmuxSession], TmuxBinaryError>
+    private typealias DiscoveryContinuation =
+        CheckedContinuation<DiscoveryResult, Never>
+    private typealias ExactProbeResult = Result<Bool, TmuxBinaryError>
+    private typealias ExactProbeContinuation =
+        CheckedContinuation<ExactProbeResult, Never>
+
+    private struct DiscoveryEntry {
+        var id: UUID
+        var task: Task<Void, Never>
+        var consumers: [UUID: DiscoveryContinuation]
+        var consumersWaitingForCancellation: [UUID: DiscoveryContinuation]
+        var isCancelling = false
+    }
+
+    private struct ExactProbeEntry {
+        var id: UUID
+        var task: Task<Void, Never>
+        var consumers: [UUID: ExactProbeContinuation]
+        var consumersWaitingForCancellation: [UUID: ExactProbeContinuation]
+        var isCancelling = false
+    }
+
+    private let discover: Discovery
+    private let exactProbe: ExactProbe
+    private var discoveryEntries = [TmuxHost: DiscoveryEntry]()
+    private var exactProbeEntries = [TmuxSessionProbeTarget: ExactProbeEntry]()
+
+    init(
+        discover: @escaping Discovery,
+        exactProbe: @escaping ExactProbe
+    ) {
+        self.discover = discover
+        self.exactProbe = exactProbe
+    }
+
+    func sessions(
+        on host: TmuxHost
+    ) async -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+        let consumerID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: .failure(
+                        .probeCancelled(shell: host.displayName)
+                    ))
+                    return
+                }
+                registerDiscoveryConsumer(
+                    continuation,
+                    id: consumerID,
+                    host: host
+                )
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelDiscoveryConsumer(id: consumerID, host: host)
+            }
+        }
+    }
+
+    func invalidateSessions(on host: TmuxHost) {
+        guard var entry = discoveryEntries[host] else {
+            return
+        }
+        let failure = DiscoveryResult.failure(
+            .probeCancelled(shell: host.displayName)
+        )
+        for value in entry.consumers.values {
+            value.resume(returning: failure)
+        }
+        for value in entry.consumersWaitingForCancellation.values {
+            value.resume(returning: failure)
+        }
+        entry.consumers.removeAll()
+        entry.consumersWaitingForCancellation.removeAll()
+        entry.isCancelling = true
+        entry.task.cancel()
+        discoveryEntries[host] = entry
+    }
+
+    func session(
+        _ target: TmuxSessionProbeTarget
+    ) async -> TmuxSessionProbeOutcome {
+        guard target.socketName != nil else {
+            switch await sessions(on: .ssh(target.host)) {
+            case let .success(sessions):
+                return sessions.contains(where: { $0.name == target.name })
+                    ? .present
+                    : .absent
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+
+        let consumerID = UUID()
+        let result: ExactProbeResult = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: .failure(
+                        .probeCancelled(shell: target.host.displayName)
+                    ))
+                    return
+                }
+                registerExactProbeConsumer(
+                    continuation,
+                    id: consumerID,
+                    target: target
+                )
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelExactProbeConsumer(
+                    id: consumerID,
+                    target: target
+                )
+            }
+        }
+        return Self.outcome(for: result)
+    }
+
+    private func registerDiscoveryConsumer(
+        _ continuation: DiscoveryContinuation,
+        id consumerID: UUID,
+        host: TmuxHost
+    ) {
+        guard var entry = discoveryEntries[host] else {
+            startDiscovery(
+                on: host,
+                consumers: [consumerID: continuation]
+            )
+            return
+        }
+        if entry.isCancelling {
+            entry.consumersWaitingForCancellation[consumerID] = continuation
+        } else {
+            entry.consumers[consumerID] = continuation
+        }
+        discoveryEntries[host] = entry
+    }
+
+    private func startDiscovery(
+        on host: TmuxHost,
+        consumers: [UUID: DiscoveryContinuation]
+    ) {
+        let id = UUID()
+        let discover = discover
+        let task = Task {
+            let result = await discover(host)
+            self.completeDiscovery(result, id: id, host: host)
+        }
+        discoveryEntries[host] = DiscoveryEntry(
+            id: id,
+            task: task,
+            consumers: consumers,
+            consumersWaitingForCancellation: [:]
+        )
+    }
+
+    private func completeDiscovery(
+        _ result: DiscoveryResult,
+        id: UUID,
+        host: TmuxHost
+    ) {
+        guard let entry = discoveryEntries[host], entry.id == id else {
+            return
+        }
+        discoveryEntries.removeValue(forKey: host)
+        if entry.isCancelling {
+            if !entry.consumersWaitingForCancellation.isEmpty {
+                startDiscovery(
+                    on: host,
+                    consumers: entry.consumersWaitingForCancellation
+                )
+            }
+            return
+        }
+        for value in entry.consumers.values {
+            value.resume(returning: result)
+        }
+    }
+
+    private func cancelDiscoveryConsumer(id: UUID, host: TmuxHost) {
+        guard var entry = discoveryEntries[host] else { return }
+        let failure = DiscoveryResult.failure(
+            .probeCancelled(shell: host.displayName)
+        )
+        if let consumer = entry.consumers.removeValue(forKey: id) {
+            consumer.resume(returning: failure)
+            if entry.consumers.isEmpty {
+                entry.isCancelling = true
+                entry.task.cancel()
+            }
+        } else if let consumer = entry.consumersWaitingForCancellation
+            .removeValue(forKey: id) {
+            consumer.resume(returning: failure)
+        }
+        discoveryEntries[host] = entry
+    }
+
+    private func registerExactProbeConsumer(
+        _ continuation: ExactProbeContinuation,
+        id consumerID: UUID,
+        target: TmuxSessionProbeTarget
+    ) {
+        guard var entry = exactProbeEntries[target] else {
+            startExactProbe(
+                target,
+                consumers: [consumerID: continuation]
+            )
+            return
+        }
+        if entry.isCancelling {
+            entry.consumersWaitingForCancellation[consumerID] = continuation
+        } else {
+            entry.consumers[consumerID] = continuation
+        }
+        exactProbeEntries[target] = entry
+    }
+
+    private func startExactProbe(
+        _ target: TmuxSessionProbeTarget,
+        consumers: [UUID: ExactProbeContinuation]
+    ) {
+        let id = UUID()
+        let exactProbe = exactProbe
+        let task = Task {
+            let result = await exactProbe(target)
+            self.completeExactProbe(result, id: id, target: target)
+        }
+        exactProbeEntries[target] = ExactProbeEntry(
+            id: id,
+            task: task,
+            consumers: consumers,
+            consumersWaitingForCancellation: [:]
+        )
+    }
+
+    private func completeExactProbe(
+        _ result: ExactProbeResult,
+        id: UUID,
+        target: TmuxSessionProbeTarget
+    ) {
+        guard let entry = exactProbeEntries[target], entry.id == id else {
+            return
+        }
+        exactProbeEntries.removeValue(forKey: target)
+        if entry.isCancelling {
+            if !entry.consumersWaitingForCancellation.isEmpty {
+                startExactProbe(
+                    target,
+                    consumers: entry.consumersWaitingForCancellation
+                )
+            }
+            return
+        }
+        for value in entry.consumers.values {
+            value.resume(returning: result)
+        }
+    }
+
+    private func cancelExactProbeConsumer(
+        id: UUID,
+        target: TmuxSessionProbeTarget
+    ) {
+        guard var entry = exactProbeEntries[target] else { return }
+        let failure = ExactProbeResult.failure(
+            .probeCancelled(shell: target.host.displayName)
+        )
+        if let consumer = entry.consumers.removeValue(forKey: id) {
+            consumer.resume(returning: failure)
+            if entry.consumers.isEmpty {
+                entry.isCancelling = true
+                entry.task.cancel()
+            }
+        } else if let consumer = entry.consumersWaitingForCancellation
+            .removeValue(forKey: id) {
+            consumer.resume(returning: failure)
+        }
+        exactProbeEntries[target] = entry
+    }
+
+    private static func outcome(
+        for result: Result<Bool, TmuxBinaryError>
+    ) -> TmuxSessionProbeOutcome {
+        switch result {
+        case .success(true): .present
+        case .success(false): .absent
+        case let .failure(error): .failure(error)
+        }
+    }
+}

--- a/Sources/App/TmuxSessionReconnectSupervisor.swift
+++ b/Sources/App/TmuxSessionReconnectSupervisor.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+enum TmuxReconnectDecision: Sendable {
+    case retry
+    case stop
+}
+
+@MainActor
+final class TmuxSessionReconnectSupervisor {
+    typealias Attempt = @MainActor @Sendable () async -> TmuxReconnectDecision
+    typealias Sleep = @Sendable (Duration) async throws -> Void
+
+    nonisolated static let defaultProbeDeadline = Duration.seconds(15)
+    private nonisolated static let defaultIntervals = [
+        Duration.seconds(1),
+        .seconds(2),
+        .seconds(4),
+        .seconds(8),
+        .seconds(16),
+        .seconds(30),
+    ]
+
+    private enum Phase {
+        case idle
+        case probing
+        case waiting
+    }
+
+    private enum AttemptRace: Sendable {
+        case decision(TmuxReconnectDecision)
+        case deadline
+        case cancelled
+    }
+
+    private let intervals: [Duration]
+    private let probeDeadline: Duration
+    private let sleep: Sleep
+    private(set) var isRunning = false
+    private var phase = Phase.idle
+    private var generation = UUID()
+    private var task: Task<Void, Never>?
+    private var waitTask: Task<Void, Error>?
+
+    init(
+        intervals: [Duration] = defaultIntervals,
+        probeDeadline: Duration = defaultProbeDeadline,
+        sleep: @escaping Sleep = { try await Task.sleep(for: $0) }
+    ) {
+        precondition(!intervals.isEmpty)
+        self.intervals = intervals
+        self.probeDeadline = probeDeadline
+        self.sleep = sleep
+    }
+
+    func start(attempt: @escaping Attempt) {
+        cancel()
+        let generation = UUID()
+        self.generation = generation
+        isRunning = true
+        phase = .probing
+        task = Task { [weak self] in
+            await self?.run(generation: generation, attempt: attempt)
+        }
+    }
+
+    func reconnectNow() {
+        guard isRunning, phase == .waiting else { return }
+        waitTask?.cancel()
+    }
+
+    func cancel() {
+        generation = UUID()
+        task?.cancel()
+        waitTask?.cancel()
+        task = nil
+        waitTask = nil
+        phase = .idle
+        isRunning = false
+    }
+
+    nonisolated static func remainingDelay(
+        interval: Duration,
+        elapsed: Duration
+    ) -> Duration {
+        max(.zero, interval - elapsed)
+    }
+
+    private func run(
+        generation: UUID,
+        attempt: @escaping Attempt
+    ) async {
+        var intervalIndex = 0
+        while isCurrent(generation) {
+            phase = .probing
+            let clock = ContinuousClock()
+            let started = clock.now
+            let decision = await runAttempt(attempt)
+            guard isCurrent(generation) else { return }
+            switch decision {
+            case .stop:
+                finish(generation)
+                return
+            case .retry:
+                break
+            }
+
+            let interval = intervals[min(intervalIndex, intervals.count - 1)]
+            intervalIndex += 1
+            let delay = Self.remainingDelay(
+                interval: interval,
+                elapsed: started.duration(to: clock.now)
+            )
+            phase = .waiting
+            let sleep = sleep
+            let waitTask = Task { try await sleep(delay) }
+            self.waitTask = waitTask
+            _ = await waitTask.result
+            guard isCurrent(generation) else { return }
+            self.waitTask = nil
+        }
+    }
+
+    private func runAttempt(
+        _ attempt: @escaping Attempt
+    ) async -> TmuxReconnectDecision {
+        let deadline = probeDeadline
+        return await withTaskGroup(of: AttemptRace.self) { group in
+            group.addTask {
+                await .decision(attempt())
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: deadline)
+                    return .deadline
+                } catch {
+                    return .cancelled
+                }
+            }
+
+            let first = await group.next() ?? .cancelled
+            group.cancelAll()
+            while await group.next() != nil {}
+            switch first {
+            case let .decision(decision):
+                return decision
+            case .deadline:
+                return .retry
+            case .cancelled:
+                return .stop
+            }
+        }
+    }
+
+    private func isCurrent(_ generation: UUID) -> Bool {
+        self.generation == generation && !Task.isCancelled
+    }
+
+    private func finish(_ generation: UUID) {
+        guard self.generation == generation else { return }
+        task = nil
+        waitTask = nil
+        phase = .idle
+        isRunning = false
+    }
+}

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3918,7 +3918,10 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func resumeTmuxReconnectAfterSSHRecovery(hostID: UUID) {
-        guard var context = activeTmuxReconnectContext,
+        guard case .needsAttention(_, true) = activeBorrowedTmuxRecoveryState,
+              let request = tmuxConnectionRecoveryRequest,
+              request.hostID == hostID,
+              var context = activeTmuxReconnectContext,
               context.selection.hostID == hostID,
               activeBorrowedTmuxHandle?.id == context.handleID
         else { return }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -69,6 +69,15 @@ enum BorrowedTmuxRecoveryState: Equatable {
         }
         return false
     }
+
+    var allowsReconnectNow: Bool {
+        switch self {
+        case .reconnecting:
+            true
+        case let .needsAttention(_, canReviewConnection):
+            !canReviewConnection
+        }
+    }
 }
 
 @MainActor
@@ -3895,7 +3904,17 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func reconnectActiveTmuxSessionNow() {
-        tmuxReconnectSupervisor.reconnectNow()
+        guard let recoveryState = activeBorrowedTmuxRecoveryState,
+              recoveryState.allowsReconnectNow
+        else { return }
+        if recoveryState.isReconnecting {
+            tmuxReconnectSupervisor.reconnectNow()
+            return
+        }
+        guard let context = activeTmuxReconnectContext,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return }
+        startTmuxReconnect(context)
     }
 
     func resumeTmuxReconnectAfterSSHRecovery(hostID: UUID) {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3346,15 +3346,11 @@ final class WorkspaceSceneModel: ObservableObject {
         activeBorrowedTmuxLaunchMode = effectiveLaunchMode
         borrowedTmuxConnectionStates[handle.id] = .connecting
         if attachmentHost.isRemote {
-            let establishingWorkspace = intent == .userInitiated
-                && effectiveLaunchMode == .attach
-                && selection.worktreePath != nil
-                && (selection.socketName != nil || !sessionIsDiscovered)
             activeTmuxReconnectContext = ActiveTmuxReconnectContext(
                 selection: selection,
                 handleID: handle.id,
                 host: attachmentHost,
-                phase: establishingWorkspace
+                phase: openWorkspace
                     ? .establishingWorkspace
                     : .attachOnly,
                 surfaceExitCode: nil
@@ -3823,7 +3819,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 intent: .userInitiated
             )
             return .stop
-        case .failure(.probeCancelled):
+        case .failure(.probeCancelled), .failure(.probeTimedOut):
             return .retry
         case let .failure(.sshConnectionFailed(_, classification)):
             switch classification.kind {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -59,6 +59,18 @@ struct WorkspaceInventoryRefreshProgress: Equatable {
     }
 }
 
+enum BorrowedTmuxRecoveryState: Equatable {
+    case reconnecting(message: String)
+    case needsAttention(message: String, canReviewConnection: Bool)
+
+    var isReconnecting: Bool {
+        if case .reconnecting = self {
+            return true
+        }
+        return false
+    }
+}
+
 @MainActor
 final class WorktreeMutationCoordinator {
     struct Scope: Hashable, Sendable {
@@ -160,6 +172,9 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias TmuxSessionDiscovery = @Sendable (
         TmuxHost
     ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError>
+    typealias TmuxSessionExactProbe = @Sendable (
+        TmuxSessionProbeTarget
+    ) -> Result<Bool, TmuxBinaryError>
     typealias TmuxSessionKilling = @Sendable (
         WorkspaceTmuxSessionSelection, TmuxSessionIdentity, TmuxHost
     ) async throws -> Void
@@ -195,6 +210,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private var endedCreatedTmuxSessionHandles: Set<UUID> = []
     private var confirmedEndedTmuxSessionHandles: Set<UUID> = []
     private let createdSessionDiscoveryDelays: [Duration]
+    private let tmuxSessionProbeBroker: TmuxSessionProbeBroker
+    private let tmuxReconnectSupervisor: TmuxSessionReconnectSupervisor
     @Published private(set) var workspaceInventoryState:
         WorkspaceInventoryState = .loading
     @Published private(set) var workspaceInventoryWarning: String?
@@ -264,6 +281,23 @@ final class WorkspaceSceneModel: ObservableObject {
     private var activeBorrowedTmuxHandle: BorrowedTmuxSessionHandle?
     private(set) var activeBorrowedTmuxLaunchMode:
         TmuxAttachmentLaunchMode?
+    @Published private(set) var activeBorrowedTmuxRecoveryState:
+        BorrowedTmuxRecoveryState?
+    @Published private(set) var tmuxConnectionRecoveryRequest:
+        TmuxConnectionRecoveryRequest?
+    private enum RemoteTmuxEstablishmentPhase: Equatable {
+        case establishingWorkspace
+        case attachOnly
+    }
+    private struct ActiveTmuxReconnectContext: Equatable {
+        var selection: WorkspaceTmuxSessionSelection
+        var handleID: UUID
+        var host: TmuxHost
+        var phase: RemoteTmuxEstablishmentPhase
+        var surfaceExitCode: UInt32?
+    }
+    private var activeTmuxReconnectContext: ActiveTmuxReconnectContext?
+    private var establishmentConfirmationTask: Task<Void, Never>?
     @Published private(set) var isWorkspaceRestorationPending = false
     @Published private(set) var suppressesAutomaticWorktreeSessionOpen = false
     private var pendingRestoration: WorkspaceWindowState?
@@ -559,6 +593,13 @@ final class WorkspaceSceneModel: ObservableObject {
                 resolver.discoverSessions(on: info)
             }
         },
+        tmuxExactSessionProbe: @escaping TmuxSessionExactProbe = { target in
+            TmuxBinaryResolver().sessionExists(
+                name: target.name,
+                socketName: target.socketName,
+                on: target.host
+            )
+        },
         tmuxSessionKiller: @escaping TmuxSessionKilling = {
             selection, identity, host in
             try await TmuxSessionKiller().kill(
@@ -611,6 +652,12 @@ final class WorkspaceSceneModel: ObservableObject {
             .milliseconds(250), .milliseconds(500), .seconds(1), .seconds(2),
             .seconds(4), .seconds(8),
         ],
+        tmuxReconnectIntervals: [Duration] = [
+            .seconds(1), .seconds(2), .seconds(4), .seconds(8),
+            .seconds(16), .seconds(30),
+        ],
+        tmuxReconnectProbeDeadline: Duration =
+            TmuxSessionReconnectSupervisor.defaultProbeDeadline,
         startServices: Bool = false
     ) throws {
         self.database = database
@@ -630,6 +677,32 @@ final class WorkspaceSceneModel: ObservableObject {
         self.kwtPullRequestImporter = kwtPullRequestImporter
         self.kwtProjectRegistration = kwtProjectRegistration
         self.tmuxSessionDiscovery = tmuxSessionDiscovery
+        tmuxSessionProbeBroker = TmuxSessionProbeBroker(
+            discover: { host in
+                let probe = Task.detached(priority: .utility) {
+                    tmuxSessionDiscovery(host)
+                }
+                return await withTaskCancellationHandler {
+                    await probe.value
+                } onCancel: {
+                    probe.cancel()
+                }
+            },
+            exactProbe: { target in
+                let probe = Task.detached(priority: .utility) {
+                    tmuxExactSessionProbe(target)
+                }
+                return await withTaskCancellationHandler {
+                    await probe.value
+                } onCancel: {
+                    probe.cancel()
+                }
+            }
+        )
+        tmuxReconnectSupervisor = TmuxSessionReconnectSupervisor(
+            intervals: tmuxReconnectIntervals,
+            probeDeadline: tmuxReconnectProbeDeadline
+        )
         self.tmuxSessionKiller = tmuxSessionKiller
         self.tmuxSessionIdentityReader = tmuxSessionIdentityReader
         self.tmuxSessionStyler = tmuxSessionStyler
@@ -712,6 +785,9 @@ final class WorkspaceSceneModel: ObservableObject {
             [weak self] handle in
             guard self?.activeBorrowedTmuxHandle == handle else { return }
             self?.objectWillChange.send()
+            if self?.activeBorrowedTmuxRecoveryState != nil {
+                self?.prepareActiveBorrowedTmuxSurface()
+            }
         }
         activityControllerBacking = ActivityMonitoringController(
             notificationService: notificationService,
@@ -1082,6 +1158,7 @@ final class WorkspaceSceneModel: ObservableObject {
     /// tmux server sessions they attach to. Called by `WorkspaceWindow` before
     /// the scene model leaves the app-level window registry.
     func shutdown() async {
+        cancelTmuxReconnect()
         kwtInventoryTask?.cancel()
         tmuxDiscoveryTask?.cancel()
         createdSessionDiscoveryTasks.values.forEach { $0.cancel() }
@@ -2111,14 +2188,14 @@ final class WorkspaceSceneModel: ObservableObject {
         inventoryRefreshProgress.tmuxCompleted = false
         isTmuxDiscoveryLoading = true
         updateWorkspaceInventoryState()
-        let tmuxSessionDiscovery = tmuxSessionDiscovery
+        let broker = tmuxSessionProbeBroker
         tmuxDiscoveryTask = Task { [weak self] in
             await withTaskGroup(
                 of: (UUID, Result<[DiscoveredTmuxSession], TmuxBinaryError>).self
             ) { group in
                 for (hostID, host) in targets {
                     group.addTask {
-                        (hostID, tmuxSessionDiscovery(host))
+                        await (hostID, broker.sessions(on: host))
                     }
                 }
                 for await (hostID, result) in group {
@@ -2127,33 +2204,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         group.cancelAll()
                         return
                     }
-                    guard case let .success(discovered) = result else {
-                        if case let .failure(error) = result {
-                            self.tmuxReachabilityByHost[hostID] = false
-                            let hostName = self.snapshot.host(id: hostID)?.name
-                                ?? "Unknown host"
-                            self.tmuxDiscoveryFailuresByHost[hostID] =
-                                "\(hostName): \(error.localizedDescription)"
-                        }
-                        self.applyInventoryOverlayIfNeeded()
-                        self.updateWorkspaceInventoryState()
-                        continue
-                    }
-                    self.tmuxDiscoveryFailuresByHost.removeValue(forKey: hostID)
-                    self.tmuxReachabilityByHost[hostID] = true
-                    self.tmuxLastSeenByHost[hostID] = Date()
-                    self.reconcileEndedTmuxSession(
-                        discovered,
-                        hostID: hostID
-                    )
-                    self.tmuxSessionsByHost[hostID] =
-                        self.reconciledTmuxSessions(
-                            discovered,
-                            hostID: hostID
-                        )
-                    self.applyInventoryOverlayIfNeeded()
-                    self.updateWorkspaceInventoryState()
-                    self.applyDeferredTmuxPresentationIfReady()
+                    self.applyTmuxDiscoveryResult(result, hostID: hostID)
                 }
             }
             guard let self, !Task.isCancelled,
@@ -2162,6 +2213,35 @@ final class WorkspaceSceneModel: ObservableObject {
             inventoryRefreshProgress.tmuxCompleted = true
             updateWorkspaceInventoryState()
         }
+    }
+
+    private func applyTmuxDiscoveryResult(
+        _ result: Result<[DiscoveredTmuxSession], TmuxBinaryError>,
+        hostID: UUID
+    ) {
+        guard case let .success(discovered) = result else {
+            if case let .failure(error) = result {
+                tmuxReachabilityByHost[hostID] = false
+                let hostName = snapshot.host(id: hostID)?.name
+                    ?? "Unknown host"
+                tmuxDiscoveryFailuresByHost[hostID] =
+                    "\(hostName): \(error.localizedDescription)"
+            }
+            applyInventoryOverlayIfNeeded()
+            updateWorkspaceInventoryState()
+            return
+        }
+        tmuxDiscoveryFailuresByHost.removeValue(forKey: hostID)
+        tmuxReachabilityByHost[hostID] = true
+        tmuxLastSeenByHost[hostID] = Date()
+        reconcileEndedTmuxSession(discovered, hostID: hostID)
+        tmuxSessionsByHost[hostID] = reconciledTmuxSessions(
+            discovered,
+            hostID: hostID
+        )
+        applyInventoryOverlayIfNeeded()
+        updateWorkspaceInventoryState()
+        applyDeferredTmuxPresentationIfReady()
     }
 
     private func reconcileEndedTmuxSession(
@@ -2183,7 +2263,10 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
-    private func fenceTmuxDiscoveryForCreationReconciliation() {
+    private func fenceTmuxDiscoveryForCreationReconciliation(
+        host: TmuxHost
+    ) {
+        tmuxSessionProbeBroker.invalidateSessions(on: host)
         tmuxDiscoveryGeneration += 1
         tmuxDiscoveryTask?.cancel()
         tmuxDiscoveryTask = nil
@@ -2368,6 +2451,7 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         guard let active = activeBorrowedTmuxSelection,
               hostIDs.contains(active.hostID) else { return }
+        cancelTmuxReconnect()
         activeBorrowedTmuxSelection = nil
         activeBorrowedTmuxHandle = nil
         activeBorrowedTmuxLaunchMode = nil
@@ -3095,7 +3179,9 @@ final class WorkspaceSceneModel: ObservableObject {
     func borrowedTmuxSessionView(
         host: HostSummary,
         sessionName: String,
-        defersTerminalResize: Bool
+        defersTerminalResize: Bool,
+        onReconnectNow: @escaping () -> Void = {},
+        onReviewConnection: @escaping () -> Void = {}
     ) -> AnyView? {
         guard TmuxHostResolver.resolve(host) != nil else {
             return AnyView(
@@ -3125,6 +3211,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         && $0.tmuxSessionName == sessionName
                 }?.name,
                 connectionState: borrowedTmuxConnectionStates[handle.id],
+                recoveryState: activeBorrowedTmuxRecoveryState,
                 attachmentClosure:
                 nativeTmuxSessionCoordinator.attachmentClosure(handle),
                 sessionClosed:
@@ -3141,6 +3228,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 onRetryRequest: { [weak self] in
                     self?.retryBorrowedTmuxSession(selection)
                 },
+                onReconnectNow: onReconnectNow,
+                onReviewConnection: onReviewConnection,
                 onHostSettingsRequest: { [weak self] in
                     SettingsStore.shared.selectedDomain = .hosts
                     self?.isSettingsPresented = true
@@ -3217,7 +3306,9 @@ final class WorkspaceSceneModel: ObservableObject {
             selection.worktreeGeneration = generation
         }
         let effectiveLaunchMode: TmuxAttachmentLaunchMode =
-            selection.socketName == nil ? launchMode : .attach
+            selection.socketName != nil && launchMode == .create
+                ? .attach
+                : launchMode
         if let active = activeBorrowedTmuxSelection, active != selection {
             closeBorrowedTmuxSession(active)
         }
@@ -3254,6 +3345,23 @@ final class WorkspaceSceneModel: ObservableObject {
         activeBorrowedTmuxHandle = handle
         activeBorrowedTmuxLaunchMode = effectiveLaunchMode
         borrowedTmuxConnectionStates[handle.id] = .connecting
+        if attachmentHost.isRemote {
+            let establishingWorkspace = intent == .userInitiated
+                && effectiveLaunchMode == .attach
+                && selection.worktreePath != nil
+                && (selection.socketName != nil || !sessionIsDiscovered)
+            activeTmuxReconnectContext = ActiveTmuxReconnectContext(
+                selection: selection,
+                handleID: handle.id,
+                host: attachmentHost,
+                phase: establishingWorkspace
+                    ? .establishingWorkspace
+                    : .attachOnly,
+                surfaceExitCode: nil
+            )
+        } else {
+            activeTmuxReconnectContext = nil
+        }
         if effectiveLaunchMode == .create {
             transferPendingCreation(for: selection, to: handle)
         }
@@ -3305,6 +3413,7 @@ final class WorkspaceSceneModel: ObservableObject {
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
         guard activeBorrowedTmuxSelection == selection else { return }
+        cancelTmuxReconnect()
         if let handle = activeBorrowedTmuxHandle {
             cancelTmuxPresentationTasks(handleID: handle.id)
             confirmedEndedTmuxSessionHandles.remove(handle.id)
@@ -3539,11 +3648,39 @@ final class WorkspaceSceneModel: ObservableObject {
     ) {
         borrowedTmuxConnectionStates[handle.id] = state
         if state == .connected {
+            confirmedEndedTmuxSessionHandles.remove(handle.id)
+            activeBorrowedTmuxRecoveryState = nil
+            tmuxConnectionRecoveryRequest = nil
+            if activeTmuxReconnectContext?.handleID == handle.id {
+                activeTmuxReconnectContext?.surfaceExitCode = nil
+                startEstablishmentConfirmationIfNeeded(handle: handle)
+            }
             applyDeferredTmuxPresentationIfReady()
+        }
+        if case .disconnected = state,
+           activeBorrowedTmuxHandle == handle,
+           activeBorrowedTmuxRecoveryState != nil,
+           nativeTmuxSessionCoordinator.attachmentClosure(handle)
+           == .launchFailed {
+            cancelTmuxReconnect()
+            return
         }
         if case .disconnected = state,
            nativeTmuxSessionCoordinator.hasLaunched(handle) {
             cancelTmuxPresentationTasks(handleID: handle.id)
+            if activeBorrowedTmuxHandle == handle,
+               var context = activeTmuxReconnectContext,
+               context.handleID == handle.id,
+               context.host.isRemote,
+               case let .processExited(code) =
+               nativeTmuxSessionCoordinator.attachmentClosure(handle) {
+                establishmentConfirmationTask?.cancel()
+                establishmentConfirmationTask = nil
+                context.surfaceExitCode = code
+                activeTmuxReconnectContext = context
+                startTmuxReconnect(context)
+                return
+            }
             scheduleTmuxSessionDiscovery()
         }
         guard pendingCreatedTmuxSessions[handle.id] != nil else {
@@ -3564,6 +3701,259 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         case .connecting, .reconnecting:
             break
+        }
+    }
+
+    private func startTmuxReconnect(_ context: ActiveTmuxReconnectContext) {
+        guard activeTmuxReconnectContext == context,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return }
+        activeBorrowedTmuxRecoveryState = .reconnecting(
+            message: "Waiting for \(hostName(for: context.selection.hostID)). "
+                + "Ghosthub will reconnect automatically."
+        )
+        tmuxConnectionRecoveryRequest = nil
+        tmuxReconnectSupervisor.start { [weak self] in
+            guard let self else { return .stop }
+            return await attemptTmuxReconnect(context)
+        }
+    }
+
+    private func attemptTmuxReconnect(
+        _ context: ActiveTmuxReconnectContext
+    ) async -> TmuxReconnectDecision {
+        guard activeTmuxReconnectContext == context,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return .stop }
+        let outcome = await tmuxProbeOutcome(for: context)
+        guard !Task.isCancelled else { return .retry }
+        guard activeTmuxReconnectContext == context,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return .stop }
+        return reconnectDecision(for: context, outcome: outcome)
+    }
+
+    private func tmuxProbeOutcome(
+        for context: ActiveTmuxReconnectContext
+    ) async -> TmuxSessionProbeOutcome {
+        guard case let .ssh(host) = context.host else {
+            return .failure(.sessionContextUnavailable)
+        }
+        if context.selection.socketName == nil {
+            let result = await tmuxSessionProbeBroker.sessions(
+                on: context.host
+            )
+            guard !Task.isCancelled else {
+                return .failure(.probeCancelled(
+                    shell: context.host.displayName
+                ))
+            }
+            guard activeTmuxReconnectContext == context,
+                  activeBorrowedTmuxHandle?.id == context.handleID,
+                  snapshot.host(id: context.selection.hostID)
+                  .flatMap(TmuxHostResolver.resolve) == context.host
+            else {
+                return .failure(.sessionContextUnavailable)
+            }
+            if case let .failure(error) = result,
+               case .probeCancelled = error {
+                return .failure(error)
+            }
+            applyTmuxDiscoveryResult(
+                result,
+                hostID: context.selection.hostID
+            )
+            switch result {
+            case let .success(sessions):
+                return sessions.contains { $0.name == context.selection.name }
+                    ? .present
+                    : .absent
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return await tmuxSessionProbeBroker.session(
+            TmuxSessionProbeTarget(
+                host: host,
+                name: context.selection.name,
+                socketName: context.selection.socketName
+            )
+        )
+    }
+
+    private func reconnectDecision(
+        for context: ActiveTmuxReconnectContext,
+        outcome: TmuxSessionProbeOutcome
+    ) -> TmuxReconnectDecision {
+        guard !Task.isCancelled else { return .retry }
+        guard activeTmuxReconnectContext == context,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return .stop }
+        switch outcome {
+        case .present:
+            guard context.surfaceExitCode == 255 else {
+                stopTmuxReconnectWithUnableToAttach(
+                    "The remote tmux client exited before it could attach."
+                )
+                return .stop
+            }
+            confirmedEndedTmuxSessionHandles.remove(context.handleID)
+            relaunchTmuxSession(
+                context.selection,
+                launchMode: .attachOnly,
+                intent: .restoreOnly
+            )
+            return .stop
+        case .absent:
+            guard context.phase == .establishingWorkspace else {
+                confirmedEndedTmuxSessionHandles.insert(context.handleID)
+                activeBorrowedTmuxRecoveryState = nil
+                tmuxConnectionRecoveryRequest = nil
+                return .stop
+            }
+            guard context.surfaceExitCode == 255 else {
+                stopTmuxReconnectWithUnableToAttach(
+                    "The remote workspace could not be established."
+                )
+                return .stop
+            }
+            relaunchTmuxSession(
+                context.selection,
+                launchMode: .attach,
+                intent: .userInitiated
+            )
+            return .stop
+        case .failure(.probeCancelled):
+            return .retry
+        case let .failure(.sshConnectionFailed(_, classification)):
+            switch classification.kind {
+            case .transport:
+                activeBorrowedTmuxRecoveryState = .reconnecting(
+                    message: classification.diagnostic.summary + " "
+                        + "Ghosthub will reconnect automatically."
+                )
+                return .retry
+            case .authenticationRequired, .hostKeyReviewRequired:
+                let message = classification.diagnostic.summary + " "
+                    + classification.diagnostic.recoverySuggestion
+                activeBorrowedTmuxRecoveryState = .needsAttention(
+                    message: message,
+                    canReviewConnection: true
+                )
+                if tmuxConnectionRecoveryRequest == nil {
+                    tmuxConnectionRecoveryRequest =
+                        TmuxConnectionRecoveryRequest(
+                            hostID: context.selection.hostID,
+                            message: message
+                        )
+                }
+                return .stop
+            case .hostKeyChanged:
+                activeBorrowedTmuxRecoveryState = .needsAttention(
+                    message: classification.diagnostic.summary + " "
+                        + classification.diagnostic.recoverySuggestion,
+                    canReviewConnection: false
+                )
+                tmuxConnectionRecoveryRequest = nil
+                return .stop
+            }
+        case let .failure(error):
+            stopTmuxReconnectWithUnableToAttach(error.localizedDescription)
+            return .stop
+        }
+    }
+
+    private func relaunchTmuxSession(
+        _ selection: WorkspaceTmuxSessionSelection,
+        launchMode: TmuxAttachmentLaunchMode,
+        intent: TmuxPresentationIntent
+    ) {
+        guard presentTmuxSession(
+            selection,
+            launchMode: launchMode,
+            intent: intent
+        ) != nil else {
+            stopTmuxReconnectWithUnableToAttach(
+                "The remote host is no longer available."
+            )
+            return
+        }
+        prepareActiveBorrowedTmuxSurface()
+    }
+
+    private func stopTmuxReconnectWithUnableToAttach(_ reason: String) {
+        activeBorrowedTmuxRecoveryState = nil
+        tmuxConnectionRecoveryRequest = nil
+        guard let handle = activeBorrowedTmuxHandle else { return }
+        borrowedTmuxConnectionStates[handle.id] = .disconnected(
+            reason: reason
+        )
+    }
+
+    private func hostName(for hostID: UUID) -> String {
+        snapshot.host(id: hostID)?.name ?? "the remote host"
+    }
+
+    func reconnectActiveTmuxSessionNow() {
+        tmuxReconnectSupervisor.reconnectNow()
+    }
+
+    func resumeTmuxReconnectAfterSSHRecovery(hostID: UUID) {
+        guard var context = activeTmuxReconnectContext,
+              context.selection.hostID == hostID,
+              activeBorrowedTmuxHandle?.id == context.handleID
+        else { return }
+        context.surfaceExitCode = 255
+        activeTmuxReconnectContext = context
+        tmuxConnectionRecoveryRequest = nil
+        startTmuxReconnect(context)
+    }
+
+    private func cancelTmuxReconnect() {
+        tmuxReconnectSupervisor.cancel()
+        establishmentConfirmationTask?.cancel()
+        establishmentConfirmationTask = nil
+        activeTmuxReconnectContext = nil
+        activeBorrowedTmuxRecoveryState = nil
+        tmuxConnectionRecoveryRequest = nil
+    }
+
+    private func startEstablishmentConfirmationIfNeeded(
+        handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let context = activeTmuxReconnectContext,
+              context.handleID == handle.id,
+              context.phase == .establishingWorkspace
+        else { return }
+        establishmentConfirmationTask?.cancel()
+        let delays = [.zero] + createdSessionDiscoveryDelays
+        establishmentConfirmationTask = Task { [weak self] in
+            for delay in delays {
+                do {
+                    try await Task.sleep(for: delay)
+                } catch {
+                    return
+                }
+                guard let self,
+                      !Task.isCancelled,
+                      activeTmuxReconnectContext == context,
+                      borrowedTmuxConnectionStates[handle.id] == .connected
+                else { return }
+                let outcome = await tmuxProbeOutcome(for: context)
+                guard !Task.isCancelled,
+                      activeTmuxReconnectContext == context,
+                      borrowedTmuxConnectionStates[handle.id] == .connected
+                else { return }
+                if outcome == .present {
+                    activeTmuxReconnectContext?.phase = .attachOnly
+                    establishmentConfirmationTask = nil
+                    return
+                }
+            }
+            guard let self,
+                  activeTmuxReconnectContext == context
+            else { return }
+            establishmentConfirmationTask = nil
         }
     }
 
@@ -3761,7 +4151,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 else { return }
                 switch result {
                 case let .success(discovered):
-                    fenceTmuxDiscoveryForCreationReconciliation()
+                    fenceTmuxDiscoveryForCreationReconciliation(host: host)
                     tmuxDiscoveryFailuresByHost.removeValue(
                         forKey: pending.hostID
                     )
@@ -3804,7 +4194,7 @@ final class WorkspaceSceneModel: ObservableObject {
             else { return }
             createdSessionDiscoveryTasks.removeValue(forKey: handleID)
             exhaustedCreatedTmuxSessionHandles.insert(handleID)
-            fenceTmuxDiscoveryForCreationReconciliation()
+            fenceTmuxDiscoveryForCreationReconciliation(host: host)
         }
     }
 
@@ -3925,8 +4315,8 @@ final class WorkspaceSceneModel: ObservableObject {
         switch launchMode {
         case .create:
             createTmuxSession(selection)
-        case .attach:
-            presentTmuxSession(selection, launchMode: .attach)
+        case .attach, .attachOnly:
+            presentTmuxSession(selection, launchMode: launchMode)
         }
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -4316,14 +4316,19 @@ final class WorkspaceSceneModel: ObservableObject {
         _ selection: WorkspaceTmuxSessionSelection
     ) {
         guard activeBorrowedTmuxSelection == selection else { return }
+        let sessionConfirmedEnded = activeBorrowedTmuxHandle.map {
+            confirmedEndedTmuxSessionHandles.contains($0.id)
+        } == true
         let recreateEndedNamedSession =
-            selection.socketName == nil
+            sessionConfirmedEnded
+                && selection.socketName == nil
                 && selection.worktreeID == nil
                 && selection.worktreePath == nil
-                && activeBorrowedTmuxHandle.map {
-                    confirmedEndedTmuxSessionHandles.contains($0.id)
-                } == true
-        let launchMode = activeBorrowedTmuxLaunchMode ?? .attach
+        let launchMode = Self.retryLaunchMode(
+            for: selection,
+            current: activeBorrowedTmuxLaunchMode,
+            sessionConfirmedEnded: sessionConfirmedEnded
+        )
         closeBorrowedTmuxSession(selection)
         if recreateEndedNamedSession {
             guard let handle = presentTmuxSession(
@@ -4340,6 +4345,17 @@ final class WorkspaceSceneModel: ObservableObject {
         case .attach, .attachOnly:
             presentTmuxSession(selection, launchMode: launchMode)
         }
+    }
+
+    static func retryLaunchMode(
+        for selection: WorkspaceTmuxSessionSelection,
+        current: TmuxAttachmentLaunchMode?,
+        sessionConfirmedEnded: Bool
+    ) -> TmuxAttachmentLaunchMode {
+        if sessionConfirmedEnded, selection.worktreePath != nil {
+            return .attach
+        }
+        return current ?? .attach
     }
 
     private var isApplicationActiveForResourceMonitoring: Bool {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3332,6 +3332,10 @@ final class WorkspaceSceneModel: ObservableObject {
             && selection.socketName == nil
             && selection.worktreePath != nil
             && (!sessionIsDiscovered || !managedKwtUnavailable)
+        let protectedSessionNeedsEstablishment = intent == .userInitiated
+            && effectiveLaunchMode == .attach
+            && selection.socketName != nil
+            && selection.worktreePath != nil
         let handle = nativeTmuxSessionCoordinator.attach(
             hostID: selection.hostID,
             name: selection.name,
@@ -3350,7 +3354,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 selection: selection,
                 handleID: handle.id,
                 host: attachmentHost,
-                phase: openWorkspace
+                phase: openWorkspace || protectedSessionNeedsEstablishment
                     ? .establishingWorkspace
                     : .attachOnly,
                 surfaceExitCode: nil

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -643,15 +643,20 @@ struct WorkspaceWindow: View {
                 activeTmuxSessionIsConnected:
                 sceneModel.activeBorrowedTmuxSessionIsConnected,
                 activeTmuxSessionCanApplyTheme:
-                sceneModel.canApplyThemeToActiveTmuxSession
+                sceneModel.canApplyThemeToActiveTmuxSession,
+                tmuxConnectionRecoveryRequest:
+                sceneModel.tmuxConnectionRecoveryRequest
             ),
             content: ContentBuilders(
                 tmuxSessionContentBuilder: {
-                    [sceneModel] host, sessionName, defersTerminalResize in
+                    [sceneModel]
+                    host, sessionName, defersTerminalResize, actions in
                     sceneModel.borrowedTmuxSessionView(
                         host: host,
                         sessionName: sessionName,
-                        defersTerminalResize: defersTerminalResize
+                        defersTerminalResize: defersTerminalResize,
+                        onReconnectNow: actions.reconnectNow,
+                        onReviewConnection: actions.reviewConnection
                     )
                 },
                 settingsSheetBuilder: { settingsStore in
@@ -779,6 +784,15 @@ struct WorkspaceWindow: View {
                 },
                 refreshWorkspaceInventory: { [sceneModel] in
                     sceneModel.refreshKwtInventory()
+                },
+                reconnectActiveTmuxSessionNow: { [sceneModel] in
+                    sceneModel.reconnectActiveTmuxSessionNow()
+                },
+                resumeTmuxReconnectAfterSSHRecovery: {
+                    [sceneModel] hostID in
+                    sceneModel.resumeTmuxReconnectAfterSSHRecovery(
+                        hostID: hostID
+                    )
                 },
                 reviewSSHHostKey: { [sceneModel] hostID, inventoryWarning in
                     await sceneModel.sshConnectionRecovery(

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -172,6 +172,7 @@ public enum TmuxHost: Codable, Hashable, Sendable {
 
 public enum TmuxAttachmentLaunchMode: String, Codable, Equatable, Sendable {
     case attach
+    case attachOnly
     case create
 }
 
@@ -229,7 +230,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                         workingDirectory: workingDirectory,
                         sshConnectionArguments: sshConnectionArguments
                     )
-                } else if protectedWorkspacePath == nil,
+                } else if launchMode != .attachOnly,
+                          protectedWorkspacePath == nil,
                           workspacePath != nil {
                     command = windowsRemoteWorkspaceAttachCommand(
                         info: info,
@@ -252,7 +254,9 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     workingDirectory: workingDirectory,
                     sshConnectionArguments: sshConnectionArguments
                 )
-            } else if protectedWorkspacePath == nil, workspacePath != nil {
+            } else if launchMode != .attachOnly,
+                      protectedWorkspacePath == nil,
+                      workspacePath != nil {
                 command = remoteWorkspaceAttachCommand(
                     info: info,
                     tmuxPath: tmuxPath,
@@ -347,6 +351,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     commands.append("exec \(attach)")
                 }
             }
+        case .attachOnly:
+            commands.append(
+                presentationCommand?.bestEffortCommand(
+                    tmuxPath: tmuxPath
+                ) ?? ":"
+            )
+            commands.append("exec \(attach)")
         case .create:
             let createAndAttach = localCreateAndAttachCommand(
                 tmuxPath: tmuxPath,
@@ -444,7 +455,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             )
         }
         let attach: String
-        if let protectedWorkspacePath {
+        if let protectedWorkspacePath, launchMode != .attachOnly {
             let protectedAttach: String
             if let remoteKwtCommandPrelude {
                 let kwtAttach = remoteKwtCommandPrelude
@@ -468,7 +479,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             attach = "exec \(tmuxAttach)"
         }
         var remoteAttachCommands = ["unset TMUX TMUX_PANE"]
-        if protectedWorkspacePath == nil, includesPresentation {
+        if includesPresentation,
+           protectedWorkspacePath == nil || launchMode == .attachOnly {
             remoteAttachCommands.append(
                 presentationCommand?.bestEffortCommand(
                     tmuxPath: tmuxPath
@@ -482,7 +494,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         let remoteAttach = accountLoginShellCommand(
             remoteAttachCommands.joined(separator: "; ")
         )
-        return sshReconnectCommand(
+        return sshAttachCommand(
             label: "ghosthub-ssh-tmux",
             info: info,
             allocateTTY: true,
@@ -531,29 +543,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 sshConnectionArguments: sshConnectionArguments
             )
         )
-        let reconnectAttach = remoteAttachCommand(
-            info: info,
-            tmuxPath: tmuxPath,
-            remoteKwtCommandPrelude: nil,
-            sshConnectionArguments: sshConnectionArguments
-        )
-        let hasSession = tmuxArguments(
-            tmuxPath,
-            "has-session", "-t", "=\(sessionName)"
-        ).map(shellQuotedCommandArgument).joined(separator: " ")
-        let remoteProbe = "unset TMUX TMUX_PANE; "
-            + "exec \(hasSession) >/dev/null 2>&1"
-        let sessionProbe = sshReconnectCommand(
-            label: "ghosthub-ssh-kwt-probe",
-            info: info,
-            allocateTTY: false,
-            remoteCommand: accountLoginShellCommand(remoteProbe),
-            sshConnectionArguments: sshConnectionArguments
-        )
         return shellCommand([
             "/bin/sh", "-c", Self.remoteWorkspaceAttachScript,
             "ghosthub-ssh-kwt-attach",
-            initialAttach, sessionProbe, reconnectAttach,
+            initialAttach,
         ])
     }
 
@@ -590,33 +583,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 sshConnectionArguments: sshConnectionArguments
             )
         )
-        let probeScript = """
-        $ErrorActionPreference = 'Stop'
-        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-        Remove-Item Env:TMUX, Env:TMUX_PANE -ErrorAction SilentlyContinue
-        \(windowsMuxCommand(
-            tmuxPath: tmuxPath,
-            arguments: ["has-session", "-t", "=\(sessionName)"]
-        )) *> $null
-        exit $LASTEXITCODE
-        """
-        let sessionProbe = sshReconnectCommand(
-            label: "ghosthub-ssh-kwt-probe",
-            info: info,
-            allocateTTY: false,
-            remoteCommand: powerShellEncodedCommand(probeScript),
-            sshConnectionArguments: sshConnectionArguments
-        )
-        let reconnectAttach = windowsRemoteAttachCommand(
-            info: info,
-            tmuxPath: tmuxPath,
-            windowsKwtRelativePath: windowsKwtRelativePath,
-            sshConnectionArguments: sshConnectionArguments
-        )
         return shellCommand([
             "/bin/sh", "-c", Self.remoteWorkspaceAttachScript,
             "ghosthub-ssh-kwt-attach",
-            initialAttach, sessionProbe, reconnectAttach,
+            initialAttach,
         ])
     }
 
@@ -627,7 +597,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         sshConnectionArguments: [String]
     ) -> String {
         let attach: String
-        if let protectedWorkspacePath {
+        if let protectedWorkspacePath, launchMode != .attachOnly {
             attach = """
             \(powerShellKwtResolutionPrelude(
                 managedRelativePath: windowsKwtRelativePath
@@ -650,7 +620,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         exit $LASTEXITCODE
         """
         let remoteCommand = powerShellEncodedCommand(script)
-        return sshReconnectCommand(
+        return sshAttachCommand(
             label: "ghosthub-ssh-psmux",
             info: info,
             allocateTTY: true,
@@ -659,54 +629,24 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         )
     }
 
-    private func sshReconnectCommand(
+    private func sshAttachCommand(
         label: String,
         info: SSHHostInfo,
         allocateTTY: Bool,
         remoteCommand: String,
         sshConnectionArguments: [String]
     ) -> String {
-        let evidenceArguments = [
-            "-o", "PermitLocalCommand=yes",
-            "-o",
-            "LocalCommand=/usr/bin/touch \"$GHOSTHUB_SSH_CONNECTION_MARKER\"",
-        ]
         return shellCommand(
             [
-                "/bin/sh", "-c", Self.sshReconnectScript,
+                "/bin/sh", "-c", Self.sshAttachScript,
                 label,
-                shellCommand(sshControlCheckArguments(
-                    info: info,
-                    sshConnectionArguments: sshConnectionArguments
-                )),
             ] + sshArguments(
                 info: info,
                 allocateTTY: allocateTTY,
                 remoteCommand: remoteCommand,
                 sshConnectionArguments: sshConnectionArguments
-                    + evidenceArguments
             )
         )
-    }
-
-    private func sshControlCheckArguments(
-        info: SSHHostInfo,
-        sshConnectionArguments: [String]
-    ) -> [String] {
-        var arguments = [
-            "/usr/bin/ssh", "-O", "check",
-            "-o", "BatchMode=yes",
-            "-o", "ControlMaster=no",
-            "-o", "ControlPersist=no",
-        ]
-        arguments.append(contentsOf: sshConnectionArguments)
-        if let port = info.port {
-            arguments.append(contentsOf: ["-p", "\(port)"])
-        }
-        let destination = info.user.map { "\($0)@\(info.hostname)" }
-            ?? info.hostname
-        arguments.append(contentsOf: ["--", destination])
-        return arguments
     }
 
     private func remoteCreateThenAttachCommand(
@@ -880,8 +820,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         return directory.isEmpty || directory == "/" ? nil : directory
     }
 
-    /// Runs creation once and, after success, permanently switches this
-    /// terminal process to the attach-only reconnect command.
+    /// Runs creation once and, after success, switches this terminal process
+    /// to one attach-only command.
     static let remoteCreateThenAttachScript = """
     /bin/sh -c "$1"
     status=$?
@@ -889,77 +829,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     exec /bin/sh -c "$2"
     """
 
-    /// The first kwt client stays attached while it creates the workspace. An
-    /// SSH transport loss probes the exact session through the ordinary retry
-    /// loop: confirmed presence advances to attach-only reconnect, while
-    /// confirmed absence retries kwt because the original SSH connection may
-    /// have failed before the remote command ran. Absent-session retries use
-    /// the same bounded backoff as ordinary SSH reconnects.
+    /// Runs one workspace establishment attempt. Native recovery probes the
+    /// exact session before deciding whether establishment may run again.
     static let remoteWorkspaceAttachScript = """
-    delay=1
-    while :; do
-        started=$(date +%s)
-        /bin/sh -c "$1"
-        status=$?
-        [ "$status" -eq 255 ] || exit "$status"
-        /bin/sh -c "$2"
-        status=$?
-        case "$status" in
-            0) exec /bin/sh -c "$3" ;;
-            1)
-                now=$(date +%s)
-                if [ $((now - started)) -ge 30 ]; then delay=1; fi
-                printf '\r\n[Ghosthub: workspace session absent; retrying in %ss]\r\n' "$delay"
-                sleep "$delay"
-                if [ "$delay" -lt 30 ]; then
-                    delay=$((delay * 2))
-                    [ "$delay" -le 30 ] || delay=30
-                fi
-                ;;
-            *) exit "$status" ;;
-        esac
-    done
+    exec /bin/sh -c "$1"
     """
 
-    /// OpenSSH reserves status 255 for transport/setup failure. Brief transport
-    /// interruptions retry, while persistent failures exit so Ghosthub can
-    /// recover authentication natively. Clean detach and ordinary tmux failures
-    /// pass through unchanged.
-    static let sshReconnectScript = """
-    control_check=$1
-    shift
-    umask 077
-    connection_marker=$(/usr/bin/mktemp /tmp/ghosthub-ssh.XXXXXX) || exit 255
-    /bin/rm -f "$connection_marker"
-    export GHOSTHUB_SSH_CONNECTION_MARKER="$connection_marker"
-    trap '/bin/rm -f "$connection_marker"' EXIT
-    delay=1
-    failures=0
-    while :; do
-        /bin/rm -f "$connection_marker"
-        started=$(date +%s)
-        "$@"
-        status=$?
-        [ "$status" -eq 255 ] || exit "$status"
-        # A slow 255 can still be proxy, authentication, or transport setup
-        # failure. Elapsed time alone must never make it a successful attach.
-        now=$(date +%s)
-        if [ -e "$connection_marker" ] || {
-            [ -n "$control_check" ] &&
-            [ $((now - started)) -ge 30 ] &&
-            /bin/sh -c "$control_check" >/dev/null 2>&1
-        }; then
-            delay=1
-            failures=0
-        fi
-        failures=$((failures + 1))
-        [ "$failures" -lt 3 ] || exit "$status"
-        printf '\r\n[Ghosthub: SSH disconnected; reconnecting in %ss]\r\n' "$delay"
-        sleep "$delay"
-        if [ "$delay" -lt 30 ]; then
-            delay=$((delay * 2))
-            [ "$delay" -le 30 ] || delay=30
-        fi
-    done
-    """
+    /// Runs one OpenSSH attachment attempt and returns its exact status to the
+    /// native presentation owner.
+    static let sshAttachScript = "exec \"$@\""
 }

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -274,13 +274,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             }
             let recordedCommand: String
             if let remoteExitStatusPath, !remoteExitStatusPath.isEmpty {
-                recordedCommand = "GHOSTHUB_SSH_EXIT_STATUS_PATH="
-                    + shellQuotedCommandArgument(remoteExitStatusPath)
-                    + "; export GHOSTHUB_SSH_EXIT_STATUS_PATH; "
-                    + command
+                recordedCommand = shellCommand([
+                    "/bin/sh", "-c", Self.remoteExitStatusScript,
+                    "ghosthub-ssh-status", remoteExitStatusPath, command,
+                ])
             } else {
-                recordedCommand = "unset GHOSTHUB_SSH_EXIT_STATUS_PATH; "
-                    + command
+                recordedCommand = command
             }
             return surfaceAccountLoginShellCommand(recordedCommand)
         }
@@ -846,17 +845,17 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     exec /bin/sh -c "$1"
     """
 
-    /// Runs one OpenSSH attachment attempt and records its exact status before
-    /// returning it. Libghostty's macOS login wrapper can otherwise report a
-    /// successful child exit for a failed nested command.
-    static let sshAttachScript = """
-    ghosthub_status_path=${GHOSTHUB_SSH_EXIT_STATUS_PATH-}
-    unset GHOSTHUB_SSH_EXIT_STATUS_PATH
-    "$@"
+    /// Records the final status of the complete remote establishment or
+    /// attachment command before libghostty's macOS login wrapper can obscure
+    /// a failed nested OpenSSH process.
+    static let remoteExitStatusScript = """
+    /bin/sh -c "$2"
     ghosthub_status=$?
-    if [ -n "$ghosthub_status_path" ]; then
-        printf '%s\n' "$ghosthub_status" > "$ghosthub_status_path"
-    fi
+    printf '%s\n' "$ghosthub_status" > "$1"
     exit "$ghosthub_status"
     """
+
+    /// Runs one OpenSSH attachment attempt and returns its exact status to its
+    /// immediate one-shot command owner.
+    static let sshAttachScript = "exec \"$@\""
 }

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -211,7 +211,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         remoteKwtCommandPrelude: String? = nil,
         windowsKwtRelativePath: String? = nil,
         workingDirectory: String? = nil,
-        sshConnectionArguments: [String] = tmuxSSHConnectionArguments()
+        sshConnectionArguments: [String] = tmuxSSHConnectionArguments(),
+        remoteExitStatusPath: String? = nil
     ) -> String {
         switch host {
         case .local:
@@ -271,7 +272,17 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     sshConnectionArguments: sshConnectionArguments
                 )
             }
-            return surfaceAccountLoginShellCommand(command)
+            let recordedCommand: String
+            if let remoteExitStatusPath, !remoteExitStatusPath.isEmpty {
+                recordedCommand = "GHOSTHUB_SSH_EXIT_STATUS_PATH="
+                    + shellQuotedCommandArgument(remoteExitStatusPath)
+                    + "; export GHOSTHUB_SSH_EXIT_STATUS_PATH; "
+                    + command
+            } else {
+                recordedCommand = "unset GHOSTHUB_SSH_EXIT_STATUS_PATH; "
+                    + command
+            }
+            return surfaceAccountLoginShellCommand(recordedCommand)
         }
     }
 
@@ -835,7 +846,17 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     exec /bin/sh -c "$1"
     """
 
-    /// Runs one OpenSSH attachment attempt and returns its exact status to the
-    /// native presentation owner.
-    static let sshAttachScript = "exec \"$@\""
+    /// Runs one OpenSSH attachment attempt and records its exact status before
+    /// returning it. Libghostty's macOS login wrapper can otherwise report a
+    /// successful child exit for a failed nested command.
+    static let sshAttachScript = """
+    ghosthub_status_path=${GHOSTHUB_SSH_EXIT_STATUS_PATH-}
+    unset GHOSTHUB_SSH_EXIT_STATUS_PATH
+    "$@"
+    ghosthub_status=$?
+    if [ -n "$ghosthub_status_path" ]; then
+        printf '%s\n' "$ghosthub_status" > "$ghosthub_status_path"
+    fi
+    exit "$ghosthub_status"
+    """
 }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -555,8 +555,17 @@ public struct RootView: View {
     }
 
     private func retrySSHRecovery() {
+        let recoveryHostID =
+            tmuxRecoveryRequestRouter.recoveryHostIDToResume(
+                reviewedHostID: sshHostKeyReview.hostID,
+                presentation: sshHostKeyReview.presentation,
+                activeRequest: display.tmuxConnectionRecoveryRequest
+            )
         cancelSSHAuthenticationIfNeeded()
         sshHostKeyReview.dismiss()
+        if let recoveryHostID {
+            handlers.resumeTmuxReconnectAfterSSHRecovery?(recoveryHostID)
+        }
         handlers.refreshWorkspaceInventory?()
     }
 

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -937,6 +937,12 @@ public struct RootView: View {
                             host.id,
                             inventoryWarning: tmuxRecoveryWarning(
                                 for: host.id
+                            ),
+                            tmuxRecoveryRequestID:
+                            tmuxRecoveryRequestRouter.recoveryRequestID(
+                                for: host.id,
+                                activeRequest:
+                                display.tmuxConnectionRecoveryRequest
                             )
                         )
                     }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -32,6 +32,8 @@ public struct RootView: View {
     @State private var newTmuxSessionHost: HostSummary?
     @State private var addProjectHost: HostSummary?
     @State private var workspaceAlert: WorkspaceAlert?
+    @State private var tmuxRecoveryRequestRouter =
+        TmuxConnectionRecoveryRequestRouter()
     @StateObject private var sshHostKeyReview =
         WorkspaceSSHHostKeyReviewModel()
     @AppStorage(WorkspaceSidebarOrderStorage.worktreeKey)
@@ -78,6 +80,18 @@ public struct RootView: View {
     }
     public var body: some View {
         contentWithNotifications
+            .onAppear {
+                reviewTmuxConnectionRequestIfNeeded()
+            }
+            .onChange(
+                of: display.tmuxConnectionRecoveryRequest?.id
+            ) { _, _ in
+                reviewTmuxConnectionRequestIfNeeded()
+            }
+            .onChange(of: sshHostKeyReview.isPresented) { wasPresented, isPresented in
+                guard wasPresented, !isPresented else { return }
+                reviewTmuxConnectionRequestIfNeeded()
+            }
             .sheet(isPresented: $isCommandPalettePresented) {
                 CommandPaletteView(
                     commands: paletteCommands,
@@ -516,6 +530,30 @@ public struct RootView: View {
         }
     }
 
+    private func tmuxRecoveryWarning(for hostID: UUID) -> String {
+        if let request = display.tmuxConnectionRecoveryRequest,
+           request.hostID == hostID {
+            return request.message
+        }
+        return display.workspaceInventoryWarningsByHost[hostID]
+            ?? "The remote tmux connection needs attention."
+    }
+
+    private func reviewTmuxConnectionRequestIfNeeded() {
+        Task { @MainActor in
+            await Task.yield()
+            guard let request = tmuxRecoveryRequestRouter.take(
+                display.tmuxConnectionRecoveryRequest,
+                whileReviewIsPresented: sshHostKeyReview.isPresented
+            )
+            else { return }
+            reviewSSHHostKey(
+                request.hostID,
+                inventoryWarning: request.message
+            )
+        }
+    }
+
     private func retrySSHRecovery() {
         cancelSSHAuthenticationIfNeeded()
         sshHostKeyReview.dismiss()
@@ -570,7 +608,9 @@ public struct RootView: View {
                 return
             case .connected:
                 handlers.cancelSSHAuthentication?(hostID)
-                sshHostKeyReview.authenticationSucceeded()
+                sshHostKeyReview.authenticationSucceeded {
+                    handlers.resumeTmuxReconnectAfterSSHRecovery?(hostID)
+                }
                 handlers.refreshWorkspaceInventory?()
                 return
             }
@@ -858,7 +898,20 @@ public struct RootView: View {
             let view = content.tmuxSessionContentBuilder?(
                 host,
                 presentedSession.name,
-                isSidebarTransitioning
+                isSidebarTransitioning,
+                TmuxSessionContentActions(
+                    reconnectNow: {
+                        handlers.reconnectActiveTmuxSessionNow?()
+                    },
+                    reviewConnection: {
+                        reviewSSHHostKey(
+                            host.id,
+                            inventoryWarning: tmuxRecoveryWarning(
+                                for: host.id
+                            )
+                        )
+                    }
+                )
             ) {
             view
         } else if display.suppressesAutomaticWorktreeSessionOpen,

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -512,7 +512,8 @@ public struct RootView: View {
 
     private func reviewSSHHostKey(
         _ hostID: UUID,
-        inventoryWarning: String
+        inventoryWarning: String,
+        tmuxRecoveryRequestID: UUID? = nil
     ) {
         guard let review = handlers.reviewSSHHostKey,
               let host = snapshot.host(id: hostID) else {
@@ -523,6 +524,7 @@ public struct RootView: View {
             await sshHostKeyReview.review(
                 hostID: hostID,
                 hostName: host.name,
+                tmuxRecoveryRequestID: tmuxRecoveryRequestID,
                 using: {
                     await review(hostID, inventoryWarning)
                 }
@@ -549,18 +551,22 @@ public struct RootView: View {
             else { return }
             reviewSSHHostKey(
                 request.hostID,
-                inventoryWarning: request.message
+                inventoryWarning: request.message,
+                tmuxRecoveryRequestID: request.id
             )
         }
     }
 
     private func retrySSHRecovery() {
         let recoveryHostID =
-            tmuxRecoveryRequestRouter.recoveryHostIDToResume(
-                reviewedHostID: sshHostKeyReview.hostID,
-                presentation: sshHostKeyReview.presentation,
-                activeRequest: display.tmuxConnectionRecoveryRequest
-            )
+            sshHostKeyReview.presentation == .inventoryIssue
+                ? tmuxRecoveryRequestRouter.recoveryHostIDToResume(
+                    reviewedHostID: sshHostKeyReview.hostID,
+                    reviewRequestID:
+                    sshHostKeyReview.tmuxRecoveryRequestID,
+                    activeRequest: display.tmuxConnectionRecoveryRequest
+                )
+                : nil
         cancelSSHAuthenticationIfNeeded()
         sshHostKeyReview.dismiss()
         if let recoveryHostID {
@@ -612,13 +618,27 @@ public struct RootView: View {
                     hostID,
                     inventoryWarning:
                     display.workspaceInventoryWarningsByHost[hostID]
-                        ?? "Remote inventory is unavailable."
+                        ?? "Remote inventory is unavailable.",
+                    tmuxRecoveryRequestID:
+                    sshHostKeyReview.tmuxRecoveryRequestID
                 )
                 return
             case .connected:
+                let recoveryHostID =
+                    tmuxRecoveryRequestRouter.recoveryHostIDToResume(
+                        reviewedHostID: hostID,
+                        reviewRequestID:
+                        sshHostKeyReview.tmuxRecoveryRequestID,
+                        activeRequest:
+                        display.tmuxConnectionRecoveryRequest
+                    )
                 handlers.cancelSSHAuthentication?(hostID)
                 sshHostKeyReview.authenticationSucceeded {
-                    handlers.resumeTmuxReconnectAfterSSHRecovery?(hostID)
+                    if let recoveryHostID {
+                        handlers.resumeTmuxReconnectAfterSSHRecovery?(
+                            recoveryHostID
+                        )
+                    }
                 }
                 handlers.refreshWorkspaceInventory?()
                 return

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -204,6 +204,20 @@ struct TmuxConnectionRecoveryRequestRouter {
         reviewedRequestID = request.id
         return request
     }
+
+    func recoveryHostIDToResume(
+        reviewedHostID: UUID?,
+        presentation: SSHConnectionRecoveryPresentation,
+        activeRequest: TmuxConnectionRecoveryRequest?
+    ) -> UUID? {
+        guard presentation == .inventoryIssue,
+              let reviewedHostID,
+              let activeRequest,
+              activeRequest.id == reviewedRequestID,
+              activeRequest.hostID == reviewedHostID
+        else { return nil }
+        return reviewedHostID
+    }
 }
 
 public struct InteractionHandlers {

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -25,6 +25,8 @@ public struct WorkspaceDisplayState {
     public let activeTmuxSession: WorkspaceTmuxSessionSelection?
     public let activeTmuxSessionIsConnected: Bool
     public let activeTmuxSessionCanApplyTheme: Bool
+    public let tmuxConnectionRecoveryRequest:
+        TmuxConnectionRecoveryRequest?
 
     public init(
         snapshot: WorkspaceSnapshot,
@@ -46,7 +48,9 @@ public struct WorkspaceDisplayState {
         suppressesAutomaticWorktreeSessionOpen: Bool = false,
         activeTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeTmuxSessionIsConnected: Bool = false,
-        activeTmuxSessionCanApplyTheme: Bool = false
+        activeTmuxSessionCanApplyTheme: Bool = false,
+        tmuxConnectionRecoveryRequest:
+        TmuxConnectionRecoveryRequest? = nil
     ) {
         self.snapshot = snapshot
         self.workspaceResourceSummary = workspaceResourceSummary
@@ -74,20 +78,35 @@ public struct WorkspaceDisplayState {
             activeTmuxSessionIsConnected
         self.activeTmuxSessionCanApplyTheme =
             activeTmuxSessionCanApplyTheme
+        self.tmuxConnectionRecoveryRequest =
+            tmuxConnectionRecoveryRequest
+    }
+}
+
+public struct TmuxSessionContentActions {
+    public let reconnectNow: () -> Void
+    public let reviewConnection: () -> Void
+
+    public init(
+        reconnectNow: @escaping () -> Void,
+        reviewConnection: @escaping () -> Void
+    ) {
+        self.reconnectNow = reconnectNow
+        self.reviewConnection = reviewConnection
     }
 }
 
 /// View factory closures and providers consumed by RootView.
 public struct ContentBuilders {
     public let tmuxSessionContentBuilder:
-        ((HostSummary, String, Bool) -> AnyView?)?
+        ((HostSummary, String, Bool, TmuxSessionContentActions) -> AnyView?)?
     public let settingsSheetBuilder: ((SettingsStore) -> AnyView)?
     public let logViewerBuilder: (() -> AnyView?)?
     public let sshAuthenticationBuilder: ((UUID) -> AnyView?)?
 
     public init(
         tmuxSessionContentBuilder:
-        ((HostSummary, String, Bool) -> AnyView?)? = nil,
+        ((HostSummary, String, Bool, TmuxSessionContentActions) -> AnyView?)? = nil,
         settingsSheetBuilder: ((SettingsStore) -> AnyView)? = nil,
         logViewerBuilder: (() -> AnyView?)? = nil,
         sshAuthenticationBuilder: ((UUID) -> AnyView?)? = nil
@@ -160,6 +179,33 @@ public enum SSHHostKeyReviewRequirement: Equatable, Sendable {
     case authenticationRequired
 }
 
+public struct TmuxConnectionRecoveryRequest:
+    Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let hostID: UUID
+    public let message: String
+
+    public init(id: UUID = UUID(), hostID: UUID, message: String) {
+        self.id = id
+        self.hostID = hostID
+        self.message = message
+    }
+}
+
+struct TmuxConnectionRecoveryRequestRouter {
+    private(set) var reviewedRequestID: UUID?
+
+    mutating func take(
+        _ request: TmuxConnectionRecoveryRequest?,
+        whileReviewIsPresented: Bool
+    ) -> TmuxConnectionRecoveryRequest? {
+        guard let request, reviewedRequestID != request.id else { return nil }
+        guard !whileReviewIsPresented else { return nil }
+        reviewedRequestID = request.id
+        return request
+    }
+}
+
 public struct InteractionHandlers {
     public let closeWindow: (() -> Void)?
     public let dismissLogViewer: (() -> Void)?
@@ -176,6 +222,8 @@ public struct InteractionHandlers {
         ((WorkspaceTmuxSessionSelection) async throws -> Void)?
     public let createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let refreshWorkspaceInventory: (() -> Void)?
+    public let reconnectActiveTmuxSessionNow: (() -> Void)?
+    public let resumeTmuxReconnectAfterSSHRecovery: ((UUID) -> Void)?
     public let reviewSSHHostKey:
         ((UUID, String) async -> SSHConnectionRecoveryResult)?
     public let trustSSHHostKey:
@@ -216,6 +264,8 @@ public struct InteractionHandlers {
         ((WorkspaceTmuxSessionSelection) async throws -> Void)? = nil,
         createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         refreshWorkspaceInventory: (() -> Void)? = nil,
+        reconnectActiveTmuxSessionNow: (() -> Void)? = nil,
+        resumeTmuxReconnectAfterSSHRecovery: ((UUID) -> Void)? = nil,
         reviewSSHHostKey:
         ((UUID, String) async -> SSHConnectionRecoveryResult)? = nil,
         trustSSHHostKey:
@@ -251,6 +301,9 @@ public struct InteractionHandlers {
         self.applyTmuxSessionTheme = applyTmuxSessionTheme
         self.createTmuxSession = createTmuxSession
         self.refreshWorkspaceInventory = refreshWorkspaceInventory
+        self.reconnectActiveTmuxSessionNow = reconnectActiveTmuxSessionNow
+        self.resumeTmuxReconnectAfterSSHRecovery =
+            resumeTmuxReconnectAfterSSHRecovery
         self.reviewSSHHostKey = reviewSSHHostKey
         self.trustSSHHostKey = trustSSHHostKey
         self.isSSHAuthenticationReady = isSSHAuthenticationReady

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -207,13 +207,14 @@ struct TmuxConnectionRecoveryRequestRouter {
 
     func recoveryHostIDToResume(
         reviewedHostID: UUID?,
-        presentation: SSHConnectionRecoveryPresentation,
+        reviewRequestID: UUID?,
         activeRequest: TmuxConnectionRecoveryRequest?
     ) -> UUID? {
-        guard presentation == .inventoryIssue,
-              let reviewedHostID,
+        guard let reviewedHostID,
+              let reviewRequestID,
               let activeRequest,
-              activeRequest.id == reviewedRequestID,
+              reviewRequestID == reviewedRequestID,
+              activeRequest.id == reviewRequestID,
               activeRequest.hostID == reviewedHostID
         else { return nil }
         return reviewedHostID

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -205,6 +205,17 @@ struct TmuxConnectionRecoveryRequestRouter {
         return request
     }
 
+    func recoveryRequestID(
+        for hostID: UUID,
+        activeRequest: TmuxConnectionRecoveryRequest?
+    ) -> UUID? {
+        guard let activeRequest,
+              activeRequest.id == reviewedRequestID,
+              activeRequest.hostID == hostID
+        else { return nil }
+        return activeRequest.id
+    }
+
     func recoveryHostIDToResume(
         reviewedHostID: UUID?,
         reviewRequestID: UUID?,
@@ -212,10 +223,10 @@ struct TmuxConnectionRecoveryRequestRouter {
     ) -> UUID? {
         guard let reviewedHostID,
               let reviewRequestID,
-              let activeRequest,
-              reviewRequestID == reviewedRequestID,
-              activeRequest.id == reviewRequestID,
-              activeRequest.hostID == reviewedHostID
+              recoveryRequestID(
+                  for: reviewedHostID,
+                  activeRequest: activeRequest
+              ) == reviewRequestID
         else { return nil }
         return reviewedHostID
     }

--- a/Sources/UI/SSHHostKeyReviewView.swift
+++ b/Sources/UI/SSHHostKeyReviewView.swift
@@ -102,8 +102,9 @@ final class WorkspaceSSHHostKeyReviewModel: ObservableObject {
         hostID = nil
     }
 
-    func authenticationSucceeded() {
+    func authenticationSucceeded(onConnected: () -> Void = {}) {
         guard presentation == .authentication else { return }
+        onConnected()
         resolvedPresentation = .authenticationSucceeded
     }
 }

--- a/Sources/UI/SSHHostKeyReviewView.swift
+++ b/Sources/UI/SSHHostKeyReviewView.swift
@@ -13,6 +13,7 @@ enum SSHConnectionRecoveryPresentation: Equatable {
 @MainActor
 final class WorkspaceSSHHostKeyReviewModel: ObservableObject {
     @Published private(set) var hostID: UUID?
+    @Published private(set) var tmuxRecoveryRequestID: UUID?
     @Published private(set) var hostName = ""
     @Published private(set) var confirmation: SSHHostKeyConfirmation?
     @Published private(set) var errorMessage: String?
@@ -35,11 +36,13 @@ final class WorkspaceSSHHostKeyReviewModel: ObservableObject {
     func review(
         hostID: UUID,
         hostName: String,
+        tmuxRecoveryRequestID: UUID? = nil,
         using load: () async -> SSHConnectionRecoveryResult
     ) async {
         let generation = UUID()
         self.generation = generation
         self.hostID = hostID
+        self.tmuxRecoveryRequestID = tmuxRecoveryRequestID
         self.hostName = hostName
         confirmation = nil
         errorMessage = nil
@@ -100,6 +103,7 @@ final class WorkspaceSSHHostKeyReviewModel: ObservableObject {
         guard !isTrusting else { return }
         generation = UUID()
         hostID = nil
+        tmuxRecoveryRequestID = nil
     }
 
     func authenticationSucceeded(onConnected: () -> Void = {}) {

--- a/Tests/App/BorrowedTmuxSessionViewTests.swift
+++ b/Tests/App/BorrowedTmuxSessionViewTests.swift
@@ -48,6 +48,7 @@ struct BorrowedTmuxSessionViewTests {
         )
 
         #expect(!view.showsReviewConnection)
+        #expect(view.primaryRecoveryActionTitle == "Reconnect Now")
         #expect(view.showsHostSettingsAction)
     }
 

--- a/Tests/App/BorrowedTmuxSessionViewTests.swift
+++ b/Tests/App/BorrowedTmuxSessionViewTests.swift
@@ -7,6 +7,50 @@ import Testing
 
 @MainActor
 struct BorrowedTmuxSessionViewTests {
+    @Test("reconnecting presentation promises automatic recovery")
+    func reconnectingPresentation() {
+        let view = makeView(
+            recoveryState: .reconnecting(
+                message:
+                "Waiting for build-box. Ghosthub will reconnect automatically."
+            )
+        )
+
+        #expect(view.recoveryTitle == "Connection interrupted")
+        #expect(view.showsReconnectProgress)
+        #expect(view.primaryRecoveryActionTitle == "Reconnect Now")
+        #expect(!view.showsReviewConnection)
+        #expect(view.showsHostSettingsAction)
+    }
+
+    @Test("attention presentation stops promising automatic recovery")
+    func attentionPresentation() {
+        let view = makeView(
+            recoveryState: .needsAttention(
+                message: "SSH authentication is required.",
+                canReviewConnection: true
+            )
+        )
+
+        #expect(view.recoveryTitle == "Connection needs attention")
+        #expect(!view.showsReconnectProgress)
+        #expect(view.showsReviewConnection)
+        #expect(view.showsHostSettingsAction)
+    }
+
+    @Test("changed host identity does not offer ineffective native review")
+    func changedHostIdentityPresentation() {
+        let view = makeView(
+            recoveryState: .needsAttention(
+                message: "Verify the host and update its known-hosts entry.",
+                canReviewConnection: false
+            )
+        )
+
+        #expect(!view.showsReviewConnection)
+        #expect(view.showsHostSettingsAction)
+    }
+
     @Test("a failed borrowed attachment shows its reason and retries")
     func failureShowsReasonAndRetry() {
         var retryCount = 0
@@ -86,7 +130,7 @@ struct BorrowedTmuxSessionViewTests {
             hostName: "build-box",
             isRemoteHost: true,
             connectionState: .disconnected(reason: "SSH connection failed"),
-            attachmentClosure: .processExited,
+            attachmentClosure: .processExited(code: 1),
             surface: { nil },
             onCloseRequest: {},
             onRetryRequest: {},
@@ -114,5 +158,25 @@ struct BorrowedTmuxSessionViewTests {
         )
 
         #expect(!view.showsHostSettingsAction)
+    }
+
+    private func makeView(
+        recoveryState: BorrowedTmuxRecoveryState?
+    ) -> BorrowedTmuxSessionView {
+        BorrowedTmuxSessionView(
+            handle: BorrowedTmuxSessionHandle(
+                id: UUID(), hostID: UUID(), name: "editor", surfaceID: UUID()
+            ),
+            hostName: "build-box",
+            isRemoteHost: true,
+            connectionState: .disconnected(reason: nil),
+            recoveryState: recoveryState,
+            surface: { nil },
+            onCloseRequest: {},
+            onRetryRequest: {},
+            onReconnectNow: {},
+            onReviewConnection: {},
+            onHostSettingsRequest: {}
+        )
     }
 }

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -364,6 +364,40 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(store.removedKeys.count == 1)
     }
 
+    @Test("a missing terminal surface is a launch failure")
+    func missingSurfaceDoesNotLaunch() async {
+        let store = MissingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        var states: [ConnectionState] = []
+        var isSurfaceReady = false
+        coordinator.onStateChanged = { _, state in states.append(state) }
+        coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "release-work",
+            host: .local
+        )
+
+        await waitUntilMainActor { isSurfaceReady }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor {
+            states.contains {
+                if case .disconnected = $0 {
+                    return true
+                }
+                return false
+            }
+        }
+
+        #expect(!states.contains(.connected))
+        #expect(!coordinator.hasLaunched(handle))
+        #expect(coordinator.attachmentClosure(handle) == .launchFailed)
+        #expect(store.removedKeyCount == 1)
+    }
+
     @Test("a detached live client records a closed attachment")
     func detachedLiveClientClosesAttachment() async throws {
         let store = RecordingTmuxSurfaceStore()
@@ -418,8 +452,8 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(coordinator.attachmentClosure(handle) == .detached)
     }
 
-    @Test("an exited attachment process is recorded as a failure outcome")
-    func exitedProcessRecordsFailureOutcome() async throws {
+    @Test("SSH transport exit remains distinguishable from clean detach")
+    func recordsTransportExitCode() async throws {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
@@ -441,10 +475,13 @@ struct NativeTmuxSessionCoordinatorTests {
         _ = coordinator.surface(handle: handle)
 
         let close = try #require(store.surface.closeObservers[handle.id])
-        close(false, 1)
+        close(false, 255)
 
         #expect(coordinator.hasClosedAttachment(handle))
-        #expect(coordinator.attachmentClosure(handle) == .processExited)
+        #expect(
+            coordinator.attachmentClosure(handle)
+                == .processExited(code: 255)
+        )
     }
 }
 
@@ -452,4 +489,20 @@ private enum SurfaceLaunchTestError: LocalizedError {
     case rejected
 
     var errorDescription: String? { "Surface launch rejected" }
+}
+
+@MainActor
+private final class MissingTmuxSurfaceStore: TmuxSurfaceStoring {
+    private(set) var removedKeyCount = 0
+
+    func paneSurface(
+        for key: SurfaceKey,
+        configuration: TerminalSurfaceConfiguration
+    ) -> (any TmuxPaneSurfacing)? {
+        nil
+    }
+
+    func removeSurface(for key: SurfaceKey) {
+        removedKeyCount += 1
+    }
 }

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -50,6 +50,52 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(!command.contains("status-style"))
     }
 
+    @Test("surface reports connected once per attachment generation")
+    func surfaceReportsConnectedOncePerAttachmentGeneration() async throws {
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        let hostID = UUID()
+        var states: [ConnectionState] = []
+        var readyCount = 0
+        coordinator.onStateChanged = { _, state in states.append(state) }
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: hostID,
+            name: "release-work",
+            host: .local
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor {
+            states.filter { $0 == .connected }.count == 1
+        }
+
+        _ = coordinator.surface(handle: handle)
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(states.filter { $0 == .connected }.count == 1)
+        #expect(coordinator.hasLaunched(handle))
+
+        let close = try #require(store.surface.closeObservers[handle.id])
+        close(false, 255)
+        let reattached = coordinator.attach(
+            hostID: hostID,
+            name: "release-work",
+            host: .local
+        )
+        #expect(reattached == handle)
+        await waitUntilMainActor { readyCount == 2 }
+        _ = coordinator.surface(handle: reattached)
+        await waitUntilMainActor {
+            states.filter { $0 == .connected }.count == 2
+        }
+
+        #expect(coordinator.hasLaunched(handle))
+    }
+
     @Test("new session launch reads the current terminal presentation style")
     func newSessionLaunchReadsCurrentPresentationStyle() async throws {
         let store = RecordingTmuxSurfaceStore()

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -498,13 +498,17 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(coordinator.attachmentClosure(handle) == .detached)
     }
 
-    @Test("SSH transport exit remains distinguishable from clean detach")
+    @Test("recorded SSH transport status overrides libghostty exit status")
     func recordsTransportExitCode() async throws {
+        let statusDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: statusDirectory) }
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
             tmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteExitStatusDirectory: statusDirectory
         )
         var isSurfaceReady = false
         coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
@@ -520,8 +524,18 @@ struct NativeTmuxSessionCoordinatorTests {
         await waitUntilMainActor { isSurfaceReady }
         _ = coordinator.surface(handle: handle)
 
+        let statusFile = try #require(
+            FileManager.default.contentsOfDirectory(
+                at: statusDirectory,
+                includingPropertiesForKeys: nil
+            ).first
+        )
+        try "255\n".write(
+            to: statusFile, atomically: true, encoding: .utf8
+        )
+
         let close = try #require(store.surface.closeObservers[handle.id])
-        close(false, 255)
+        close(false, 0)
 
         #expect(coordinator.hasClosedAttachment(handle))
         #expect(

--- a/Tests/App/SSHConnectionFailureTests.swift
+++ b/Tests/App/SSHConnectionFailureTests.swift
@@ -5,6 +5,56 @@ import Testing
 @Suite("SSH connection failure classification")
 struct SSHConnectionFailureTests {
     @Test(
+        "classifies SSH failures for native recovery",
+        arguments: [
+            (
+                "Permission denied (publickey,password).",
+                SSHConnectionFailure.Classification.Kind.authenticationRequired
+            ),
+            (
+                "Host key verification failed.",
+                SSHConnectionFailure.Classification.Kind.hostKeyReviewRequired
+            ),
+            (
+                "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!",
+                SSHConnectionFailure.Classification.Kind.hostKeyChanged
+            ),
+            (
+                "Offending ED25519 key in /Users/example/.ssh/known_hosts:4",
+                SSHConnectionFailure.Classification.Kind.hostKeyChanged
+            ),
+            (
+                "ssh: connect to host example.test port 22: Network is unreachable",
+                SSHConnectionFailure.Classification.Kind.transport
+            ),
+        ]
+    )
+    func classifiesRecovery(
+        output: String,
+        expected: SSHConnectionFailure.Classification.Kind
+    ) {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: output
+        )
+
+        #expect(classification.kind == expected)
+    }
+
+    @Test("changed host keys require manual known-hosts remediation")
+    func diagnosesChangedHostKey() {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!"
+        )
+
+        #expect(classification.kind == .hostKeyChanged)
+        #expect(classification.diagnostic.recoverySuggestion.contains(
+            "known-hosts"
+        ))
+    }
+
+    @Test(
         "only authentication failures request secure entry",
         arguments: [
             ("Permission denied (publickey,password).", true),

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -171,6 +171,42 @@ struct RemoteEnvironment {
     let snapshot: WorkspaceSnapshot
 }
 
+struct RemoteTmuxTestEnvironment {
+    let database: WorkspaceDatabase
+    let snapshot: WorkspaceSnapshot
+    let localHostID: UUID
+    let remoteHost: HostSummary
+}
+
+func setupRemoteTmuxEnvironment() throws -> RemoteTmuxTestEnvironment {
+    let standard = try setupStandardEnvironment()
+    let remoteHost = HostSummary(
+        id: UUID(),
+        configKey: "build-box",
+        name: "Build Box",
+        kind: .remote,
+        platform: .linux,
+        sshDestination: "wesm@build-box",
+        preferredTransport: .ssh,
+        lastKnownReachable: true,
+        tmuxSessions: [
+            TmuxSessionSummary(
+                name: "release-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+    )
+    var snapshot = standard.snapshot
+    snapshot.hosts.append(remoteHost)
+    return RemoteTmuxTestEnvironment(
+        database: standard.database,
+        snapshot: snapshot,
+        localHostID: standard.host.id,
+        remoteHost: remoteHost
+    )
+}
+
 func setupRemoteEnvironment() throws -> RemoteEnvironment {
     let database = try WorkspaceDatabase.inMemory()
     let hostID = UUID()
@@ -318,6 +354,8 @@ func makeModel(
     },
     tmuxSessionDiscovery: @escaping
     WorkspaceSceneModel.TmuxSessionDiscovery = { _ in .success([]) },
+    tmuxExactSessionProbe: @escaping
+    WorkspaceSceneModel.TmuxSessionExactProbe = { _ in .success(false) },
     tmuxSessionKiller: @escaping
     WorkspaceSceneModel.TmuxSessionKilling = {
         selection, identity, host in
@@ -360,6 +398,12 @@ func makeModel(
         .milliseconds(250), .milliseconds(500), .seconds(1), .seconds(2),
         .seconds(4), .seconds(8),
     ],
+    tmuxReconnectIntervals: [Duration] = [
+        .seconds(1), .seconds(2), .seconds(4), .seconds(8),
+        .seconds(16), .seconds(30),
+    ],
+    tmuxReconnectProbeDeadline: Duration =
+        TmuxSessionReconnectSupervisor.defaultProbeDeadline,
     startServices: Bool = false
 ) throws -> WorkspaceSceneModel {
     return try WorkspaceSceneModel(
@@ -381,6 +425,7 @@ func makeModel(
         kwtPullRequestImporter: kwtPullRequestImporter,
         kwtProjectRegistration: kwtProjectRegistration,
         tmuxSessionDiscovery: tmuxSessionDiscovery,
+        tmuxExactSessionProbe: tmuxExactSessionProbe,
         tmuxSessionKiller: tmuxSessionKiller,
         tmuxSessionIdentityReader: tmuxSessionIdentityReader,
         tmuxSessionStyler: tmuxSessionStyler,
@@ -394,6 +439,8 @@ func makeModel(
         createdSessionDiscoveryDelays: createdSessionDiscoveryDelays,
         deferredTmuxPresentationRetryDelays:
         deferredTmuxPresentationRetryDelays,
+        tmuxReconnectIntervals: tmuxReconnectIntervals,
+        tmuxReconnectProbeDeadline: tmuxReconnectProbeDeadline,
         startServices: startServices
     )
 }

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -551,6 +551,57 @@ struct TmuxBinaryResolverTests {
         #expect(try resolver.discoverSessions().get().isEmpty)
     }
 
+    @Test("a missing tmux socket confirms session absence")
+    func missingSocketIsAbsence() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghosthub-tmux-absence-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let tmux = directory.appendingPathComponent("tmux")
+        try """
+        #!/bin/sh
+        if [ "$1" = "-V" ]; then
+          printf 'tmux 3.3a\n'
+          exit 0
+        fi
+        printf 'error connecting to /tmp/tmux-501/default (No such file or directory)\n' >&2
+        exit 1
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, command in
+                return TmuxBinaryResolver.runProcess(
+                    executable: "/bin/sh",
+                    arguments: ["-c", command],
+                    timeout: 5,
+                    environmentOverrides: [
+                        "PATH": "\(directory.path):/usr/bin:/bin",
+                    ]
+                )
+            }
+        )
+
+        #expect(try resolver.discoverSessions(on: host).get().isEmpty)
+        #expect(try !resolver.sessionExists(
+            name: "pr-32",
+            socketName: "kwt-pr-0123456789abcdef",
+            on: host
+        ).get())
+    }
+
     @Test("a reachable default server error is not confirmed absence")
     func defaultServerErrorIsNotAbsence() {
         let host = SSHHostInfo(

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -171,7 +171,8 @@ struct TmuxBinaryResolverTests {
             #expect(command.contains("command -v tmux"))
             return (
                 status: 0,
-                stdout: "welcome\n/usr/local/bin/tmux\ntmux 3.2a\n"
+                stdout: "welcome\n/usr/local/bin/tmux\ntmux 3.2a\n",
+                stderr: ""
             )
         })
 
@@ -181,22 +182,172 @@ struct TmuxBinaryResolverTests {
         )
     }
 
-    @Test("SSH transport failure is not reported as a login shell failure")
+    @Test("SSH stderr is preserved for native recovery classification")
     func reportsRemoteSSHFailure() {
         let host = SSHHostInfo(
             user: "wesm", hostname: "untrusted-host", port: nil
         )
         let resolver = TmuxBinaryResolver(
             remoteProcessRunner: { _, _ in
-                (status: 255, stdout: "")
+                (
+                    status: 255,
+                    stdout: "",
+                    stderr: "Permission denied (publickey,password)."
+                )
             }
         )
         let expected = TmuxBinaryError.sshConnectionFailed(
-            host: host.displayName
+            host: host.displayName,
+            classification: SSHConnectionFailure.classify(
+                status: 255,
+                output: "Permission denied (publickey,password)."
+            )
         )
 
         #expect(resolver.resolveTmuxPath(on: host) == .failure(expected))
         #expect(resolver.discoverSessions(on: host) == .failure(expected))
+    }
+
+    @Test("protected POSIX probe uses exact socket and session targets")
+    func probesProtectedPOSIXSession() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, command in
+                #expect(command.contains("-L"))
+                #expect(command.contains("kwt-pr-0123456789abcdef"))
+                #expect(command.contains("has-session"))
+                #expect(command.contains("=pr-32"))
+                return (
+                    status: 0,
+                    stdout: "/usr/bin/tmux\ntmux 3.4\n"
+                        + "GHOSTHUB_TMUX_SESSION_PRESENT\n",
+                    stderr: ""
+                )
+            }
+        )
+
+        #expect(try resolver.sessionExists(
+            name: "pr-32",
+            socketName: "kwt-pr-0123456789abcdef",
+            on: host
+        ).get())
+    }
+
+    @Test("exact probe recognizes an absent session")
+    func probesAbsentSession() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, _ in
+                (
+                    status: 0,
+                    stdout: "/usr/bin/tmux\ntmux 3.4\n"
+                        + "GHOSTHUB_TMUX_SESSION_ABSENT\n",
+                    stderr: ""
+                )
+            }
+        )
+
+        #expect(try !resolver.sessionExists(
+            name: "pr-32",
+            socketName: nil,
+            on: host
+        ).get())
+    }
+
+    @Test("exact probe rejects an unsupported tmux version")
+    func exactProbeRejectsOldVersion() {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, _ in
+                (
+                    status: 0,
+                    stdout: "/usr/bin/tmux\ntmux 3.1c\n"
+                        + "GHOSTHUB_TMUX_SESSION_PRESENT\n",
+                    stderr: ""
+                )
+            }
+        )
+
+        #expect(resolver.sessionExists(
+            name: "pr-32",
+            socketName: "kwt-pr-0123456789abcdef",
+            on: host
+        ) == .failure(.unsupportedVersion(found: "tmux 3.1c")))
+    }
+
+    @Test("exact probe does not treat generic tmux failure as absence")
+    func exactProbePreservesGenericFailure() {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, _ in
+                (
+                    status: 1,
+                    stdout: "/usr/bin/tmux\ntmux 3.4\n",
+                    stderr: "error connecting to /tmp/tmux: Permission denied"
+                )
+            }
+        )
+
+        #expect(resolver.sessionExists(
+            name: "pr-32",
+            socketName: "kwt-pr-0123456789abcdef",
+            on: host
+        ) == .failure(.shellFailed(status: 1)))
+    }
+
+    @Test("protected Windows probe uses exact socket and session targets")
+    func probesProtectedWindowsSession() throws {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "arm-builder",
+            port: nil,
+            platform: .windows
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, command in
+                for argument in [
+                    "-L",
+                    "kwt-pr-0123456789abcdef",
+                    "has-session",
+                    "-t",
+                    "=pr-32",
+                ] {
+                    #expect(command.contains(
+                        Data(argument.utf8).base64EncodedString()
+                    ))
+                }
+                #expect(!command.contains("kwt-pr-0123456789abcdef"))
+                #expect(!command.contains("=pr-32"))
+                return (
+                    status: 0,
+                    stdout: "C:\\Tools\\tmux.exe\r\ntmux 3.4\r\n"
+                        + "GHOSTHUB_TMUX_SESSION_PRESENT\r\n",
+                    stderr: ""
+                )
+            }
+        )
+
+        #expect(try resolver.sessionExists(
+            name: "pr-32",
+            socketName: "kwt-pr-0123456789abcdef",
+            on: host
+        ).get())
     }
 
     @Test("Windows resolution discovers the psmux tmux alias")
@@ -217,7 +368,8 @@ struct TmuxBinaryResolverTests {
                     status: 0,
                     stdout:
                     #"C:\Users\wesm\scoop\apps\psmux\current\tmux.exe"#
-                        + "\ntmux 3.3.7\n"
+                        + "\ntmux 3.3.7\n",
+                    stderr: ""
                 )
             }
         )
@@ -332,7 +484,9 @@ struct TmuxBinaryResolverTests {
                     tmux 3.4
                     GHOSTHUB_TMUX_SESSION\t3\t202\t$7\t99\t\tremote-work
 
-                    """
+                    """,
+
+                    stderr: ""
                 )
             }
         )
@@ -369,7 +523,8 @@ struct TmuxBinaryResolverTests {
                     stdout: "C:\\Tools\\psmux\\tmux.exe\r\n"
                         + "tmux 3.3.7\r\n"
                         + "GHOSTHUB_TMUX_SESSION\t2\t202\t$7"
-                        + "\t1783344091\t\twindows-work\r\n"
+                        + "\t1783344091\t\twindows-work\r\n",
+                    stderr: ""
                 )
             }
         )
@@ -394,6 +549,76 @@ struct TmuxBinaryResolverTests {
         })
 
         #expect(try resolver.discoverSessions().get().isEmpty)
+    }
+
+    @Test("a reachable default server error is not confirmed absence")
+    func defaultServerErrorIsNotAbsence() {
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { _, _ in
+                (
+                    status: 1,
+                    stdout: "/usr/bin/tmux\ntmux 3.3a\n",
+                    stderr: "error connecting to /tmp/tmux-501/default (Permission denied)\n"
+                )
+            }
+        )
+
+        #expect(
+            resolver.discoverSessions(on: host)
+                == .failure(.shellFailed(status: 1))
+        )
+    }
+
+    @Test("default discovery preserves a generic tmux status one failure")
+    func discoveryCommandPreservesGenericFailure() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghosthub-tmux-discovery-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let tmux = directory.appendingPathComponent("tmux")
+        try """
+        #!/bin/sh
+        if [ "$1" = "-V" ]; then
+          printf 'tmux 3.3a\n'
+          exit 0
+        fi
+        printf 'error connecting to tmux server (Permission denied)\n' >&2
+        exit 1
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+
+        let shell = directory.appendingPathComponent("account-shell")
+        try """
+        #!/bin/sh
+        PATH=\(shellQuotedCommandArgument(directory.path)):/usr/bin:/bin
+        export PATH
+        exec /bin/sh -c "$2"
+        """.write(to: shell, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shell.path
+        )
+
+        let resolver = TmuxBinaryResolver(
+            loginShellProvider: { shell.path }
+        )
+
+        #expect(
+            resolver.discoverSessions()
+                == .failure(.shellFailed(status: 1))
+        )
     }
 
     @Test("nonzero exit maps to notFound")

--- a/Tests/App/TmuxSessionProbeBrokerTests.swift
+++ b/Tests/App/TmuxSessionProbeBrokerTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import GhosthubTmux
+import Testing
+@testable import GhosthubApp
+
+private final class ProbeCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.withLock { value }
+    }
+
+    @discardableResult
+    func increment() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}
+
+private final class ProbeLifetimeCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var starts = 0
+    private var active = 0
+    private var maximumActive = 0
+    private var cancellations = 0
+
+    func begin() -> Int {
+        lock.withLock {
+            starts += 1
+            active += 1
+            maximumActive = max(maximumActive, active)
+            return starts
+        }
+    }
+
+    func end(cancelled: Bool = false) {
+        lock.withLock {
+            active -= 1
+            if cancelled {
+                cancellations += 1
+            }
+        }
+    }
+
+    var snapshot: (starts: Int, maximumActive: Int, cancellations: Int) {
+        lock.withLock { (starts, maximumActive, cancellations) }
+    }
+}
+
+private actor ProbeGate {
+    private var waiters = [CheckedContinuation<Void, Never>]()
+    private var arrivalWaiters = [CheckedContinuation<Void, Never>]()
+    private var isOpen = false
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+            let arrivals = arrivalWaiters
+            arrivalWaiters.removeAll()
+            arrivals.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilBlocked(count: Int = 1) async {
+        guard waiters.count < count else { return }
+        await withCheckedContinuation { continuation in
+            arrivalWaiters.append(continuation)
+        }
+        if waiters.count < count {
+            await waitUntilBlocked(count: count)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let blocked = waiters
+        waiters.removeAll()
+        blocked.forEach { $0.resume() }
+    }
+}
+
+@Suite("Tmux session probe broker")
+struct TmuxSessionProbeBrokerTests {
+    @MainActor
+    @Test("concurrent default-socket consumers share one discovery")
+    func coalescesDefaultDiscovery() async {
+        let calls = ProbeCounter()
+        let gate = ProbeGate()
+        let broker = TmuxSessionProbeBroker(
+            discover: { _ in
+                calls.increment()
+                await gate.wait()
+                return .success([])
+            },
+            exactProbe: { _ in .success(false) }
+        )
+
+        async let first = broker.sessions(on: .local)
+        async let second = broker.sessions(on: .local)
+        await gate.waitUntilBlocked()
+        await Task.yield()
+        await gate.open()
+        _ = await (first, second)
+
+        #expect(calls.count == 1)
+    }
+
+    @MainActor
+    @Test("distinct protected sessions keep distinct exact probes")
+    func keepsProtectedTargetsDistinct() async {
+        let calls = ProbeCounter()
+        let gate = ProbeGate()
+        let host = SSHHostInfo(
+            user: "wesm",
+            hostname: "build-box",
+            port: nil
+        )
+        let broker = TmuxSessionProbeBroker(
+            discover: { _ in .success([]) },
+            exactProbe: { _ in
+                calls.increment()
+                await gate.wait()
+                return .success(true)
+            }
+        )
+
+        async let first = broker.session(TmuxSessionProbeTarget(
+            host: host,
+            name: "first",
+            socketName: "kwt-first"
+        ))
+        async let second = broker.session(TmuxSessionProbeTarget(
+            host: host,
+            name: "second",
+            socketName: "kwt-second"
+        ))
+        await gate.waitUntilBlocked(count: 2)
+        await gate.open()
+
+        #expect(await first == .present)
+        #expect(await second == .present)
+        #expect(calls.count == 2)
+    }
+
+    @MainActor
+    @Test("completed discovery does not remain cached")
+    func removesCompletedDiscovery() async {
+        let calls = ProbeCounter()
+        let broker = TmuxSessionProbeBroker(
+            discover: { _ in
+                calls.increment()
+                return .success([])
+            },
+            exactProbe: { _ in .success(false) }
+        )
+
+        _ = await broker.sessions(on: .local)
+        _ = await broker.sessions(on: .local)
+
+        #expect(calls.count == 2)
+    }
+
+    @MainActor
+    @Test("a cancelled sole consumer drains before its successor starts")
+    func cancellationDrainsBeforeSuccessor() async {
+        let lifetime = ProbeLifetimeCounter()
+        let cancellationDrain = ProbeGate()
+        let broker = TmuxSessionProbeBroker(
+            discover: { _ in
+                let call = lifetime.begin()
+                guard call == 1 else {
+                    lifetime.end()
+                    return .success([])
+                }
+                do {
+                    try await Task.sleep(for: .seconds(10))
+                    lifetime.end()
+                    return .success([])
+                } catch {
+                    await cancellationDrain.wait()
+                    lifetime.end(cancelled: true)
+                    return .failure(.probeCancelled(shell: "localhost"))
+                }
+            },
+            exactProbe: { _ in .success(false) }
+        )
+
+        let first = Task { await broker.sessions(on: .local) }
+        await waitUntil { lifetime.snapshot.starts == 1 }
+        first.cancel()
+        #expect(
+            await first.value
+                == .failure(.probeCancelled(shell: "localhost"))
+        )
+
+        let second = Task { await broker.sessions(on: .local) }
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(lifetime.snapshot.starts == 1)
+        #expect(lifetime.snapshot.maximumActive == 1)
+
+        await cancellationDrain.open()
+        #expect(await second.value == .success([]))
+        #expect(lifetime.snapshot.starts == 2)
+        #expect(lifetime.snapshot.maximumActive == 1)
+        #expect(lifetime.snapshot.cancellations == 1)
+    }
+
+    @MainActor
+    @Test("invalidation drains before a replacement discovery starts")
+    func invalidationDrainsBeforeReplacement() async {
+        let lifetime = ProbeLifetimeCounter()
+        let cancellationDrain = ProbeGate()
+        let broker = TmuxSessionProbeBroker(
+            discover: { _ in
+                let call = lifetime.begin()
+                guard call == 1 else {
+                    lifetime.end()
+                    return .success([])
+                }
+                do {
+                    try await Task.sleep(for: .seconds(10))
+                    lifetime.end()
+                    return .success([])
+                } catch {
+                    await cancellationDrain.wait()
+                    lifetime.end(cancelled: true)
+                    return .failure(.probeCancelled(shell: "localhost"))
+                }
+            },
+            exactProbe: { _ in .success(false) }
+        )
+
+        let first = Task { await broker.sessions(on: .local) }
+        await waitUntil { lifetime.snapshot.starts == 1 }
+        broker.invalidateSessions(on: .local)
+        #expect(
+            await first.value
+                == .failure(.probeCancelled(shell: "localhost"))
+        )
+
+        let replacement = Task { await broker.sessions(on: .local) }
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(lifetime.snapshot.starts == 1)
+        #expect(lifetime.snapshot.maximumActive == 1)
+
+        await cancellationDrain.open()
+        #expect(await replacement.value == .success([]))
+        #expect(lifetime.snapshot.starts == 2)
+        #expect(lifetime.snapshot.maximumActive == 1)
+        #expect(lifetime.snapshot.cancellations == 1)
+    }
+}

--- a/Tests/App/TmuxSessionReconnectSupervisorTests.swift
+++ b/Tests/App/TmuxSessionReconnectSupervisorTests.swift
@@ -196,7 +196,9 @@ struct TmuxSessionReconnectSupervisorTests {
             return .retry
         }
 
-        await waitUntilMainActor { attempts.count == 2 }
+        await waitUntilMainActor {
+            attempts.count == 2 && !supervisor.isRunning
+        }
 
         #expect(attempts.cancellations == 1)
         #expect(attempts.maximumActive == 1)

--- a/Tests/App/TmuxSessionReconnectSupervisorTests.swift
+++ b/Tests/App/TmuxSessionReconnectSupervisorTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+private final class ReconnectAttemptCounter {
+    private(set) var count = 0
+    private(set) var active = 0
+    private(set) var maximumActive = 0
+    private(set) var cancellations = 0
+
+    @discardableResult
+    func begin() -> Int {
+        count += 1
+        active += 1
+        maximumActive = max(maximumActive, active)
+        return count
+    }
+
+    func end(cancelled: Bool = false) {
+        active -= 1
+        if cancelled {
+            cancellations += 1
+        }
+    }
+}
+
+private actor ReconnectAttemptGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var blocked = false
+
+    func wait() async {
+        blocked = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func isBlocked() -> Bool {
+        blocked
+    }
+
+    func open() {
+        blocked = false
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor ReconnectSleepRecorder {
+    private(set) var count = 0
+
+    func sleep(_ duration: Duration) async throws {
+        count += 1
+        try await Task.sleep(for: duration)
+    }
+}
+
+@Suite("Tmux reconnect supervisor", .serialized)
+@MainActor
+struct TmuxSessionReconnectSupervisorTests {
+    @Test(
+        "probe runtime counts against the attempt-start interval",
+        arguments: [
+            (
+                Duration.seconds(1),
+                Duration.milliseconds(250),
+                Duration.milliseconds(750)
+            ),
+            (Duration.seconds(2), Duration.seconds(3), Duration.zero),
+            (Duration.seconds(30), Duration.seconds(15), Duration.seconds(15)),
+        ]
+    )
+    func remainingDelay(
+        interval: Duration,
+        elapsed: Duration,
+        expected: Duration
+    ) {
+        #expect(TmuxSessionReconnectSupervisor.remainingDelay(
+            interval: interval,
+            elapsed: elapsed
+        ) == expected)
+    }
+
+    @Test("failed attempts continue until one stops the supervisor")
+    func retriesUntilStopped() async {
+        let attempts = ReconnectAttemptCounter()
+        let supervisor = TmuxSessionReconnectSupervisor(
+            intervals: [.milliseconds(1)],
+            probeDeadline: .seconds(1)
+        )
+        supervisor.start {
+            let count = attempts.begin()
+            attempts.end()
+            return count == 3 ? .stop : .retry
+        }
+
+        await waitUntilMainActor { attempts.count == 3 }
+
+        #expect(!supervisor.isRunning)
+    }
+
+    @Test("Reconnect Now interrupts the pending delay")
+    func reconnectNowInterruptsDelay() async {
+        let attempts = ReconnectAttemptCounter()
+        let sleeps = ReconnectSleepRecorder()
+        let supervisor = TmuxSessionReconnectSupervisor(
+            intervals: [.seconds(10)],
+            probeDeadline: .seconds(1),
+            sleep: { try await sleeps.sleep($0) }
+        )
+        supervisor.start {
+            let count = attempts.begin()
+            attempts.end()
+            return count == 2 ? .stop : .retry
+        }
+        await waitUntil { await sleeps.count == 1 }
+
+        supervisor.reconnectNow()
+        await waitUntilMainActor(timeout: .milliseconds(250)) {
+            attempts.count == 2
+        }
+
+        #expect(!supervisor.isRunning)
+    }
+
+    @Test("Reconnect Now never overlaps an in-flight attempt")
+    func reconnectNowDoesNotOverlapProbe() async {
+        let attempts = ReconnectAttemptCounter()
+        let gate = ReconnectAttemptGate()
+        let supervisor = TmuxSessionReconnectSupervisor(
+            intervals: [.milliseconds(1)],
+            probeDeadline: .seconds(1)
+        )
+        supervisor.start {
+            let count = attempts.begin()
+            if count == 1 {
+                await gate.wait()
+            }
+            attempts.end()
+            return count == 2 ? .stop : .retry
+        }
+        await waitUntil { await gate.isBlocked() }
+
+        supervisor.reconnectNow()
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(attempts.count == 1)
+        #expect(attempts.maximumActive == 1)
+
+        await gate.open()
+        await waitUntilMainActor { attempts.count == 2 }
+        #expect(attempts.maximumActive == 1)
+    }
+
+    @Test("cancel ignores a stale attempt completion")
+    func cancelIgnoresStaleCompletion() async {
+        let attempts = ReconnectAttemptCounter()
+        let gate = ReconnectAttemptGate()
+        let supervisor = TmuxSessionReconnectSupervisor(
+            intervals: [.milliseconds(1)],
+            probeDeadline: .seconds(1)
+        )
+        supervisor.start {
+            attempts.begin()
+            await gate.wait()
+            attempts.end()
+            return .retry
+        }
+        await waitUntil { await gate.isBlocked() }
+
+        supervisor.cancel()
+        await gate.open()
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(attempts.count == 1)
+        #expect(!supervisor.isRunning)
+    }
+
+    @Test("overlong probes are cancelled before retrying")
+    func cancelsOverlongProbe() async {
+        let attempts = ReconnectAttemptCounter()
+        let supervisor = TmuxSessionReconnectSupervisor(
+            intervals: [.milliseconds(1)],
+            probeDeadline: .milliseconds(20)
+        )
+        supervisor.start {
+            let count = attempts.begin()
+            guard count == 1 else {
+                attempts.end()
+                return .stop
+            }
+            do {
+                try await Task.sleep(for: .seconds(10))
+                attempts.end()
+            } catch {
+                attempts.end(cancelled: true)
+            }
+            return .retry
+        }
+
+        await waitUntilMainActor { attempts.count == 2 }
+
+        #expect(attempts.cancellations == 1)
+        #expect(attempts.maximumActive == 1)
+        #expect(!supervisor.isRunning)
+    }
+}

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -44,7 +44,13 @@ final class RestorationInventoryState: @unchecked Sendable {
         let published = isPublished
         lock.unlock()
         guard reachable else {
-            return .failure(.sshConnectionFailed(host: host.displayName))
+            return .failure(.sshConnectionFailed(
+                host: host.displayName,
+                classification: SSHConnectionFailure.classify(
+                    status: 255,
+                    output: ""
+                )
+            ))
         }
         return .success(published ? [
             DiscoveredTmuxSession(

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -355,7 +355,7 @@ struct WorkspaceRestorationTests {
 
         #expect(model.activeBorrowedTmuxSelection == nil)
         await waitUntilMainActor {
-            inventory.attemptCount == 1
+            inventory.attemptCount >= 1
                 && model.snapshot.host(id: environment.host.id)?.lastSeenAt
                 != nil
         }

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -354,7 +354,7 @@ struct WorkspaceRestorationTests {
         ))
 
         #expect(model.activeBorrowedTmuxSelection == nil)
-        await waitUntilMainActor {
+        await waitUntilMainActor(timeout: .seconds(15)) {
             inventory.attemptCount >= 1
                 && model.snapshot.host(id: environment.host.id)?.lastSeenAt
                 != nil

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -354,6 +354,11 @@ struct WorkspaceRestorationTests {
         ))
 
         #expect(model.activeBorrowedTmuxSelection == nil)
+        await waitUntilMainActor {
+            inventory.attemptCount == 1
+                && model.snapshot.host(id: environment.host.id)?.lastSeenAt
+                != nil
+        }
         inventory.publishExactSession()
         model.refreshTmuxSessionDiscovery()
         await waitUntilMainActor {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1700,6 +1700,100 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("cached worktree kwt interruption retries establishment")
+    func cachedWorktreeInterruptionRetriesEstablishment() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == true
+        )
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(!model.activeBorrowedTmuxSessionIsConfirmedEnded)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == true
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("resolver timeout remains retryable")
+    func resolverTimeoutRemainsRetryable() async throws {
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.probeTimedOut(shell: "build-box")),
+            .success([
+                DiscoveredTmuxSession(
+                    name: "release-work",
+                    windowCount: 1,
+                    createdAt: nil,
+                    managed: false
+                ),
+            ]),
+        ])
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(discoveries.count == 2)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("default-socket probe deadline preserves reconnecting state")
     func defaultSocketProbeDeadlinePreservesReconnectingState() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2374,12 +2374,23 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("changed host key pauses with manual remediation")
+    @Test("changed host key can reconnect after manual remediation")
     func changedHostKeyRequiresManualRemediation() async throws {
         let classification = SSHConnectionFailure.classify(
             status: 255,
             output: "REMOTE HOST IDENTIFICATION HAS CHANGED!"
         )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.sshConnectionFailed(
+                host: "build-box", classification: classification
+            )),
+            .success([
+                DiscoveredTmuxSession(
+                    name: "release-work", windowCount: 1,
+                    createdAt: nil, managed: false
+                ),
+            ]),
+        ])
         let environment = try setupRemoteTmuxEnvironment()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
@@ -2388,11 +2399,7 @@ struct WorkspaceTmuxDiscoveryTests {
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
-            tmuxSessionDiscovery: { _ in
-                .failure(.sshConnectionFailed(
-                    host: "build-box", classification: classification
-                ))
-            },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -2416,6 +2423,14 @@ struct WorkspaceTmuxDiscoveryTests {
         }
         #expect(message.contains("known-hosts"))
         #expect(model.tmuxConnectionRecoveryRequest == nil)
+
+        model.reconnectActiveTmuxSessionNow()
+
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+        #expect(discoveries.count == 2)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2424,6 +2424,16 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(message.contains("known-hosts"))
         #expect(model.tmuxConnectionRecoveryRequest == nil)
 
+        model.resumeTmuxReconnectAfterSSHRecovery(
+            hostID: environment.remoteHost.id
+        )
+        #expect(
+            model.activeBorrowedTmuxRecoveryState == .needsAttention(
+                message: message,
+                canReviewConnection: false
+            )
+        )
+
         model.reconnectActiveTmuxSessionNow()
 
         await waitUntilMainActor {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -444,6 +444,25 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("reopening an ended worktree restores establishment mode")
+    func endedWorktreeRetryRestoresEstablishmentMode() {
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "kwt-ghosthub-main",
+            worktreeID: UUID(),
+            worktreePath: "/srv/ghosthub"
+        )
+
+        #expect(
+            WorkspaceSceneModel.retryLaunchMode(
+                for: selection,
+                current: .attachOnly,
+                sessionConfirmedEnded: true
+            ) == .attach
+        )
+    }
+
+    @MainActor
     @Test("explicit reselection attaches a replaced worktree's session")
     func explicitReselectionAttachesReplacedSession() throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -343,7 +343,7 @@ struct WorkspaceTmuxDiscoveryTests {
         }
     }
 
-    private final class CancellableDiscoveryState: @unchecked Sendable {
+    private final class CancellableProbeState: @unchecked Sendable {
         private let lock = NSLock()
         private var started = false
         private var cancelled = false
@@ -351,6 +351,16 @@ struct WorkspaceTmuxDiscoveryTests {
         func discover(
             _ host: TmuxHost
         ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+            .failure(waitForCancellation())
+        }
+
+        func probe(
+            _ target: TmuxSessionProbeTarget
+        ) -> Result<Bool, TmuxBinaryError> {
+            .failure(waitForCancellation())
+        }
+
+        private func waitForCancellation() -> TmuxBinaryError {
             lock.lock()
             started = true
             lock.unlock()
@@ -360,7 +370,7 @@ struct WorkspaceTmuxDiscoveryTests {
             lock.lock()
             cancelled = true
             lock.unlock()
-            return .failure(.probeCancelled(shell: "test"))
+            return .probeCancelled(shell: "test")
         }
 
         var didStart: Bool {
@@ -1191,7 +1201,13 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             remoteTmuxPathProvider: { _ in
-                .failure(.sshConnectionFailed(host: "office-linux"))
+                .failure(.sshConnectionFailed(
+                    host: "office-linux",
+                    classification: SSHConnectionFailure.classify(
+                        status: 255,
+                        output: ""
+                    )
+                ))
             }
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1229,7 +1245,11 @@ struct WorkspaceTmuxDiscoveryTests {
             tmuxSessionDiscovery: { _ in
                 guard attempts.increment() > 1 else {
                     return .failure(.sshConnectionFailed(
-                        host: "office-linux"
+                        host: "office-linux",
+                        classification: SSHConnectionFailure.classify(
+                            status: 255,
+                            output: ""
+                        )
                     ))
                 }
                 return .success([
@@ -1538,7 +1558,7 @@ struct WorkspaceTmuxDiscoveryTests {
     @Test("shutdown cancels detached creation discovery")
     func shutdownCancelsDetachedCreationDiscovery() async throws {
         let environment = try setupStandardEnvironment()
-        let discovery = CancellableDiscoveryState()
+        let discovery = CancellableProbeState()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
@@ -1618,6 +1638,677 @@ struct WorkspaceTmuxDiscoveryTests {
             model.prepareActiveBorrowedTmuxSurface()
             return store.requestCount > 0
         }
+    }
+
+    @MainActor
+    @Test("transport loss automatically reattaches when the session returns")
+    func transportLossAutomaticallyReattaches() async throws {
+        let transport = SSHConnectionFailure.classify(
+            status: 255,
+            output: "ssh: connect to host build-box port 22: Network is unreachable"
+        )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.sshConnectionFailed(
+                host: "build-box",
+                classification: transport
+            )),
+            .success([
+                DiscoveredTmuxSession(
+                    name: "release-work",
+                    windowCount: 1,
+                    createdAt: nil,
+                    managed: false
+                ),
+            ]),
+        ])
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remoteSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(remoteSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("attach-session")
+                == true
+        )
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'") == false
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("default-socket probe deadline preserves reconnecting state")
+    func defaultSocketProbeDeadlinePreservesReconnectingState() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let discovery = CancellableProbeState()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: discovery.discover,
+            tmuxReconnectIntervals: [.seconds(10)],
+            tmuxReconnectProbeDeadline: .milliseconds(20)
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor { discovery.didCancel }
+
+        #expect(
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        )
+        #expect(
+            model.snapshot.host(id: environment.remoteHost.id)?
+                .lastKnownReachable == true
+        )
+        #expect(
+            model.workspaceInventoryWarningsByHost[
+                environment.remoteHost.id
+            ] == nil
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("creation reconciliation invalidation keeps reconnecting")
+    func creationReconciliationInvalidationKeepsReconnecting() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let attempts = Counter()
+        let creationGate = BlockingGate()
+        let reconnectProbe = CancellableProbeState()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { host in
+                switch attempts.increment() {
+                case 1:
+                    creationGate.wait()
+                case 2:
+                    return reconnectProbe.discover(host)
+                default:
+                    break
+                }
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "created-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            createdSessionDiscoveryDelays: [.seconds(10)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        defer { creationGate.release() }
+        let createdSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "created-work"
+        )
+        model.createTmuxSession(createdSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let createdObserverIDs = Set(
+            surfaceStore.surface.closeObservers.keys
+        )
+        model.closeBorrowedTmuxSession(createdSelection)
+        await waitUntilMainActor { creationGate.didStart }
+
+        let reconnectSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(reconnectSelection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        let reconnectObserverID = try #require(
+            Set(surfaceStore.surface.closeObservers.keys)
+                .subtracting(createdObserverIDs).first
+        )
+        let reconnectObserver = try #require(
+            surfaceStore.surface.closeObservers[reconnectObserverID]
+        )
+        reconnectObserver(false, 255)
+        await waitUntilMainActor { reconnectProbe.didStart }
+
+        creationGate.release()
+
+        await waitUntilMainActor {
+            reconnectProbe.didCancel
+                && attempts.count == 3
+                && surfaceStore.requestCount == 3
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+        #expect(attempts.count == 3)
+        #expect(surfaceStore.requestCount == 3)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        #expect(
+            model.workspaceInventoryWarningsByHost[
+                environment.remoteHost.id
+            ] == nil
+        )
+        #expect(
+            model.snapshot.host(id: environment.remoteHost.id)?
+                .lastKnownReachable == true
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("exact probe deadline retries automatically")
+    func exactProbeDeadlineRetriesAutomatically() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let attempts = Counter()
+        let probe = CancellableProbeState()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxExactSessionProbe: { target in
+                switch attempts.increment() {
+                case 1:
+                    return probe.probe(target)
+                default:
+                    return .success(true)
+                }
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .milliseconds(20)
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "protected-work",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            probe.didCancel
+                && attempts.count == 2
+                && surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(attempts.count == 2)
+        #expect(surfaceStore.requestCount == 2)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("stale reconnect discovery cannot mutate a replacement endpoint")
+    func staleReconnectDiscoveryCannotMutateReplacementEndpoint()
+        async throws {
+        let environment = try setupStandardEnvironment()
+        let oldTarget = TmuxHost.ssh(SSHHostInfo(
+            user: "wesm",
+            hostname: "old.example.com",
+            port: nil
+        ))
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@old.example.com"
+            ),
+        ])
+        let discoveryGate = BlockingGate()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { host in
+                #expect(host == oldTarget)
+                discoveryGate.wait()
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "stale-session",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        defer { discoveryGate.release() }
+        model.refreshHosts()
+        let remoteHost = try #require(
+            model.snapshot.hosts.first { $0.configKey == "laptop" }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: remoteHost.id,
+            name: "stale-session"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor { discoveryGate.didStart }
+
+        configuredHosts.value = [
+            SSHHost(
+                configKey: "laptop",
+                name: "Laptop",
+                platform: .macOS,
+                sshDestination: "wesm@new.example.com"
+            ),
+        ]
+        model.refreshHosts()
+        discoveryGate.release()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let updatedHost = try #require(
+            model.snapshot.hosts.first { $0.configKey == "laptop" }
+        )
+        #expect(updatedHost.sshDestination == "wesm@new.example.com")
+        #expect(updatedHost.tmuxSessions.isEmpty)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("Reconnect Now interrupts the scene supervisor wait")
+    func reconnectNowInterruptsSceneWait() async throws {
+        let transport = SSHConnectionFailure.classify(
+            status: 255,
+            output: "Network is unreachable"
+        )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.sshConnectionFailed(
+                host: "build-box", classification: transport
+            )),
+            .success([
+                DiscoveredTmuxSession(
+                    name: "release-work", windowCount: 1,
+                    createdAt: nil, managed: false
+                ),
+            ]),
+        ])
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            tmuxReconnectIntervals: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor { discoveries.count == 1 }
+
+        model.reconnectActiveTmuxSessionNow()
+
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("default-socket absence ends a confirmed session")
+    func defaultSocketAbsenceEndsSession() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConfirmedEnded
+        }
+        #expect(surfaceStore.requestCount == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("interrupted establishment clears provisional ended state")
+    func interruptedEstablishmentClearsEndedState() async throws {
+        let environment = try setupRemoteEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionName = "kwt-ghosthub-main"
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(!model.activeBorrowedTmuxSessionIsConfirmedEnded)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == true
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a failed replacement stops promising automatic recovery")
+    func failedReplacementStopsAutomaticRecovery() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxRecoveryState == nil
+        }
+
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        model.reconnectActiveTmuxSessionNow()
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(surfaceStore.requestCount == 2)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("protected-socket absence ends without probing through a surface")
+    func protectedSocketAbsenceEndsWithoutSurface() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let probes = TmuxExactProbeResultQueue([.success(false)])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxExactSessionProbe: { _ in probes.removeFirst() },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "protected-work",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConfirmedEnded
+        }
+        #expect(probes.count == 1)
+        #expect(surfaceStore.requestCount == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("protected recovery stays direct and attach-only")
+    func protectedRecoveryUsesAttachOnly() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let probes = TmuxExactProbeResultQueue([.success(true)])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxExactSessionProbe: { _ in probes.removeFirst() },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "protected-work",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("attach-session"))
+        #expect(command.contains("kwt-pr-0123456789abcdef"))
+        #expect(!command.contains(" pr attach "))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("authentication failure pauses and requests native recovery")
+    func authenticationFailureRequestsRecovery() async throws {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: "Permission denied (publickey,password)."
+        )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.sshConnectionFailed(
+                host: "build-box", classification: classification
+            )),
+        ])
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            model.tmuxConnectionRecoveryRequest != nil
+        }
+        #expect(
+            model.tmuxConnectionRecoveryRequest?.hostID
+                == environment.remoteHost.id
+        )
+        guard case .needsAttention(_, true) =
+            model.activeBorrowedTmuxRecoveryState
+        else {
+            Issue.record("Expected reviewable attention state")
+            await model.shutdown()
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(discoveries.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("changed host key pauses with manual remediation")
+    func changedHostKeyRequiresManualRemediation() async throws {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: "REMOTE HOST IDENTIFICATION HAS CHANGED!"
+        )
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in
+                .failure(.sshConnectionFailed(
+                    host: "build-box", classification: classification
+                ))
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState != nil
+                && model.activeBorrowedTmuxRecoveryState?.isReconnecting == false
+        }
+        guard case let .needsAttention(message, false) =
+            model.activeBorrowedTmuxRecoveryState
+        else {
+            Issue.record("Expected manual attention state")
+            await model.shutdown()
+            return
+        }
+        #expect(message.contains("known-hosts"))
+        #expect(model.tmuxConnectionRecoveryRequest == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("clean detach never starts automatic recovery")
+    func cleanDetachDoesNotReconnect() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        surfaceStore.surface.closeObservers.values.first?(false, 0)
+        try await Task.sleep(for: .milliseconds(30))
+
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        #expect(surfaceStore.requestCount == 1)
+        await model.shutdown()
     }
 
     @MainActor
@@ -2554,7 +3245,7 @@ struct WorkspaceTmuxDiscoveryTests {
 @MainActor
 private final class SceneTmuxPaneSurfaceStub: TmuxPaneSurfacing {
     var blocksClipboardReads = false
-    var launchError: Error? { nil }
+    var launchError: Error?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
 
@@ -2563,6 +3254,14 @@ private final class SceneTmuxPaneSurfaceStub: TmuxPaneSurfacing {
         onSurfaceClosed: @escaping (Bool, UInt32?) -> Void
     ) {
         closeObservers[id] = onSurfaceClosed
+    }
+}
+
+private enum SceneSurfaceLaunchError: LocalizedError {
+    case rejected
+
+    var errorDescription: String? {
+        "The terminal rejected the replacement surface."
     }
 }
 
@@ -2582,4 +3281,48 @@ private final class SceneTmuxSurfaceStoreStub: TmuxSurfaceStoring {
     }
 
     func removeSurface(for key: SurfaceKey) {}
+}
+
+private final class TmuxDiscoveryResultQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values:
+        [Result<[DiscoveredTmuxSession], TmuxBinaryError>]
+    private var removalCount = 0
+
+    init(_ values: [Result<[DiscoveredTmuxSession], TmuxBinaryError>]) {
+        self.values = values
+    }
+
+    func removeFirst()
+        -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
+        lock.withLock {
+            removalCount += 1
+            return values.removeFirst()
+        }
+    }
+
+    var count: Int {
+        lock.withLock { removalCount }
+    }
+}
+
+private final class TmuxExactProbeResultQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Result<Bool, TmuxBinaryError>]
+    private var removalCount = 0
+
+    init(_ values: [Result<Bool, TmuxBinaryError>]) {
+        self.values = values
+    }
+
+    func removeFirst() -> Result<Bool, TmuxBinaryError> {
+        lock.withLock {
+            removalCount += 1
+            return values.removeFirst()
+        }
+    }
+
+    var count: Int {
+        lock.withLock { removalCount }
+    }
 }

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2247,6 +2247,48 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("protected kwt interruption retries establishment")
+    func protectedKwtInterruptionRetriesEstablishment() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let probes = TmuxExactProbeResultQueue([
+            .success(false),
+            .success(false),
+            .success(false),
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxExactSessionProbe: { _ in probes.removeFirst() },
+            createdSessionDiscoveryDelays: [.seconds(10)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "protected-work",
+            worktreePath: "/srv/ghosthub-pr-42",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(!model.activeBorrowedTmuxSessionIsConfirmedEnded)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("protected recovery stays direct and attach-only")
     func protectedRecoveryUsesAttachOnly() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -216,8 +216,8 @@ struct WorkspaceWorktreeRemovalTests {
         secondModel.startKwtInventory()
         secondModel.startTmuxSessionDiscovery()
         await waitUntilMainActor {
-            secondLoads.load() == 1
-                && secondDiscoveries.load() == 1
+            secondLoads.load() >= 1
+                && secondDiscoveries.load() >= 1
         }
 
         let request = try await firstModel.prepareWorktreeRemoval(removable.id)

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -392,7 +392,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                 activeTmuxSession: activeTmuxSession
             ),
             content: ContentBuilders(
-                tmuxSessionContentBuilder: { _, _, _ in
+                tmuxSessionContentBuilder: { _, _, _, _ in
                     tmuxContentBuilder()
                 }
             ),
@@ -1569,7 +1569,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
                         activeTmuxSession: model.activeTmuxSession
                     ),
                     content: ContentBuilders(
-                        tmuxSessionContentBuilder: { _, sessionName, _ in
+                        tmuxSessionContentBuilder: { _, sessionName, _, _ in
                             guard let surfaceView =
                                 surfacesBySession[sessionName]
                             else { return nil }

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -1110,6 +1110,49 @@ struct TmuxAttachmentInfoTests {
         #expect(try String(contentsOf: counter, encoding: .utf8) == "x")
     }
 
+    @Test("remote worktree records an SSH establishment failure")
+    func remoteWorktreeRecordsSSHFailure() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let status = directory.appendingPathComponent("ssh-status")
+        let command = TmuxAttachmentInfo(
+            sessionName: "fixture-session",
+            host: .ssh(SSHHostInfo(
+                user: "test-user",
+                hostname: "test-host.invalid",
+                port: nil
+            )),
+            workspacePath: "/srv/project"
+        ).attachCommand(
+            tmuxPath: "/usr/bin/tmux",
+            remoteKwtCommandPrelude: "ghosthub_kwt_path=/usr/bin/kwt; ",
+            sshConnectionArguments: [
+                "-o", "ProxyCommand=/usr/bin/false",
+            ],
+            remoteExitStatusPath: status.path
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            "--noprofile", "--norc", "-c", "exec -l " + command,
+        ]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "SHELL": "/bin/sh",
+        ]) { _, new in new }
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 255)
+        #expect(try String(contentsOf: status, encoding: .utf8) == "255\n")
+    }
+
     @Test("Windows named creation runs once before psmux attachment")
     func windowsRemoteCreationIsOneShot() throws {
         let command = TmuxAttachmentInfo(
@@ -1233,7 +1276,6 @@ struct TmuxAttachmentInfoTests {
         )
         defer { try? FileManager.default.removeItem(at: directory) }
         let counter = directory.appendingPathComponent("count")
-        let status = directory.appendingPathComponent("status")
         let fake = directory.appendingPathComponent("fake-ssh")
         try """
         #!/bin/sh
@@ -1252,7 +1294,6 @@ struct TmuxAttachmentInfoTests {
         ]
         process.environment = ProcessInfo.processInfo.environment.merging([
             "GHOSTHUB_TEST_COUNTER": counter.path,
-            "GHOSTHUB_SSH_EXIT_STATUS_PATH": status.path,
         ]) { _, new in new }
         let output = Pipe()
         process.standardOutput = output
@@ -1262,7 +1303,6 @@ struct TmuxAttachmentInfoTests {
 
         #expect(process.terminationStatus == 255)
         #expect(try String(contentsOf: counter, encoding: .utf8) == "x")
-        #expect(try String(contentsOf: status, encoding: .utf8) == "255\n")
         #expect(!String(
             decoding: output.fileHandleForReading.readDataToEndOfFile(),
             as: UTF8.self

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -1017,6 +1017,7 @@ struct TmuxAttachmentInfoTests {
         )
         defer { try? FileManager.default.removeItem(at: directory) }
         let marker = directory.appendingPathComponent("account-shell-ready")
+        let status = directory.appendingPathComponent("ssh-status")
         let shell = directory.appendingPathComponent("account-shell")
         try """
         #!/bin/sh
@@ -1041,7 +1042,8 @@ struct TmuxAttachmentInfoTests {
             ))
         ).attachCommand(
             tmuxPath: "/usr/bin/true",
-            sshConnectionArguments: ["-V"]
+            sshConnectionArguments: ["-V"],
+            remoteExitStatusPath: status.path
         )
         let process = Process()
         let output = Pipe()
@@ -1069,6 +1071,7 @@ struct TmuxAttachmentInfoTests {
             Comment(rawValue: text)
         )
         #expect(FileManager.default.fileExists(atPath: marker.path))
+        #expect(try String(contentsOf: status, encoding: .utf8) == "0\n")
     }
 
     @Test("remote worktree returns the first establishment outcome")
@@ -1230,6 +1233,7 @@ struct TmuxAttachmentInfoTests {
         )
         defer { try? FileManager.default.removeItem(at: directory) }
         let counter = directory.appendingPathComponent("count")
+        let status = directory.appendingPathComponent("status")
         let fake = directory.appendingPathComponent("fake-ssh")
         try """
         #!/bin/sh
@@ -1248,6 +1252,7 @@ struct TmuxAttachmentInfoTests {
         ]
         process.environment = ProcessInfo.processInfo.environment.merging([
             "GHOSTHUB_TEST_COUNTER": counter.path,
+            "GHOSTHUB_SSH_EXIT_STATUS_PATH": status.path,
         ]) { _, new in new }
         let output = Pipe()
         process.standardOutput = output
@@ -1257,6 +1262,7 @@ struct TmuxAttachmentInfoTests {
 
         #expect(process.terminationStatus == 255)
         #expect(try String(contentsOf: counter, encoding: .utf8) == "x")
+        #expect(try String(contentsOf: status, encoding: .utf8) == "255\n")
         #expect(!String(
             decoding: output.fileHandleForReading.readDataToEndOfFile(),
             as: UTF8.self

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -478,7 +478,7 @@ struct TmuxAttachmentInfoTests {
         ))
     }
 
-    @Test("remote attachment adds keepalives and transport-only retry")
+    @Test("remote attachment adds keepalives to one SSH attempt")
     func remoteAttachCommand() {
         let info = TmuxAttachmentInfo(
             sessionName: "docbank",
@@ -497,10 +497,9 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'ServerAliveInterval=15'"))
         #expect(command.contains("'ServerAliveCountMax=3'"))
         #expect(command.contains("'TCPKeepAlive=yes'"))
-        #expect(command.contains("'PermitLocalCommand=yes'"))
-        #expect(command.contains("GHOSTHUB_SSH_CONNECTION_MARKER"))
-        #expect(command.contains("-O"))
-        #expect(command.contains("check"))
+        #expect(!command.contains("'PermitLocalCommand=yes'"))
+        #expect(!command.contains("GHOSTHUB_SSH_CONNECTION_MARKER"))
+        #expect(!command.contains("reconnecting in"))
         #expect(command.contains("'wesm@build-box'"))
         #expect(command.contains("'attach-session'"))
         #expect(command.contains("'-E'"))
@@ -590,7 +589,7 @@ struct TmuxAttachmentInfoTests {
         #expect(!script.contains("‘"))
     }
 
-    @Test("Windows worktrees open through kwt before psmux reconnect")
+    @Test("Windows worktrees run one kwt establishment attempt")
     func windowsRemoteWorkspaceAttachCommand() throws {
         let command = TmuxAttachmentInfo(
             sessionName: "release work",
@@ -608,41 +607,22 @@ struct TmuxAttachmentInfoTests {
         )
 
         #expect(command.contains("ghosthub-ssh-kwt-attach"))
-        #expect(command.contains("ghosthub-ssh-kwt-probe"))
+        #expect(!command.contains("ghosthub-ssh-kwt-probe"))
         let decoded = try Self.decodedPowerShellScripts(from: command)
-        let scripts = try #require(decoded.count == 3 ? decoded : nil)
-        #expect(scripts[0].contains(
+        let script = try #require(decoded.count == 1 ? decoded[0] : nil)
+        #expect(script.contains(
             powerShellEncodedArgument(
                 #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
             )
         ))
-        #expect(!scripts[0].contains("Get-Command kwt.exe"))
-        #expect(scripts[0].contains(
+        #expect(!script.contains("Get-Command kwt.exe"))
+        #expect(script.contains(
             "& $ghosthubKwt 'open' "
                 + powerShellEncodedArgument(#"C:\code\release work"#)
         ))
-        #expect(scripts[1].contains(
-            "& " + [
-                #"C:\Program Files\psmux\tmux.exe"#,
-                "has-session",
-                "-t",
-                "=release work",
-            ]
-            .map(powerShellEncodedArgument)
-            .joined(separator: " ")
-        ))
-        #expect(scripts[2].contains(
-            "& " + [
-                #"C:\Program Files\psmux\tmux.exe"#,
-                "attach-session",
-                "-E",
-                "-t",
-                "=release work",
-            ]
-            .map(powerShellEncodedArgument)
-            .joined(separator: " ")
-        ))
-        #expect(!scripts.joined().contains("exec /bin/sh"))
+        #expect(!script.contains("has-session"))
+        #expect(!script.contains("attach-session"))
+        #expect(!script.contains("exec /bin/sh"))
     }
 
     @Test("isolated remote attachment targets the returned tmux socket")
@@ -683,6 +663,62 @@ struct TmuxAttachmentInfoTests {
         if let kwtPosition, let stylePosition {
             #expect(kwtPosition < stylePosition)
         }
+    }
+
+    @Test("confirmed protected POSIX session reattaches through tmux only")
+    func protectedPOSIXAttachOnlyCommand() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "pr-32",
+            host: .ssh(SSHHostInfo(
+                user: "wesm", hostname: "build-box", port: nil
+            )),
+            socketName: "kwt-pr-0123456789abcdef",
+            protectedWorkspacePath: "/worktrees/pr-32",
+            launchMode: .attachOnly
+        ).attachCommand(
+            tmuxPath: "/usr/bin/tmux",
+            remoteKwtCommandPrelude:
+            "ghosthub_kwt_path=\"$HOME/.ghosthub/kwt\"; "
+        )
+
+        #expect(command.contains("kwt-pr-0123456789abcdef"))
+        #expect(command.contains("attach-session"))
+        #expect(command.contains("=pr-32"))
+        #expect(!command.contains("ghosthub_kwt_path"))
+        #expect(!command.contains("/worktrees/pr-32"))
+    }
+
+    @Test("confirmed protected Windows session reattaches through psmux only")
+    func protectedWindowsAttachOnlyCommand() throws {
+        let command = TmuxAttachmentInfo(
+            sessionName: "pr-32",
+            host: .ssh(SSHHostInfo(
+                user: "wesm",
+                hostname: "arm-builder",
+                port: nil,
+                platform: .windows
+            )),
+            socketName: "kwt-pr-0123456789abcdef",
+            protectedWorkspacePath: #"C:\worktrees\pr-32"#,
+            launchMode: .attachOnly
+        ).attachCommand(
+            tmuxPath: #"C:\Tools\psmux\tmux.exe"#,
+            windowsKwtRelativePath: #"helpers\kwt.exe"#
+        )
+        let script = try Self.decodedPowerShellScript(from: command)
+
+        for argument in [
+            "-L",
+            "kwt-pr-0123456789abcdef",
+            "attach-session",
+            "-E",
+            "-t",
+            "=pr-32",
+        ] {
+            #expect(script.contains(powerShellEncodedArgument(argument)))
+        }
+        #expect(!script.contains("ghosthubKwt"))
+        #expect(!script.contains(#"C:\worktrees\pr-32"#))
     }
 
     @Test("normal SSH arguments preserve OpenSSH connection sharing")
@@ -746,8 +782,8 @@ struct TmuxAttachmentInfoTests {
         )
     }
 
-    @Test("remote creation presents before its reconnect loop")
-    func remoteCreationPresentsBeforeReconnectLoop() {
+    @Test("remote creation presents before its attachment attempt")
+    func remoteCreationPresentsBeforeAttachment() {
         let info = TmuxAttachmentInfo(
             sessionName: "release-work",
             host: .ssh(SSHHostInfo(
@@ -774,26 +810,20 @@ struct TmuxAttachmentInfoTests {
         #expect(
             command.components(separatedBy: "new-session").count == 2
         )
-        #expect(
-            command.components(
-                separatedBy: "SSH disconnected; reconnecting"
-            ).count == 2
-        )
+        #expect(!command.contains("SSH disconnected; reconnecting"))
         let presentationPosition = command.range(
             of: "while IFS= read -r ghosthub_window"
         )?.lowerBound
-        let reconnectPosition = command.range(
-            of: "SSH disconnected; reconnecting"
-        )?.lowerBound
+        let attachPosition = command.range(of: "attach-session")?.lowerBound
         #expect(presentationPosition != nil)
-        #expect(reconnectPosition != nil)
+        #expect(attachPosition != nil)
         #expect(
             command.components(
                 separatedBy: "while IFS= read -r ghosthub_window"
             ).count - 1 == 1
         )
-        if let presentationPosition, let reconnectPosition {
-            #expect(presentationPosition < reconnectPosition)
+        if let presentationPosition, let attachPosition {
+            #expect(presentationPosition < attachPosition)
         }
         // The escape depth of "$?" varies with the surrounding quoting
         // layers, so match any depth rather than a hardcoded count.
@@ -883,12 +913,12 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'-tt'"))
         #expect(command.contains("/srv/widget feature"))
         #expect(!command.contains("--start-session"))
-        #expect(command.contains("ghosthub-ssh-kwt-probe"))
-        #expect(command.contains("has-session"))
+        #expect(!command.contains("ghosthub-ssh-kwt-probe"))
+        #expect(!command.contains("has-session"))
         #expect(
             command.components(
                 separatedBy: "${SHELL:-/bin/sh}"
-            ).count - 1 == 4
+            ).count - 1 == 2
         )
     }
 
@@ -1041,117 +1071,40 @@ struct TmuxAttachmentInfoTests {
         #expect(FileManager.default.fileExists(atPath: marker.path))
     }
 
-    @Test("remote worktree switches to tmux only after transport loss")
-    func remoteWorktreeReconnectsAfterTransportLoss() throws {
+    @Test("remote worktree returns the first establishment outcome")
+    func remoteWorktreeEstablishmentIsOneShot() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: directory, withIntermediateDirectories: true
         )
         defer { try? FileManager.default.removeItem(at: directory) }
+        let counter = directory.appendingPathComponent("initial-count")
         let initial = directory.appendingPathComponent("initial")
-        let probe = directory.appendingPathComponent("probe")
-        let reconnect = directory.appendingPathComponent("reconnect")
-        try "#!/bin/sh\nexit 255\n".write(
-            to: initial, atomically: true, encoding: .utf8
-        )
-        try "#!/bin/sh\nexit 0\n".write(
-            to: probe, atomically: true, encoding: .utf8
-        )
-        try """
-        #!/bin/sh
-        : > "$GHOSTHUB_RECONNECT_MARKER"
-        """.write(to: reconnect, atomically: true, encoding: .utf8)
-        for executable in [initial, probe, reconnect] {
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755], ofItemAtPath: executable.path
-            )
-        }
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [
-            "-c", TmuxAttachmentInfo.remoteWorkspaceAttachScript,
-            "ghosthub-test", initial.path, probe.path, reconnect.path,
-        ]
-        process.environment = ProcessInfo.processInfo.environment.merging([
-            "GHOSTHUB_RECONNECT_MARKER": reconnect.path + ".ran",
-        ]) { _, new in new }
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-
-        #expect(process.terminationStatus == 0)
-        #expect(FileManager.default.fileExists(
-            atPath: reconnect.path + ".ran"
-        ))
-    }
-
-    @Test("remote worktree retries kwt when transport fails before creation")
-    func remoteWorktreeRetriesKwtWhenSessionIsAbsent() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let initialCounter = directory.appendingPathComponent("initial-count")
-        let sleepCounter = directory.appendingPathComponent("sleep-count")
-        let initial = directory.appendingPathComponent("initial")
-        let probe = directory.appendingPathComponent("probe")
-        let reconnect = directory.appendingPathComponent("reconnect")
-        let sleep = directory.appendingPathComponent("sleep")
         try """
         #!/bin/sh
         printf x >> "$GHOSTHUB_INITIAL_COUNTER"
-        [ "$(wc -c < "$GHOSTHUB_INITIAL_COUNTER")" -gt 1 ] && exit 0
         exit 255
         """.write(to: initial, atomically: true, encoding: .utf8)
-        try "#!/bin/sh\nexit 1\n".write(
-            to: probe, atomically: true, encoding: .utf8
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: initial.path
         )
-        try """
-        #!/bin/sh
-        : > "$GHOSTHUB_RECONNECT_MARKER"
-        """.write(to: reconnect, atomically: true, encoding: .utf8)
-        try """
-        #!/bin/sh
-        printf '%s\n' "$1" >> "$GHOSTHUB_SLEEP_COUNTER"
-        """.write(to: sleep, atomically: true, encoding: .utf8)
-        for executable in [initial, probe, reconnect, sleep] {
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755], ofItemAtPath: executable.path
-            )
-        }
-
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
             "-c", TmuxAttachmentInfo.remoteWorkspaceAttachScript,
-            "ghosthub-test", initial.path, probe.path, reconnect.path,
+            "ghosthub-test", initial.path,
         ]
         process.environment = ProcessInfo.processInfo.environment.merging([
-            "GHOSTHUB_INITIAL_COUNTER": initialCounter.path,
-            "GHOSTHUB_RECONNECT_MARKER": reconnect.path + ".ran",
-            "GHOSTHUB_SLEEP_COUNTER": sleepCounter.path,
-            "PATH": directory.path + ":"
-                + ProcessInfo.processInfo.environment["PATH", default: ""],
+            "GHOSTHUB_INITIAL_COUNTER": counter.path,
         ]) { _, new in new }
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         try process.run()
         process.waitUntilExit()
 
-        #expect(process.terminationStatus == 0)
-        #expect(
-            try String(contentsOf: initialCounter, encoding: .utf8) == "xx"
-        )
-        #expect(
-            try String(contentsOf: sleepCounter, encoding: .utf8) == "1\n"
-        )
-        #expect(!FileManager.default.fileExists(
-            atPath: reconnect.path + ".ran"
-        ))
+        #expect(process.terminationStatus == 255)
+        #expect(try String(contentsOf: counter, encoding: .utf8) == "x")
     }
 
     @Test("Windows named creation runs once before psmux attachment")
@@ -1208,8 +1161,8 @@ struct TmuxAttachmentInfoTests {
         ))
     }
 
-    @Test("attach retries never rerun the completed create phase")
-    func reconnectDoesNotRepeatCreation() throws {
+    @Test("named creation runs once before one attachment attempt")
+    func remoteCreationAndAttachmentAreOneShot() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
@@ -1240,8 +1193,8 @@ struct TmuxAttachmentInfoTests {
         }
         let createCommand = shellQuotedCommandArgument(fakeCreate.path)
         let attachCommand = [
-            "/bin/sh", "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", "", fakeAttach.path,
+            "/bin/sh", "-c", TmuxAttachmentInfo.sshAttachScript,
+            "ghosthub-test", fakeAttach.path,
         ].map(shellQuotedCommandArgument).joined(separator: " ")
 
         let process = Process()
@@ -1259,58 +1212,17 @@ struct TmuxAttachmentInfoTests {
         try process.run()
         process.waitUntilExit()
 
-        #expect(process.terminationStatus == 0)
+        #expect(process.terminationStatus == 255)
         #expect(
             try String(contentsOf: createCounter, encoding: .utf8) == "x"
         )
         #expect(
-            try String(contentsOf: attachCounter, encoding: .utf8) == "xx"
+            try String(contentsOf: attachCounter, encoding: .utf8) == "x"
         )
     }
 
-    @Test("SSH status 255 retries, then clean tmux exit stops")
-    func reconnectsOnlyTransportFailure() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let counter = directory.appendingPathComponent("count")
-        let fake = directory.appendingPathComponent("fake-ssh")
-        try """
-        #!/bin/sh
-        count=0
-        [ ! -f "$GHOSTHUB_TEST_COUNTER" ] || count=$(cat "$GHOSTHUB_TEST_COUNTER")
-        count=$((count + 1))
-        printf '%s' "$count" > "$GHOSTHUB_TEST_COUNTER"
-        [ "$count" -gt 1 ] && exit 0
-        exit 255
-        """.write(to: fake, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755], ofItemAtPath: fake.path
-        )
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [
-            "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", "", fake.path,
-        ]
-        process.environment = ProcessInfo.processInfo.environment.merging([
-            "GHOSTHUB_TEST_COUNTER": counter.path,
-        ]) { _, new in new }
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-
-        #expect(process.terminationStatus == 0)
-        #expect(try String(contentsOf: counter, encoding: .utf8) == "2")
-    }
-
-    @Test("persistent SSH failure returns control to native recovery")
-    func persistentSSHFailureStopsReconnect() throws {
+    @Test("remote attach returns the first SSH transport failure")
+    func remoteAttachIsOneShot() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
@@ -1331,139 +1243,24 @@ struct TmuxAttachmentInfoTests {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
-            "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", "", fake.path,
+            "-c", TmuxAttachmentInfo.sshAttachScript,
+            "ghosthub-test", fake.path,
         ]
         process.environment = ProcessInfo.processInfo.environment.merging([
             "GHOSTHUB_TEST_COUNTER": counter.path,
         ]) { _, new in new }
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
         try process.run()
         process.waitUntilExit()
 
         #expect(process.terminationStatus == 255)
-        #expect(try String(contentsOf: counter, encoding: .utf8) == "xxx")
-    }
-
-    @Test("slow SSH failures still return control to native recovery")
-    func slowPersistentSSHFailureStopsReconnect() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let counter = directory.appendingPathComponent("count")
-        let clock = directory.appendingPathComponent("clock")
-        let fakeSSH = directory.appendingPathComponent("fake-ssh")
-        let fakeDate = directory.appendingPathComponent("date")
-        let fakeSleep = directory.appendingPathComponent("sleep")
-        try """
-        #!/bin/sh
-        printf x >> "$GHOSTHUB_TEST_COUNTER"
-        [ "$(wc -c < "$GHOSTHUB_TEST_COUNTER")" -gt 4 ] && exit 0
-        exit 255
-        """.write(to: fakeSSH, atomically: true, encoding: .utf8)
-        try """
-        #!/bin/sh
-        count=0
-        [ ! -f "$GHOSTHUB_TEST_CLOCK" ] || count=$(cat "$GHOSTHUB_TEST_CLOCK")
-        count=$((count + 1))
-        printf '%s' "$count" > "$GHOSTHUB_TEST_CLOCK"
-        if [ $((count % 2)) -eq 1 ]; then printf '0\n'; else printf '31\n'; fi
-        """.write(to: fakeDate, atomically: true, encoding: .utf8)
-        try "#!/bin/sh\nexit 0\n".write(
-            to: fakeSleep, atomically: true, encoding: .utf8
-        )
-        for executable in [fakeSSH, fakeDate, fakeSleep] {
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755], ofItemAtPath: executable.path
-            )
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [
-            "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", "", fakeSSH.path,
-        ]
-        process.environment = ProcessInfo.processInfo.environment.merging([
-            "GHOSTHUB_TEST_COUNTER": counter.path,
-            "GHOSTHUB_TEST_CLOCK": clock.path,
-            "PATH": directory.path + ":"
-                + ProcessInfo.processInfo.environment["PATH", default: ""],
-        ]) { _, new in new }
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-
-        #expect(process.terminationStatus == 255)
-        #expect(try String(contentsOf: counter, encoding: .utf8) == "xxx")
-    }
-
-    @Test("multiplexed attachment evidence resets the reconnect budget")
-    func multiplexedAttachmentEvidenceResetsReconnectBudget() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let counter = directory.appendingPathComponent("count")
-        let clock = directory.appendingPathComponent("clock")
-        let fakeSSH = directory.appendingPathComponent("fake-ssh")
-        let fakeCheck = directory.appendingPathComponent("fake-check")
-        let fakeDate = directory.appendingPathComponent("date")
-        let fakeSleep = directory.appendingPathComponent("sleep")
-        try """
-        #!/bin/sh
-        printf x >> "$GHOSTHUB_TEST_COUNTER"
-        count=$(wc -c < "$GHOSTHUB_TEST_COUNTER")
-        [ "$count" -gt 5 ] && exit 0
-        exit 255
-        """.write(to: fakeSSH, atomically: true, encoding: .utf8)
-        try """
-        #!/bin/sh
-        [ "$(wc -c < "$GHOSTHUB_TEST_COUNTER")" -eq 3 ]
-        """.write(to: fakeCheck, atomically: true, encoding: .utf8)
-        try """
-        #!/bin/sh
-        count=0
-        [ ! -f "$GHOSTHUB_TEST_CLOCK" ] || count=$(cat "$GHOSTHUB_TEST_CLOCK")
-        count=$((count + 1))
-        printf '%s' "$count" > "$GHOSTHUB_TEST_CLOCK"
-        if [ $((count % 2)) -eq 1 ]; then printf '0\n'; else printf '31\n'; fi
-        """.write(to: fakeDate, atomically: true, encoding: .utf8)
-        try "#!/bin/sh\nexit 0\n".write(
-            to: fakeSleep, atomically: true, encoding: .utf8
-        )
-        for executable in [fakeSSH, fakeCheck, fakeDate, fakeSleep] {
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755], ofItemAtPath: executable.path
-            )
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = [
-            "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", fakeCheck.path, fakeSSH.path,
-        ]
-        process.environment = ProcessInfo.processInfo.environment.merging([
-            "GHOSTHUB_TEST_COUNTER": counter.path,
-            "GHOSTHUB_TEST_CLOCK": clock.path,
-            "PATH": directory.path + ":"
-                + ProcessInfo.processInfo.environment["PATH", default: ""],
-        ]) { _, new in new }
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-
-        #expect(process.terminationStatus == 255)
-        #expect(try String(contentsOf: counter, encoding: .utf8) == "xxxxx")
+        #expect(try String(contentsOf: counter, encoding: .utf8) == "x")
+        #expect(!String(
+            decoding: output.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        ).contains("reconnecting in"))
     }
 
     @Test("ordinary remote-command failure does not reconnect")
@@ -1488,8 +1285,8 @@ struct TmuxAttachmentInfoTests {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
-            "-c", TmuxAttachmentInfo.sshReconnectScript,
-            "ghosthub-test", "", fake.path,
+            "-c", TmuxAttachmentInfo.sshAttachScript,
+            "ghosthub-test", fake.path,
         ]
         process.environment = ProcessInfo.processInfo.environment.merging([
             "GHOSTHUB_TEST_COUNTER": counter.path,

--- a/Tests/UI/SSHHostKeyReviewModelTests.swift
+++ b/Tests/UI/SSHHostKeyReviewModelTests.swift
@@ -108,6 +108,38 @@ struct SSHHostKeyReviewModelTests {
         #expect(model.presentation == .authenticationSucceeded)
     }
 
+    @Test("successful authentication resumes the paused connection")
+    func successfulAuthenticationResumesConnection() async {
+        let model = WorkspaceSSHHostKeyReviewModel()
+        var resumeCount = 0
+
+        await model.review(hostID: UUID(), hostName: "Build Node") {
+            .authenticationRequired
+        }
+        model.authenticationSucceeded {
+            resumeCount += 1
+        }
+
+        #expect(resumeCount == 1)
+        #expect(model.presentation == .authenticationSucceeded)
+    }
+
+    @Test("non-authentication presentation cannot resume connection")
+    func nonAuthenticationDoesNotResumeConnection() async {
+        let model = WorkspaceSSHHostKeyReviewModel()
+        var resumeCount = 0
+
+        await model.review(hostID: UUID(), hostName: "Build Node") {
+            .connectionIssue("Still offline.")
+        }
+        model.authenticationSucceeded {
+            resumeCount += 1
+        }
+
+        #expect(resumeCount == 0)
+        #expect(model.presentation == .connectionIssue)
+    }
+
     @Test("dismissal retains success throughout the sheet closing animation")
     func dismissalRetainsSuccessfulPresentation() async {
         let model = WorkspaceSSHHostKeyReviewModel()

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -373,7 +373,7 @@ private struct StabilityTestHarness: View {
             ),
             content: ContentBuilders(
                 tmuxSessionContentBuilder: {
-                    _, sessionName, defersTerminalResize in
+                    _, sessionName, defersTerminalResize, _ in
                     model.recordTerminalResizeDeferral(
                         defersTerminalResize
                     )

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -128,9 +128,28 @@ struct TmuxSessionPresentationLifecycleTests {
         #expect(
             router.recoveryHostIDToResume(
                 reviewedHostID: hostID,
-                presentation: .inventoryIssue,
+                reviewRequestID: request.id,
                 activeRequest: request
             ) == hostID
+        )
+    }
+
+    @Test("unrelated SSH authentication cannot resume tmux recovery")
+    func unrelatedSSHAuthenticationCannotResumeTmuxRecovery() {
+        let hostID = UUID()
+        let request = TmuxConnectionRecoveryRequest(
+            hostID: hostID,
+            message: "SSH authentication is required."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+        _ = router.take(request, whileReviewIsPresented: false)
+
+        #expect(
+            router.recoveryHostIDToResume(
+                reviewedHostID: hostID,
+                reviewRequestID: nil,
+                activeRequest: request
+            ) == nil
         )
     }
 

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -115,6 +115,25 @@ struct TmuxSessionPresentationLifecycleTests {
         )
     }
 
+    @Test("retrying resolved tmux recovery resumes the paused host")
+    func resolvedTmuxRecoveryRetryResumesPausedHost() {
+        let hostID = UUID()
+        let request = TmuxConnectionRecoveryRequest(
+            hostID: hostID,
+            message: "SSH authentication is required."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+        _ = router.take(request, whileReviewIsPresented: false)
+
+        #expect(
+            router.recoveryHostIDToResume(
+                reviewedHostID: hostID,
+                presentation: .inventoryIssue,
+                activeRequest: request
+            ) == hostID
+        )
+    }
+
     @Test("endpoint invalidation removes the active tmux presentation")
     func endpointInvalidationRemovesActivePresentation() {
         let hostID = UUID()

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -153,6 +153,29 @@ struct TmuxSessionPresentationLifecycleTests {
         )
     }
 
+    @Test("successful manual review resumes the active tmux recovery")
+    func successfulManualReviewResumesActiveTmuxRecovery() {
+        let hostID = UUID()
+        let request = TmuxConnectionRecoveryRequest(
+            hostID: hostID,
+            message: "SSH authentication is required."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+        _ = router.take(request, whileReviewIsPresented: false)
+        let manualReviewRequestID = router.recoveryRequestID(
+            for: hostID,
+            activeRequest: request
+        )
+
+        #expect(
+            router.recoveryHostIDToResume(
+                reviewedHostID: hostID,
+                reviewRequestID: manualReviewRequestID,
+                activeRequest: request
+            ) == hostID
+        )
+    }
+
     @Test("endpoint invalidation removes the active tmux presentation")
     func endpointInvalidationRemovesActivePresentation() {
         let hostID = UUID()

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -66,6 +66,55 @@ struct TmuxSessionPresentationLifecycleTests {
         #expect(!didDetach)
     }
 
+    @Test("a stable tmux recovery request auto-opens only once")
+    func stableTmuxRecoveryRequestOpensOnce() {
+        let request = TmuxConnectionRecoveryRequest(
+            hostID: UUID(),
+            message: "SSH authentication is required."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+
+        #expect(
+            router.take(request, whileReviewIsPresented: false) == request
+        )
+        #expect(router.take(request, whileReviewIsPresented: false) == nil)
+    }
+
+    @Test("a new tmux recovery request can open after dismissal")
+    func newTmuxRecoveryRequestCanReopen() {
+        let hostID = UUID()
+        let first = TmuxConnectionRecoveryRequest(
+            hostID: hostID,
+            message: "SSH authentication is required."
+        )
+        let second = TmuxConnectionRecoveryRequest(
+            hostID: hostID,
+            message: "The SSH host key needs review."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+
+        #expect(router.take(first, whileReviewIsPresented: false) == first)
+        #expect(router.take(nil, whileReviewIsPresented: false) == nil)
+        #expect(router.take(first, whileReviewIsPresented: false) == nil)
+        #expect(router.take(second, whileReviewIsPresented: false) == second)
+    }
+
+    @Test("tmux recovery waits for an existing SSH review to dismiss")
+    func tmuxRecoveryWaitsForExistingReview() {
+        let request = TmuxConnectionRecoveryRequest(
+            hostID: UUID(),
+            message: "SSH authentication is required."
+        )
+        var router = TmuxConnectionRecoveryRequestRouter()
+
+        #expect(
+            router.take(request, whileReviewIsPresented: true) == nil
+        )
+        #expect(
+            router.take(request, whileReviewIsPresented: false) == request
+        )
+    }
+
     @Test("endpoint invalidation removes the active tmux presentation")
     func endpointInvalidationRemovesActivePresentation() {
         let hostID = UUID()
@@ -361,7 +410,7 @@ private struct EndpointChangePresentationHarness: View {
         RootView(
             display: model.display,
             content: ContentBuilders(
-                tmuxSessionContentBuilder: { _, _, _ in
+                tmuxSessionContentBuilder: { _, _, _, _ in
                     AnyView(
                         ActiveTmuxPresentationMarker()
                     )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -446,6 +446,9 @@ authentication or host-key failures pause it and route through native SSH
 recovery. Exact absence ends an established presentation, while reachable
 non-transport failures become an unable-to-attach state. Navigation, endpoint
 changes, replacement presentations, and scene shutdown cancel stale work.
+OpenSSH attachment wrappers record their exact exit status through an app-owned
+per-launch temporary file because libghostty's outer macOS login process does
+not reliably preserve a nested command's status.
 
 ## State Ownership
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -380,9 +380,10 @@ operation can fail. After success, Ghosthub closes the matching current active
 selection and navigates away only when the killed target is active at
 completion time, so switching sessions during the command is preserved. The
 action terminates all of that session's windows, panes, and processes. For SSH,
-Ghosthub supplies keepalives and retries
-transport status 255. Tmux owns all windows, panes, history, input, rendering,
-and server-side lifetime.
+Ghosthub supplies keepalives. Remote shell commands are one-shot; the active
+scene owns transport-status-255 recovery, probe scheduling, authentication and
+host-key escalation, and attach-only client replacement. Tmux owns all windows,
+panes, history, input, rendering, and server-side lifetime.
 
 Ghosthub applies the selected Tmux Theme when it creates a new bare session.
 Built-in themes provide fixed colors; Follow ghostty.conf uses the effective
@@ -414,15 +415,18 @@ presentation uses one atomic
 `new-session -A` create-or-attach invocation so `destroy-unattached` cannot
 remove a newly created session before the client arrives. Remote presentation
 performs one idempotent, detached create-if-absent phase before ordinary
-attachment, then permanently enters the attach-only SSH reconnect loop.
+attachment. Once established, its native reconnect supervisor permanently
+limits all later replacements to attach-only clients.
 Before opening an ordinary worktree, Ghosthub asks kwt to establish or repair
 that exact path's canonical session without attaching. Kwt inventory includes
 worktrees whose sessions are not currently running, so inventory membership is
 not evidence that attach-only will succeed. Kwt owns any required layout and
 environment bootstrap; Ghosthub then presents an ordinary tmux client. The
-remote establishment phase runs once, and transport reconnects remain
-attach-only. Discovered sessions that are not bound to worktrees are always
-attach-only.
+remote establishment phase runs once after its attachment is confirmed, and
+transport reconnects remain attach-only. If transport interrupts an
+unconfirmed kwt establishment, authoritative exact-session absence may rerun
+that establishment because the remote command may never have executed.
+Discovered sessions that are not bound to worktrees are always attach-only.
 
 Ghosthub publishes the requested name optimistically. Reconciliation starts
 only after the terminal runtime accepts the command, then checks direct tmux
@@ -431,6 +435,17 @@ is still running; only an authoritative empty inventory after both retry
 exhaustion and command termination may retire it. Confirmation permanently
 demotes later retries to attach-only. Host endpoint changes and scene shutdown
 cancel pending probes.
+
+Each active remote tmux presentation owns at most one native reconnect
+supervisor. It uses the host's shared in-flight default-socket inventory probe,
+or an exact headless `has-session` probe for a protected socket. Attempt starts
+follow 1, 2, 4, 8, 16, and 30-second intervals, include probe runtime, and are
+bounded by a 15-second probe deadline. Transport failures continue
+automatically and **Reconnect Now** advances the existing schedule;
+authentication or host-key failures pause it and route through native SSH
+recovery. Exact absence ends an established presentation, while reachable
+non-transport failures become an unable-to-attach state. Navigation, endpoint
+changes, replacement presentations, and scene shutdown cancel stale work.
 
 ## State Ownership
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -446,9 +446,9 @@ authentication or host-key failures pause it and route through native SSH
 recovery. Exact absence ends an established presentation, while reachable
 non-transport failures become an unable-to-attach state. Navigation, endpoint
 changes, replacement presentations, and scene shutdown cancel stale work.
-OpenSSH attachment wrappers record their exact exit status through an app-owned
-per-launch temporary file because libghostty's outer macOS login process does
-not reliably preserve a nested command's status.
+Each complete remote establishment or attachment command records its final
+status through an app-owned per-launch temporary file because libghostty's
+outer macOS login process does not reliably preserve a nested command's status.
 
 ## State Ownership
 

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -118,8 +118,9 @@ scene; native scene restoration still supplies geometry and tab grouping when
 available. Once assigned, the scene model's complete logical descriptor replaces
 any delayed same-ID native payload with stale navigation or tmux data.
 An ordinary local session must be present in direct discovery before Ghosthub
-runs the exact `attach-session` path. Remote sessions use that same rule and the
-existing SSH keepalive and transport-reconnect loop.
+runs the exact `attach-session` path. Remote sessions use that same rule and,
+after a confirmed attachment, Ghosthub's native reconnect supervisor owns any
+transport recovery.
 Offline or otherwise unavailable targets remain pending and retry when normal
 inventory refreshes publish new state. Navigating the window elsewhere cancels
 the pending target. If a scene was captured without an active tmux
@@ -145,8 +146,9 @@ Explicit local creation uses one atomic `new-session -A` create-or-attach
 client invocation. This closes the detached-session race when the user's tmux
 server has `destroy-unattached` enabled. Explicit remote creation performs a
 one-shot `has-session`/detached `new-session` phase before ordinary attachment.
-The remote process then enters the attach-only SSH reconnect loop, so a later
-transport reconnect can never rerun creation. The session name is validated
+The remote process then performs one ordinary attachment. If that client later
+loses its transport, the native reconnect supervisor can only launch another
+attach-only client; it can never rerun creation. The session name is validated
 before launch and passed as one shell-quoted argument. If the exact name
 already exists, it is attached without creating or structurally changing panes
 or windows.
@@ -161,16 +163,16 @@ discovery contains the canonical name, because the session may have exited
 since the sample. If the managed helper is explicitly unavailable, a cached
 discovered session remains usable through ordinary `tmux attach-session`. On a
 remote host, only an SSH transport loss can hand a kwt-opened session to
-Ghosthub's attach-only reconnect loop. Ghosthub first retries SSH to probe the
-exact session: confirmed presence advances to ordinary attachment, while
-confirmed absence reruns `kwt open` because the failed SSH connection may never
-have executed it. On POSIX hosts, every remote tmux phase (creation,
+Ghosthub's native recovery supervisor. Ghosthub first probes the exact session:
+confirmed presence advances to ordinary attachment, while confirmed absence
+reruns `kwt open` only if the interrupted establishment was never confirmed.
+Once attachment is confirmed, every later recovery remains attach-only. On
+POSIX hosts, every remote tmux phase (creation,
 attachment, open, and probe, styled or not) runs through the account login
 shell so settings such as `TMUX_TMPDIR` resolve the same tmux server as later
 styling and identity commands. On Windows, those phases use encoded
-PowerShell commands
-within the same OpenSSH account environment. Confirmed absence retries use
-bounded exponential backoff. Unbound discovered sessions remain attach-only.
+PowerShell commands within the same OpenSSH account environment. Unbound
+discovered sessions remain attach-only.
 Ghosthub does not expose rename, split, resize, window, or pane operations.
 Kill Session is exposed separately from presentation only for a session known
 to be running and always requires confirmation.
@@ -211,19 +213,40 @@ connection and remain noninteractive. Every control connection is named for
 one app launch and supervised by a parent-held descriptor that stays open for
 the app lifetime, so an app crash terminates the SSH master and a later launch
 cannot reuse its socket.
-Exit status 255, OpenSSH's transport/setup failure status, reconnects with
-bounded exponential backoff. A direct connection's OpenSSH `LocalCommand`
-writes a private marker after transport and authentication succeed. For a
-multiplexed client, a sufficiently long attachment resets its retry budget only
-when the supervised control master is still healthy afterward. Attempts without
-either signal exit after two retries regardless of how long setup took, so
-Ghosthub's native recovery flow can reauthenticate. Other statuses pass through
-unchanged, so a normal tmux detach or a missing session does not create a
-reconnect loop. Host
-verification emits a marker only after the remote command begins. Status 255
-and local wrapper failures such as an unconfirmed timeout leave the host
-offline; a nonzero login-shell or probe-command status is reachable and
-degraded only when that marker proves the remote account executed the probe.
+Remote attachment and establishment shell commands are one-shot: they contain
+no retry timing and never print reconnect status into the terminal buffer.
+After a confirmed attachment exits with OpenSSH's transport/setup status 255,
+the scene's native supervisor probes the real SSH and tmux path at attempt-start
+intervals of 1, 2, 4, 8, 16, and then 30 seconds. Each probe has a 15-second
+end-to-end deadline; its runtime counts against the interval, and an overrun
+clamps the next delay to zero. Attempts never overlap. **Reconnect Now** wakes
+the same supervisor immediately instead of starting a parallel path.
+
+Default-socket recovery shares the host's in-flight `list-sessions` probe with
+inventory discovery. Protected sockets use a headless
+`tmux -L <socket> has-session -t =<name>` probe so an unsuccessful attempt never
+creates or flashes a terminal surface. Confirmed presence launches one new
+attach-only client. Confirmed absence ends a default-socket or protected-socket
+presentation only when that exact session had already been established; an
+unconfirmed interrupted kwt establishment may rerun its one-shot creation path.
+A reachable non-transport tmux failure is presented as unable to attach rather
+than retried indefinitely. A clean detach does not start recovery.
+
+Transport failures continue retrying automatically, with no more than 30
+seconds between attempt starts. Authentication and host-key review failures
+pause automatic retry and open the existing native recovery flow. Successful
+recovery resumes the same supervisor. Dismissing it leaves an honest
+**Connection needs attention** presentation with **Review Connection** when
+native review is available and **Host Settings** otherwise. A changed known-host
+identity still requires the explicit known-hosts remediation described by that
+flow; Ghosthub never silently accepts it.
+
+A direct connection's OpenSSH `LocalCommand` writes a private marker after
+transport and authentication succeed. Host verification emits a marker only
+after the remote command begins. Status 255 and local wrapper failures such as
+an unconfirmed timeout leave the host offline; a nonzero login-shell or
+probe-command status is reachable and degraded only when that marker proves the
+remote account executed the probe.
 
 The initial psmux path allocates an ordinary SSH PTY and targets Windows 11
 build 22523 or newer. Older ConPTY builds preserve keyboard input but consume

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -215,10 +215,11 @@ the app lifetime, so an app crash terminates the SSH master and a later launch
 cannot reuse its socket.
 Remote attachment and establishment shell commands are one-shot: they contain
 no retry timing and never print reconnect status into the terminal buffer.
-Each local OpenSSH wrapper records its exact exit status in an app-owned,
-per-attachment temporary file before it exits. The native coordinator consumes
-that status instead of relying on libghostty's outer macOS login process, whose
-reported status may be zero even when nested OpenSSH exited 255.
+The local wrapper around each complete remote command records its final status
+in an app-owned, per-attachment temporary file before it exits. The native
+coordinator consumes that status instead of relying on libghostty's outer macOS
+login process, whose reported status may be zero even when nested OpenSSH
+exited 255.
 After a confirmed attachment exits with OpenSSH's transport/setup status 255,
 the scene's native supervisor probes the real SSH and tmux path at attempt-start
 intervals of 1, 2, 4, 8, 16, and then 30 seconds. Each probe has a 15-second

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -242,7 +242,9 @@ seconds between attempt starts. Authentication and host-key review failures
 pause automatic retry and open the existing native recovery flow. Successful
 recovery resumes the same supervisor. If SSH is already reachable when that
 flow checks again, **Retry** resumes the supervisor as well as refreshing host
-inventory. Dismissing it leaves an honest
+inventory. Only the recovery flow opened for that active tmux request may
+resume it; authentication started from ordinary host inventory never reopens a
+session. Dismissing it leaves an honest
 **Connection needs attention** presentation with **Review Connection** when
 native review is available and **Host Settings** otherwise. A changed known-host
 identity still requires the explicit known-hosts remediation described by that

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -240,7 +240,9 @@ than retried indefinitely. A clean detach does not start recovery.
 Transport failures continue retrying automatically, with no more than 30
 seconds between attempt starts. Authentication and host-key review failures
 pause automatic retry and open the existing native recovery flow. Successful
-recovery resumes the same supervisor. Dismissing it leaves an honest
+recovery resumes the same supervisor. If SSH is already reachable when that
+flow checks again, **Retry** resumes the supervisor as well as refreshing host
+inventory. Dismissing it leaves an honest
 **Connection needs attention** presentation with **Review Connection** when
 native review is available and **Host Settings** otherwise. A changed known-host
 identity still requires the explicit known-hosts remediation described by that

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -215,6 +215,10 @@ the app lifetime, so an app crash terminates the SSH master and a later launch
 cannot reuse its socket.
 Remote attachment and establishment shell commands are one-shot: they contain
 no retry timing and never print reconnect status into the terminal buffer.
+Each local OpenSSH wrapper records its exact exit status in an app-owned,
+per-attachment temporary file before it exits. The native coordinator consumes
+that status instead of relying on libghostty's outer macOS login process, whose
+reported status may be zero even when nested OpenSSH exited 255.
 After a confirmed attachment exits with OpenSSH's transport/setup status 255,
 the scene's native supervisor probes the real SSH and tmux path at attempt-start
 intervals of 1, 2, 4, 8, 16, and then 30 seconds. Each probe has a 15-second

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -246,7 +246,9 @@ inventory. Only the recovery flow opened for that active tmux request may
 resume it; authentication started from ordinary host inventory never reopens a
 session. Dismissing it leaves an honest
 **Connection needs attention** presentation with **Review Connection** when
-native review is available and **Host Settings** otherwise. A changed known-host
+native review is available; reopening that review retains the active recovery
+request and can resume its supervisor after success. **Host Settings** remains
+the fallback otherwise. A changed known-host
 identity still requires the explicit known-hosts remediation described by that
 flow; Ghosthub never silently accepts it.
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -207,7 +207,9 @@ const imageAlt = {
               finishes, <strong>Retry</strong> resumes the same automatic
               reconnect supervisor immediately. Authentication opened from an
               ordinary host inventory warning only refreshes that inventory;
-              it never reopens a tmux session.
+              it never reopens a tmux session. If you dismiss a session’s
+              recovery sheet, <strong>Review Connection</strong> reopens the
+              same recovery request so successful review can resume it.
             </p>
           </aside>
         </div>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -205,7 +205,9 @@ const imageAlt = {
               <strong>Connection needs attention</strong> and opens the native
               recovery flow. If the connection has recovered before that check
               finishes, <strong>Retry</strong> resumes the same automatic
-              reconnect supervisor immediately.
+              reconnect supervisor immediately. Authentication opened from an
+              ordinary host inventory warning only refreshes that inventory;
+              it never reopens a tmux session.
             </p>
           </aside>
         </div>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -203,7 +203,9 @@ const imageAlt = {
               session with the server-side process state still intact. If SSH
               needs authentication or host-key review, the screen changes to
               <strong>Connection needs attention</strong> and opens the native
-              recovery flow.
+              recovery flow. If the connection has recovered before that check
+              finishes, <strong>Retry</strong> resumes the same automatic
+              reconnect supervisor immediately.
             </p>
           </aside>
         </div>

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -195,10 +195,15 @@ const imageAlt = {
           <aside class="reconnect">
             <span aria-hidden="true">↻</span>
             <p>
-              <strong>Lose your connection?</strong> Ghosthub retries SSH with
-              keepalives and bounded backoff. When connectivity returns, it
-              automatically reattaches to the same exact tmux session, with
-              the server-side process state still intact.
+              <strong>Lose your connection?</strong> Ghosthub shows a calm
+              connection-interrupted screen and keeps trying automatically,
+              with no more than 30 seconds between attempts. Choose
+              <strong>Reconnect Now</strong> to try immediately. When
+              connectivity returns, Ghosthub reattaches to the same exact tmux
+              session with the server-side process state still intact. If SSH
+              needs authentication or host-key review, the screen changes to
+              <strong>Connection needs attention</strong> and opens the native
+              recovery flow.
             </p>
           </aside>
         </div>


### PR DESCRIPTION
When an SSH transport dropped, Ghosthub delegated recovery to a shell loop that eventually exited and left the user with a manual reconnect button. That violated the terminal ownership contract: tmux owns session lifetime, while Ghosthub must keep the client presentation connected.

This moves connection-lifetime supervision into the app. Remote presentations now show a native waiting state, probe the authoritative tmux endpoint with bounded backoff, and reattach automatically when connectivity returns; Reconnect Now simply wakes the same supervisor. Clean detaches, ended sessions, reachable attach failures, authentication failures, and host-key review remain distinct so the UI never promises recovery when native attention is required. Confirmed sessions reconnect attach-only and cannot accidentally rerun workspace creation.

Validated with SwiftFormat, 46 libghostty bootstrap tests, 132 Python tests, the full Swift and libghostty smoke suites, the essential kwt/tmux/sidebar workflows, and a packaged app build. RoboRev is clear.