### PR TITLE
Add Ghostty-style tmux pane splitting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,9 @@ layer, as subject to direct iteration.
   must coordinate privately with Kenn Software and sign the CLA before their
   work can be accepted.
 - Never include superpowers planning documents (`docs/superpowers/specs/`,
-  `docs/superpowers/plans/`) in a pull request. They are local working
-  artifacts; remove them from the branch before pushing or opening a pull
-  request.
+  `docs/superpowers/plans/`) in a pull request. Creating and using them locally
+  during development is fine; they are local working artifacts. Remove them
+  from the branch before pushing, opening, or updating a pull request.
 - Do not poll or watch GitHub Actions through `gh`, the GitHub API, or browser automation unless the user explicitly asks you to do so.
 - **NO DATABASE MIGRATIONS** until the first production release. Update the current schema, bootstrap paths, fixtures, and tests directly.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Ghosthub requires:
 - macOS 26 (Tahoe) or newer
 - tmux 3.2 or newer locally and on remote macOS or Linux hosts
 
+Cmd-D and Cmd-Shift-D pane splitting requires tmux 3.4 or newer on the host.
+Older tmux versions remain supported through their normal pane-splitting keys.
+
 Experimental native Windows hosts require Windows 11 build 22523 or newer,
 OpenSSH, Windows PowerShell 5.1 or newer, and psmux with its `tmux.exe`
 compatibility alias available.

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import GhosthubSettings
 import GhosthubTerminal
+import GhosthubTerminalSupport
 import GhosthubUI
 import GhosthubWorkspace
 #if canImport(AppKit)
@@ -15,6 +16,30 @@ enum QuitPolicy {
     }
 }
 
