### PR TITLE
Wait for reconnect supervisor completion

### DIFF
--- a/Tests/App/TmuxSessionReconnectSupervisorTests.swift
+++ b/Tests/App/TmuxSessionReconnectSupervisorTests.swift
@@ -93,7 +93,9 @@ struct TmuxSessionReconnectSupervisorTests {
             return count == 3 ? .stop : .retry
         }
 
-        await waitUntilMainActor { attempts.count == 3 }
+        await waitUntilMainActor {
+            attempts.count == 3 && !supervisor.isRunning
+        }
 
         #expect(!supervisor.isRunning)
     }
@@ -116,7 +118,7 @@ struct TmuxSessionReconnectSupervisorTests {
 
         supervisor.reconnectNow()
         await waitUntilMainActor(timeout: .milliseconds(250)) {
-            attempts.count == 2
+            attempts.count == 2 && !supervisor.isRunning
         }
 
         #expect(!supervisor.isRunning)


### PR DESCRIPTION
The reconnect supervisor's attempt callback increments its test counter before the supervisor drains the deadline task and applies `.stop`. On loaded CI runners, the test can therefore see the expected attempt count while `isRunning` is legitimately still true for a few scheduler turns, producing the false failure seen in [CI run 31116119488](https://github.com/kenn-io/ghosthub/actions/runs/31116119488/job/92665995271).

This waits for the complete observable contract—the expected attempt count and a stopped supervisor—in both stop-path tests. Production scheduling is unchanged. The targeted suite passed 25 consecutive repetitions, the full 959-test Swift suite passed, and the app build is green.