### PR TITLE
Ignore local worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Vendor/ghostty/
 # Local test and task state
 test-results/
 .kata.local.toml
+.worktrees/
 
 # roborev snapshots
 /.roborev/


### PR DESCRIPTION
Local .worktrees/ directories are development-only state created for isolated checkouts. Leaving them unignored makes fresh worktrees show repository noise and increases the chance that local state is accidentally staged.

Add a repository-level ignore rule so isolated checkout state stays local without changing tracked project files. The change is limited to ignore configuration; git diff --check and git check-ignore confirm the rule is valid and effective.