+#if canImport(AppKit)
+enum PaneSplitCommand {
+    static func usesKeyboardShortcut(
+        canSplit: Bool,
+        hasEffectiveKeyboardFocus: Bool
+    ) -> Bool {
+        canSplit && hasEffectiveKeyboardFocus
+    }
+
+    @MainActor
+    static func requiresKeyboardFocus(
+        _ shortcut: TerminalTmuxSplitShortcut,
+        currentEvent: NSEvent? = NSApplication.shared.currentEvent
+    ) -> Bool {
+        guard currentEvent?.type == .keyDown else { return false }
+        return TerminalTmuxSplitShortcut.matching(
+            flags: currentEvent?.modifierFlags ?? [],
+            charactersIgnoringModifiers:
+            currentEvent?.charactersIgnoringModifiers
+        ) == shortcut
+    }
+}
+#endif
+
 @main
 struct GhosthubApp: App {
     @StateObject private var terminalRuntime = LibghosttyRuntime.shared
@@ -25,6 +50,8 @@ struct GhosthubApp: App {
     private let updateRelaunchRestorer = UpdateRelaunchRestorer()
     #endif
     @FocusedValue(\.sceneModel) private var focusedSceneModel
+    @FocusedValue(\.tmuxTerminalHasEffectiveKeyboardFocus)
+    private var tmuxTerminalHasEffectiveKeyboardFocus
     @Environment(\.openWindow) private var openWindow
     @State private var didRequestLaunchActivation = false
     #if canImport(AppKit)
@@ -275,6 +302,45 @@ struct GhosthubApp: App {
                 appDelegate.requestNewWorkspaceTab()
             }
             .keyboardShortcut("t")
+
+            Divider()
+
+            Button("Split Right") {
+                focusedSceneModel?.splitActiveTmuxPane(
+                    .right,
+                    requiresKeyboardFocus: PaneSplitCommand
+                        .requiresKeyboardFocus(.right)
+                )
+            }
+            .keyboardShortcut(
+                PaneSplitCommand.usesKeyboardShortcut(
+                    canSplit:
+                    focusedSceneModel?.canSplitActiveTmuxPane == true,
+                    hasEffectiveKeyboardFocus:
+                    tmuxTerminalHasEffectiveKeyboardFocus == true
+                ) ? KeyboardShortcut("d") : nil
+            )
+            .disabled(focusedSceneModel?.canSplitActiveTmuxPane != true)
+
+            Button("Split Down") {
+                focusedSceneModel?.splitActiveTmuxPane(
+                    .down,
+                    requiresKeyboardFocus: PaneSplitCommand
+                        .requiresKeyboardFocus(.down)
+                )
+            }
+            .keyboardShortcut(
+                PaneSplitCommand.usesKeyboardShortcut(
+                    canSplit:
+                    focusedSceneModel?.canSplitActiveTmuxPane == true,
+                    hasEffectiveKeyboardFocus:
+                    tmuxTerminalHasEffectiveKeyboardFocus == true
+                ) ? KeyboardShortcut(
+                    "d",
+                    modifiers: [.command, .shift]
+                ) : nil
+            )
+            .disabled(focusedSceneModel?.canSplitActiveTmuxPane != true)
 
             Divider()
 

--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -234,6 +234,19 @@ private struct NativeTmuxTerminalView: View {
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .textBackgroundColor))
+        .overlay(alignment: .top) {
+            if let message = surfaceView.tmuxSplitErrorMessage {
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .padding(10)
+                    .background(
+                        .regularMaterial,
+                        in: RoundedRectangle(cornerRadius: 8)
+                    )
+                    .padding()
+                    .allowsHitTesting(false)
+            }
+        }
         .onAppear {
             surfaceView.registerPaneCloseRequestObserver(
                 id: observerID,
@@ -247,5 +260,9 @@ private struct NativeTmuxTerminalView: View {
         .onDisappear {
             surfaceView.unregisterPaneFocusObserver(id: observerID)
         }
+        .focusedSceneValue(
+            \.tmuxTerminalHasEffectiveKeyboardFocus,
+            surfaceView.hasEffectiveKeyboardFocus
+        )
     }
 }

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -1,17 +1,37 @@
 import Foundation
 import GhosthubTerminal
+import GhosthubTerminalSupport
 import GhosthubTmux
 import GhosthubWorkspace
 
 @MainActor
 protocol TmuxPaneSurfacing: AnyObject {
     var blocksClipboardReads: Bool { get set }
+    var tmuxSplitShortcutHandler: ((TerminalTmuxSplitShortcut) -> Void)? {
+        get set
+    }
+    var tmuxSplitErrorMessage: String? { get set }
+    var hasEffectiveKeyboardFocus: Bool { get }
     var launchError: Error? { get }
     var childExitCode: UInt32? { get }
     func registerSurfaceCloseObserver(
         id: UUID,
         onSurfaceClosed: @escaping (Bool, UInt32?) -> Void
     )
+}
+
+extension TmuxPaneSurfacing {
+    var tmuxSplitShortcutHandler: ((TerminalTmuxSplitShortcut) -> Void)? {
+        get { nil }
+        set {}
+    }
+
+    var tmuxSplitErrorMessage: String? {
+        get { nil }
+        set {}
+    }
+
+    var hasEffectiveKeyboardFocus: Bool { false }
 }
 
 extension TerminalSurfaceView: TmuxPaneSurfacing {
@@ -33,11 +53,16 @@ protocol TmuxSurfaceStoring: AnyObject {
         for key: SurfaceKey,
         configuration: TerminalSurfaceConfiguration
     ) -> TmuxPaneSurfacing?
+    func paneSurfaceIfPresent(for key: SurfaceKey) -> TmuxPaneSurfacing?
     func surfaceIdentity(for key: SurfaceKey) -> UInt?
     func removeSurface(for key: SurfaceKey)
 }
 
 extension TmuxSurfaceStoring {
+    func paneSurfaceIfPresent(for _: SurfaceKey) -> TmuxPaneSurfacing? {
+        nil
+    }
+
     func surfaceIdentity(for _: SurfaceKey) -> UInt? {
         nil
     }
@@ -53,6 +78,10 @@ extension TerminalSurfaceCoordinator: TmuxSurfaceStoring {
 
     func surfaceIdentity(for key: SurfaceKey) -> UInt? {
         surfaceIfPresent(for: key)?.surfaceIdentity
+    }
+
+    func paneSurfaceIfPresent(for key: SurfaceKey) -> TmuxPaneSurfacing? {
+        surfaceIfPresent(for: key)
     }
 }
 
@@ -90,6 +119,11 @@ private struct NativeTmuxSessionKey: Hashable {
     var socketName: String?
 }
 
+private struct NativeTmuxPathCacheKey: Hashable {
+    var host: TmuxHost
+    var sshConnection: SSHConnectionArgumentsCacheKey
+}
+
 private struct NativeTmuxAttachment {
     var id: UUID
     var host: TmuxHost
@@ -103,7 +137,10 @@ private struct NativeTmuxAttachment {
     var initialCommand: String?
     var workingDirectory: String?
     var openWorkspace: Bool
-    var sshConnectionArguments: [String]
+    var sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
+    var sessionIdentity: TmuxSessionIdentity?
+    var paneSplitClientToken: String
+    var supportsPaneSplitting: Bool
     var remoteExitStatusURL: URL?
 }
 
@@ -112,13 +149,31 @@ private struct NativeTmuxAttachment {
 /// only binary resolution and the disposable local libghostty presentation.
 @MainActor
 final class NativeTmuxSessionCoordinator {
+    private struct PaneSplitRequest {
+        var shortcut: TerminalTmuxSplitShortcut
+        var target: TmuxPaneSplitTarget
+        var surface: any TmuxPaneSurfacing
+        var attachmentID: UUID
+    }
+
+    private struct PaneSplitWorker {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
+
+    private struct PaneSplitClientBinding {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
+
     private let terminalCoordinator: any TmuxSurfaceStoring
     private let tmuxPathProvider:
-        @Sendable () -> Result<String, TmuxBinaryError>
+        @Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>
     private let remoteTmuxPathProvider:
-        @Sendable (SSHHostInfo) -> Result<String, TmuxBinaryError>
+        @Sendable (SSHHostInfo, [String])
+        -> Result<ResolvedTmuxBinary, TmuxBinaryError>
     private let sshConnectionArgumentsProvider:
-        @Sendable (SSHHostInfo) -> [String]
+        @Sendable (SSHHostInfo) -> SSHConnectionArgumentsSnapshot
     private let localKwtPathProvider: @Sendable () -> String?
     private let remoteKwtCommandPreludeProvider: @Sendable () -> String?
     private let windowsKwtRelativePathProvider: @Sendable () -> String?
@@ -126,15 +181,21 @@ final class NativeTmuxSessionCoordinator {
     private let appliesPresentationStyleToExistingSessionsProvider:
         () -> Bool
     private let remoteExitStatusDirectory: URL
+    private let paneSplitter: TmuxPaneSplitter
     private var handlesByKey: [NativeTmuxSessionKey: BorrowedTmuxSessionHandle] = [:]
     private var targetHostsByHandle: [UUID: TmuxHost] = [:]
     private var attachments: [UUID: NativeTmuxAttachment] = [:]
     private var attachmentClosures: [UUID: BorrowedTmuxAttachmentClosure] = [:]
     private var launchedHandles: Set<UUID> = []
     private var reportedConnectedAttachmentIDs: [UUID: UUID] = [:]
-    private var tmuxPathsByHost: [TmuxHost: String] = [:]
+    private var tmuxBinariesByConnection:
+        [NativeTmuxPathCacheKey: ResolvedTmuxBinary] = [:]
     private var provisioningHandles: Set<UUID> = []
     private var provisioningTasks: [UUID: Task<Void, Never>] = [:]
+    private var paneSplitRequests: [UUID: [PaneSplitRequest]] = [:]
+    private var paneSplitWorkers: [UUID: PaneSplitWorker] = [:]
+    private var paneSplitClientBindings: [UUID: PaneSplitClientBinding] = [:]
+    private var paneSplitClients: [UUID: TmuxPaneSplitClientIdentity] = [:]
     private var deferredPresentationStyleHandles: Set<UUID> = []
     private var isShuttingDown = false
 
@@ -143,7 +204,8 @@ final class NativeTmuxSessionCoordinator {
 
     init(
         terminalCoordinator: any TmuxSurfaceStoring,
-        tmuxPathProvider: @escaping @Sendable () -> Result<String, TmuxBinaryError>,
+        tmuxPathProvider: @escaping @Sendable ()
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError>,
         localKwtPathProvider: @escaping @Sendable () -> String? = {
             KwtBinaryLocator.bundledPath()
         },
@@ -163,17 +225,43 @@ final class NativeTmuxSessionCoordinator {
         @escaping () -> TmuxPresentationStyle? = { nil },
         appliesPresentationStyleToExistingSessionsProvider:
         @escaping () -> Bool = { false },
-        remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
-            -> Result<String, TmuxBinaryError> = {
-                TmuxBinaryResolver().resolveTmuxPath(on: $0)
+        remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo, [String])
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError> = {
+                TmuxBinaryResolver().resolveTmuxBinary(
+                    on: $0,
+                    sshConnectionArguments: $1
+                )
             },
         sshConnectionArgumentsProvider:
-        @escaping @Sendable (SSHHostInfo) -> [String] = {
-            SSHConnectionPool.connectionArguments(for: $0)
-                + SSHConfigurationResolver.noninteractiveHostKeyArguments(
-                    for: $0
+        @escaping @Sendable (SSHHostInfo)
+            -> SSHConnectionArgumentsSnapshot = {
+                let snapshot = SSHConnectionPool.configurationSnapshot(for: $0)
+                let provider = snapshot.configurationProvider
+                let controlPath = SSHConnectionPool.authenticationIdentity(
+                    for: snapshot
+                )?.controlPath
+                let connectionSnapshot = SSHConfigurationResolver
+                    .connectionArgumentsSnapshot(
+                        for: $0,
+                        configurationProvider: provider
+                    )
+                return connectionSnapshot.replacingArguments(
+                    tmuxSSHConnectionArguments()
+                        + connectionSnapshot.arguments
+                        + SSHConnectionPool.proxyArguments(
+                            for: snapshot.target,
+                            configurationProvider: provider
+                        )
+                        + SSHConnectionPool.connectionArguments(
+                            controlPath: controlPath
+                        )
+                        + SSHConfigurationResolver.noninteractiveHostKeyArguments(
+                            for: $0,
+                            configurationProvider: provider
+                        )
                 )
-        },
+            },
+        paneSplitter: TmuxPaneSplitter = TmuxPaneSplitter(),
         remoteExitStatusDirectory: URL = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "ghosthub-tmux-exit-\(UUID().uuidString)",
@@ -193,6 +281,7 @@ final class NativeTmuxSessionCoordinator {
         self.remoteTmuxPathProvider = remoteTmuxPathProvider
         self.sshConnectionArgumentsProvider =
             sshConnectionArgumentsProvider
+        self.paneSplitter = paneSplitter
         self.remoteExitStatusDirectory = remoteExitStatusDirectory
     }
 
@@ -204,7 +293,8 @@ final class NativeTmuxSessionCoordinator {
         launchMode: TmuxAttachmentLaunchMode = .attach,
         initialCommand: String? = nil,
         workingDirectory: String? = nil,
-        openWorkspace: Bool = false
+        openWorkspace: Bool = false,
+        sessionIdentity: TmuxSessionIdentity? = nil
     ) -> BorrowedTmuxSessionHandle {
         let key = NativeTmuxSessionKey(
             hostID: hostID,
@@ -234,34 +324,43 @@ final class NativeTmuxSessionCoordinator {
 
         provisioningHandles.insert(handle.id)
         onStateChanged?(handle, .connecting)
-        let cachedPath = tmuxPathsByHost[host]
+        let cachedBinaries = tmuxBinariesByConnection
         let tmuxPathProvider = tmuxPathProvider
         let remoteTmuxPathProvider = remoteTmuxPathProvider
         let sshConnectionArgumentsProvider =
             sshConnectionArgumentsProvider
         provisioningTasks[handle.id] = Task { [weak self] in
             let probe = Task.detached(priority: .userInitiated) {
-                let resolution: Result<String, TmuxBinaryError>
-                if let cachedPath {
-                    resolution = .success(cachedPath)
+                let sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
+                if case let .ssh(info) = host {
+                    sshConnectionSnapshot =
+                        sshConnectionArgumentsProvider(info)
+                } else {
+                    sshConnectionSnapshot = SSHConnectionArgumentsSnapshot(
+                        arguments: []
+                    )
+                }
+                let cacheKey = NativeTmuxPathCacheKey(
+                    host: host,
+                    sshConnection: sshConnectionSnapshot.cacheKey
+                )
+                let resolution: Result<ResolvedTmuxBinary, TmuxBinaryError>
+                if let cachedBinary = cachedBinaries[cacheKey] {
+                    resolution = .success(cachedBinary)
                 } else {
                     switch host {
                     case .local:
                         resolution = tmuxPathProvider()
                     case let .ssh(info):
-                        resolution = remoteTmuxPathProvider(info)
+                        resolution = remoteTmuxPathProvider(
+                            info,
+                            sshConnectionSnapshot.arguments
+                        )
                     }
                 }
-                let sshConnectionArguments: [String]
-                if case let .ssh(info) = host {
-                    sshConnectionArguments =
-                        sshConnectionArgumentsProvider(info)
-                } else {
-                    sshConnectionArguments = []
-                }
-                return (resolution, sshConnectionArguments)
+                return (resolution, sshConnectionSnapshot, cacheKey)
             }
-            let (resolution, sshConnectionArguments) =
+            let (resolution, sshConnectionSnapshot, cacheKey) =
                 await withTaskCancellationHandler {
                     await probe.value
                 } onCancel: {
@@ -275,7 +374,9 @@ final class NativeTmuxSessionCoordinator {
                 initialCommand: launchMode == .create ? initialCommand : nil,
                 workingDirectory: workingDirectory,
                 openWorkspace: openWorkspace,
-                sshConnectionArguments: sshConnectionArguments,
+                sessionIdentity: sessionIdentity,
+                sshConnectionSnapshot: sshConnectionSnapshot,
+                tmuxPathCacheKey: cacheKey,
                 resolution: resolution
             )
         }
@@ -290,8 +391,10 @@ final class NativeTmuxSessionCoordinator {
         initialCommand: String?,
         workingDirectory: String?,
         openWorkspace: Bool,
-        sshConnectionArguments: [String],
-        resolution: Result<String, TmuxBinaryError>
+        sessionIdentity: TmuxSessionIdentity?,
+        sshConnectionSnapshot: SSHConnectionArgumentsSnapshot,
+        tmuxPathCacheKey: NativeTmuxPathCacheKey,
+        resolution: Result<ResolvedTmuxBinary, TmuxBinaryError>
     ) {
         provisioningTasks.removeValue(forKey: handle.id)
         provisioningHandles.remove(handle.id)
@@ -300,15 +403,16 @@ final class NativeTmuxSessionCoordinator {
               targetHostsByHandle[handle.id] == host,
               attachments[handle.id] == nil else { return }
         switch resolution {
-        case let .success(path):
-            tmuxPathsByHost[host] = path
+        case let .success(resolved):
+            tmuxBinariesByConnection[tmuxPathCacheKey] = resolved
+            let attachmentID = UUID()
             let protectedWorkspacePath = socketName == nil
                 ? nil
                 : workingDirectory
             attachments[handle.id] = NativeTmuxAttachment(
-                id: UUID(),
+                id: attachmentID,
                 host: host,
-                tmuxPath: path,
+                tmuxPath: resolved.path,
                 kwtPath: host.isRemote ? nil : localKwtPathProvider(),
                 remoteKwtCommandPrelude: host.isRemote
                     ? remoteKwtCommandPreludeProvider()
@@ -322,7 +426,14 @@ final class NativeTmuxSessionCoordinator {
                 initialCommand: launchMode == .create ? initialCommand : nil,
                 workingDirectory: workingDirectory,
                 openWorkspace: openWorkspace,
-                sshConnectionArguments: sshConnectionArguments,
+                sshConnectionSnapshot: sshConnectionSnapshot,
+                sessionIdentity: sessionIdentity,
+                paneSplitClientToken: attachmentID.uuidString.lowercased(),
+                supportsPaneSplitting: TmuxPaneSplitter
+                    .supportsPaneSplitting(
+                        version: resolved.version,
+                        host: host
+                    ),
                 remoteExitStatusURL: host.isRemote
                     ? prepareRemoteExitStatusFile()
                     : nil
@@ -366,6 +477,7 @@ final class NativeTmuxSessionCoordinator {
             handlesByKey.removeValue(forKey: key)
         }
         provisioningTasks.removeValue(forKey: handle.id)?.cancel()
+        cancelPaneSplits(handleID: handle.id)
         provisioningHandles.remove(handle.id)
         targetHostsByHandle.removeValue(forKey: handle.id)
         removeRemoteExitStatusFile(attachments.removeValue(forKey: handle.id))
@@ -445,10 +557,11 @@ final class NativeTmuxSessionCoordinator {
                     windowsKwtRelativePath:
                     attachment.windowsKwtRelativePath,
                     workingDirectory: attachment.workingDirectory,
-                    sshConnectionArguments: tmuxSSHConnectionArguments()
-                        + attachment.sshConnectionArguments,
+                    sshConnectionArguments:
+                    attachment.sshConnectionSnapshot.arguments,
                     remoteExitStatusPath:
-                    attachment.remoteExitStatusURL?.path
+                    attachment.remoteExitStatusURL?.path,
+                    clientTTYToken: attachment.paneSplitClientToken
                 )
             )
         )
@@ -468,6 +581,29 @@ final class NativeTmuxSessionCoordinator {
             deferredPresentationStyleHandles.insert(handle.id)
         }
         surface.blocksClipboardReads = attachment.host.isRemote
+        let splitTarget = TmuxPaneSplitTarget(
+            host: attachment.host,
+            tmuxPath: attachment.tmuxPath,
+            sessionName: handle.name,
+            socketName: attachment.socketName,
+            sshConnectionArguments: attachment.sshConnectionSnapshot.arguments,
+            expectedIdentity: attachment.sessionIdentity,
+            clientToken: attachment.paneSplitClientToken,
+            expectedClient: paneSplitClients[handle.id]
+        )
+        if attachment.supportsPaneSplitting {
+            surface.tmuxSplitShortcutHandler = {
+                [weak self, weak surface] shortcut in
+                guard let self, let surface else { return }
+                enqueuePaneSplit(
+                    shortcut,
+                    target: splitTarget,
+                    surface: surface,
+                    handle: handle,
+                    attachmentID: attachment.id
+                )
+            }
+        }
         surface.registerSurfaceCloseObserver(
             id: handle.id,
             onSurfaceClosed: { [weak self] processAlive, childExitCode in
@@ -479,6 +615,11 @@ final class NativeTmuxSessionCoordinator {
             }
         )
         launchedHandles.insert(handle.id)
+        startPaneSplitClientBinding(
+            target: splitTarget,
+            handle: handle,
+            attachmentID: attachment.id
+        )
         if reportedConnectedAttachmentIDs[handle.id] != attachment.id {
             reportedConnectedAttachmentIDs[handle.id] = attachment.id
             reportSurfaceStateLater(
@@ -490,10 +631,169 @@ final class NativeTmuxSessionCoordinator {
         return surface as? TerminalSurfaceView
     }
 
+    private func enqueuePaneSplit(
+        _ shortcut: TerminalTmuxSplitShortcut,
+        target: TmuxPaneSplitTarget,
+        surface: any TmuxPaneSurfacing,
+        handle: BorrowedTmuxSessionHandle,
+        attachmentID: UUID
+    ) {
+        guard let client = paneSplitClients[handle.id] else {
+            surface.tmuxSplitErrorMessage = TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux client identity is unavailable."
+            ).localizedDescription
+            startPaneSplitClientBinding(
+                target: target,
+                handle: handle,
+                attachmentID: attachmentID
+            )
+            return
+        }
+        var target = target
+        target.expectedClient = client
+        paneSplitRequests[handle.id, default: []].append(PaneSplitRequest(
+            shortcut: shortcut,
+            target: target,
+            surface: surface,
+            attachmentID: attachmentID
+        ))
+        guard paneSplitWorkers[handle.id] == nil else { return }
+
+        let workerID = UUID()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await runPaneSplitQueue(
+                handle: handle,
+                workerID: workerID
+            )
+        }
+        paneSplitWorkers[handle.id] = PaneSplitWorker(
+            id: workerID,
+            task: task
+        )
+    }
+
+    private func runPaneSplitQueue(
+        handle: BorrowedTmuxSessionHandle,
+        workerID: UUID
+    ) async {
+        defer {
+            if paneSplitWorkers[handle.id]?.id == workerID {
+                paneSplitWorkers.removeValue(forKey: handle.id)
+                paneSplitRequests.removeValue(forKey: handle.id)
+            }
+        }
+
+        while !Task.isCancelled {
+            guard paneSplitWorkers[handle.id]?.id == workerID,
+                  var requests = paneSplitRequests[handle.id],
+                  !requests.isEmpty
+            else { return }
+            let request = requests.removeFirst()
+            paneSplitRequests[handle.id] = requests
+            guard attachments[handle.id]?.id == request.attachmentID,
+                  launchedHandles.contains(handle.id)
+            else { continue }
+
+            request.surface.tmuxSplitErrorMessage = nil
+            var target = request.target
+            let expectedClient = target.expectedClient
+                ?? paneSplitClients[handle.id]
+            target.expectedClient = expectedClient
+            switch await paneSplitter.clientIdentity(target: target) {
+            case let .success(client):
+                guard attachments[handle.id]?.id == request.attachmentID
+                else { return }
+                if let expectedClient,
+                   !client.matchesClient(expectedClient) {
+                    let failure = TmuxPaneSplitFailure(
+                        host: target.host.displayName,
+                        sessionName: target.sessionName,
+                        status: 75,
+                        diagnostic: "The attached tmux session changed."
+                    )
+                    request.surface.tmuxSplitErrorMessage =
+                        failure.localizedDescription
+                    continue
+                }
+                paneSplitClients[handle.id] = client
+                target.expectedIdentity = client.sessionIdentity
+                target.expectedClient = client
+            case let .failure(failure):
+                guard !Task.isCancelled,
+                      paneSplitWorkers[handle.id]?.id == workerID,
+                      attachments[handle.id]?.id == request.attachmentID
+                else { return }
+                request.surface.tmuxSplitErrorMessage =
+                    failure.localizedDescription
+                continue
+            }
+            let failure = await paneSplitter.split(
+                request.shortcut,
+                target: target
+            )
+            guard !Task.isCancelled,
+                  paneSplitWorkers[handle.id]?.id == workerID,
+                  attachments[handle.id]?.id == request.attachmentID
+            else { return }
+            request.surface.tmuxSplitErrorMessage = failure?.localizedDescription
+            if let failure {
+                AppLogger.shared.error(
+                    "tmux pane split: \(failure.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    private func startPaneSplitClientBinding(
+        target: TmuxPaneSplitTarget,
+        handle: BorrowedTmuxSessionHandle,
+        attachmentID: UUID
+    ) {
+        guard attachments[handle.id]?.id == attachmentID,
+              attachments[handle.id]?.supportsPaneSplitting == true,
+              launchedHandles.contains(handle.id),
+              paneSplitClients[handle.id] == nil,
+              paneSplitClientBindings[handle.id] == nil
+        else { return }
+
+        let bindingID = UUID()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let result = await paneSplitter.clientIdentity(target: target)
+            guard !Task.isCancelled,
+                  paneSplitClientBindings[handle.id]?.id == bindingID,
+                  attachments[handle.id]?.id == attachmentID
+            else { return }
+            paneSplitClientBindings.removeValue(forKey: handle.id)
+            guard case let .success(client) = result else { return }
+            paneSplitClients[handle.id] = client
+            terminalCoordinator.paneSurfaceIfPresent(
+                for: surfaceKey(handle)
+            )?.tmuxSplitErrorMessage = nil
+            onSurfaceReady?(handle)
+        }
+        paneSplitClientBindings[handle.id] = PaneSplitClientBinding(
+            id: bindingID,
+            task: task
+        )
+    }
+
+    private func cancelPaneSplits(handleID: UUID) {
+        paneSplitClientBindings.removeValue(forKey: handleID)?.task.cancel()
+        paneSplitWorkers.removeValue(forKey: handleID)?.task.cancel()
+        paneSplitRequests.removeValue(forKey: handleID)
+        paneSplitClients.removeValue(forKey: handleID)
+    }
+
     private func failSurfaceLaunch(
         _ handle: BorrowedTmuxSessionHandle,
         reason: String
     ) {
+        cancelPaneSplits(handleID: handle.id)
         attachmentClosures[handle.id] = .launchFailed
         removeRemoteExitStatusFile(attachments.removeValue(forKey: handle.id))
         reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
@@ -507,6 +807,23 @@ final class NativeTmuxSessionCoordinator {
 
     func surfaceIdentity(handle: BorrowedTmuxSessionHandle) -> UInt? {
         terminalCoordinator.surfaceIdentity(for: surfaceKey(handle))
+    }
+
+    func supportsPaneSplitting(_ handle: BorrowedTmuxSessionHandle) -> Bool {
+        attachments[handle.id]?.supportsPaneSplitting == true
+    }
+
+    func requestPaneSplit(
+        _ shortcut: TerminalTmuxSplitShortcut,
+        handle: BorrowedTmuxSessionHandle,
+        requiresKeyboardFocus: Bool
+    ) {
+        guard let surface = terminalCoordinator.paneSurfaceIfPresent(
+            for: surfaceKey(handle)
+        ),
+            !requiresKeyboardFocus || surface.hasEffectiveKeyboardFocus
+        else { return }
+        surface.tmuxSplitShortcutHandler?(shortcut)
     }
 
     private func reportSurfaceStateLater(
@@ -536,6 +853,7 @@ final class NativeTmuxSessionCoordinator {
         let key = sessionKey(handle)
         guard handlesByKey[key] == handle else { return }
         let attachment = attachments.removeValue(forKey: handle.id)
+        cancelPaneSplits(handleID: handle.id)
         let recordedExitCode = consumeRemoteExitStatus(attachment)
         if let recordedExitCode {
             attachmentClosures[handle.id] = recordedExitCode == 0
@@ -561,7 +879,13 @@ final class NativeTmuxSessionCoordinator {
         isShuttingDown = true
         let handles = Array(handlesByKey.values)
         provisioningTasks.values.forEach { $0.cancel() }
+        paneSplitClientBindings.values.forEach { $0.task.cancel() }
+        paneSplitWorkers.values.forEach { $0.task.cancel() }
         provisioningTasks.removeAll()
+        paneSplitClientBindings.removeAll()
+        paneSplitWorkers.removeAll()
+        paneSplitRequests.removeAll()
+        paneSplitClients.removeAll()
         provisioningHandles.removeAll()
         handlesByKey.removeAll()
         targetHostsByHandle.removeAll()
@@ -634,4 +958,5 @@ final class NativeTmuxSessionCoordinator {
             socketName: handle.socketName
         )
     }
+
 }

--- a/Sources/App/SSHConfigurationResolver.swift
+++ b/Sources/App/SSHConfigurationResolver.swift
@@ -37,7 +37,91 @@ struct EffectiveProxyJumpHop: Sendable {
     let configuration: EffectiveSSHConfiguration
 }
 
+private final class TemporarySSHConfiguration: @unchecked Sendable {
+    let url: URL
+    private let directory: URL
+
+    init(url: URL, directory: URL) {
+        self.url = url
+        self.directory = directory
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+struct SSHConnectionArgumentsCacheKey: Hashable, Sendable {
+    let arguments: [String]
+    let configurationLines: [String]
+}
+
+struct SSHConnectionArgumentsSnapshot: Sendable {
+    let arguments: [String]
+    let cacheKey: SSHConnectionArgumentsCacheKey
+    private let temporaryConfiguration: TemporarySSHConfiguration?
+
+    var configurationURL: URL? { temporaryConfiguration?.url }
+
+    init(arguments: [String]) {
+        self.arguments = arguments
+        cacheKey = SSHConnectionArgumentsCacheKey(
+            arguments: arguments,
+            configurationLines: []
+        )
+        temporaryConfiguration = nil
+    }
+
+    fileprivate init(
+        arguments: [String],
+        cacheKey: SSHConnectionArgumentsCacheKey,
+        temporaryConfiguration: TemporarySSHConfiguration?
+    ) {
+        self.arguments = arguments
+        self.cacheKey = cacheKey
+        self.temporaryConfiguration = temporaryConfiguration
+    }
+
+    func replacingArguments(
+        _ arguments: [String]
+    ) -> SSHConnectionArgumentsSnapshot {
+        let configurationPath = temporaryConfiguration?.url.path
+        return SSHConnectionArgumentsSnapshot(
+            arguments: arguments,
+            cacheKey: SSHConnectionArgumentsCacheKey(
+                arguments: arguments.map {
+                    $0 == configurationPath ? "/dev/null" : $0
+                },
+                configurationLines: cacheKey.configurationLines
+            ),
+            temporaryConfiguration: temporaryConfiguration
+        )
+    }
+}
+
 enum SSHConfigurationResolver {
+    private static let connectionConfigurationOptions = [
+        "addkeystoagent": "AddKeysToAgent",
+        "certificatefile": "CertificateFile",
+        "enablesshkeysign": "EnableSSHKeysign",
+        "forwardagent": "ForwardAgent",
+        "gssapiauthentication": "GSSAPIAuthentication",
+        "gssapidelegatecredentials": "GSSAPIDelegateCredentials",
+        "hostbasedacceptedalgorithms": "HostbasedAcceptedAlgorithms",
+        "hostbasedauthentication": "HostbasedAuthentication",
+        "identitiesonly": "IdentitiesOnly",
+        "identityagent": "IdentityAgent",
+        "identityfile": "IdentityFile",
+        "kbdinteractiveauthentication": "KbdInteractiveAuthentication",
+        "passwordauthentication": "PasswordAuthentication",
+        "pkcs11provider": "PKCS11Provider",
+        "preferredauthentications": "PreferredAuthentications",
+        "pubkeyacceptedalgorithms": "PubkeyAcceptedAlgorithms",
+        "pubkeyauthentication": "PubkeyAuthentication",
+        "securitykeyprovider": "SecurityKeyProvider",
+        "usekeychain": "UseKeychain",
+    ]
+
     typealias ConfigurationProvider = @Sendable (SSHHostInfo)
         -> EffectiveSSHConfiguration?
 
@@ -350,7 +434,71 @@ enum SSHConfigurationResolver {
                 "addressfamily",
                 "bindaddress",
                 "bindinterface",
+                "escapechar",
+                "sendenv",
             ]
+        )
+    }
+
+    static func connectionArgumentsSnapshot(
+        for host: SSHHostInfo,
+        configurationProvider: ConfigurationProvider,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) -> SSHConnectionArgumentsSnapshot {
+        let configuration = configurationProvider(host)
+        let frozenProvider: ConfigurationProvider = { _ in configuration }
+        var arguments = snapshotConnectionArguments(
+            for: host,
+            configurationProvider: frozenProvider
+        )
+        let configurationLines = connectionConfigurationLines(configuration)
+        guard !configurationLines.isEmpty else {
+            return SSHConnectionArgumentsSnapshot(arguments: arguments)
+        }
+
+        let directory = temporaryDirectory.appendingPathComponent(
+            "ghosthub-ssh-snapshot-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let url = directory.appendingPathComponent("config")
+        let contents = configurationLines.joined(separator: "\n") + "\n"
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            guard FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data(contents.utf8),
+                attributes: [.posixPermissions: 0o600]
+            ) else { throw CocoaError(.fileWriteUnknown) }
+        } catch {
+            try? FileManager.default.removeItem(at: directory)
+            return SSHConnectionArgumentsSnapshot(arguments: [
+                "-F", "/dev/null",
+                "-o", "ProxyCommand=/usr/bin/false",
+            ])
+        }
+        if arguments.count >= 2,
+           arguments[0] == "-F",
+           arguments[1] == "/dev/null" {
+            arguments[1] = url.path
+        } else {
+            arguments.insert(contentsOf: ["-F", url.path], at: 0)
+        }
+        return SSHConnectionArgumentsSnapshot(
+            arguments: arguments,
+            cacheKey: SSHConnectionArgumentsCacheKey(
+                arguments: arguments.map {
+                    $0 == url.path ? "/dev/null" : $0
+                },
+                configurationLines: configurationLines
+            ),
+            temporaryConfiguration: TemporarySSHConfiguration(
+                url: url,
+                directory: directory
+            )
         )
     }
 
@@ -472,5 +620,30 @@ enum SSHConfigurationResolver {
     private static func meaningfulProxyValue(_ value: String?) -> String? {
         guard let value, value.lowercased() != "none" else { return nil }
         return value
+    }
+
+    private static func connectionConfigurationLines(
+        _ configuration: EffectiveSSHConfiguration?
+    ) -> [String] {
+        configuration?.resolvedOptions.compactMap { option in
+            guard let separator = option.firstIndex(of: "=") else {
+                return nil
+            }
+            let name = String(option[..<separator]).lowercased()
+            let value = String(option[option.index(after: separator)...])
+            if name == "setenv" {
+                return "SetEnv \(quotedConfigurationValue(value))"
+            }
+            guard let directive = connectionConfigurationOptions[name] else {
+                return nil
+            }
+            return "\(directive) \(quotedConfigurationValue(value))"
+        } ?? []
+    }
+
+    private static func quotedConfigurationValue(_ value: String) -> String {
+        "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"") + "\""
     }
 }

--- a/Sources/App/SSHConnectionPool.swift
+++ b/Sources/App/SSHConnectionPool.swift
@@ -357,23 +357,27 @@ enum SSHConnectionPool {
             SSHConfigurationResolver.configuration
     ) -> String? {
         guard let proxy = target.precedingTarget,
-              let controlPath = authenticationIdentity(
+              let identity = authenticationIdentity(
                   for: proxy,
                   configurationProvider: configurationProvider
-              )?.controlPath
+              )
         else { return nil }
+        let endpoint = identity.displayHost
         var arguments = [
             "/usr/bin/ssh",
+            "-F", "/dev/null",
             "-o", "BatchMode=yes",
             "-o", "ControlMaster=no",
             "-o", "ControlPersist=no",
-            "-o", "ControlPath=\(controlPath)",
+            "-o", "ControlPath=\(identity.controlPath)",
+            "-o", "ProxyJump=none",
+            "-o", "ProxyCommand=/usr/bin/false",
         ]
-        if let port = proxy.host.port {
+        if let port = endpoint.port {
             arguments.append(contentsOf: ["-p", String(port)])
         }
         arguments.append(contentsOf: [
-            "-W", "[%h]:%p", destination(for: proxy.host),
+            "-W", "[%h]:%p", destination(for: endpoint),
         ])
         return arguments.map(shellQuotedCommandArgument).joined(separator: " ")
     }

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -46,7 +46,7 @@ enum TmuxBinaryError: Error, Equatable, LocalizedError, Sendable {
     case probeCancelled(shell: String)
     case probeOutputExceeded(shell: String)
     case sessionContextUnavailable
-    case unsupportedVersion(found: String)
+    case unsupportedVersion(found: String, minimum: String)
     case ownershipPersistenceFailed
 
     var errorDescription: String? {
@@ -72,8 +72,8 @@ enum TmuxBinaryError: Error, Equatable, LocalizedError, Sendable {
                 + " output. Check noisy shell startup files and retry."
         case .sessionContextUnavailable:
             return "The worktree is no longer available for terminal setup."
-        case let .unsupportedVersion(found):
-            return "Ghosthub requires tmux 3.2 or newer, but found"
+        case let .unsupportedVersion(found, minimum):
+            return "Ghosthub requires tmux \(minimum) or newer, but found"
                 + " \(found.isEmpty ? "an unrecognized version" : found)."
         case .ownershipPersistenceFailed:
             return "Ghosthub could not save the tmux session ownership"
@@ -107,6 +107,11 @@ struct DiscoveredTmuxSession: Equatable, Sendable {
     }
 }
 
+struct ResolvedTmuxBinary: Equatable, Sendable {
+    var path: String
+    var version: String
+}
+
 /// Resolves the tmux binary through the user's login shell, because a
 /// launchd-launched GUI app does not inherit Homebrew or user-bin PATH
 /// entries. Reads the passwd shell (not $SHELL, which may be absent).
@@ -118,7 +123,9 @@ struct TmuxBinaryResolver: Sendable {
     typealias ProcessRunner = @Sendable (_ shell: String, _ command: String)
         -> (status: Int32, stdout: String)
     typealias RemoteProcessRunner = @Sendable (
-        _ host: SSHHostInfo, _ command: String
+        _ host: SSHHostInfo,
+        _ sshConnectionArguments: [String],
+        _ command: String
     ) -> (status: Int32, stdout: String, stderr: String)
 
     private let processRunner: ProcessRunner
@@ -136,26 +143,53 @@ struct TmuxBinaryResolver: Sendable {
                 shell: shell, command: command, timeout: processTimeout
             )
         }
-        self.remoteProcessRunner = remoteProcessRunner ?? { host, command in
+        self.remoteProcessRunner = remoteProcessRunner ?? {
+            host, sshConnectionArguments, command in
             Self.runRemoteLoginShellSeparatingStandardError(
                 host: host,
                 command: command,
                 timeout: processTimeout,
-                accountShell: loginShellProvider()
+                accountShell: loginShellProvider(),
+                sshConnectionArguments: sshConnectionArguments
             )
         }
         self.loginShellProvider = loginShellProvider
     }
 
     func resolveTmuxPath() -> Result<String, TmuxBinaryError> {
+        resolveTmuxBinary().map(\.path)
+    }
+
+    func resolveTmuxBinary() -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
         let shell = loginShellProvider()
         let result = processRunner(shell, Self.probeCommand)
-        return Self.parseProbe(result, shell: shell)
+        return Self.parseProbe(result, shell: shell, platform: .posix)
     }
 
     func resolveTmuxPath(on host: SSHHostInfo) -> Result<String, TmuxBinaryError> {
+        resolveTmuxPath(
+            on: host,
+            sshConnectionArguments: Self.remoteConnectionArguments(for: host)
+        )
+    }
+
+    func resolveTmuxPath(
+        on host: SSHHostInfo,
+        sshConnectionArguments: [String]
+    ) -> Result<String, TmuxBinaryError> {
+        resolveTmuxBinary(
+            on: host,
+            sshConnectionArguments: sshConnectionArguments
+        ).map(\.path)
+    }
+
+    func resolveTmuxBinary(
+        on host: SSHHostInfo,
+        sshConnectionArguments: [String]
+    ) -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
         let result = remoteProcessRunner(
             host,
+            sshConnectionArguments,
             Self.probeCommand(for: host.platform)
         )
         if result.status == 255 {
@@ -169,7 +203,8 @@ struct TmuxBinaryResolver: Sendable {
         }
         return Self.parseProbe(
             (status: result.status, stdout: result.stdout),
-            shell: host.displayName
+            shell: host.displayName,
+            platform: host.platform
         )
     }
 
@@ -177,7 +212,8 @@ struct TmuxBinaryResolver: Sendable {
         let shell = loginShellProvider()
         return Self.parseDiscovery(
             processRunner(shell, Self.discoveryCommand),
-            shell: shell
+            shell: shell,
+            platform: .posix
         )
     }
 
@@ -186,6 +222,7 @@ struct TmuxBinaryResolver: Sendable {
     ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
         let result = remoteProcessRunner(
             host,
+            Self.remoteConnectionArguments(for: host),
             Self.discoveryCommand(for: host.platform)
         )
         if result.status == 255 {
@@ -199,7 +236,8 @@ struct TmuxBinaryResolver: Sendable {
         }
         return Self.parseDiscovery(
             (status: result.status, stdout: result.stdout),
-            shell: host.displayName
+            shell: host.displayName,
+            platform: host.platform
         )
     }
 
@@ -210,6 +248,7 @@ struct TmuxBinaryResolver: Sendable {
     ) -> Result<Bool, TmuxBinaryError> {
         let result = remoteProcessRunner(
             host,
+            Self.remoteConnectionArguments(for: host),
             Self.sessionProbeCommand(
                 name: name,
                 socketName: socketName,
@@ -239,7 +278,8 @@ struct TmuxBinaryResolver: Sendable {
         }
         switch Self.parseProbe(
             (status: result.status, stdout: result.stdout),
-            shell: host.displayName
+            shell: host.displayName,
+            platform: host.platform
         ) {
         case let .failure(error):
             return .failure(error)
@@ -408,8 +448,9 @@ struct TmuxBinaryResolver: Sendable {
 
     private static func parseProbe(
         _ result: (status: Int32, stdout: String),
-        shell: String
-    ) -> Result<String, TmuxBinaryError> {
+        shell: String,
+        platform: SSHHostInfo.Platform
+    ) -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
         guard result.status == 0 else {
             if result.status == timedOutStatus {
                 return .failure(.probeTimedOut(shell: shell))
@@ -438,10 +479,13 @@ struct TmuxBinaryResolver: Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let version = lines[pathIndex + 1]
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard isSupported(version) else {
-            return .failure(.unsupportedVersion(found: version))
+        guard isSupported(version, platform: platform) else {
+            return .failure(.unsupportedVersion(
+                found: version,
+                minimum: minimumVersion(for: platform)
+            ))
         }
-        return .success(path)
+        return .success(ResolvedTmuxBinary(path: path, version: version))
     }
 
     private static func isAbsoluteExecutablePath(_ value: String) -> Bool {
@@ -457,24 +501,30 @@ struct TmuxBinaryResolver: Sendable {
 
     private static func parseDiscovery(
         _ result: (status: Int32, stdout: String),
-        shell: String
+        shell: String,
+        platform: SSHHostInfo.Platform
     ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError> {
         if result.status != 0 {
             switch result.status {
             case timedOutStatus, cancelledStatus, outputExceededStatus:
-                if case let .failure(error) = parseProbe(result, shell: shell) {
+                if case let .failure(error) = parseProbe(
+                    result,
+                    shell: shell,
+                    platform: platform
+                ) {
                     return .failure(error)
                 }
             default:
                 if case .success = parseProbe(
                     (status: 0, stdout: result.stdout),
-                    shell: shell
+                    shell: shell,
+                    platform: platform
                 ) {
                     return .failure(.shellFailed(status: result.status))
                 }
             }
         }
-        switch parseProbe(result, shell: shell) {
+        switch parseProbe(result, shell: shell, platform: platform) {
         case let .failure(error):
             return .failure(error)
         case .success:
@@ -507,7 +557,10 @@ struct TmuxBinaryResolver: Sendable {
         return .success(sessions)
     }
 
-    private static func isSupported(_ output: String) -> Bool {
+    private static func isSupported(
+        _ output: String,
+        platform: SSHHostInfo.Platform
+    ) -> Bool {
         let fields = output.split(whereSeparator: \.isWhitespace)
         guard fields.count >= 2, fields[0] == "tmux" else { return false }
         let components = fields[1].split(separator: ".", maxSplits: 1)
@@ -515,7 +568,14 @@ struct TmuxBinaryResolver: Sendable {
               let major = Int(components[0]) else { return false }
         let minorDigits = components[1].prefix(while: \.isNumber)
         guard let minor = Int(minorDigits) else { return false }
-        return major > 3 || (major == 3 && minor >= 2)
+        let minimumMinor = 2
+        return major > 3 || (major == 3 && minor >= minimumMinor)
+    }
+
+    private static func minimumVersion(
+        for platform: SSHHostInfo.Platform
+    ) -> String {
+        "3.2"
     }
 
     static func loginShell() -> String {
@@ -590,11 +650,12 @@ struct TmuxBinaryResolver: Sendable {
         host: SSHHostInfo,
         command: String,
         timeout: TimeInterval,
-        accountShell: String = loginShell()
+        accountShell: String = loginShell(),
+        sshConnectionArguments: [String]? = nil
     ) -> (status: Int32, stdout: String, stderr: String) {
         let command = (["/usr/bin/ssh"] + remoteLoginArguments(
-            host: host,
-            command: command
+            host: host, command: command,
+            sshConnectionArguments: sshConnectionArguments
         )).map(shellQuotedCommandArgument).joined(separator: " ")
         return runProcess(
             executable: accountShell,
@@ -605,17 +666,13 @@ struct TmuxBinaryResolver: Sendable {
 
     private static func remoteLoginArguments(
         host: SSHHostInfo,
-        command: String
+        command: String,
+        sshConnectionArguments: [String]? = nil
     ) -> [String] {
         var arguments = ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]
-        arguments.append(contentsOf: tmuxSSHConnectionArguments())
         arguments.append(contentsOf:
-            SSHConnectionPool.connectionArguments(for: host)
+            sshConnectionArguments ?? remoteConnectionArguments(for: host)
         )
-        arguments.append(contentsOf:
-            SSHConfigurationResolver.noninteractiveHostKeyArguments(
-                for: host
-            ))
         if let port = host.port {
             arguments.append(contentsOf: ["-p", String(port)])
         }
@@ -624,6 +681,16 @@ struct TmuxBinaryResolver: Sendable {
             "--", target, remoteLoginCommand(host: host, command: command),
         ])
         return arguments
+    }
+
+    private static func remoteConnectionArguments(
+        for host: SSHHostInfo
+    ) -> [String] {
+        tmuxSSHConnectionArguments()
+            + SSHConnectionPool.connectionArguments(for: host)
+            + SSHConfigurationResolver.noninteractiveHostKeyArguments(
+                for: host
+            )
     }
 
     static func remoteLoginCommand(

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -131,7 +131,22 @@ struct TmuxPaneSplitter: Sendable {
         } onCancel: {
             task.cancel()
         }
-        guard !Task.isCancelled else { return nil }
+        if Task.isCancelled {
+            let cleanupCommand = Self.cleanupCommand(
+                tmuxPath: target.tmuxPath,
+                socketName: target.socketName,
+                hookIndex: hookIndex
+            )
+            let cleanupTask = Task.detached(priority: .userInitiated) {
+                runner(
+                    target.host,
+                    target.sshConnectionArguments,
+                    cleanupCommand
+                )
+            }
+            _ = await cleanupTask.value
+            return nil
+        }
         if result.diagnostic.split(whereSeparator: \.isNewline)
             .contains(Substring(mismatchMarker)) {
             return TmuxPaneSplitFailure(
@@ -208,11 +223,29 @@ struct TmuxPaneSplitter: Sendable {
             mismatchMarker, ";",
             "set-hook", "-gu", hookName,
         ].map(shellQuotedCommandArgument).joined(separator: " ")
-        let cleanup = tmux + " " + [
-            "set-hook", "-gu", hookName,
-        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let cleanup = cleanupCommand(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            hookIndex: hookIndex
+        )
         return queue + "; ghosthub_status=$?; "
             + cleanup + " >/dev/null 2>&1; exit \"$ghosthub_status\""
+    }
+
+    static func cleanupCommand(
+        tmuxPath: String,
+        socketName: String?,
+        hookIndex: Int
+    ) -> String {
+        var arguments = [tmuxPath]
+        if let socketName, !socketName.isEmpty {
+            arguments += ["-L", socketName]
+        }
+        arguments += [
+            "set-hook", "-gu", "after-refresh-client[\(hookIndex)]",
+        ]
+        return arguments.map(shellQuotedCommandArgument)
+            .joined(separator: " ")
     }
 
     static func guardedHookBody(

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -1,0 +1,457 @@
+import Foundation
+import GhosthubTerminalSupport
+import GhosthubTmux
+
+struct TmuxPaneSplitTarget: Sendable {
+    var host: TmuxHost
+    var tmuxPath: String
+    var sessionName: String
+    var socketName: String?
+    var sshConnectionArguments: [String]
+    var expectedIdentity: TmuxSessionIdentity?
+    var clientToken: String?
+    var expectedClient: TmuxPaneSplitClientIdentity?
+}
+
+struct TmuxPaneSplitClientIdentity: Hashable, Sendable {
+    var serverPID: String
+    var clientPID: String
+    var clientCreatedAt: String
+    var clientTTY: String
+    var sessionID: String
+    var sessionCreatedAt: String
+    var paneID: String
+
+    var sessionIdentity: TmuxSessionIdentity {
+        TmuxSessionIdentity(
+            serverPID: serverPID,
+            sessionID: sessionID,
+            createdAt: sessionCreatedAt
+        )
+    }
+
+    func matchesClient(_ other: Self) -> Bool {
+        serverPID == other.serverPID
+            && clientPID == other.clientPID
+            && clientCreatedAt == other.clientCreatedAt
+            && clientTTY == other.clientTTY
+            && sessionID == other.sessionID
+            && sessionCreatedAt == other.sessionCreatedAt
+    }
+
+}
+
+struct TmuxPaneSplitFailure: Error, Equatable, LocalizedError, Sendable {
+    var host: String
+    var sessionName: String
+    var status: Int32
+    var diagnostic: String
+
+    var errorDescription: String? {
+        var description =
+            "tmux could not split pane in “\(sessionName)” on \(host) "
+                + "(status \(status))."
+        if !diagnostic.isEmpty {
+            description += " \(diagnostic)"
+        }
+        return description
+    }
+}
+
+struct TmuxPaneSplitter: Sendable {
+    private static let clientIdentityMarker =
+        "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t"
+    private static let identityMismatchMarker =
+        "GHOSTHUB_TMUX_SPLIT_IDENTITY_MISMATCH"
+    typealias Runner = @Sendable (
+        TmuxHost,
+        [String],
+        String
+    ) -> (status: Int32, diagnostic: String)
+
+    private let runner: Runner
+
+    init(runner: Runner? = nil) {
+        self.runner = runner ?? Self.run
+    }
+
+    static func supportsPaneSplitting(
+        version: String,
+        host: TmuxHost
+    ) -> Bool {
+        guard platform(for: host) == .posix else { return false }
+        let fields = version.split(whereSeparator: \.isWhitespace)
+        guard fields.count == 2, fields[0] == "tmux" else { return false }
+        let components = fields[1].split(separator: ".", maxSplits: 1)
+        guard components.count == 2,
+              let major = Int(components[0]),
+              let minor = Int(components[1].prefix(while: \.isNumber))
+        else { return false }
+        return major > 3 || (major == 3 && minor >= 4)
+    }
+
+    func split(
+        _ shortcut: TerminalTmuxSplitShortcut,
+        target: TmuxPaneSplitTarget
+    ) async -> TmuxPaneSplitFailure? {
+        guard Self.platform(for: target.host) == .posix,
+              let expectedClient = target.expectedClient
+        else {
+            return TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux client identity is unavailable."
+            )
+        }
+        let mismatchMarker = Self.identityMismatchMarker
+            + "_\(UUID().uuidString)"
+        let hookIndex = Int.random(in: 1_000_000_000 ... 2_000_000_000)
+        let command = Self.command(
+            tmuxPath: target.tmuxPath,
+            socketName: target.socketName,
+            shortcut: shortcut,
+            expectedClient: expectedClient,
+            mismatchMarker: mismatchMarker,
+            hookIndex: hookIndex
+        )
+        let runner = runner
+        let task = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else {
+                return (status: Int32(0), diagnostic: "")
+            }
+            return runner(
+                target.host,
+                target.sshConnectionArguments,
+                command
+            )
+        }
+        let result = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard !Task.isCancelled else { return nil }
+        if result.diagnostic.split(whereSeparator: \.isNewline)
+            .contains(Substring(mismatchMarker)) {
+            return TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux session changed."
+            )
+        }
+        if result.status != 0,
+           Self.normalizedDiagnostic(result.diagnostic)
+           .hasPrefix("can't find client:") {
+            return TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux session changed."
+            )
+        }
+        guard result.status != 0 else { return nil }
+        return TmuxPaneSplitFailure(
+            host: target.host.displayName,
+            sessionName: target.sessionName,
+            status: result.status,
+            diagnostic: Self.normalizedDiagnostic(result.diagnostic)
+        )
+    }
+
+    static func command(
+        tmuxPath: String,
+        socketName: String?,
+        shortcut: TerminalTmuxSplitShortcut,
+        expectedClient: TmuxPaneSplitClientIdentity,
+        mismatchMarker: String,
+        hookIndex: Int
+    ) -> String {
+        var arguments = [tmuxPath]
+        if let socketName, !socketName.isEmpty {
+            arguments += ["-L", socketName]
+        }
+        let tmux = arguments.map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let hookName = "after-refresh-client[\(hookIndex)]"
+        let mutation = [
+            "split-window",
+            shortcut == .right ? "-h" : "-v",
+            "-t", expectedClient.paneID,
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let clientIdentity = "#{&&:"
+            + "#{==:#{client_pid},\(expectedClient.clientPID)},"
+            + "#{&&:"
+            + "#{==:#{client_created},\(expectedClient.clientCreatedAt)},"
+            + "#{==:#{client_tty},\(expectedClient.clientTTY)}}}"
+        let exactClient = "#{==:#{L:#{?\(clientIdentity),1,}},1}"
+        let condition = "#{&&:"
+            + expectedClient.sessionIdentity.formatCondition
+            + ",#{&&:\(exactClient),"
+            + "#{&&:#{==:#{pane_id},\(expectedClient.paneID)},"
+            + "#{==:#{hook_argument_0},\(mismatchMarker)}}}}"
+        let split = [
+            "if-shell", "-F", condition,
+            mutation,
+            "display-message -p "
+                + shellQuotedCommandArgument(mismatchMarker),
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let guardedMutation = guardedHookBody(
+            hookName: hookName,
+            marker: mismatchMarker,
+            action: split
+        )
+        let queue = tmux + " " + [
+            "set-hook", "-g", hookName, guardedMutation, ";",
+            "refresh-client", "-t", expectedClient.clientTTY,
+            mismatchMarker, ";",
+            "set-hook", "-gu", hookName,
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let cleanup = tmux + " " + [
+            "set-hook", "-gu", hookName,
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        return queue + "; ghosthub_status=$?; "
+            + cleanup + " >/dev/null 2>&1; exit \"$ghosthub_status\""
+    }
+
+    static func guardedHookBody(
+        hookName: String,
+        marker: String,
+        action: String
+    ) -> String {
+        let markerCondition = "#{==:#{hook_argument_0},\(marker)}"
+        let removeHook = [
+            "set-hook", "-gu", hookName,
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        return [
+            "if-shell", "-F", markerCondition,
+            removeHook + " ; " + action,
+            "",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+    }
+
+    func clientIdentity(
+        target: TmuxPaneSplitTarget
+    ) async -> Result<TmuxPaneSplitClientIdentity, TmuxPaneSplitFailure> {
+        guard let clientToken = target.clientToken else {
+            return .failure(clientIdentityUnavailable(target: target))
+        }
+        let command = Self.clientIdentityCommand(
+            tmuxPath: target.tmuxPath,
+            socketName: target.socketName,
+            clientToken: clientToken,
+            platform: Self.platform(for: target.host)
+        )
+        let result = await run(command: command, target: target)
+        guard result.status == 0 else {
+            return .failure(TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: result.status,
+                diagnostic: Self.normalizedDiagnostic(result.diagnostic)
+            ))
+        }
+        guard let client = Self.parseClientIdentity(result.diagnostic) else {
+            return .failure(clientIdentityUnavailable(target: target))
+        }
+        guard target.expectedIdentity == nil
+            || client.sessionIdentity == target.expectedIdentity
+        else {
+            return .failure(TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux session changed."
+            ))
+        }
+        return .success(client)
+    }
+
+    private func run(
+        command: String,
+        target: TmuxPaneSplitTarget
+    ) async -> (status: Int32, diagnostic: String) {
+        let runner = runner
+        let task = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else {
+                return (status: Int32(0), diagnostic: "")
+            }
+            return runner(target.host, target.sshConnectionArguments, command)
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private static func clientIdentityCommand(
+        tmuxPath: String,
+        socketName: String?,
+        clientToken: String,
+        platform: SSHHostInfo.Platform
+    ) -> String {
+        guard platform == .posix,
+              !clientToken.isEmpty,
+              clientToken.utf8.allSatisfy({ byte in
+                  byte == 45 || byte >= 48 && byte <= 57
+                      || byte >= 65 && byte <= 90
+                      || byte >= 97 && byte <= 122
+              })
+        else { return "exit 75" }
+        var arguments = [tmuxPath]
+        if let socketName, !socketName.isEmpty {
+            arguments += ["-L", socketName]
+        }
+        let tmux = arguments.map(shellQuotedCommandArgument).joined(separator: " ")
+        var identityArguments = ["list-clients"]
+        identityArguments += [
+            "-F",
+            "#{pid}\t#{client_pid}\t#{client_created}"
+                + "\t#{client_tty}\t#{session_id}\t#{session_created}"
+                + "\t#{pane_id}",
+        ]
+        let identityProbe = tmux + " "
+            + identityArguments.map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let identityFilter =
+            "while IFS=\"$(printf '\\t')\" read -r "
+                + "ghosthub_identity_server_pid ghosthub_identity_client_pid "
+                + "ghosthub_identity_client_created ghosthub_identity_tty "
+                + "ghosthub_identity_session_id ghosthub_identity_session_created "
+                + "ghosthub_identity_pane_id; "
+                + "do [ \"$ghosthub_identity_tty\" = \"$ghosthub_client_tty\" ] "
+                + "|| continue; printf "
+                + "'%s%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' "
+                + "\(shellQuotedCommandArgument(clientIdentityMarker)) "
+                + "\"$ghosthub_identity_server_pid\" "
+                + "\"$ghosthub_identity_client_pid\" "
+                + "\"$ghosthub_identity_client_created\" "
+                + "\"$ghosthub_identity_tty\" "
+                + "\"$ghosthub_identity_session_id\" "
+                + "\"$ghosthub_identity_session_created\" "
+                + "\"$ghosthub_identity_pane_id\"; break; done"
+        let path = "\"$HOME/.ghosthub/tmux-clients/\(clientToken)\""
+        return "ghosthub_client_tty=; "
+            + "for ghosthub_client_probe_delay in "
+            + "0.01 0.02 0.04 0.08 0.16 0.32 0.64 1 1 1 1; do "
+            + "ghosthub_client_tty=; "
+            + "IFS= read -r ghosthub_client_tty < \(path) 2>/dev/null || :; "
+            + "if [ -n \"$ghosthub_client_tty\" ]; then "
+            + "ghosthub_client_identity=$(\(identityProbe) 2>/dev/null "
+            + "| \(identityFilter)) "
+            + "&& [ -n \"$ghosthub_client_identity\" ] "
+            + "&& { printf '%s\\n' \"$ghosthub_client_identity\"; break; }; "
+            + "fi; sleep \"$ghosthub_client_probe_delay\"; done"
+    }
+
+    private static func parseClientIdentity(
+        _ output: String
+    ) -> TmuxPaneSplitClientIdentity? {
+        guard let line = output.split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .last(where: { $0.hasPrefix(clientIdentityMarker) })
+        else { return nil }
+        let fields = line.dropFirst(clientIdentityMarker.count).split(
+            separator: "\t", maxSplits: 6,
+            omittingEmptySubsequences: false
+        )
+        guard fields.count == 7,
+              isNumeric(fields[0]),
+              isNumeric(fields[1]),
+              isNumeric(fields[2]),
+              fields[3].first == "/",
+              fields[4].first == "$",
+              isNumeric(fields[4].dropFirst()),
+              isNumeric(fields[5]),
+              fields[6].first == "%",
+              isNumeric(fields[6].dropFirst())
+        else { return nil }
+        return TmuxPaneSplitClientIdentity(
+            serverPID: String(fields[0]),
+            clientPID: String(fields[1]),
+            clientCreatedAt: String(fields[2]),
+            clientTTY: String(fields[3]),
+            sessionID: String(fields[4]),
+            sessionCreatedAt: String(fields[5]),
+            paneID: String(fields[6])
+        )
+    }
+
+    private func clientIdentityUnavailable(
+        target: TmuxPaneSplitTarget
+    ) -> TmuxPaneSplitFailure {
+        TmuxPaneSplitFailure(
+            host: target.host.displayName,
+            sessionName: target.sessionName,
+            status: 75,
+            diagnostic: "The attached tmux client identity is unavailable."
+        )
+    }
+
+    private static func isNumeric<S: StringProtocol>(_ value: S) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { $0 >= 48 && $0 <= 57 }
+    }
+
+    private static func run(
+        host: TmuxHost,
+        sshConnectionArguments: [String],
+        command: String
+    ) -> (status: Int32, diagnostic: String) {
+        switch host {
+        case .local:
+            let result = TmuxBinaryResolver.runLoginShell(
+                shell: TmuxBinaryResolver.loginShell(),
+                command: command,
+                timeout: 15,
+                captureStandardError: true
+            )
+            return (result.status, result.stdout)
+        case let .ssh(info):
+            var arguments = [
+                "-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+            ]
+            arguments += sshConnectionArguments
+            if let port = info.port {
+                arguments += ["-p", String(port)]
+            }
+            let destination = info.user.map { "\($0)@\(info.hostname)" }
+                ?? info.hostname
+            arguments += [
+                "--",
+                destination,
+                TmuxBinaryResolver.remoteLoginCommand(
+                    host: info,
+                    command: command
+                ),
+            ]
+            let result = TmuxBinaryResolver.runProcessInLoginShell(
+                executable: "/usr/bin/ssh",
+                arguments: arguments,
+                timeout: 15,
+                captureStandardError: true
+            )
+            return (result.status, result.stdout)
+        }
+    }
+
+    private static func normalizedDiagnostic(_ diagnostic: String) -> String {
+        let normalized = diagnostic
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        return String(normalized.prefix(400))
+    }
+
+    private static func platform(
+        for host: TmuxHost
+    ) -> SSHHostInfo.Platform {
+        switch host {
+        case .local:
+            return .posix
+        case let .ssh(info):
+            return info.platform
+        }
+    }
+
+}

--- a/Sources/App/TmuxPathCache.swift
+++ b/Sources/App/TmuxPathCache.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Memoizes a tmux-path resolution, but only for a successful result.
+/// Memoizes a tmux binary resolution, but only for a successful result.
 ///
-/// `TmuxBinaryResolver.resolveTmuxPath()` shells out to the login shell,
+/// `TmuxBinaryResolver.resolveTmuxBinary()` shells out to the login shell,
 /// which is worth caching for the lifetime of the coordinator. A failure
 /// (tmux not on PATH) must NOT be cached the same way: installing tmux after
 /// the first failed resolve (`brew install tmux`) should be picked up on the
@@ -12,24 +12,29 @@ import Foundation
 /// main actor — a slow login shell must never beachball the UI on first open.
 final class TmuxPathCache: @unchecked Sendable {
     private let lock = NSLock()
-    private var cachedPath: String?
-    private let resolve: @Sendable () -> Result<String, TmuxBinaryError>
+    private var cachedBinary: ResolvedTmuxBinary?
+    private let resolve:
+        @Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>
 
-    init(resolve: @escaping @Sendable () -> Result<String, TmuxBinaryError>) {
+    init(
+        resolve: @escaping @Sendable ()
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError>
+    ) {
         self.resolve = resolve
     }
 
-    func resolveTmuxPath() -> Result<String, TmuxBinaryError> {
+    func resolveTmuxBinary()
+        -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
         lock.lock()
-        if let cachedPath {
+        if let cachedBinary {
             lock.unlock()
-            return .success(cachedPath)
+            return .success(cachedBinary)
         }
         lock.unlock()
         let resolved = resolve()
-        if case let .success(path) = resolved {
+        if case let .success(binary) = resolved {
             lock.lock()
-            cachedPath = path
+            cachedBinary = binary
             lock.unlock()
         }
         return resolved

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -438,6 +438,29 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         return borrowedTmuxConnectionStates[handle.id] == .connected
     }
+    var canSplitActiveTmuxPane: Bool {
+        guard let selection = activeBorrowedTmuxSelection,
+              isConnectedActiveTmuxSession(selection),
+              let handle = activeBorrowedTmuxHandle,
+              nativeTmuxSessionCoordinator.supportsPaneSplitting(handle)
+        else { return false }
+        return true
+    }
+
+    func splitActiveTmuxPane(
+        _ shortcut: TerminalTmuxSplitShortcut,
+        requiresKeyboardFocus: Bool = false
+    ) {
+        guard canSplitActiveTmuxPane,
+              let handle = activeBorrowedTmuxHandle
+        else { return }
+        nativeTmuxSessionCoordinator.requestPaneSplit(
+            shortcut,
+            handle: handle,
+            requiresKeyboardFocus: requiresKeyboardFocus
+        )
+    }
+
     var canApplyThemeToActiveTmuxSession: Bool {
         guard let selection = activeBorrowedTmuxSelection,
               isConnectedActiveTmuxSession(selection),
@@ -686,13 +709,16 @@ final class WorkspaceSceneModel: ObservableObject {
         notificationService: NotificationService,
         nativeTmuxSurfaceStore: (any TmuxSurfaceStoring)? = nil,
         nativeTmuxPathProvider:
-        (@Sendable () -> Result<String, TmuxBinaryError>)? = nil,
+        (@Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>)? = nil,
         localKwtPathProvider: @escaping @Sendable () -> String? = {
             KwtBinaryLocator.bundledPath()
         },
-        remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
-            -> Result<String, TmuxBinaryError> = {
-                TmuxBinaryResolver().resolveTmuxPath(on: $0)
+        remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo, [String])
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError> = {
+                TmuxBinaryResolver().resolveTmuxBinary(
+                    on: $0,
+                    sshConnectionArguments: $1
+                )
             },
         tmuxPresentationStyleProvider:
         @escaping (UInt?) -> TmuxPresentationStyle? = { _ in nil },
@@ -944,13 +970,13 @@ final class WorkspaceSceneModel: ObservableObject {
         let tmuxResolver = TmuxBinaryResolver()
         let tmuxPathCache = TmuxPathCache(
             resolve: nativeTmuxPathProvider
-                ?? tmuxResolver.resolveTmuxPath
+                ?? tmuxResolver.resolveTmuxBinary
         )
         nativeTmuxSessionCoordinatorBacking = NativeTmuxSessionCoordinator(
             terminalCoordinator: nativeTmuxSurfaceStore
                 ?? terminalCoordinator,
             tmuxPathProvider: {
-                tmuxPathCache.resolveTmuxPath()
+                tmuxPathCache.resolveTmuxBinary()
             },
             localKwtPathProvider: localKwtPathProvider,
             presentationStyleProvider: {
@@ -3866,7 +3892,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 ? initialCommand
                 : nil,
             workingDirectory: selection.worktreePath,
-            openWorkspace: openWorkspace
+            openWorkspace: openWorkspace,
+            sessionIdentity: Self.discoveredTmuxSessionIdentity(
+                selection,
+                hostSummary: host
+            )
         )
         let phase: RemoteTmuxEstablishmentPhase
         if openWorkspace || protectedSessionNeedsEstablishment {

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -15,10 +15,19 @@ struct FocusedSceneModelKey: FocusedValueKey {
     typealias Value = WorkspaceSceneModel
 }
 
+struct TmuxTerminalKeyboardFocusKey: FocusedValueKey {
+    typealias Value = Bool
+}
+
 extension FocusedValues {
     var sceneModel: WorkspaceSceneModel? {
         get { self[FocusedSceneModelKey.self] }
         set { self[FocusedSceneModelKey.self] = newValue }
+    }
+
+    var tmuxTerminalHasEffectiveKeyboardFocus: Bool? {
+        get { self[TmuxTerminalKeyboardFocusKey.self] }
+        set { self[TmuxTerminalKeyboardFocusKey.self] = newValue }
     }
 }
 

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -134,6 +134,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     private nonisolated(unsafe) var eventMonitor: Any?
     var lastPerformKeyEvent: TimeInterval?
     private var consumedCommandKeyCodes: Set<UInt16> = []
+    private var consumedTmuxSplitKeyCodes: Set<UInt16> = []
     private var surfaceResizeState = SurfaceResizeState()
     private var isDeferringLiveResize = false
     private var isDeferringPresentationResize = false
@@ -148,6 +149,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     public var onPrimaryInteraction: (() -> Void)?
     public var onCloseRequest: (() -> Void)?
     public var shouldConfirmClose: (() -> Bool)?
+    @Published public var tmuxSplitErrorMessage: String?
+    /// Installed only for ordinary tmux-client surfaces. The handler sends
+    /// Ghostty-style split shortcuts through the attached client as tmux input.
+    public var tmuxSplitShortcutHandler: ((TerminalTmuxSplitShortcut) -> Void)?
     /// Control-mode surfaces render through a silent local child, so their
     /// meaningful process liveness comes from the tmux pane rather than
     /// `childProcessID`. When supplied, close confirmation uses this source.
@@ -807,6 +812,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     }
 
     private func localEventKeyUp(_ event: NSEvent) -> NSEvent? {
+        if consumedTmuxSplitKeyCodes.remove(event.keyCode) != nil {
+            return nil
+        }
         let wasConsumedCommandChord = consumedCommandKeyCodes
             .contains(event.keyCode)
         guard event.modifierFlags.contains(.command)
@@ -816,6 +824,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
                 consumedCommandKeyCodes.remove(event.keyCode)
             }
             return event
+        }
+        if tmuxSplitShortcut(for: event) != nil {
+            return nil
         }
         if isPaneCloseShortcut(event),
            hasPaneCloseHandler {
@@ -835,6 +846,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     private func localEventKeyDown(_ event: NSEvent) -> NSEvent? {
         guard event.modifierFlags.contains(.command) else { return event }
         guard hasEffectiveKeyboardFocus else { return event }
+        if handleTmuxSplitShortcut(event) {
+            return nil
+        }
         if isPaneCloseShortcut(event),
            hasPaneCloseHandler {
             closeWithOptionalConfirmation()
@@ -1106,6 +1120,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             ensureFirstResponder()
         }
         guard hasEffectiveKeyboardFocus else { return false }
+
+        if handleTmuxSplitShortcut(event) {
+            return true
+        }
 
         if isPaneCloseShortcut(event),
            hasPaneCloseHandler {
@@ -1644,6 +1662,11 @@ extension TerminalSurfaceView {
         return fontZoomShortcutHandler?(command) == true
     }
 
+    @discardableResult
+    func handleTmuxSplitShortcutForTesting(_ event: NSEvent) -> Bool {
+        handleTmuxSplitShortcut(event)
+    }
+
     func markConsumedCommandKeyCodeForTesting(_ keyCode: UInt16) {
         consumedCommandKeyCodes.insert(keyCode)
     }
@@ -1670,9 +1693,37 @@ extension TerminalSurfaceView {
             hasPaneCloseHandler: hasPaneCloseHandler
         )
     }
+
+    package var hasEffectiveKeyboardFocus: Bool {
+        guard let window, window.isKeyWindow,
+              window.attachedSheet == nil
+        else { return false }
+        return focused || window.firstResponder === self
+    }
 }
 
 private extension TerminalSurfaceView {
+    func tmuxSplitShortcut(
+        for event: NSEvent
+    ) -> TerminalTmuxSplitShortcut? {
+        guard tmuxSplitShortcutHandler != nil else { return nil }
+        return TerminalTmuxSplitShortcut.matching(
+            flags: event.modifierFlags,
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers
+        )
+    }
+
+    func handleTmuxSplitShortcut(_ event: NSEvent) -> Bool {
+        guard let shortcut = tmuxSplitShortcut(for: event) else {
+            return false
+        }
+        consumedTmuxSplitKeyCodes.insert(event.keyCode)
+        if !event.isARepeat {
+            tmuxSplitShortcutHandler?(shortcut)
+        }
+        return true
+    }
+
     func fontZoomCommand(
         for event: NSEvent
     ) -> TerminalFontZoomCommand? {
@@ -1715,13 +1766,6 @@ private extension TerminalSurfaceView {
             keyCode: event.keyCode,
             hasPaneCloseHandler: hasPaneCloseHandler
         )
-    }
-
-    var hasEffectiveKeyboardFocus: Bool {
-        guard let window, window.isKeyWindow,
-              window.attachedSheet == nil
-        else { return false }
-        return focused || window.firstResponder === self
     }
 }
 

--- a/Sources/TerminalSupport/TerminalTmuxSplitShortcut.swift
+++ b/Sources/TerminalSupport/TerminalTmuxSplitShortcut.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+/// Ghostty-style pane splitting requested from an attached tmux surface.
+public enum TerminalTmuxSplitShortcut: Equatable, Sendable {
+    case right
+    case down
+
+    public static func matching(
+        flags: NSEvent.ModifierFlags,
+        charactersIgnoringModifiers: String?
+    ) -> Self? {
+        let flags = flags.intersection([
+            .command,
+            .shift,
+            .control,
+            .option,
+        ])
+        guard charactersIgnoringModifiers?.lowercased() == "d" else {
+            return nil
+        }
+
+        switch flags {
+        case .command:
+            return .right
+        case [.command, .shift]:
+            return .down
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -78,6 +78,9 @@ public final class TerminalSurfaceView: ObservableObject {
     public var onPrimaryInteraction: (() -> Void)?
     public var onCloseRequest: (() -> Void)?
     public var shouldConfirmClose: (() -> Bool)?
+    @Published public var tmuxSplitErrorMessage: String?
+    public var tmuxSplitShortcutHandler: ((TerminalTmuxSplitShortcut) -> Void)?
+    package var hasEffectiveKeyboardFocus = false
     public var hasRunningChildProcessOverride: (() -> Bool)?
     public var onSurfaceClosed: ((Bool) -> Void)?
     /// Mirrors `TerminalSurfaceView.tmuxPaneInputSink` so tmux control-mode

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -215,14 +215,19 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         windowsKwtRelativePath: String? = nil,
         workingDirectory: String? = nil,
         sshConnectionArguments: [String] = tmuxSSHConnectionArguments(),
-        remoteExitStatusPath: String? = nil
+        remoteExitStatusPath: String? = nil,
+        clientTTYToken: String? = nil
     ) -> String {
         switch host {
         case .local:
-            return localAttachCommand(
+            let command = localAttachCommand(
                 tmuxPath: tmuxPath,
                 kwtPath: kwtPath,
                 workingDirectory: workingDirectory
+            )
+            return recordedClientTTYCommand(
+                command,
+                token: clientTTYToken
             )
         case let .ssh(info):
             let command: String
@@ -232,7 +237,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                         info: info,
                         tmuxPath: tmuxPath,
                         workingDirectory: workingDirectory,
-                        sshConnectionArguments: sshConnectionArguments
+                        sshConnectionArguments: sshConnectionArguments,
+                        clientTTYToken: clientTTYToken
                     )
                 } else if launchMode != .attachOnly,
                           protectedWorkspacePath == nil,
@@ -258,14 +264,16 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                         tmuxPath: tmuxPath,
                         workingDirectory: workingDirectory,
                         initialCommand: initialCommand,
-                        sshConnectionArguments: sshConnectionArguments
+                        sshConnectionArguments: sshConnectionArguments,
+                        clientTTYToken: clientTTYToken
                     )
                 } else {
                     command = remoteCreateThenAttachCommand(
                         info: info,
                         tmuxPath: tmuxPath,
                         workingDirectory: workingDirectory,
-                        sshConnectionArguments: sshConnectionArguments
+                        sshConnectionArguments: sshConnectionArguments,
+                        clientTTYToken: clientTTYToken
                     )
                 }
             } else if launchMode != .attachOnly,
@@ -275,14 +283,16 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     info: info,
                     tmuxPath: tmuxPath,
                     remoteKwtCommandPrelude: remoteKwtCommandPrelude,
-                    sshConnectionArguments: sshConnectionArguments
+                    sshConnectionArguments: sshConnectionArguments,
+                    clientTTYToken: clientTTYToken
                 )
             } else {
                 command = remoteAttachCommand(
                     info: info,
                     tmuxPath: tmuxPath,
                     remoteKwtCommandPrelude: remoteKwtCommandPrelude,
-                    sshConnectionArguments: sshConnectionArguments
+                    sshConnectionArguments: sshConnectionArguments,
+                    clientTTYToken: clientTTYToken
                 )
             }
             let recordedCommand: String
@@ -471,6 +481,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         tmuxPath: String,
         remoteKwtCommandPrelude: String?,
         sshConnectionArguments: [String],
+        clientTTYToken: String?,
         includesPresentation: Bool = true
     ) -> String {
         if info.platform == .windows {
@@ -518,7 +529,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         // so login-initialized settings such as TMUX_TMPDIR resolve the same
         // tmux server as later styling and identity commands.
         let remoteAttach = accountLoginShellCommand(
-            remoteAttachCommands.joined(separator: "; ")
+            recordedClientTTYBody(
+                remoteAttachCommands.joined(separator: "; "),
+                token: clientTTYToken
+            )
         )
         return sshAttachCommand(
             label: "ghosthub-ssh-tmux",
@@ -533,14 +547,16 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         info: SSHHostInfo,
         tmuxPath: String,
         remoteKwtCommandPrelude: String?,
-        sshConnectionArguments: [String]
+        sshConnectionArguments: [String],
+        clientTTYToken: String?
     ) -> String {
         guard let workspacePath else {
             return remoteAttachCommand(
                 info: info,
                 tmuxPath: tmuxPath,
                 remoteKwtCommandPrelude: nil,
-                sshConnectionArguments: sshConnectionArguments
+                sshConnectionArguments: sshConnectionArguments,
+                clientTTYToken: clientTTYToken
             )
         }
         let remoteOpen: String
@@ -557,10 +573,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
                     + "exit 127"
         }
-        let initialBody = [
+        let initialBody = recordedClientTTYBody([
             "unset TMUX TMUX_PANE",
             remoteOpen,
-        ].joined(separator: "; ")
+        ].joined(separator: "; "), token: clientTTYToken)
         let initialAttach = shellCommand(
             sshArguments(
                 info: info,
@@ -679,7 +695,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         info: SSHHostInfo,
         tmuxPath: String,
         workingDirectory: String?,
-        sshConnectionArguments: [String]
+        sshConnectionArguments: [String],
+        clientTTYToken: String?
     ) -> String {
         var remoteCreate: String
         if info.platform == .windows {
@@ -724,6 +741,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             tmuxPath: tmuxPath,
             remoteKwtCommandPrelude: nil,
             sshConnectionArguments: sshConnectionArguments,
+            clientTTYToken: clientTTYToken,
             includesPresentation: false
         )
         return shellCommand([
@@ -741,7 +759,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         tmuxPath: String,
         workingDirectory: String?,
         initialCommand: String,
-        sshConnectionArguments: [String]
+        sshConnectionArguments: [String],
+        clientTTYToken: String?
     ) -> String {
         var createArguments = tmuxArguments(
             tmuxPath,
@@ -756,7 +775,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         let createAndAttach = createArguments
             .map(shellQuotedCommandArgument)
             .joined(separator: " ")
-        let initialBody = "unset TMUX TMUX_PANE; exec \(createAndAttach)"
+        let initialBody = recordedClientTTYBody(
+            "unset TMUX TMUX_PANE; exec \(createAndAttach)",
+            token: clientTTYToken
+        )
         return shellCommand(
             sshArguments(
                 info: info,
@@ -783,6 +805,70 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             .map(shellQuotedCommandArgument).joined(separator: " ")
         return "\(hasSession) 2>/dev/null || "
             + "\(createSession) || \(hasSession)"
+    }
+
+    private func recordedClientTTYCommand(
+        _ command: String,
+        token: String?
+    ) -> String {
+        guard let token else { return command }
+        return shellCommand([
+            "/bin/sh", "-c",
+            recordedClientTTYBody(
+                command,
+                token: token
+            ),
+        ])
+    }
+
+    private func recordedClientTTYBody(
+        _ command: String,
+        token: String?
+    ) -> String {
+        guard let token,
+              !token.isEmpty,
+              token.utf8.allSatisfy({ byte in
+                  byte == 45 || byte >= 48 && byte <= 57
+                      || byte >= 65 && byte <= 90
+                      || byte >= 97 && byte <= 122
+              })
+        else { return command }
+        let nestedCommand = shellCommand(["/bin/sh", "-c", command])
+        return [
+            "unset TMUX TMUX_PANE",
+            "ghosthub_client_tty_dir=\"$HOME/.ghosthub/tmux-clients\"",
+            "ghosthub_client_tty_path=\"$ghosthub_client_tty_dir/\(token)\"",
+            "ghosthub_client_tty_tmp=\"$ghosthub_client_tty_path.$$\"",
+            "ghosthub_client_pid=",
+            "ghosthub_client_token_ready=",
+            "ghosthub_client_tty=$(tty 2>/dev/null) "
+                + "|| ghosthub_client_tty=",
+            "if [ -n \"$ghosthub_client_tty\" ] "
+                + "&& (umask 077; mkdir -p \"$ghosthub_client_tty_dir\"); "
+                + "then ghosthub_client_token_ready=1; fi",
+            "ghosthub_client_cleanup() { rm -f "
+                + "\"$ghosthub_client_tty_path\" "
+                + "\"$ghosthub_client_tty_tmp\"; "
+                + "case \"$ghosthub_client_pid\" in "
+                + "''|*[!0-9]*) ;; *) kill \"$ghosthub_client_pid\" "
+                + "2>/dev/null || : ;; esac; }",
+            "trap ghosthub_client_cleanup 0",
+            "trap 'exit 129' HUP",
+            "trap 'exit 130' INT",
+            "trap 'exit 143' TERM",
+            "if [ -n \"$ghosthub_client_token_ready\" ]; then "
+                + "(umask 077; printf '%s\\n' \"$ghosthub_client_tty\" "
+                + "> \"$ghosthub_client_tty_tmp\") "
+                + "&& mv -f \"$ghosthub_client_tty_tmp\" "
+                + "\"$ghosthub_client_tty_path\" || :; fi",
+            "exec 3<&0",
+            "\(nestedCommand) <&3 3<&- & ghosthub_client_pid=$!",
+            "wait \"$ghosthub_client_pid\"",
+            "ghosthub_client_status=$?",
+            "ghosthub_client_pid=",
+            "exec 3<&-",
+            "exit \"$ghosthub_client_status\"",
+        ].joined(separator: "; ")
     }
 
     private func windowsCreateIfAbsentScript(

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -792,6 +792,10 @@ struct NativeTmuxSessionCoordinatorTests {
                 if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
                     return (0, coordinatorSplitClientOutput)
                 }
+                if command.contains("'set-hook' '-gu'"),
+                   !command.contains("'refresh-client'") {
+                    return (0, "")
+                }
                 if !command.contains("-v") {
                     events.withLock { $0.append("start-right") }
                     let deadline = Date().addingTimeInterval(5)

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -5,15 +5,63 @@ import GhosthubWorkspace
 import Testing
 @testable import GhosthubApp
 
+private let coordinatorSplitIdentity = TmuxSessionIdentity(
+    serverPID: "123",
+    sessionID: "$7",
+    createdAt: "456"
+)
+private let coordinatorSplitClientOutput =
+    "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t123\t789\t321"
+        + "\t/dev/ttys001\t$7\t456\t%9\n"
+
+private func supportedPaneSplitter(
+    _ runner: @escaping TmuxPaneSplitter.Runner
+) -> TmuxPaneSplitter {
+    TmuxPaneSplitter(runner: runner)
+}
+
 @Suite("Native tmux connection identity", .serialized)
 @MainActor
 struct NativeTmuxSessionCoordinatorTests {
+    @Test("attachment reuses the version from binary resolution")
+    func attachmentReusesResolvedVersion() async {
+        let runnerCalls = LockedValue(0)
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: {
+                .success(ResolvedTmuxBinary(
+                    path: "/opt/homebrew/bin/tmux",
+                    version: "tmux 3.4a"
+                ))
+            },
+            paneSplitter: TmuxPaneSplitter { _, _, _ in
+                runnerCalls.withLock { $0 += 1 }
+                return (1, "unexpected command")
+            }
+        )
+        var isReady = false
+        coordinator.onSurfaceReady = { _ in isReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "one-version-probe",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { isReady }
+        _ = coordinator.surface(handle: handle)
+
+        #expect(coordinator.supportsPaneSplitting(handle))
+        #expect(runnerCalls.load() == 0)
+    }
+
     @Test("creation carries a launch command but attachment drops it")
     func launchCommandIsCreationOnly() async throws {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") }
         )
         var readyHandles = Set<UUID>()
         coordinator.onSurfaceReady = { readyHandles.insert($0.id) }
@@ -50,12 +98,107 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(attachCommand.contains("attach-session"))
     }
 
+    @Test("undiscovered attachments bind during surface establishment")
+    func undiscoveredAttachmentBindsDuringSurfaceEstablishment() async throws {
+        let identityCommands = LockedValue<[String]>([])
+        let splitCommands = LockedValue(0)
+        let releaseBinding = DispatchSemaphore(value: 0)
+        defer { releaseBinding.signal() }
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    var isInitialBinding = false
+                    identityCommands.withLock {
+                        $0.append(command)
+                        isInitialBinding = $0.count == 1
+                    }
+                    if isInitialBinding {
+                        _ = releaseBinding.wait(timeout: .now() + 5)
+                    }
+                    return (0, coordinatorSplitClientOutput)
+                }
+                splitCommands.withLock { $0 += 1 }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "undiscovered",
+            host: .local
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { identityCommands.load().count == 1 }
+
+        let bindingCommand = try #require(identityCommands.load().first)
+        #expect(bindingCommand.contains("'list-clients' '-F'"))
+        #expect(coordinator.supportsPaneSplitting(handle))
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        #expect(splitCommands.load() == 0)
+        #expect(store.surface.tmuxSplitErrorMessage?.contains(
+            "client identity is unavailable"
+        ) == true)
+
+        releaseBinding.signal()
+        await waitUntilMainActor { readyCount == 2 }
+        handler(.right)
+        await waitUntilMainActor { splitCommands.load() == 1 }
+    }
+
+    @Test("tmux older than 3.4 does not install pane split shortcuts")
+    func oldTmuxDoesNotInstallSplitHandler() async {
+        let store = RecordingTmuxSurfaceStore()
+        let host = TmuxHost.ssh(SSHHostInfo(
+            user: "operator",
+            hostname: "legacy.example.test",
+            port: 2222
+        ))
+        let sshArguments = [
+            "-F", "/dev/null",
+            "-o", "HostName=legacy.internal.test",
+        ]
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution(
+                    "/usr/local/bin/tmux",
+                    version: "tmux 3.3a"
+                )
+            },
+            sshConnectionArgumentsProvider: { _ in
+                SSHConnectionArgumentsSnapshot(arguments: sshArguments)
+            }
+        )
+        var isReady = false
+        coordinator.onSurfaceReady = { _ in isReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "older-tmux",
+            host: host,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { isReady }
+        _ = coordinator.surface(handle: handle)
+
+        #expect(store.surface.tmuxSplitShortcutHandler == nil)
+        #expect(!coordinator.supportsPaneSplitting(handle))
+    }
+
     @Test("new named sessions use tmux create-or-attach mode")
     func namedSessionUsesCreateMode() async throws {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") }
         )
         var states: [ConnectionState] = []
         var readyHandles: [BorrowedTmuxSessionHandle] = []
@@ -65,7 +208,8 @@ struct NativeTmuxSessionCoordinatorTests {
             hostID: UUID(),
             name: "release-work",
             host: .local,
-            launchMode: .create
+            launchMode: .create,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         #expect(coordinator.surface(handle: handle) == nil)
@@ -97,7 +241,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         let hostID = UUID()
         var states: [ConnectionState] = []
@@ -107,7 +251,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let handle = coordinator.attach(
             hostID: hostID,
             name: "release-work",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { readyCount == 1 }
@@ -126,7 +271,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let reattached = coordinator.attach(
             hostID: hostID,
             name: "release-work",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
         #expect(reattached == handle)
         await waitUntilMainActor { readyCount == 2 }
@@ -147,7 +293,7 @@ struct NativeTmuxSessionCoordinatorTests {
         )
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             presentationStyleProvider: { style }
         )
         var isReady = false
@@ -156,7 +302,8 @@ struct NativeTmuxSessionCoordinatorTests {
             hostID: UUID(),
             name: "docbank",
             host: .local,
-            launchMode: .create
+            launchMode: .create,
+            sessionIdentity: coordinatorSplitIdentity
         )
         style = TmuxPresentationStyle(
             foreground: "#EEEEEE",
@@ -179,7 +326,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             presentationStyleProvider: {
                 TmuxPresentationStyle(
                     foreground: "#3B4851",
@@ -192,7 +339,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "existing",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isReady }
@@ -211,7 +359,7 @@ struct NativeTmuxSessionCoordinatorTests {
         var appliesPresentationStyle = true
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             presentationStyleProvider: {
                 TmuxPresentationStyle(
                     foreground: "#3B4851",
@@ -227,7 +375,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "existing",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isReady }
@@ -249,7 +398,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             localKwtPathProvider: {
                 "/Applications/Ghosthub.app/Contents/Helpers/kwt"
             },
@@ -268,7 +417,8 @@ struct NativeTmuxSessionCoordinatorTests {
             name: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
-            workingDirectory: "/worktrees/pr-32"
+            workingDirectory: "/worktrees/pr-32",
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isReady }
@@ -281,7 +431,6 @@ struct NativeTmuxSessionCoordinatorTests {
             "/Applications/Ghosthub.app/Contents/Helpers/kwt"
         ))
         #expect(command.contains("/worktrees/pr-32"))
-        #expect(command.contains(#"'\''pr'\'' '\''attach'\''"#))
         #expect(command.contains("kwt-pr-0123456789abcdef"))
         #expect(!command.contains("'open'"))
     }
@@ -291,7 +440,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             localKwtPathProvider: {
                 "/Applications/Ghosthub.app/Contents/Helpers/kwt"
             }
@@ -303,7 +452,8 @@ struct NativeTmuxSessionCoordinatorTests {
             name: "kwt-widget-feature",
             host: .local,
             workingDirectory: "/worktrees/widget",
-            openWorkspace: true
+            openWorkspace: true,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isReady }
@@ -326,10 +476,12 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             sshConnectionArgumentsProvider: { _ in
-                ["-o", "StrictHostKeyChecking=yes"]
+                SSHConnectionArgumentsSnapshot(arguments: [
+                    "-o", "StrictHostKeyChecking=yes",
+                ])
             }
         )
         var isReady = false
@@ -341,7 +493,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 user: "operator",
                 hostname: "build.example.test",
                 port: nil
-            ))
+            )),
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isReady }
@@ -353,13 +506,504 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(command.contains("StrictHostKeyChecking=yes"))
     }
 
+    @Test("split shortcuts use the attachment's fixed remote route")
+    func splitShortcutUsesAttachmentRoute() async throws {
+        let calls = LockedValue<[(TmuxHost, [String], String)]>([])
+        let resolutionArguments = LockedValue<[String]?>(nil)
+        let routeProviderCalls = LockedValue(0)
+        let routeArguments = LockedValue([
+            "-F", "/dev/null",
+            "-o", "HostName=attached.example.test",
+            "-o", "ControlPath=/tmp/ghosthub-attached",
+        ])
+        let store = RecordingTmuxSurfaceStore()
+        let host = TmuxHost.ssh(SSHHostInfo(
+            user: "operator",
+            hostname: "build.example.test",
+            port: 2222
+        ))
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, arguments in
+                resolutionArguments.store(arguments)
+                return successfulTmuxResolution("/usr/local/bin/tmux")
+            },
+            sshConnectionArgumentsProvider: { _ in
+                routeProviderCalls.withLock { $0 += 1 }
+                return SSHConnectionArgumentsSnapshot(
+                    arguments: routeArguments.load()
+                )
+            },
+            paneSplitter: supportedPaneSplitter { host, arguments, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                calls.withLock { $0.append((host, arguments, command)) }
+                return (1, "no space for new pane\n")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "release-work",
+            host: host,
+            socketName: "isolated",
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        routeArguments.store([
+            "-F", "/dev/null",
+            "-o", "HostName=reconfigured.example.test",
+            "-o", "ControlPath=/tmp/ghosthub-reconfigured",
+        ])
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.down)
+        await waitUntilMainActor { calls.load().count == 1 }
+        await waitUntilMainActor {
+            store.surface.tmuxSplitErrorMessage != nil
+        }
+
+        let call = try #require(calls.load().first)
+        #expect(call.0 == host)
+        #expect(resolutionArguments.load() == call.1)
+        #expect(call.1 == [
+            "-F", "/dev/null",
+            "-o", "HostName=attached.example.test",
+            "-o", "ControlPath=/tmp/ghosthub-attached",
+        ])
+        #expect(routeProviderCalls.load() == 1)
+        #expect(!call.2.contains("'list-clients' '-F'"))
+        #expect(call.2.contains("'refresh-client' '-t' '/dev/ttys001'"))
+        #expect(call.2.contains("split-window"))
+        #expect(call.2.contains("-v"))
+        #expect(!call.2.contains("=release-work:"))
+        #expect(store.surface.tmuxSplitErrorMessage?.contains(
+            "release-work"
+        ) == true)
+        #expect(store.surface.tmuxSplitErrorMessage?.contains(
+            "no space for new pane"
+        ) == true)
+    }
+
+    @Test("remote tmux path cache follows the frozen SSH route")
+    func remoteTmuxPathCacheUsesConnectionIdentity() async {
+        let routeArguments = LockedValue([
+            "-F", "/dev/null",
+            "-o", "HostName=first.example.test",
+        ])
+        let resolvedArguments = LockedValue<[[String]]>([])
+        let store = RecordingTmuxSurfaceStore()
+        let hostID = UUID()
+        let host = TmuxHost.ssh(SSHHostInfo(
+            user: "operator",
+            hostname: "build.example.test",
+            port: nil
+        ))
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, arguments in
+                resolvedArguments.withLock { $0.append(arguments) }
+                return successfulTmuxResolution("/usr/local/bin/tmux")
+            },
+            sshConnectionArgumentsProvider: { _ in
+                SSHConnectionArgumentsSnapshot(
+                    arguments: routeArguments.load()
+                )
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+
+        _ = coordinator.attach(
+            hostID: hostID,
+            name: "first",
+            host: host
+        )
+        await waitUntilMainActor { readyCount == 1 }
+        routeArguments.store([
+            "-F", "/dev/null",
+            "-o", "HostName=second.example.test",
+        ])
+        _ = coordinator.attach(
+            hostID: hostID,
+            name: "second",
+            host: host
+        )
+        await waitUntilMainActor { readyCount == 2 }
+        _ = coordinator.attach(
+            hostID: hostID,
+            name: "third",
+            host: host
+        )
+        await waitUntilMainActor { readyCount == 3 }
+
+        #expect(resolvedArguments.load() == [
+            ["-F", "/dev/null", "-o", "HostName=first.example.test"],
+            ["-F", "/dev/null", "-o", "HostName=second.example.test"],
+        ])
+    }
+
+    @Test("keyboard splits require effective terminal focus")
+    func keyboardSplitRequiresTerminalFocus() async throws {
+        let calls = LockedValue<[String]>([])
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                calls.withLock { $0.append(command) }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "focused",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        coordinator.requestPaneSplit(
+            .right,
+            handle: handle,
+            requiresKeyboardFocus: true
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(calls.load().isEmpty)
+
+        coordinator.requestPaneSplit(
+            .right,
+            handle: handle,
+            requiresKeyboardFocus: false
+        )
+        await waitUntilMainActor { calls.load().count == 1 }
+
+        store.surface.hasEffectiveKeyboardFocus = true
+        coordinator.requestPaneSplit(
+            .down,
+            handle: handle,
+            requiresKeyboardFocus: true
+        )
+        await waitUntilMainActor { calls.load().count == 2 }
+    }
+
+    @Test("native Windows surfaces do not intercept pane split shortcuts")
+    func windowsSurfaceDoesNotInstallSplitHandler() async {
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("tmux.exe") }
+        )
+        var isReady = false
+        coordinator.onSurfaceReady = { _ in isReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "windows",
+            host: .ssh(SSHHostInfo(
+                user: "operator",
+                hostname: "windows.example.test",
+                port: nil,
+                platform: .windows
+            )),
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { isReady }
+        _ = coordinator.surface(handle: handle)
+
+        #expect(store.surface.tmuxSplitShortcutHandler == nil)
+    }
+
+    @Test("split requests run in attachment order")
+    func splitRequestsAreSerialized() async throws {
+        let events = LockedValue<[String]>([])
+        let releaseFirst = DispatchSemaphore(value: 0)
+        defer { releaseFirst.signal() }
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                if !command.contains("-v") {
+                    events.withLock { $0.append("start-right") }
+                    _ = releaseFirst.wait(timeout: .now() + 5)
+                    events.withLock { $0.append("finish-right") }
+                } else {
+                    events.withLock { $0.append("start-down") }
+                    events.withLock { $0.append("finish-down") }
+                }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "ordered",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { events.load() == ["start-right"] }
+        handler(.down)
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(events.load() == ["start-right"])
+
+        releaseFirst.signal()
+        await waitUntilMainActor { events.load().count == 4 }
+        #expect(events.load() == [
+            "start-right",
+            "finish-right",
+            "start-down",
+            "finish-down",
+        ])
+    }
+
+    @Test("detaching cancels the running split and its queue")
+    func detachCancelsSplitQueue() async throws {
+        let events = LockedValue<[String]>([])
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                if !command.contains("-v") {
+                    events.withLock { $0.append("start-right") }
+                    let deadline = Date().addingTimeInterval(5)
+                    while Date() < deadline,
+                          !withUnsafeCurrentTask(body: {
+                              $0?.isCancelled == true
+                          }) {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                    let wasCancelled = withUnsafeCurrentTask(body: {
+                        $0?.isCancelled == true
+                    })
+                    events.withLock {
+                        $0.append(wasCancelled ? "cancel-right" : "timeout")
+                    }
+                } else {
+                    events.withLock { $0.append("run-down") }
+                }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let hostID = UUID()
+        let handle = coordinator.attach(
+            hostID: hostID,
+            name: "cancelled",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { events.load() == ["start-right"] }
+        handler(.down)
+
+        coordinator.detach(hostID: hostID, name: "cancelled")
+
+        await waitUntilMainActor { events.load().count == 2 }
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(events.load() == ["start-right", "cancel-right"])
+    }
+
+    @Test("failed client binding can be retried without queuing a split")
+    func failedClientBindingCanBeRetried() async throws {
+        let clientLookups = LockedValue(0)
+        let splitCommands = LockedValue(0)
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    var attempt = 0
+                    clientLookups.withLock {
+                        $0 += 1
+                        attempt = $0
+                    }
+                    if attempt == 1 {
+                        return (1, "no clients yet")
+                    }
+                    return (0, coordinatorSplitClientOutput)
+                }
+                splitCommands.withLock { $0 += 1 }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "appearing",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { clientLookups.load() == 1 }
+        #expect(coordinator.supportsPaneSplitting(handle))
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { readyCount == 2 }
+        #expect(store.surface.tmuxSplitErrorMessage == nil)
+        #expect(splitCommands.load() == 0)
+        handler(.down)
+        await waitUntilMainActor { splitCommands.load() == 1 }
+        #expect(clientLookups.load() == 3)
+        #expect(store.surface.tmuxSplitErrorMessage == nil)
+    }
+
+    @Test("a replacement client reusing the attachment TTY is rejected")
+    func reusedClientTTYIsRejected() async throws {
+        let clientLookups = LockedValue(0)
+        let splitCommands = LockedValue(0)
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    var lookup = 0
+                    clientLookups.withLock {
+                        $0 += 1
+                        lookup = $0
+                    }
+                    if lookup <= 2 {
+                        return (0, coordinatorSplitClientOutput)
+                    }
+                    return (
+                        0,
+                        "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t123\t790\t322"
+                            + "\t/dev/ttys001\t$7\t456\t%9\n"
+                    )
+                }
+                splitCommands.withLock { $0 += 1 }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "reused-tty",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { splitCommands.load() == 1 }
+        handler(.down)
+        await waitUntilMainActor {
+            store.surface.tmuxSplitErrorMessage != nil
+                || splitCommands.load() == 2
+        }
+
+        #expect(clientLookups.load() == 3)
+        #expect(splitCommands.load() == 1)
+        #expect(store.surface.tmuxSplitErrorMessage?.contains(
+            "attached tmux session changed"
+        ) == true)
+    }
+
+    @Test("the attached client may move to another pane between splits")
+    func attachedClientPaneMayChange() async throws {
+        let clientLookups = LockedValue(0)
+        let splitCommands = LockedValue<[String]>([])
+        let store = RecordingTmuxSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    var lookup = 0
+                    clientLookups.withLock {
+                        $0 += 1
+                        lookup = $0
+                    }
+                    if lookup <= 2 {
+                        return (0, coordinatorSplitClientOutput)
+                    }
+                    return (
+                        0,
+                        "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t123\t789\t321"
+                            + "\t/dev/ttys001\t$7\t456\t%10\n"
+                    )
+                }
+                splitCommands.withLock { $0.append(command) }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "moving-client",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.tmuxSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { splitCommands.load().count == 1 }
+        handler(.down)
+        await waitUntilMainActor {
+            store.surface.tmuxSplitErrorMessage != nil
+                || splitCommands.load().count == 2
+        }
+
+        #expect(clientLookups.load() == 3)
+        #expect(splitCommands.load().count == 2)
+        #expect(splitCommands.load().last?.contains("'%10'") == true)
+        #expect(store.surface.tmuxSplitErrorMessage == nil)
+    }
+
     @Test("endpoint changes replace provisioning and active handles")
     func endpointChangesReplaceHandles() async throws {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
         )
         var states: [UUID: ConnectionState] = [:]
         coordinator.onStateChanged = { handle, state in
@@ -373,7 +1017,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 user: "user",
                 hostname: "old.example.com",
                 port: nil
-            ))
+            )),
+            sessionIdentity: coordinatorSplitIdentity
         )
         let second = coordinator.attach(
             hostID: hostID,
@@ -382,7 +1027,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 user: "user",
                 hostname: "new.example.com",
                 port: nil
-            ))
+            )),
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         #expect(first.id != second.id)
@@ -399,7 +1045,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 user: "user",
                 hostname: "third.example.com",
                 port: 2222
-            ))
+            )),
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         #expect(third.id != second.id)
@@ -416,7 +1063,7 @@ struct NativeTmuxSessionCoordinatorTests {
         )
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         var states: [ConnectionState] = []
         var isSurfaceReady = false
@@ -426,7 +1073,8 @@ struct NativeTmuxSessionCoordinatorTests {
             hostID: UUID(),
             name: "release-work",
             host: .local,
-            launchMode: .create
+            launchMode: .create,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isSurfaceReady }
@@ -457,7 +1105,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = MissingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         var states: [ConnectionState] = []
         var isSurfaceReady = false
@@ -466,7 +1114,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "release-work",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
 
         await waitUntilMainActor { isSurfaceReady }
@@ -491,7 +1140,7 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         var states: [ConnectionState] = []
         var isSurfaceReady = false
@@ -500,7 +1149,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "release-work",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
         await waitUntilMainActor { isSurfaceReady }
         _ = coordinator.surface(handle: handle)
@@ -521,14 +1171,15 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") }
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         var isSurfaceReady = false
         coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "release-work",
-            host: .local
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
         )
         await waitUntilMainActor { isSurfaceReady }
         _ = coordinator.surface(handle: handle)
@@ -548,8 +1199,8 @@ struct NativeTmuxSessionCoordinatorTests {
         let store = RecordingTmuxSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
             terminalCoordinator: store,
-            tmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             remoteExitStatusDirectory: statusDirectory
         )
         var isSurfaceReady = false
@@ -561,7 +1212,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 user: "dev",
                 hostname: "build.example.test",
                 port: nil
-            ))
+            )),
+            sessionIdentity: coordinatorSplitIdentity
         )
         await waitUntilMainActor { isSurfaceReady }
         _ = coordinator.surface(handle: handle)

--- a/Tests/App/PaneSplitCommandTests.swift
+++ b/Tests/App/PaneSplitCommandTests.swift
@@ -1,0 +1,66 @@
+#if canImport(AppKit)
+import AppKit
+import GhosthubTerminalSupport
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+struct PaneSplitCommandTests {
+    @Test("menu key equivalents require effective terminal focus")
+    func menuKeyboardShortcutAvailability() {
+        #expect(PaneSplitCommand.usesKeyboardShortcut(
+            canSplit: true,
+            hasEffectiveKeyboardFocus: true
+        ))
+        #expect(!PaneSplitCommand.usesKeyboardShortcut(
+            canSplit: true,
+            hasEffectiveKeyboardFocus: false
+        ))
+        #expect(!PaneSplitCommand.usesKeyboardShortcut(
+            canSplit: false,
+            hasEffectiveKeyboardFocus: true
+        ))
+    }
+
+    @Test("only exact pane split chords require terminal focus")
+    func focusRequirementMatchesPhysicalShortcut() throws {
+        let splitRight = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            isARepeat: false,
+            keyCode: 2
+        ))
+        let keyboardMenuSelection = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        ))
+
+        #expect(PaneSplitCommand.requiresKeyboardFocus(
+            .right,
+            currentEvent: splitRight
+        ))
+        #expect(!PaneSplitCommand.requiresKeyboardFocus(
+            .down,
+            currentEvent: splitRight
+        ))
+        #expect(!PaneSplitCommand.requiresKeyboardFocus(
+            .right,
+            currentEvent: keyboardMenuSelection
+        ))
+    }
+}
+#endif

--- a/Tests/App/SSHConfigurationResolverTests.swift
+++ b/Tests/App/SSHConfigurationResolverTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GhosthubTmux
 import Testing
 @testable import GhosthubApp
@@ -325,9 +326,11 @@ struct SSHConfigurationResolverTests {
         )
         let preserved = [
             "ciphers=aes256-gcm@openssh.com",
+            "escapechar=none",
             "kexalgorithms=curve25519-sha256",
             "macs=hmac-sha2-512-etm@openssh.com",
             "requiredrsasize=4096",
+            "sendenv=TMUX_TMPDIR",
         ]
 
         let arguments = SSHConfigurationResolver.snapshotConnectionArguments(
@@ -339,6 +342,7 @@ struct SSHConfigurationResolverTests {
                     proxyJump: nil,
                     proxyCommand: nil,
                     resolvedOptions: preserved + [
+                        "setenv=GHOSTHUB_TMUX_PROFILE=fleet-secret",
                         "identityfile=/credentials/id_ed25519",
                     ]
                 )
@@ -348,7 +352,137 @@ struct SSHConfigurationResolverTests {
         for option in preserved {
             #expect(arguments.contains(option))
         }
+        #expect(!arguments.contains(
+            "setenv=GHOSTHUB_TMUX_PROFILE=fleet-secret"
+        ))
         #expect(!arguments.contains("identityfile=/credentials/id_ed25519"))
+    }
+
+    @Test("connection snapshots keep SetEnv values in a private config file")
+    func protectsSetEnvValuesFromProcessArguments() throws {
+        let host = SSHHostInfo(
+            user: "deploy",
+            hostname: "build.example.test",
+            port: nil
+        )
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let snapshot = SSHConfigurationResolver.connectionArgumentsSnapshot(
+            for: host,
+            configurationProvider: { _ in
+                EffectiveSSHConfiguration(
+                    user: "deploy",
+                    strictHostKeyChecking: "yes",
+                    proxyJump: nil,
+                    proxyCommand: nil,
+                    resolvedOptions: [
+                        "sendenv=TMUX_TMPDIR",
+                        "setenv=GHOSTHUB_TOKEN=fleet secret#value",
+                    ]
+                )
+            },
+            temporaryDirectory: temporaryDirectory
+        )
+
+        let configurationURL = try #require(snapshot.configurationURL)
+        #expect(snapshot.arguments.contains(configurationURL.path))
+        #expect(!snapshot.arguments.joined(separator: " ").contains(
+            "fleet secret#value"
+        ))
+        let contents = try String(
+            contentsOf: configurationURL,
+            encoding: .utf8
+        )
+        #expect(contents.contains(
+            "SetEnv \"GHOSTHUB_TOKEN=fleet secret#value\""
+        ))
+        let fileAttributes = try FileManager.default.attributesOfItem(
+            atPath: configurationURL.path
+        )
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: configurationURL.deletingLastPathComponent().path
+        )
+        let filePermissions = try #require(
+            fileAttributes[.posixPermissions] as? NSNumber
+        )
+        let directoryPermissions = try #require(
+            directoryAttributes[.posixPermissions] as? NSNumber
+        )
+        #expect(filePermissions.intValue & 0o777 == 0o600)
+        #expect(directoryPermissions.intValue & 0o777 == 0o700)
+    }
+
+    @Test("connection snapshots retain authentication configuration")
+    func preservesAuthenticationWithoutControlConnection() throws {
+        let host = SSHHostInfo(
+            user: "deploy",
+            hostname: "build.example.test",
+            port: nil
+        )
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let snapshot = SSHConfigurationResolver.connectionArgumentsSnapshot(
+            for: host,
+            configurationProvider: { _ in
+                EffectiveSSHConfiguration(
+                    user: "deploy",
+                    strictHostKeyChecking: "yes",
+                    proxyJump: nil,
+                    proxyCommand: nil,
+                    resolvedOptions: [
+                        "authenticationmethods=publickey,password",
+                        "certificatefile=/credentials/deploy-cert.pub",
+                        "enablesshkeysign=yes",
+                        "identitiesonly=yes",
+                        "identityagent=/run/user/501/ssh-agent.sock",
+                        "identityfile=/credentials/deploy key",
+                        "preferredauthentications=publickey,password",
+                        "usekeychain=yes",
+                    ]
+                )
+            },
+            temporaryDirectory: temporaryDirectory
+        )
+
+        let configurationURL = try #require(snapshot.configurationURL)
+        let contents = try String(
+            contentsOf: configurationURL,
+            encoding: .utf8
+        )
+        #expect(!contents.contains("AuthenticationMethods"))
+        #expect(contents.contains(
+            "CertificateFile \"/credentials/deploy-cert.pub\""
+        ))
+        #expect(contents.contains("EnableSSHKeysign \"yes\""))
+        #expect(contents.contains("IdentitiesOnly \"yes\""))
+        #expect(contents.contains(
+            "IdentityAgent \"/run/user/501/ssh-agent.sock\""
+        ))
+        #expect(contents.contains(
+            "IdentityFile \"/credentials/deploy key\""
+        ))
+        #expect(contents.contains(
+            "PreferredAuthentications \"publickey,password\""
+        ))
+        #expect(contents.contains("UseKeychain \"yes\""))
+        let parsed = TmuxBinaryResolver.runProcess(
+            executable: "/usr/bin/ssh",
+            arguments: ["-G"] + snapshot.arguments + ["--", "example.invalid"],
+            timeout: 5
+        )
+        #expect(parsed.status == 0, Comment(rawValue: parsed.stderr))
     }
 
     @Test("opaque proxy commands fail routine SSH operations closed")

--- a/Tests/App/SSHConnectionPoolTests.swift
+++ b/Tests/App/SSHConnectionPoolTests.swift
@@ -382,8 +382,18 @@ struct SSHConnectionPoolTests {
         )
         let arguments = SSHConnectionPool.proxyArguments(
             for: target,
-            configurationProvider: { _ in
-                EffectiveSSHConfiguration(
+            configurationProvider: { host in
+                if host == proxy {
+                    return EffectiveSSHConfiguration(
+                        user: "frozen-relay",
+                        strictHostKeyChecking: "yes",
+                        proxyJump: nil,
+                        proxyCommand: nil,
+                        hostname: "relay.internal.test",
+                        port: 2222
+                    )
+                }
+                return EffectiveSSHConfiguration(
                     user: "operator",
                     strictHostKeyChecking: "yes",
                     proxyJump: nil,
@@ -395,10 +405,14 @@ struct SSHConnectionPoolTests {
         #expect(arguments.contains("ProxyJump=none"))
         #expect(arguments.contains(where: {
             $0.hasPrefix("ProxyCommand=")
+                && $0.contains("'-F' '/dev/null'")
+                && $0.contains("ProxyJump=none")
+                && $0.contains("ProxyCommand=/usr/bin/false")
                 && $0.contains("ControlPath=")
                 && $0.contains("ControlMaster=no")
                 && $0.contains("ControlPersist=no")
-                && $0.contains("relay@jump.example.test")
+                && $0.contains("'-p' '2222'")
+                && $0.contains("frozen-relay@relay.internal.test")
         }))
     }
 

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -12,6 +12,13 @@ import GhosthubWorkspace
 import GhosthubTerminalSupport
 @testable import GhosthubApp
 
+func successfulTmuxResolution(
+    _ path: String,
+    version: String = "tmux 3.4"
+) -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
+    .success(ResolvedTmuxBinary(path: path, version: version))
+}
+
 // MARK: - Environment Setup
 
 struct HostEnv {
@@ -295,12 +302,12 @@ func makeModel(
     notificationService: any NotificationService = NotificationServiceStub(),
     nativeTmuxSurfaceStore: (any TmuxSurfaceStoring)? = nil,
     nativeTmuxPathProvider:
-    (@Sendable () -> Result<String, TmuxBinaryError>)? = nil,
+    (@Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>)? = nil,
     localKwtPathProvider: @escaping @Sendable () -> String? = {
         KwtBinaryLocator.bundledPath()
     },
-    remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
-        -> Result<String, TmuxBinaryError> = { _ in
+    remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo, [String])
+        -> Result<ResolvedTmuxBinary, TmuxBinaryError> = { _, _ in
             .failure(.notFound(shell: "test"))
         },
     tmuxPresentationStyleProvider:
@@ -483,6 +490,10 @@ final class RecordingTmuxSurfaceStore: TmuxSurfaceStoring {
         return surface
     }
 
+    func paneSurfaceIfPresent(for _: SurfaceKey) -> (any TmuxPaneSurfacing)? {
+        requestedConfigurations.isEmpty ? nil : surface
+    }
+
     func removeSurface(for key: SurfaceKey) {
         removedKeys.append(key)
     }
@@ -491,6 +502,9 @@ final class RecordingTmuxSurfaceStore: TmuxSurfaceStoring {
 @MainActor
 final class RecordingTmuxPaneSurface: TmuxPaneSurfacing {
     var blocksClipboardReads = false
+    var tmuxSplitErrorMessage: String?
+    var hasEffectiveKeyboardFocus = false
+    var tmuxSplitShortcutHandler: ((TerminalTmuxSplitShortcut) -> Void)?
     let launchError: Error?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -25,10 +25,28 @@ struct TmuxBinaryResolverTests {
             #expect(command.hasPrefix("ghosthub_tmux_path="))
             return (
                 status: 0,
-                stdout: "/opt/homebrew/bin/tmux\ntmux 3.6a\n"
+                stdout: "/opt/homebrew/bin/tmux\ntmux 3.2a\n"
             )
         })
         #expect(try resolver.resolveTmuxPath().get() == "/opt/homebrew/bin/tmux")
+    }
+
+    @Test("resolution preserves the probed tmux version")
+    func preservesVersion() throws {
+        let resolver = TmuxBinaryResolver(processRunner: { _, _ in
+            (
+                status: 0,
+                stdout: "/opt/homebrew/bin/tmux\ntmux 3.4a\n"
+            )
+        })
+
+        #expect(
+            try resolver.resolveTmuxBinary().get()
+                == ResolvedTmuxBinary(
+                    path: "/opt/homebrew/bin/tmux",
+                    version: "tmux 3.4a"
+                )
+        )
     }
 
     @Test("account shell initializes PATH without interpreting probe syntax")
@@ -159,26 +177,42 @@ struct TmuxBinaryResolverTests {
         })
         #expect(
             resolver.resolveTmuxPath()
-                == .failure(.unsupportedVersion(found: "tmux 3.1c"))
+                == .failure(.unsupportedVersion(
+                    found: "tmux 3.1c",
+                    minimum: "3.2"
+                ))
         )
     }
 
-    @Test("remote resolution tolerates login banners and returns an absolute path")
-    func resolvesRemoteLoginShellPath() throws {
+    @Test("remote resolution uses its supplied SSH snapshot")
+    func resolvesRemotePathWithSuppliedSSHArguments() throws {
         let host = SSHHostInfo(user: "wesm", hostname: "build-box", port: 2222)
-        let resolver = TmuxBinaryResolver(remoteProcessRunner: { received, command in
-            #expect(received == host)
-            #expect(command.contains("command -v tmux"))
-            return (
-                status: 0,
-                stdout: "welcome\n/usr/local/bin/tmux\ntmux 3.2a\n",
-                stderr: ""
-            )
-        })
+        let sshArguments = [
+            "-F", "/dev/null",
+            "-o", "SetEnv=GHOSTHUB_TMUX_PROFILE=fleet",
+        ]
+        let resolver = TmuxBinaryResolver(
+            remoteProcessRunner: { received, receivedArguments, command in
+                #expect(received == host)
+                #expect(receivedArguments == sshArguments)
+                #expect(command.contains("command -v tmux"))
+                return (
+                    status: 0,
+                    stdout: "welcome\n/usr/local/bin/tmux\ntmux 3.6a\n",
+                    stderr: ""
+                )
+            }
+        )
 
         #expect(
-            try resolver.resolveTmuxPath(on: host).get()
-                == "/usr/local/bin/tmux"
+            try resolver.resolveTmuxBinary(
+                on: host,
+                sshConnectionArguments: sshArguments
+            ).get()
+                == ResolvedTmuxBinary(
+                    path: "/usr/local/bin/tmux",
+                    version: "tmux 3.6a"
+                )
         )
     }
 
@@ -188,7 +222,7 @@ struct TmuxBinaryResolverTests {
             user: "wesm", hostname: "untrusted-host", port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, _ in
+            remoteProcessRunner: { _, _, _ in
                 (
                     status: 255,
                     stdout: "",
@@ -216,14 +250,14 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, command in
+            remoteProcessRunner: { _, _, command in
                 #expect(command.contains("-L"))
                 #expect(command.contains("kwt-pr-0123456789abcdef"))
                 #expect(command.contains("has-session"))
                 #expect(command.contains("=pr-32"))
                 return (
                     status: 0,
-                    stdout: "/usr/bin/tmux\ntmux 3.4\n"
+                    stdout: "/usr/bin/tmux\ntmux 3.6\n"
                         + "GHOSTHUB_TMUX_SESSION_PRESENT\n",
                     stderr: ""
                 )
@@ -245,10 +279,10 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, _ in
+            remoteProcessRunner: { _, _, _ in
                 (
                     status: 0,
-                    stdout: "/usr/bin/tmux\ntmux 3.4\n"
+                    stdout: "/usr/bin/tmux\ntmux 3.6\n"
                         + "GHOSTHUB_TMUX_SESSION_ABSENT\n",
                     stderr: ""
                 )
@@ -270,7 +304,7 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, _ in
+            remoteProcessRunner: { _, _, _ in
                 (
                     status: 0,
                     stdout: "/usr/bin/tmux\ntmux 3.1c\n"
@@ -284,7 +318,10 @@ struct TmuxBinaryResolverTests {
             name: "pr-32",
             socketName: "kwt-pr-0123456789abcdef",
             on: host
-        ) == .failure(.unsupportedVersion(found: "tmux 3.1c")))
+        ) == .failure(.unsupportedVersion(
+            found: "tmux 3.1c",
+            minimum: "3.2"
+        )))
     }
 
     @Test("exact probe does not treat generic tmux failure as absence")
@@ -295,10 +332,10 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, _ in
+            remoteProcessRunner: { _, _, _ in
                 (
                     status: 1,
-                    stdout: "/usr/bin/tmux\ntmux 3.4\n",
+                    stdout: "/usr/bin/tmux\ntmux 3.6\n",
                     stderr: "error connecting to /tmp/tmux: Permission denied"
                 )
             }
@@ -320,7 +357,7 @@ struct TmuxBinaryResolverTests {
             platform: .windows
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, command in
+            remoteProcessRunner: { _, _, command in
                 for argument in [
                     "-L",
                     "kwt-pr-0123456789abcdef",
@@ -359,7 +396,7 @@ struct TmuxBinaryResolverTests {
             platform: .windows
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { received, command in
+            remoteProcessRunner: { received, _, command in
                 #expect(received == host)
                 #expect(command.contains("Get-Command tmux.exe"))
                 #expect(command.contains("[Console]::OutputEncoding"))
@@ -474,14 +511,14 @@ struct TmuxBinaryResolverTests {
             user: "wesm", hostname: "build-box", port: 2222
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { received, command in
+            remoteProcessRunner: { received, _, command in
                 #expect(received == host)
                 #expect(command.contains("list-sessions"))
                 return (
                     status: 0,
                     stdout: """
                     /usr/local/bin/tmux
-                    tmux 3.4
+                    tmux 3.6
                     GHOSTHUB_TMUX_SESSION\t3\t202\t$7\t99\t\tremote-work
 
                     """,
@@ -510,7 +547,7 @@ struct TmuxBinaryResolverTests {
             platform: .windows
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { received, command in
+            remoteProcessRunner: { received, _, command in
                 #expect(received == host)
                 #expect(command.contains("Get-Command tmux.exe"))
                 #expect(command.contains("'list-sessions' '-F'"))
@@ -521,7 +558,7 @@ struct TmuxBinaryResolverTests {
                 return (
                     status: 0,
                     stdout: "C:\\Tools\\psmux\\tmux.exe\r\n"
-                        + "tmux 3.3.7\r\n"
+                        + "tmux 3.6.7\r\n"
                         + "GHOSTHUB_TMUX_SESSION\t2\t202\t$7"
                         + "\t1783344091\t\twindows-work\r\n",
                     stderr: ""
@@ -545,7 +582,7 @@ struct TmuxBinaryResolverTests {
     @Test("a reachable tmux server with no sessions produces an empty inventory")
     func discoversEmptyServer() throws {
         let resolver = TmuxBinaryResolver(processRunner: { _, _ in
-            (status: 0, stdout: "/usr/bin/tmux\ntmux 3.3a\n")
+            (status: 0, stdout: "/usr/bin/tmux\ntmux 3.6a\n")
         })
 
         #expect(try resolver.discoverSessions().get().isEmpty)
@@ -565,7 +602,7 @@ struct TmuxBinaryResolverTests {
         try """
         #!/bin/sh
         if [ "$1" = "-V" ]; then
-          printf 'tmux 3.3a\n'
+          printf 'tmux 3.6a\n'
           exit 0
         fi
         printf 'error connecting to /tmp/tmux-501/default (No such file or directory)\n' >&2
@@ -582,7 +619,7 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, command in
+            remoteProcessRunner: { _, _, command in
                 return TmuxBinaryResolver.runProcess(
                     executable: "/bin/sh",
                     arguments: ["-c", command],
@@ -610,10 +647,10 @@ struct TmuxBinaryResolverTests {
             port: nil
         )
         let resolver = TmuxBinaryResolver(
-            remoteProcessRunner: { _, _ in
+            remoteProcessRunner: { _, _, _ in
                 (
                     status: 1,
-                    stdout: "/usr/bin/tmux\ntmux 3.3a\n",
+                    stdout: "/usr/bin/tmux\ntmux 3.6a\n",
                     stderr: "error connecting to /tmp/tmux-501/default (Permission denied)\n"
                 )
             }
@@ -639,7 +676,7 @@ struct TmuxBinaryResolverTests {
         try """
         #!/bin/sh
         if [ "$1" = "-V" ]; then
-          printf 'tmux 3.3a\n'
+          printf 'tmux 3.6a\n'
           exit 0
         fi
         printf 'error connecting to tmux server (Permission denied)\n' >&2
@@ -973,11 +1010,18 @@ struct TmuxPathCacheTests {
         let counter = Counter()
         let cache = TmuxPathCache {
             _ = counter.increment()
-            return .success("/opt/homebrew/bin/tmux")
+            return .success(ResolvedTmuxBinary(
+                path: "/opt/homebrew/bin/tmux",
+                version: "tmux 3.4a"
+            ))
         }
 
-        #expect(try cache.resolveTmuxPath().get() == "/opt/homebrew/bin/tmux")
-        #expect(try cache.resolveTmuxPath().get() == "/opt/homebrew/bin/tmux")
+        let expected = ResolvedTmuxBinary(
+            path: "/opt/homebrew/bin/tmux",
+            version: "tmux 3.4a"
+        )
+        #expect(try cache.resolveTmuxBinary().get() == expected)
+        #expect(try cache.resolveTmuxBinary().get() == expected)
         #expect(counter.count == 1)
     }
 
@@ -987,14 +1031,20 @@ struct TmuxPathCacheTests {
         let cache = TmuxPathCache {
             counter.increment() == 1
                 ? .failure(.notFound(shell: "/bin/zsh"))
-                : .success("/opt/homebrew/bin/tmux")
+                : .success(ResolvedTmuxBinary(
+                    path: "/opt/homebrew/bin/tmux",
+                    version: "tmux 3.4"
+                ))
         }
 
-        guard case .failure = cache.resolveTmuxPath() else {
+        guard case .failure = cache.resolveTmuxBinary() else {
             Issue.record("expected the first resolve to fail")
             return
         }
-        #expect(try cache.resolveTmuxPath().get() == "/opt/homebrew/bin/tmux")
+        #expect(
+            try cache.resolveTmuxBinary().get().path
+                == "/opt/homebrew/bin/tmux"
+        )
         #expect(counter.count == 2)
     }
 }

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -1,0 +1,1121 @@
+import Foundation
+import GhosthubTerminalSupport
+import GhosthubTmux
+import Testing
+@testable import GhosthubApp
+
+private let testSplitClient = TmuxPaneSplitClientIdentity(
+    serverPID: "123",
+    clientPID: "789",
+    clientCreatedAt: "321",
+    clientTTY: "/dev/ttys001",
+    sessionID: "$7",
+    sessionCreatedAt: "456",
+    paneID: "%9"
+)
+
+private final class TestTmuxClient {
+    let process = Process()
+    private let input = Pipe()
+    private let tokenPath: URL
+
+    init(
+        tmuxPath: String,
+        socketName: String,
+        sessionName: String,
+        clientToken: String
+    ) throws {
+        tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ghosthub/tmux-clients/\(clientToken)")
+        let command = TmuxAttachmentInfo(
+            sessionName: sessionName,
+            host: .local,
+            socketName: socketName,
+            launchMode: .attachOnly
+        ).attachCommand(
+            tmuxPath: tmuxPath,
+            clientTTYToken: clientToken
+        )
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
+        process.arguments = [
+            "-q", "/dev/null", "/bin/sh", "-c", command,
+        ]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "TERM": "xterm-256color",
+        ]) { _, new in new }
+        process.standardInput = input
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+    }
+
+    func stop() {
+        if process.isRunning {
+            process.terminate()
+        }
+        try? FileManager.default.removeItem(at: tokenPath)
+    }
+
+    func waitForIdentityPublication() async {
+        for _ in 0 ..< 600
+            where !FileManager.default.fileExists(atPath: tokenPath.path) {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private func stopTestTmuxServer(tmuxPath: String, socketName: String) {
+    _ = TmuxBinaryResolver.runProcess(
+        executable: tmuxPath,
+        arguments: [
+            "-L", socketName,
+            "kill-session", "-a", ";", "kill-session",
+        ],
+        timeout: 5
+    )
+}
+
+private func nativePaneSplitsAreAvailable(_ tmuxPath: String) -> Bool {
+    guard case let .success(binary) =
+        TmuxBinaryResolver().resolveTmuxBinary()
+    else { return false }
+    return TmuxPaneSplitter.supportsPaneSplitting(
+        version: binary.version,
+        host: .local
+    )
+}
+
+@Suite("tmux pane splitting", .serialized)
+struct TmuxPaneSplitterTests {
+    @Test("version capability requires tmux 3.4")
+    func versionCapabilityRequiresTmux34() {
+        #expect(TmuxPaneSplitter.supportsPaneSplitting(
+            version: "tmux 3.4a",
+            host: .local
+        ))
+        #expect(!TmuxPaneSplitter.supportsPaneSplitting(
+            version: "tmux 3.3a",
+            host: .local
+        ))
+        #expect(!TmuxPaneSplitter.supportsPaneSplitting(
+            version: "tmux 3.6",
+            host: .ssh(SSHHostInfo(
+                user: nil,
+                hostname: "windows.example.test",
+                port: nil,
+                platform: .windows
+            ))
+        ))
+    }
+
+    @Test("custom prefix and key bindings do not affect semantic splits")
+    func customizedBindings() async {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else {
+            return
+        }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let socketName = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ].map { "ghosthub-split-\($0)" }
+            ?? "ghosthub-split-\(UUID().uuidString.lowercased())"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        let created = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "customized",
+            ],
+            timeout: 5
+        )
+        #expect(created.status == 0)
+        let customized = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName,
+                "set-option", "-g", "prefix", "C-a", ";",
+                "unbind-key", "%", ";",
+                "unbind-key", #"""#,
+            ],
+            timeout: 5
+        )
+        #expect(customized.status == 0)
+
+        let unresolvedTarget = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "customized",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: UUID().uuidString.lowercased()
+        )
+        let unrelatedClient = try? TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "customized",
+            clientToken: UUID().uuidString.lowercased()
+        )
+        defer { unrelatedClient?.stop() }
+        let clientProcess = try? TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "customized",
+            clientToken: unresolvedTarget.clientToken ?? ""
+        )
+        defer { clientProcess?.stop() }
+        var attachedClientCount = 0
+        for _ in 0 ..< 100 where attachedClientCount != 2 {
+            let listed = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-L", socketName, "list-clients", "-F", "#{client_tty}",
+                ],
+                timeout: 5
+            )
+            attachedClientCount = listed.stdout
+                .split(whereSeparator: \.isNewline).count
+            if attachedClientCount != 2 {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        #expect(attachedClientCount == 2)
+        await clientProcess?.waitForIdentityPublication()
+        let initialClient = try? await TmuxPaneSplitter().clientIdentity(
+            target: unresolvedTarget
+        ).get()
+        #expect(initialClient != nil)
+        let renamed = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName,
+                "rename-session", "-t", "=customized:", "renamed",
+            ],
+            timeout: 5
+        )
+        #expect(renamed.status == 0)
+
+        var renamedTarget = unresolvedTarget
+        renamedTarget.expectedIdentity = initialClient?.sessionIdentity
+        renamedTarget.expectedClient = initialClient
+        let client = try? await TmuxPaneSplitter().clientIdentity(
+            target: renamedTarget
+        ).get()
+        #expect(client != nil)
+        let expectedTTY = unresolvedTarget.clientToken.flatMap { token in
+            try? String(
+                contentsOf: FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent(
+                        ".ghosthub/tmux-clients/\(token)"
+                    ),
+                encoding: .utf8
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        #expect(client?.clientTTY == expectedTTY)
+
+        let failure = await TmuxPaneSplitter().split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: tmuxPath,
+                sessionName: "customized",
+                socketName: socketName,
+                sshConnectionArguments: [],
+                expectedIdentity: client?.sessionIdentity,
+                expectedClient: client
+            )
+        )
+        #expect(failure == nil)
+        let hooks = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: ["-L", socketName, "show-hooks", "-g"],
+            timeout: 5
+        )
+        #expect(!hooks.stdout.split(whereSeparator: \.isNewline)
+            .contains(where: { $0.hasPrefix("after-refresh-client[") }))
+
+        let panes = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName, "list-panes", "-t", "=renamed:",
+                "-F", "#{pane_id}",
+            ],
+            timeout: 5
+        )
+        #expect(panes.status == 0)
+        #expect(panes.stdout.split(whereSeparator: \.isNewline).count == 2)
+    }
+
+    @Test("concurrent split hooks remain isolated by request marker")
+    func concurrentHooksRemainIsolated() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
+        let socketName = "ghosthub-concurrent-hooks-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        for sessionName in ["concurrent-a", "concurrent-b"] {
+            let created = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-f", "/dev/null", "-L", socketName,
+                    "new-session", "-d", "-s", sessionName,
+                ],
+                timeout: 5
+            )
+            #expect(created.status == 0)
+        }
+
+        let firstToken = UUID().uuidString.lowercased()
+        let secondToken = UUID().uuidString.lowercased()
+        let firstClientTarget = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "concurrent-a",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: firstToken
+        )
+        let secondClientTarget = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "concurrent-b",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: secondToken
+        )
+        let firstClientProcess = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "concurrent-a",
+            clientToken: firstToken
+        )
+        defer { firstClientProcess.stop() }
+        let secondClientProcess = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "concurrent-b",
+            clientToken: secondToken
+        )
+        defer { secondClientProcess.stop() }
+        await firstClientProcess.waitForIdentityPublication()
+        await secondClientProcess.waitForIdentityPublication()
+        let splitter = TmuxPaneSplitter()
+        let firstClient = try await splitter.clientIdentity(
+            target: firstClientTarget
+        ).get()
+        let secondClient = try await splitter.clientIdentity(
+            target: secondClientTarget
+        ).get()
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let barrierDirectory = temporaryDirectory.appendingPathComponent(
+            "barrier",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: barrierDirectory,
+            withIntermediateDirectories: false
+        )
+        let shimURL = temporaryDirectory.appendingPathComponent("tmux")
+        let shim = """
+        #!/bin/sh
+        set -eu
+        if [ "${3-}" = set-hook ] && [ "${4-}" = -g ] \
+            && [ "${8-}" = refresh-client ]; then
+          ghosthub_socket=$2
+          ghosthub_hook=$5
+          ghosthub_body=$6
+          ghosthub_tty=${10}
+          ghosthub_marker=${11}
+          ghosthub_cleanup_hook=${15}
+          \(shellQuotedCommandArgument(tmuxPath)) -L "$ghosthub_socket" \
+            set-hook -g "$ghosthub_hook" "$ghosthub_body"
+          : > \(shellQuotedCommandArgument(barrierDirectory.path))/"$ghosthub_hook"
+          ghosthub_attempt=0
+          while [ "$ghosthub_attempt" -lt 500 ]; do
+            set -- \(shellQuotedCommandArgument(barrierDirectory.path))/*
+            [ "$#" -ge 2 ] && break
+            ghosthub_attempt=$((ghosthub_attempt + 1))
+            sleep 0.01
+          done
+          [ "$#" -ge 2 ] || exit 99
+          \(shellQuotedCommandArgument(tmuxPath)) -L "$ghosthub_socket" \
+            refresh-client -t "$ghosthub_tty" "$ghosthub_marker" ';' \
+            set-hook -gu "$ghosthub_cleanup_hook"
+          exit $?
+        fi
+        exec \(shellQuotedCommandArgument(tmuxPath)) "$@"
+        """
+        try Data(shim.utf8).write(to: shimURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shimURL.path
+        )
+
+        let firstSplitTarget = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: shimURL.path,
+            sessionName: "concurrent-a",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            expectedIdentity: firstClient.sessionIdentity,
+            expectedClient: firstClient
+        )
+        let secondSplitTarget = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: shimURL.path,
+            sessionName: "concurrent-b",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            expectedIdentity: secondClient.sessionIdentity,
+            expectedClient: secondClient
+        )
+        async let first = splitter.split(.right, target: firstSplitTarget)
+        async let second = splitter.split(.down, target: secondSplitTarget)
+        let failures = await (first, second)
+
+        #expect(failures.0 == nil)
+        #expect(failures.1 == nil)
+        for sessionName in ["concurrent-a", "concurrent-b"] {
+            let panes = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-L", socketName, "list-panes", "-t", "=\(sessionName):",
+                    "-F", "#{pane_id}",
+                ],
+                timeout: 5
+            )
+            #expect(panes.stdout.split(whereSeparator: \.isNewline).count == 2)
+        }
+    }
+
+    @Test("client identity waits for attachment TTY publication")
+    func clientIdentityWaitsForTTYPublication() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.lowercased().prefix(8))
+        let socketName = "ghosthub-token-race-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        let created = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "token-race",
+            ],
+            timeout: 5
+        )
+        #expect(created.status == 0)
+
+        let token = UUID().uuidString.lowercased()
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "token-race",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: token
+        )
+        let runnerStarted = LockedValue(false)
+        let releaseRunner = DispatchSemaphore(value: 0)
+        let splitter = TmuxPaneSplitter { _, _, command in
+            runnerStarted.store(true)
+            releaseRunner.wait()
+            let result = TmuxBinaryResolver.runLoginShell(
+                shell: TmuxBinaryResolver.loginShell(),
+                command: command,
+                timeout: 15,
+                captureStandardError: true
+            )
+            return (result.status, result.stdout)
+        }
+        async let pendingIdentity = splitter.clientIdentity(target: target)
+        for _ in 0 ..< 100 where !runnerStarted.load() {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(runnerStarted.load())
+        releaseRunner.signal()
+        try await Task.sleep(for: .milliseconds(50))
+
+        let clientProcess = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "token-race",
+            clientToken: token
+        )
+        defer { clientProcess.stop() }
+        let client = try await pendingIdentity.get()
+
+        #expect(client.clientTTY.hasPrefix("/dev/"))
+        #expect(client.sessionIdentity.sessionID.hasPrefix("$"))
+    }
+
+    @Test("client identity resolves after slow attachment startup")
+    func slowAttachmentIdentityResolvesOnDemand() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.lowercased().prefix(8))
+        let socketName = "ghosthub-slow-split-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        let created = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "slow",
+            ],
+            timeout: 5
+        )
+        #expect(created.status == 0)
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let kwt = directory.appendingPathComponent("kwt")
+        try """
+        #!/bin/sh
+        sleep 6.5
+        exec "$GHOSTHUB_TEST_TMUX" -L "$GHOSTHUB_TEST_TMUX_SOCKET" \
+          attach-session -E -t '=slow'
+        """.write(to: kwt, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: kwt.path
+        )
+
+        let token = UUID().uuidString.lowercased()
+        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ghosthub/tmux-clients/\(token)")
+        defer { try? FileManager.default.removeItem(at: tokenPath) }
+        let command = TmuxAttachmentInfo(
+            sessionName: "slow",
+            host: .local,
+            socketName: socketName,
+            workspacePath: "/tmp/slow"
+        ).attachCommand(
+            tmuxPath: tmuxPath,
+            kwtPath: kwt.path,
+            clientTTYToken: token
+        )
+        let process = Process()
+        let input = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
+        process.arguments = ["-q", "/dev/null", "/bin/sh", "-c", command]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "TERM": "xterm-256color",
+            "GHOSTHUB_TEST_TMUX": tmuxPath,
+            "GHOSTHUB_TEST_TMUX_SOCKET": socketName,
+        ]) { _, new in new }
+        process.standardInput = input
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        var publishedTTY = ""
+        for _ in 0 ..< 200 where publishedTTY.isEmpty {
+            publishedTTY = ((try? String(
+                contentsOf: tokenPath,
+                encoding: .utf8
+            )) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if publishedTTY.isEmpty {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        #expect(publishedTTY.hasPrefix("/dev/"))
+
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "slow",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: token
+        )
+        let earlyClient = try? await TmuxPaneSplitter().clientIdentity(
+            target: target
+        ).get()
+        #expect(earlyClient == nil)
+        let client = try await TmuxPaneSplitter().clientIdentity(
+            target: target
+        ).get()
+        var resolvedTarget = target
+        resolvedTarget.expectedIdentity = client.sessionIdentity
+        resolvedTarget.expectedClient = client
+        #expect(await TmuxPaneSplitter().split(
+            .right,
+            target: resolvedTarget
+        ) == nil)
+    }
+
+    @Test("identity publication ignores launcher tmux and session renames")
+    func identityPublicationUsesAttachedClient() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.lowercased().prefix(8))
+        let targetSocketName = "gh-target-\(runID)"
+        let launcherSocketName = "gh-launcher-\(runID)"
+        let token = UUID().uuidString.lowercased()
+        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ghosthub/tmux-clients/\(token)")
+        let targetCreate = [
+            tmuxPath, "-f", "/dev/null", "-L", targetSocketName,
+            "new-session", "-d", "-s", "inherited-target",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let launcherCreate = [
+            tmuxPath, "-f", "/dev/null", "-L", launcherSocketName,
+            "new-session", "-d", "-s", "launcher",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        #expect(TmuxBinaryResolver.runLoginShell(
+            shell: "/bin/sh",
+            command: targetCreate,
+            timeout: 5
+        ).status == 0)
+        #expect(TmuxBinaryResolver.runLoginShell(
+            shell: "/bin/sh",
+            command: launcherCreate,
+            timeout: 5
+        ).status == 0)
+        defer {
+            stopTestTmuxServer(
+                tmuxPath: tmuxPath,
+                socketName: targetSocketName
+            )
+            stopTestTmuxServer(
+                tmuxPath: tmuxPath,
+                socketName: launcherSocketName
+            )
+            try? FileManager.default.removeItem(at: tokenPath)
+        }
+        let renameHook = [
+            tmuxPath, "-L", targetSocketName, "set-hook", "-g",
+            "client-attached",
+            "rename-session -t =inherited-target: inherited-renamed",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        #expect(TmuxBinaryResolver.runLoginShell(
+            shell: "/bin/sh",
+            command: renameHook,
+            timeout: 5
+        ).status == 0)
+        let launcherIdentity = [
+            tmuxPath, "-L", launcherSocketName, "display-message", "-p",
+            "#{socket_path}\t#{pid}",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let launcherFields = TmuxBinaryResolver.runLoginShell(
+            shell: "/bin/sh",
+            command: launcherIdentity,
+            timeout: 5
+        ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\t")
+        let launcherSocketPath = try #require(launcherFields.first)
+        let launcherPID = try #require(launcherFields.dropFirst().first)
+
+        let attach = TmuxAttachmentInfo(
+            sessionName: "inherited-target",
+            host: .local,
+            socketName: targetSocketName,
+            launchMode: .attachOnly
+        ).attachCommand(tmuxPath: tmuxPath, clientTTYToken: token)
+        let process = Process()
+        let input = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
+        process.arguments = ["-q", "/dev/null", "/bin/sh", "-c", attach]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "TERM": "xterm-256color",
+            "TMUX": "\(launcherSocketPath),\(launcherPID),0",
+            "TMUX_PANE": "%0",
+        ]) { _, new in new }
+        process.standardInput = input
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        var published = ""
+        for _ in 0 ..< 200 where published.isEmpty {
+            published = (try? String(
+                contentsOf: tokenPath,
+                encoding: .utf8
+            )) ?? ""
+            if published.isEmpty {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        let targetIdentity = [
+            tmuxPath, "-L", targetSocketName, "display-message", "-p", "-t",
+            "=inherited-renamed:",
+            "#{pid}\t#{session_id}\t#{session_created}",
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let targetIdentityResult = TmuxBinaryResolver.runLoginShell(
+            shell: "/bin/sh",
+            command: targetIdentity,
+            timeout: 5
+        )
+        let targetFields = targetIdentityResult.stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\t")
+
+        let client = try await TmuxPaneSplitter().clientIdentity(
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: tmuxPath,
+                sessionName: "inherited-target",
+                socketName: targetSocketName,
+                sshConnectionArguments: [],
+                clientToken: token
+            )
+        ).get()
+        #expect(published.split(whereSeparator: \.isNewline).count == 1)
+        #expect(targetIdentityResult.status == 0)
+        #expect(targetFields.count == 3)
+        #expect(client.serverPID == targetFields.first.map(String.init))
+        #expect(
+            client.sessionID == targetFields.dropFirst().first.map(String.init)
+        )
+        #expect(client.sessionCreatedAt == targetFields.last.map(String.init))
+        #expect(client.serverPID != String(launcherPID))
+    }
+
+    @Test("failed splits return a concise tmux diagnostic")
+    func failedSplit() async {
+        let failure = await TmuxPaneSplitter { _, _, _ in
+            (7, "  no space\nfor new pane  ")
+        }.split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: "/usr/bin/tmux",
+                sessionName: "limited",
+                socketName: nil,
+                sshConnectionArguments: [],
+                expectedIdentity: testSplitClient.sessionIdentity,
+                expectedClient: testSplitClient
+            )
+        )
+
+        #expect(failure == TmuxPaneSplitFailure(
+            host: "localhost",
+            sessionName: "limited",
+            status: 7,
+            diagnostic: "no space for new pane"
+        ))
+    }
+
+    @Test("client identity discovery lists clients by published TTY")
+    func clientIdentityUsesListClients() async throws {
+        let command = LockedValue("")
+        let client = try await TmuxPaneSplitter { _, _, received in
+            command.store(received)
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t"
+                    + "123\t789\t321\t/dev/ttys001\t$7\t456\t%9\n"
+            )
+        }.clientIdentity(
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: "/usr/bin/tmux",
+                sessionName: "review",
+                socketName: nil,
+                sshConnectionArguments: [],
+                clientToken: "attachment-token"
+            )
+        ).get()
+
+        #expect(client == testSplitClient)
+        #expect(command.load().contains("'list-clients' '-F'"))
+    }
+
+    @Test("noisy command echoes do not report an identity mismatch")
+    func noisyCommandEchoIsIgnored() async {
+        let failure = await TmuxPaneSplitter { _, _, command in
+            (0, "+ \(command)\n")
+        }.split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: "/usr/bin/tmux",
+                sessionName: "noisy",
+                socketName: nil,
+                sshConnectionArguments: [],
+                expectedIdentity: testSplitClient.sessionIdentity,
+                expectedClient: testSplitClient
+            )
+        )
+
+        #expect(failure == nil)
+    }
+
+    @Test("validation and split share one exact-client tmux queue")
+    func posixCommands() {
+        let right = TmuxPaneSplitter.command(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            socketName: "kwt-pr-0123456789abcdef",
+            shortcut: .right,
+            expectedClient: testSplitClient,
+            mismatchMarker: "TEST_MISMATCH",
+            hookIndex: 1_500_000_001
+        )
+        let down = TmuxPaneSplitter.command(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            socketName: "kwt-pr-0123456789abcdef",
+            shortcut: .down,
+            expectedClient: testSplitClient,
+            mismatchMarker: "TEST_MISMATCH",
+            hookIndex: 1_500_000_002
+        )
+        let rightSyntax = TmuxBinaryResolver.runProcess(
+            executable: "/bin/sh",
+            arguments: ["-n", "-c", right],
+            timeout: 5
+        )
+        let downSyntax = TmuxBinaryResolver.runProcess(
+            executable: "/bin/sh",
+            arguments: ["-n", "-c", down],
+            timeout: 5
+        )
+
+        #expect(rightSyntax.status == 0, Comment(rawValue: rightSyntax.stderr))
+        #expect(!right.contains("'list-clients' '-F'"))
+        #expect(right.contains("'refresh-client' '-t' '/dev/ttys001'"))
+        #expect(right.contains("'after-refresh-client["))
+        #expect(right.contains("#{L:"))
+        #expect(right.contains("#{==:#{client_pid},789}"))
+        #expect(right.contains("#{==:#{client_created},321}"))
+        #expect(right.contains("#{==:#{pane_id},%9}"))
+        #expect(right.contains("split-window"))
+        #expect(right.contains("-h"))
+        #expect(right.contains(shellQuotedCommandArgument("TEST_MISMATCH")))
+        #expect(!right.contains("=review"))
+        #expect(downSyntax.status == 0, Comment(rawValue: downSyntax.stderr))
+        #expect(!down.contains("'list-clients' '-F'"))
+        #expect(down.contains("'refresh-client' '-t' '/dev/ttys001'"))
+        #expect(down.contains("'after-refresh-client["))
+        #expect(down.contains("split-window"))
+        #expect(down.contains("-v"))
+        #expect(!down.contains("=review"))
+    }
+
+    @Test("atomic validation rejects a replacement on the expected TTY")
+    func replacementClientOnExpectedTTYIsRejected() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
+        let socketName = "ghosthub-client-identity-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        let created = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "identity",
+            ],
+            timeout: 5
+        )
+        #expect(created.status == 0)
+        let originalToken = UUID().uuidString.lowercased()
+        let replacementToken = UUID().uuidString.lowercased()
+        let original = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "identity",
+            clientToken: originalToken
+        )
+        defer { original.stop() }
+        let replacement = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "identity",
+            clientToken: replacementToken
+        )
+        defer { replacement.stop() }
+        await original.waitForIdentityPublication()
+        await replacement.waitForIdentityPublication()
+        let splitter = TmuxPaneSplitter()
+        let originalClient = try await splitter.clientIdentity(
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: tmuxPath,
+                sessionName: "identity",
+                socketName: socketName,
+                sshConnectionArguments: [],
+                clientToken: originalToken
+            )
+        ).get()
+        let replacementClient = try await splitter.clientIdentity(
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: tmuxPath,
+                sessionName: "identity",
+                socketName: socketName,
+                sshConnectionArguments: [],
+                clientToken: replacementToken
+            )
+        ).get()
+        var mismatchedClient = originalClient
+        mismatchedClient.clientTTY = replacementClient.clientTTY
+        mismatchedClient.paneID = replacementClient.paneID
+        let failure = await splitter.split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: tmuxPath,
+                sessionName: "identity",
+                socketName: socketName,
+                sshConnectionArguments: [],
+                expectedIdentity: originalClient.sessionIdentity,
+                expectedClient: mismatchedClient
+            )
+        )
+
+        #expect(failure?.diagnostic == "The attached tmux session changed.")
+        let panes = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName, "list-panes", "-t", "=identity:",
+                "-F", "#{pane_id}",
+            ],
+            timeout: 5
+        )
+        #expect(panes.stdout.split(whereSeparator: \.isNewline).count == 1)
+    }
+
+    @Test("same-name replacements cannot receive a queued split")
+    func replacementIsRejected() async {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else {
+            return
+        }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
+        let socketName = "ghosthub-replacement-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "replaceable",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: UUID().uuidString.lowercased()
+        )
+        let created = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "replaceable",
+            ],
+            timeout: 5
+        )
+        #expect(created.status == 0)
+        let clientProcess = try? TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "replaceable",
+            clientToken: target.clientToken ?? ""
+        )
+        defer { clientProcess?.stop() }
+        await clientProcess?.waitForIdentityPublication()
+        let client = try? await TmuxPaneSplitter().clientIdentity(
+            target: target
+        ).get()
+        #expect(client != nil)
+        _ = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: ["-L", socketName, "kill-session", "-t", "replaceable"],
+            timeout: 5
+        )
+        let replacement = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-f", "/dev/null", "-L", socketName,
+                "new-session", "-d", "-s", "replaceable",
+            ],
+            timeout: 5
+        )
+        #expect(replacement.status == 0)
+
+        var guardedTarget = target
+        guardedTarget.expectedIdentity = client?.sessionIdentity
+        guardedTarget.expectedClient = client
+        let failure = await TmuxPaneSplitter().split(
+            .right,
+            target: guardedTarget
+        )
+        #expect(failure?.diagnostic == "The attached tmux session changed.")
+        let panes = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName, "list-panes", "-t", "=replaceable:",
+                "-F", "#{pane_id}",
+            ],
+            timeout: 5
+        )
+        #expect(panes.status == 0)
+        #expect(panes.stdout.split(whereSeparator: \.isNewline).count == 1)
+    }
+
+    @Test("a client switched to another session cannot split the hidden session")
+    func switchedClientIsRejected() async {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let runID = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
+        let socketName = "ghosthub-client-switch-\(runID)"
+        defer {
+            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
+        }
+        for session in ["original", "visible"] {
+            let created = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-f", "/dev/null", "-L", socketName,
+                    "new-session", "-d", "-s", session,
+                ],
+                timeout: 5
+            )
+            #expect(created.status == 0)
+        }
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "original",
+            socketName: socketName,
+            sshConnectionArguments: [],
+            clientToken: UUID().uuidString.lowercased()
+        )
+        let clientProcess = try? TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            sessionName: "original",
+            clientToken: target.clientToken ?? ""
+        )
+        defer { clientProcess?.stop() }
+        await clientProcess?.waitForIdentityPublication()
+        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(
+                ".ghosthub/tmux-clients/\(target.clientToken ?? "")"
+            )
+        let client = try? await TmuxPaneSplitter().clientIdentity(
+            target: target
+        ).get()
+        guard let client else {
+            let listed = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-L", socketName, "list-clients", "-F",
+                    "#{client_tty}\t#{client_session}",
+                ],
+                timeout: 5
+            )
+            let tokenValue = (try? String(
+                contentsOf: tokenPath,
+                encoding: .utf8
+            )) ?? "<missing>"
+            let diagnostic = "tmux client identity was not published: "
+                + "status=\(listed.status), clients=\(listed.stdout), "
+                + "token=\(tokenValue)"
+            Issue.record(Comment(rawValue: diagnostic))
+            return
+        }
+        let listed = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName, "list-clients", "-F",
+                "#{client_pid}\t#{client_name}",
+            ],
+            timeout: 5
+        )
+        let clientName = listed.stdout.split(whereSeparator: \.isNewline)
+            .compactMap { line -> String? in
+                let fields = line.split(separator: "\t", maxSplits: 1)
+                guard fields.count == 2,
+                      fields[0] == Substring(client.clientPID)
+                else { return nil }
+                return String(fields[1])
+            }.first
+        guard let clientName else {
+            Issue.record("tmux client name was unavailable")
+            return
+        }
+        let switched = TmuxBinaryResolver.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", socketName, "switch-client", "-c", clientName,
+                "-t", "=visible:",
+            ],
+            timeout: 5
+        )
+        #expect(switched.status == 0)
+
+        var guardedTarget = target
+        guardedTarget.expectedIdentity = client.sessionIdentity
+        guardedTarget.expectedClient = client
+        let failure = await TmuxPaneSplitter().split(
+            .right,
+            target: guardedTarget
+        )
+        #expect(failure?.diagnostic == "The attached tmux session changed.")
+        for session in ["original", "visible"] {
+            let panes = TmuxBinaryResolver.runProcess(
+                executable: tmuxPath,
+                arguments: [
+                    "-L", socketName, "list-panes", "-t", "=\(session):",
+                    "-F", "#{pane_id}",
+                ],
+                timeout: 5
+            )
+            #expect(panes.stdout.split(whereSeparator: \.isNewline).count == 1)
+        }
+    }
+}

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -784,6 +784,49 @@ struct TmuxPaneSplitterTests {
         #expect(failure == nil)
     }
 
+    @Test("cancellation removes an installed split hook")
+    func cancellationRemovesInstalledHook() async {
+        let hookInstalled = LockedValue(false)
+        let splitStarted = LockedValue(false)
+        let commands = LockedValue<[String]>([])
+        let splitter = TmuxPaneSplitter { _, _, command in
+            commands.withLock { $0.append(command) }
+            if command.contains("'refresh-client'") {
+                hookInstalled.store(true)
+                splitStarted.store(true)
+                while !withUnsafeCurrentTask(body: {
+                    $0?.isCancelled == true
+                }) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+            } else if command.contains("'set-hook' '-gu'") {
+                hookInstalled.store(false)
+            }
+            return (0, "")
+        }
+        let task = Task {
+            await splitter.split(
+                .right,
+                target: TmuxPaneSplitTarget(
+                    host: .local,
+                    tmuxPath: "/usr/bin/tmux",
+                    sessionName: "cancelled",
+                    socketName: nil,
+                    sshConnectionArguments: [],
+                    expectedIdentity: testSplitClient.sessionIdentity,
+                    expectedClient: testSplitClient
+                )
+            )
+        }
+
+        await waitUntil { splitStarted.load() }
+        task.cancel()
+        _ = await task.value
+
+        #expect(!hookInstalled.load())
+        #expect(commands.load().count == 2)
+    }
+
     @Test("validation and split share one exact-client tmux queue")
     func posixCommands() {
         let right = TmuxPaneSplitter.command(

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -21,7 +21,10 @@ struct TmuxSessionKillerTests {
         defer {
             _ = TmuxBinaryResolver.runProcess(
                 executable: tmuxPath,
-                arguments: ["-L", socketName, "kill-server"],
+                arguments: [
+                    "-L", socketName,
+                    "kill-session", "-a", ";", "kill-session",
+                ],
                 timeout: 5
             )
         }

--- a/Tests/App/TmuxSessionStylerTests.swift
+++ b/Tests/App/TmuxSessionStylerTests.swift
@@ -171,12 +171,18 @@ struct TmuxSessionStylerTests {
         else {
             return
         }
-        let socketName = "style-\(UUID().uuidString.prefix(8).lowercased())"
+        let socketName = ProcessInfo.processInfo.environment[
+            "GHOSTHUB_TEST_TMUX_RUN_ID"
+        ].map { "ghosthub-style-\($0)" }
+            ?? "ghosthub-style-\(UUID().uuidString.lowercased())"
         let sessionName = "review"
         defer {
             _ = TmuxBinaryResolver.runProcess(
                 executable: tmuxPath,
-                arguments: ["-L", socketName, "kill-server"],
+                arguments: [
+                    "-L", socketName,
+                    "kill-session", "-a", ";", "kill-session",
+                ],
                 timeout: 5
             )
         }

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -94,7 +94,7 @@ private struct RemoteRestorationHarness {
             localHostID: UUID(),
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: inventory.discover
         )
         let savedState = WorkspaceWindowState(
@@ -293,7 +293,7 @@ private struct ProtectedRestorationHarness {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: probe.read
         )
         let savedState = WorkspaceWindowState(
@@ -332,7 +332,7 @@ struct WorkspaceRestorationTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: store,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             tmuxSessionDiscovery: inventory.discover
         )
         model.startTmuxSessionDiscovery()
@@ -674,7 +674,7 @@ struct WorkspaceRestorationTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: probe.read
         )
         let state = WorkspaceWindowState(
@@ -738,7 +738,7 @@ struct WorkspaceRestorationTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: probe.read
         )
         let state = WorkspaceWindowState(
@@ -793,7 +793,7 @@ struct WorkspaceRestorationTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: probe.read
         )
         let state = WorkspaceWindowState(
@@ -836,7 +836,7 @@ struct WorkspaceRestorationTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: probe.read
         )
         let state = WorkspaceWindowState(

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -95,7 +95,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in
                 KwtHostInventory(projects: [
                     KwtProjectInventory(
@@ -163,7 +163,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in
                 KwtHostInventory(projects: [
                     KwtProjectInventory(
@@ -251,7 +251,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in
                 KwtHostInventory(projects: [
                     KwtProjectInventory(
@@ -491,12 +491,12 @@ struct WorkspaceTmuxDiscoveryTests {
         private let gate = DispatchSemaphore(value: 0)
         private var started = false
 
-        func resolve() -> Result<String, TmuxBinaryError> {
+        func resolve() -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
             lock.lock()
             started = true
             lock.unlock()
             gate.wait()
-            return .success("/usr/bin/tmux")
+            return successfulTmuxResolution("/usr/bin/tmux")
         }
 
         var didStart: Bool {
@@ -728,7 +728,7 @@ struct WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") }
         )
 
         model.createTmuxSession(WorkspaceTmuxSessionSelection(
@@ -759,7 +759,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") }
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -788,7 +788,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         let first = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -848,7 +848,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
         )
         let first = WorkspaceTmuxSessionSelection(
             hostID: environment.remoteHost.id,
@@ -888,7 +888,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         let first = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -928,7 +928,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         var userSelection = model.selection
         userSelection.select(
@@ -1007,7 +1007,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         for name in ["first", "second"] {
             model.openBorrowedTmuxSession(.init(
@@ -1058,7 +1058,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") }
         )
         let observed = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1120,7 +1120,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         let worktree = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1188,7 +1188,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1226,7 +1226,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1305,7 +1305,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             tmuxSessionKiller: { _, _, _ in
                 throw expectedError
             }
@@ -1445,7 +1445,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: { _, _ in
                 _ = identityReads.increment()
                 return TmuxSessionIdentity(
@@ -1485,7 +1485,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionIdentityReader: { _, _ in
                 _ = identityReads.increment()
                 return TmuxSessionIdentity(
@@ -1534,7 +1534,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             tmuxSessionKiller: { _, _, _ in }
         )
         var selection = WorkspaceTmuxSessionSelection(
@@ -1576,7 +1576,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 discoveryCalls.increment() == 1
                     ? .success([discovered])
@@ -1633,7 +1633,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 _ = discoveryCalls.increment()
                 return .success([discovered])
@@ -1791,7 +1791,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -1821,7 +1821,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             createdSessionDiscoveryDelays: [.seconds(10)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1852,7 +1852,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             createdSessionDiscoveryDelays: [.seconds(10)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1892,7 +1892,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 .success([
                     DiscoveredTmuxSession(
@@ -1932,7 +1932,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             createdSessionDiscoveryDelays: [.seconds(10)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1998,7 +1998,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
-            remoteTmuxPathProvider: { _ in
+            remoteTmuxPathProvider: { _, _ in
                 .failure(.sshConnectionFailed(
                     host: "office-linux",
                     classification: SSHConnectionFailure.classify(
@@ -2039,7 +2039,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 guard attempts.increment() > 1 else {
                     return .failure(.sshConnectionFailed(
@@ -2133,7 +2133,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
             tmuxSessionDiscovery: { _ in
                 _ = attempts.increment()
@@ -2236,7 +2236,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 guard attempts.increment() >= 3 else {
                     return .success([])
@@ -2281,7 +2281,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             createdSessionDiscoveryDelays: [
                 .milliseconds(1),
@@ -2343,7 +2343,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             configuredSSHHostsProvider: { configuredHosts.value },
             createdSessionDiscoveryDelays: [.milliseconds(1)]
@@ -2410,7 +2410,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             configuredSSHHostsProvider: { configuredHosts.value }
         )
         model.refreshHosts()
@@ -2473,7 +2473,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             createdSessionDiscoveryDelays: [.zero]
         )
@@ -2505,7 +2505,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
             tmuxSessionDiscovery: discovery.discover,
             createdSessionDiscoveryDelays: [.milliseconds(1)],
@@ -2577,7 +2577,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -2626,8 +2626,8 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { host in
                 if host.isRemote {
                     return .success([
@@ -2691,7 +2691,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             createdSessionDiscoveryDelays: [.seconds(10)],
             tmuxReconnectIntervals: [.milliseconds(1)]
@@ -2755,7 +2755,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             createdSessionDiscoveryDelays: [
                 .milliseconds(10),
@@ -2834,7 +2834,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/opt/homebrew/bin/tmux") },
             createdSessionDiscoveryDelays: [.seconds(10)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -2882,7 +2882,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             createdSessionDiscoveryDelays: [.milliseconds(20)],
             tmuxReconnectIntervals: [.milliseconds(1)]
@@ -2931,7 +2931,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             createdSessionDiscoveryDelays: [.seconds(10)],
             tmuxReconnectIntervals: [.milliseconds(1)]
@@ -2981,7 +2981,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3033,7 +3033,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3066,7 +3066,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: discovery.discover,
             tmuxReconnectIntervals: [.seconds(10)],
             tmuxReconnectProbeDeadline: .milliseconds(20)
@@ -3109,7 +3109,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { host in
                 switch attempts.increment() {
                 case 1:
@@ -3205,7 +3205,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxExactSessionProbe: { target in
                 switch attempts.increment() {
                 case 1:
@@ -3264,7 +3264,7 @@ struct WorkspaceTmuxDiscoveryTests {
             database: environment.database,
             localHostID: environment.host.id,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { host in
                 #expect(host == oldTarget)
                 discoveryGate.wait()
@@ -3340,7 +3340,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.seconds(10)]
         )
@@ -3372,7 +3372,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3402,7 +3402,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3451,7 +3451,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             createdSessionDiscoveryDelays: [.seconds(10)],
             tmuxReconnectIntervals: [.milliseconds(1)]
@@ -3495,7 +3495,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 .success([
                     DiscoveredTmuxSession(
@@ -3543,8 +3543,8 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxExactSessionProbe: { _ in probes.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3599,7 +3599,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxExactSessionProbe: { _ in probes.removeFirst() },
             createdSessionDiscoveryDelays: [.seconds(10)],
             tmuxReconnectIntervals: [.milliseconds(1)]
@@ -3637,7 +3637,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxExactSessionProbe: { _ in probes.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3680,7 +3680,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3744,8 +3744,8 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { host in
                 host.isRemote ? discoveries.removeFirst() : .success([])
             },
@@ -3812,7 +3812,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in
                 .failure(.sshConnectionFailed(
                     host: "build-box",
@@ -3882,7 +3882,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3941,7 +3941,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
@@ -3969,8 +3969,8 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in .success([]) },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )

--- a/Tests/App/WorkspaceTmuxThemeTests.swift
+++ b/Tests/App/WorkspaceTmuxThemeTests.swift
@@ -113,7 +113,7 @@ struct WorkspaceTmuxThemeTests {
             localHostID: UUID(),
             snapshot: windowsSnapshot,
             nativeTmuxSurfaceStore: windowsStore,
-            remoteTmuxPathProvider: { _ in .success("tmux.exe") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("tmux.exe") },
             tmuxPresentationStyleProvider: { _ in primaryStyle }
         )
         windowsModel.openBorrowedTmuxSession(
@@ -124,6 +124,7 @@ struct WorkspaceTmuxThemeTests {
         )
         await connectActiveTmuxSession(windowsModel, store: windowsStore)
         #expect(!windowsModel.canApplyThemeToActiveTmuxSession)
+        #expect(!windowsModel.canSplitActiveTmuxPane)
         await windowsModel.shutdown()
     }
 
@@ -333,7 +334,7 @@ struct WorkspaceTmuxThemeTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: store,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             tmuxPresentationStyleProvider: { identity in
                 identity.flatMap { resolvedStyles[$0] }
             },
@@ -400,7 +401,7 @@ struct WorkspaceTmuxThemeTests {
             localHostID: UUID(),
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: store,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxPresentationStyleProvider: { _ in resolvedStyle },
             appliesTmuxPresentationStyleToExistingSessionsProvider: { true },
             tmuxSessionIdentityReader: { _, _ in sessionIdentity },
@@ -844,7 +845,7 @@ private func makeThemedScene(
         localHostID: environment.host.id,
         snapshot: environment.snapshot,
         nativeTmuxSurfaceStore: store,
-        nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+        nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
         tmuxPresentationStyleProvider: tmuxPresentationStyleProvider,
         appliesTmuxPresentationStyleToExistingSessionsProvider: {
             stylesExistingSessions

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -266,11 +266,11 @@ struct WorkspaceWorktreeRemovalTests {
         let pathResolutions = LockedValue(0)
         let completedPathResolutions = LockedValue(0)
         let resolveTmuxPath: @Sendable ()
-            -> Result<String, TmuxBinaryError> = {
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError> = {
                 pathResolutions.withLock { $0 += 1 }
                 pathGate.wait()
                 completedPathResolutions.withLock { $0 += 1 }
-                return .success("/usr/bin/tmux")
+                return successfulTmuxResolution("/usr/bin/tmux")
             }
         defer {
             pathGate.signal()
@@ -426,7 +426,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: staleSnapshot,
             nativeTmuxSurfaceStore: staleSurfaces,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             worktreeMutationCoordinator: coordinator
         )
         let staleSelection = try #require(
@@ -539,7 +539,7 @@ struct WorkspaceWorktreeRemovalTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
                 _ = await removerHold.load(beforeRemoval)
@@ -635,7 +635,7 @@ struct WorkspaceWorktreeRemovalTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
                 _ = await removerHold.load(beforeRemoval)
@@ -706,7 +706,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             localKwtPathProvider: { "/test/kwt" },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
@@ -773,7 +773,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
                 throw KwtWorktreeError.removalFailed(
@@ -841,7 +841,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             localKwtPathProvider: { "/test/kwt" },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
@@ -914,7 +914,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             localKwtPathProvider: { "/test/kwt" },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
@@ -992,7 +992,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
                 _ = await removerHold.load(beforeRemoval)
@@ -1080,7 +1080,7 @@ struct WorkspaceWorktreeRemovalTests {
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
-            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in replacementInventory },
             tmuxSessionIdentityReader: { selection, host in
                 throw TmuxSessionKillError.sessionNotRunning(
@@ -1553,7 +1553,7 @@ struct WorkspaceWorktreeRemovalTests {
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaces,
-            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             kwtInventoryLoader: { _ in beforeRemoval },
             kwtWorktreeRemover: { _, _, _, _ in
                 removals.withLock { $0 += 1 }

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -254,7 +254,8 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         charactersIgnoringModifiers: String,
         modifiers: NSEvent.ModifierFlags,
         keyCode: UInt16,
-        windowNumber: Int = 0
+        windowNumber: Int = 0,
+        isARepeat: Bool = false
     ) -> NSEvent {
         NSEvent.keyEvent(
             with: .keyDown,
@@ -265,7 +266,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             context: nil,
             characters: characters,
             charactersIgnoringModifiers: charactersIgnoringModifiers,
-            isARepeat: false,
+            isARepeat: isARepeat,
             keyCode: keyCode
         )!
     }
@@ -818,6 +819,81 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         )
         XCTAssertEqual(harness.inserted, [])
         XCTAssertEqual(harness.commands, [])
+    }
+
+    func testTmuxSplitShortcutsReachAttachedClientHandler() throws {
+        let appHandle = try requireAppHandle()
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        var shortcuts: [TerminalTmuxSplitShortcut] = []
+        view.tmuxSplitShortcutHandler = { shortcuts.append($0) }
+
+        for event in [
+            makeKeyEvent(
+                characters: "d",
+                charactersIgnoringModifiers: "d",
+                modifiers: .command,
+                keyCode: 2,
+                windowNumber: 0
+            ),
+            makeKeyEvent(
+                characters: "D",
+                charactersIgnoringModifiers: "d",
+                modifiers: [.command, .shift],
+                keyCode: 2,
+                windowNumber: 0
+            ),
+        ] {
+            XCTAssertTrue(view.handleTmuxSplitShortcutForTesting(event))
+        }
+
+        XCTAssertEqual(shortcuts, [.right, .down])
+    }
+
+    func testTmuxSplitShortcutRepeatIsConsumedWithoutSplitting() throws {
+        let appHandle = try requireAppHandle()
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        var shortcuts: [TerminalTmuxSplitShortcut] = []
+        view.tmuxSplitShortcutHandler = { shortcuts.append($0) }
+        let event = makeKeyEvent(
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            modifiers: .command,
+            keyCode: 2,
+            isARepeat: true
+        )
+
+        XCTAssertTrue(view.handleTmuxSplitShortcutForTesting(event))
+        XCTAssertEqual(shortcuts, [])
+    }
+
+    func testTmuxSplitShortcutConsumesKeyUpAfterCommandRelease() throws {
+        let appHandle = try requireAppHandle()
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        view.tmuxSplitShortcutHandler = { _ in }
+        let keyDown = makeKeyEvent(
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            modifiers: .command,
+            keyCode: 2
+        )
+        let keyUp = makeKeyUpEvent(
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            modifiers: [],
+            keyCode: 2
+        )
+
+        XCTAssertTrue(view.handleTmuxSplitShortcutForTesting(keyDown))
+        XCTAssertNil(view.processLocalEventForTesting(keyUp))
     }
 
     func testCommandShiftBracketsAreReservedForTabNavigation() throws {

--- a/Tests/TerminalSupport/TerminalTmuxSplitShortcutTests.swift
+++ b/Tests/TerminalSupport/TerminalTmuxSplitShortcutTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import Testing
+@testable import GhosthubTerminalSupport
+
+@Suite("Tmux pane split shortcuts")
+struct TerminalTmuxSplitShortcutTests {
+    @Test("Ghostty split chords map to semantic directions")
+    func splitDirections() throws {
+        let cases: [(
+            flags: NSEvent.ModifierFlags,
+            shortcut: TerminalTmuxSplitShortcut
+        )] = [
+            (NSEvent.ModifierFlags.command, .right),
+            ([.command, .capsLock], .right),
+            ([.command, .shift], .down),
+            ([.command, .shift, .capsLock], .down),
+        ]
+
+        for testCase in cases {
+            let shortcut = try #require(
+                TerminalTmuxSplitShortcut.matching(
+                    flags: testCase.flags,
+                    charactersIgnoringModifiers: "d"
+                )
+            )
+
+            #expect(shortcut == testCase.shortcut)
+        }
+    }
+
+    @Test("other Command chords remain terminal input")
+    func unrelatedInput() {
+        #expect(TerminalTmuxSplitShortcut.matching(
+            flags: [.command, .option],
+            charactersIgnoringModifiers: "d"
+        ) == nil)
+        #expect(TerminalTmuxSplitShortcut.matching(
+            flags: .command,
+            charactersIgnoringModifiers: "k"
+        ) == nil)
+    }
+}

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -5,6 +5,94 @@ import Testing
 
 @Suite("Native tmux attachment")
 struct TmuxAttachmentInfoTests {
+    @Test("POSIX attachments publish their client TTY under a unique token")
+    func posixAttachmentsPublishClientTTY() {
+        let token = "attachment-01234567"
+        let local = TmuxAttachmentInfo(
+            sessionName: "release-work",
+            host: .local
+        ).attachCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            clientTTYToken: token
+        )
+        let remote = TmuxAttachmentInfo(
+            sessionName: "release-work",
+            host: .ssh(SSHHostInfo(
+                user: "operator",
+                hostname: "build.example.test",
+                port: nil
+            ))
+        ).attachCommand(
+            tmuxPath: "/usr/bin/tmux",
+            clientTTYToken: token
+        )
+
+        for command in [local, remote] {
+            #expect(command.contains(".ghosthub/tmux-clients"))
+            #expect(command.contains(token))
+        }
+    }
+
+    @Test("slow attachments publish their client TTY immediately")
+    func slowAttachmentsPublishClientTTYImmediately() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        try """
+        #!/bin/sh
+        exec /bin/sleep 5
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        let token = "slow-\(UUID().uuidString.lowercased())"
+        let shellHome = try #require(
+            ProcessInfo.processInfo.environment["HOME"]
+        )
+        let tokenPath = URL(fileURLWithPath: shellHome, isDirectory: true)
+            .appendingPathComponent(".ghosthub/tmux-clients/\(token)")
+        defer { try? FileManager.default.removeItem(at: tokenPath) }
+        let command = TmuxAttachmentInfo(
+            sessionName: "unpublished",
+            host: .local,
+            launchMode: .attachOnly
+        ).attachCommand(tmuxPath: tmux.path, clientTTYToken: token)
+        let process = Process()
+        let input = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
+        process.arguments = ["-q", "/dev/null", "/bin/sh", "-c", command]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "TERM": "xterm-256color",
+        ]) { _, new in new }
+        process.standardInput = input
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        var publishedTTY = ""
+        for _ in 0 ..< 200 where publishedTTY.isEmpty {
+            publishedTTY = ((try? String(
+                contentsOf: tokenPath,
+                encoding: .utf8
+            )) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(publishedTTY.hasPrefix("/dev/"))
+        #expect(process.isRunning)
+    }
+
     @Test("host display names omit the default SSH port")
     func hostDisplayNames() {
         #expect(
@@ -393,7 +481,10 @@ struct TmuxAttachmentInfoTests {
         defer {
             let cleanup = Process()
             cleanup.executableURL = URL(fileURLWithPath: tmuxPath)
-            cleanup.arguments = ["-L", socketName, "kill-server"]
+            cleanup.arguments = [
+                "-L", socketName,
+                "kill-session", "-a", ";", "kill-session",
+            ]
             cleanup.standardOutput = FileHandle.nullDevice
             cleanup.standardError = FileHandle.nullDevice
             try? cleanup.run()
@@ -814,6 +905,7 @@ struct TmuxAttachmentInfoTests {
 
     @Test("remote profile creation allocates a TTY before running its command")
     func remoteProfileCreationUsesInitialTTY() {
+        let token = "profile-attachment-01234567"
         let command = TmuxAttachmentInfo(
             sessionName: "codex",
             host: .ssh(SSHHostInfo(
@@ -821,7 +913,10 @@ struct TmuxAttachmentInfoTests {
             )),
             launchMode: .create,
             initialCommand: "sudo docker exec -it codex codex"
-        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+        ).attachCommand(
+            tmuxPath: "/opt/bin/tmux",
+            clientTTYToken: token
+        )
 
         #expect(command.contains("sudo docker exec -it codex codex"))
         #expect(command.components(
@@ -830,6 +925,8 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'-tt'"))
         #expect(command.contains("new-session"))
         #expect(command.contains("'-A'"))
+        #expect(command.contains(".ghosthub/tmux-clients"))
+        #expect(command.contains(token))
         #expect(!command.contains("has-session"))
         #expect(!command.contains("attach-session"))
         #expect(!command.contains("reconnecting"))

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -300,14 +300,17 @@ def test_cancellation_reaps_daemonized_server_without_run_directory(
     if shutil.which("tmux") is None:
         pytest.skip("tmux is unavailable")
 
-    server_pid_file = tmp_path / "server.pid"
+    server_pid_file = tmp_path / "server.pids"
     tmux_dir_file = tmp_path / "tmux-dir"
     command = tmp_path / "start-server-and-wait.sh"
     command.write_text(
         "#!/bin/sh\n"
         'socket="$TMUX_TMPDIR/orphan-socket"\n'
         'tmux -S "$socket" new-session -d\n'
-        f'tmux -S "$socket" display-message -p "#{{pid}}" > "{server_pid_file}"\n'
+        f'tmux -S "$socket" display-message -p "#{{pid}}" >> "{server_pid_file}"\n'
+        'named_socket="ghosthub-pane-regression-$GHOSTHUB_TEST_TMUX_RUN_ID"\n'
+        'tmux -L "$named_socket" new-session -d\n'
+        f'tmux -L "$named_socket" display-message -p "#{{pid}}" >> "{server_pid_file}"\n'
         f'echo "$TMUX_TMPDIR" > "{tmux_dir_file}"\n'
         "sleep 30\n"
     )
@@ -329,7 +332,10 @@ def test_cancellation_reaps_daemonized_server_without_run_directory(
         wrapper.kill()
         wrapper.wait(timeout=10)
         pytest.fail("tmux server did not start")
-    server_pid = int(server_pid_file.read_text().strip())
+    server_pids = [
+        int(value) for value in server_pid_file.read_text().splitlines()
+    ]
+    assert len(server_pids) == 2
 
     # The server daemonized outside the test process group, so once its run
     # directory is gone only identity-based process cleanup can reach it.
@@ -338,14 +344,20 @@ def test_cancellation_reaps_daemonized_server_without_run_directory(
     assert wrapper.wait(timeout=10) == 143
 
     deadline = time.monotonic() + 5
-    while time.monotonic() < deadline:
-        try:
-            os.kill(server_pid, 0)
-        except ProcessLookupError:
-            return
-        time.sleep(0.05)
-    os.kill(server_pid, signal.SIGKILL)
-    pytest.fail("daemonized tmux server survived run-directory removal")
+    survivors = server_pids
+    while survivors and time.monotonic() < deadline:
+        survivors = []
+        for server_pid in server_pids:
+            try:
+                os.kill(server_pid, 0)
+            except ProcessLookupError:
+                continue
+            survivors.append(server_pid)
+        if survivors:
+            time.sleep(0.05)
+    for server_pid in survivors:
+        os.kill(server_pid, signal.SIGKILL)
+    assert not survivors, "daemonized tmux servers survived run-directory removal"
 
 
 def test_default_purge_skips_active_run_directories() -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -418,6 +418,25 @@ authentication and host-key escalation state, and attach-only client
 replacement. Inactive presentations remain supervised. Tmux owns all windows,
 panes, history, input, rendering, and server-side lifetime.
 
+Cmd-D and Cmd-Shift-D provide Ghostty-style split-right and split-down actions,
+also exposed in the File menu when the attached host reports tmux 3.4 or newer.
+Each explicit action runs `split-window -h` or `split-window -v` against the
+active pane of the attachment's exact host and socket. The attachment retains
+its resolved SSH configuration and effective endpoint, so a later SSH alias
+edit cannot reroute a split. Each POSIX surface publishes its TTY under a unique
+token; as the surface opens, Ghosthub finds that client by TTY and captures its
+stable server, client, and session identity. Each split then uses one tmux
+conditional to validate that identity and the active pane before mutating the
+layout. This follows a session rename but rejects a replacement client or a
+client switched to another session after binding. Requests
+are serialized per attachment; detaching cancels the active command and queue.
+Keyboard equivalents require effective terminal focus and no attached sheet;
+clicking the File menu action remains an explicit request. This semantic routing
+is independent of the user's tmux prefix and key tables. Command failures appear
+on the attachment rather than silently disappearing. Ghosthub does not maintain
+a parallel pane model; tmux remains layout and process authority. Native Windows
+psmux surfaces do not expose or intercept these split actions.
+
 Ghosthub applies the selected Tmux Theme when it creates a new bare session.
 Built-in themes provide fixed colors; Follow ghostty.conf uses the effective
 foreground and background retained from libghostty's surface-scoped config

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -179,7 +179,29 @@ shell so settings such as `TMUX_TMPDIR` resolve the same tmux server as later
 styling and identity commands. On Windows, those phases use encoded
 PowerShell commands within the same OpenSSH account environment. Unbound
 discovered sessions remain attach-only.
-Ghosthub does not expose rename, split, resize, window, or pane operations.
+Ghosthub does not expose rename, resize, or window operations. On an attached
+tmux terminal, Cmd-D and Cmd-Shift-D request Ghostty-style split-right and
+split-down operations; the File menu exposes the same actions and shortcuts.
+These actions require tmux 3.4 or newer; Ghosthub checks the binary on each
+local or remote attachment and leaves normal tmux key bindings available on
+older versions. On supported POSIX hosts, Ghosthub runs `split-window -h` or
+`split-window -v` against the active pane of that attachment's exact host and
+socket using its frozen SSH route. Once the client attaches, it publishes its
+TTY and stable tmux server and session identity under that attachment's unique
+token. Each split atomically finds and validates that exact client, then
+targets the session's active pane.
+Other clients attaching
+at the same time cannot be mistaken for the Ghosthub surface. Renaming the
+attached session therefore keeps splits working, while a same-named replacement
+or a client switched to another session is rejected. Failed client discovery is
+not cached, and each queued request receives its own attempt. Ghosthub
+serializes requests for the attachment. The keyboard
+shortcuts apply only while the terminal has effective keyboard focus and no
+sheet is attached; choosing either File menu item remains an explicit request.
+The action works regardless of the user's tmux prefix or key-table bindings
+while tmux remains authoritative for pane creation and layout. If tmux rejects
+a split, Ghosthub displays its diagnostic over the attachment. Native Windows
+psmux attachments do not offer pane-split actions or intercept these shortcuts.
 Kill Session is exposed separately from presentation only for a session known
 to be running and always requires confirmation.
 
@@ -201,13 +223,14 @@ the resolved host endpoint and cancelled when that endpoint changes or the
 owning window shuts down.
 
 Before discovery or attachment, Ghosthub resolves an absolute tmux-compatible
-binary path and verifies the reported tmux protocol version is 3.2 or newer.
-On POSIX hosts the login shell initializes its environment, then delegates
-Ghosthub's probe to `/bin/sh`; fish and other non-POSIX account shells never
-interpret the POSIX probe itself. On Windows, Ghosthub starts noninteractive
-Windows PowerShell and resolves `tmux.exe` with `Get-Command`.
-Successful paths are cached per host; lookup and version failures remain
-retryable and are presented to the user.
+binary path. POSIX hosts require tmux 3.2 or newer; the experimental Windows
+path accepts psmux's tmux 3.2 compatibility level. On POSIX hosts the login
+shell initializes its environment, then delegates Ghosthub's probe to
+`/bin/sh`; fish and other non-POSIX account shells never interpret the POSIX
+probe itself. On Windows, Ghosthub starts noninteractive Windows PowerShell
+and resolves `tmux.exe` with `Get-Command`.
+Successful paths are cached per frozen host connection; lookup and version
+failures remain retryable and are presented to the user.
 
 ## SSH Keepalive and Reconnect
 
@@ -367,8 +390,9 @@ session model and die with the app process.
   active-session command, never as a client-local libghostty overlay.
 - Keep mutable Ghosthub app state under `~/.ghosthub/`.
 - Do not read or depend on Ghostty.app global config.
-- Do not install Ghosthub split, zoom, or tab keybindings. Native tmux owns
-  those interactions and receives the terminal's ordinary input unchanged.
+- Do not install Ghosthub-owned layout, zoom, or tab management. Native tmux
+  owns those interactions. Explicit app shortcuts may request a semantic tmux
+  operation against the active attachment, such as pane splitting.
 - Do not disable libghostty shell integration to work around keybinding
   bugs.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -260,7 +260,25 @@ command argument and the selected host identity is fixed before launch.
 Remote creation authority is one-shot: after it succeeds, transport recovery
 can only rerun `attach-session`. Existing same-named sessions are attached
 without modifying their panes or windows. Creation never grants authority to
-rename, split, resize, or otherwise structurally mutate sessions. The separate
+rename, resize, or otherwise structurally mutate sessions. The user's explicit
+Cmd-D and Cmd-Shift-D actions grant one-shot authority to run `split-window`
+against the active pane of the attachment's fixed endpoint, frozen SSH
+configuration, socket, and captured tmux server PID, session ID, and creation
+time. Ghosthub enables these actions only after the attachment's local or
+remote binary reports tmux 3.4 or newer. After attaching, each POSIX surface
+writes its TTY under a unique attachment token on the target host. Ghosthub
+uses that TTY to bind the surface to the client's stable PID, creation time,
+server, and session identity. A single tmux conditional revalidates that bound
+identity and pane before splitting. A rename remains valid, but a replacement
+client or a client switched to another session after binding does not inherit
+the authority. Failed
+client bindings are not cached or allowed to discard later queued requests.
+Keyboard
+equivalents require effective terminal focus and no attached sheet; selecting
+the File menu item is itself an explicit request. This bypasses tmux key
+bindings by design but leaves pane creation, layout, and process startup inside
+tmux. Native Windows psmux surfaces do not expose or intercept the pane-split
+actions. The separate
 Kill Session action is offered only for a session established as running by
 discovery or a currently connected active attachment. Before confirmation,
 Ghosthub binds the selected endpoint, socket, exact target, and tmux
@@ -277,6 +295,8 @@ status/message styles and set existing window foreground/background defaults.
 This presentation-only exception targets the exact selected session, affects
 every attached client, and does not authorize changes to tmux key tables,
 prefixes, mouse behavior, windows, panes, layout, history, or process state.
+The separate explicit pane-split shortcuts authorize only creation of one pane
+at a time in the active attachment.
 
 ### Release distribution
 

--- a/tools/purge_test_tmux.sh
+++ b/tools/purge_test_tmux.sh
@@ -98,7 +98,7 @@ run_tmux_pids() {
     ps -axo pid=,command= | awk -v run_id="$run_id" \
         -v run_dir="$run_dir" '
         BEGIN {
-            socket_pattern = "^ghosthub-(test|kill)-" run_id "$"
+            socket_pattern = "^(ghosthub|gh)-[A-Za-z0-9-]+-" run_id "$"
         }
         /^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]*\/)?tmux[[:space:]]/ {
             for (field = 2; field < NF; field++) {

--- a/website/docs/content/getting-started.md
+++ b/website/docs/content/getting-started.md
@@ -13,6 +13,9 @@ Ghosthub currently requires:
 - macOS 26 (Tahoe) or newer
 - tmux 3.2 or newer on the local Mac and on each remote macOS or Linux host
 
+The Cmd-D and Cmd-Shift-D pane shortcuts require tmux 3.4 or newer on the
+attached host. With tmux 3.2 or 3.3, use your normal tmux split keys.
+
 Native Windows hosts are experimental and have additional requirements. See
 [Remote Hosts](remote-hosts.md#experimental-windows-hosts).
 

--- a/website/docs/content/keyboard-shortcuts.md
+++ b/website/docs/content/keyboard-shortcuts.md
@@ -17,6 +17,8 @@ icon: lucide/keyboard
 | Create or import a worktree | ++shift+cmd+n++ |
 | New window | ++cmd+n++ |
 | New tab | ++cmd+t++ |
+| Split the tmux pane right | ++cmd+d++ |
+| Split the tmux pane down | ++shift+cmd+d++ |
 | Close session presentation | ++cmd+w++ |
 | Close window | ++shift+cmd+w++ |
 | Open application log | ++option+cmd+l++ |
@@ -24,3 +26,10 @@ icon: lucide/keyboard
 
 Closing a presentation, window, or the app detaches from tmux. It does not end
 the session.
+
+Choose **File > Split Right** or **File > Split Down** if you prefer menus.
+Ghosthub asks tmux to split the pane directly, so custom prefixes and key
+bindings keep working. The shortcuts require a connected tmux terminal with
+keyboard focus, no open sheet, and tmux 3.4 or newer on the attached host. With
+tmux 3.2 or 3.3, use your normal tmux split keys. Pane splitting is not yet
+available on Windows psmux hosts.

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -16,6 +16,10 @@ A macOS or Linux host needs:
 - tmux 3.2 or newer
 - a destination that your Mac's OpenSSH configuration can resolve
 
+Ghosthub checks the remote tmux version when attaching. Cmd-D and Cmd-Shift-D
+pane splitting is available with tmux 3.4 or newer; older versions continue to
+work through their normal tmux key bindings.
+
 Test the same destination in Terminal first when diagnosing configuration or
 authentication:
 

--- a/website/docs/llms.txt
+++ b/website/docs/llms.txt
@@ -13,7 +13,7 @@ Ghosthub is alpha software. The Guide is a short visual tour; the Docs links bel
 - [Projects and worktrees](https://ghosthub.ai/docs/projects-worktrees.md): Register repositories and manage branch- or pull-request-backed worktrees
 - [Windows and navigation](https://ghosthub.ai/docs/windows-navigation.md): Sidebar, Command Palette, windows, tabs, and restoration
 - [Terminal configuration](https://ghosthub.ai/docs/terminal-configuration.md): Ghosthub-owned libghostty configuration and tmux themes
-- [Keyboard shortcuts](https://ghosthub.ai/docs/keyboard-shortcuts.md): Application and workspace shortcuts
+- [Keyboard shortcuts](https://ghosthub.ai/docs/keyboard-shortcuts.md): Application, workspace, and tmux pane-splitting shortcuts
 - [Privacy](https://ghosthub.ai/docs/privacy.md): Anonymous usage data and local state
 - [Troubleshooting](https://ghosthub.ai/docs/troubleshooting.md): Common local, SSH, tmux, and worktree problems
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -98,6 +98,12 @@ const imageAlt = {
             running in tmux. See <a href="/docs/sessions/">Sessions</a> for
             session lifecycle and confirmed kill controls.
           </p>
+          <p>
+            With tmux 3.4+, use <kbd>⌘D</kbd> to split right or{' '}
+            <kbd>⌘⇧D</kbd> to split down. Both are also in the{' '}
+            <strong>File</strong> menu. See the{' '}
+            <a href="/docs/keyboard-shortcuts/">keyboard shortcuts</a> reference.
+          </p>
         </div>
       </div>
       <figure class="container window">


### PR DESCRIPTION
Tmux’s prefix-based splits are awkward in a native macOS workflow, while replaying default bindings would break customized tmux configurations. This adds Cmd-D to split right and Cmd-Shift-D to split down, with matching File menu actions for discoverability.

Ghosthub resolves tmux per attachment, binds split authority to the attachment’s client and session as its terminal opens, and atomically revalidates the server, session, pane, client PID, creation time, and TTY before every split. Remote commands reuse the attachment’s frozen SSH route.

Tmux 3.4+ enables these native actions. Tmux 3.2–3.3 remains supported through normal tmux bindings, and pane splitting remains unavailable on Windows psmux hosts.