### PR TITLE
Retain tmux presentations across navigation

### DIFF
--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -66,14 +66,13 @@ struct KwtHostInventory: Equatable, Sendable {
                }) {
                 retained.worktrees = prior.worktrees
             }
-            retained.worktrees.removeAll {
-                guard let generation = $0.generation else { return false }
-                return excludingWorktrees.contains(
-                    KwtWorktreeIdentity(
-                        path: $0.path,
-                        generation: generation
+            retained.worktrees.removeAll { worktree in
+                excludingWorktrees.contains {
+                    $0.matches(
+                        path: worktree.path,
+                        generation: worktree.generation
                     )
-                )
+                }
             }
             return retained
         })
@@ -91,6 +90,11 @@ struct KwtHostInventory: Equatable, Sendable {
 struct KwtWorktreeIdentity: Hashable, Sendable {
     let path: String
     let generation: String
+
+    func matches(path: String, generation: String?) -> Bool {
+        self.path == path
+            && generation.map { self.generation == $0 } ?? true
+    }
 }
 
 enum KwtInventoryError: Error, Equatable, LocalizedError {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -377,6 +377,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private struct PendingRemovalPresentation {
         var selection: WorkspaceTmuxSessionSelection
         var launchMode: TmuxAttachmentLaunchMode
+        var requiresWorkspaceEstablishment: Bool
         var wasActive: Bool
         var userNavigationRevision: UInt64
     }
@@ -2251,6 +2252,16 @@ final class WorkspaceSceneModel: ObservableObject {
             ] = PendingRemovalPresentation(
                 selection: presentation.selection,
                 launchMode: presentation.launchMode,
+                requiresWorkspaceEstablishment:
+                presentation.reconnectContext?.phase
+                    == .establishingWorkspace
+                    || (
+                        presentation.launchMode == .attach
+                            && presentation.selection.worktreePath != nil
+                            && !nativeTmuxSessionCoordinator.hasLaunched(
+                                presentation.handle
+                            )
+                    ),
                 wasActive: activeBorrowedTmuxHandle == presentation.handle,
                 userNavigationRevision: userNavigationRevision
             )
@@ -2263,11 +2274,13 @@ final class WorkspaceSceneModel: ObservableObject {
         requiresWorkspaceReestablishment: Bool
     ) {
         for presentation in presentations.values {
+            let establishesWorkspace = requiresWorkspaceReestablishment
+                || presentation.requiresWorkspaceEstablishment
             _ = presentTmuxSession(
                 presentation.selection,
-                launchMode: requiresWorkspaceReestablishment
+                launchMode: establishesWorkspace
                     ? .attach : presentation.launchMode,
-                intent: requiresWorkspaceReestablishment
+                intent: establishesWorkspace
                     ? .userInitiated : .restoreOnly,
                 activatesPresentation: presentation.wasActive
                     && presentation.userNavigationRevision
@@ -2655,6 +2668,10 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func invalidateTmuxAttachments(for hostIDs: Set<UUID>) {
         guard !hostIDs.isEmpty else { return }
+        for scope in pendingRemovalPresentationRestorations.keys
+            where hostIDs.contains(scope.hostID) {
+            pendingRemovalPresentationRestorations.removeValue(forKey: scope)
+        }
         let pendingForInvalidatedHosts = pendingCreatedTmuxSessions.filter {
             hostIDs.contains($0.value.hostID)
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1583,6 +1583,7 @@ final class WorkspaceSceneModel: ObservableObject {
             if let sessionKillRequest = request.sessionKillRequest {
                 try await killTmuxSession(sessionKillRequest)
                 terminatedSession = true
+                requiresWorkspaceReestablishment = true
             }
             guard removalHostEndpointMatches(request) else {
                 throw KwtWorktreeError.removalTargetChanged
@@ -2257,8 +2258,18 @@ final class WorkspaceSceneModel: ObservableObject {
                         generation: selection.worktreeGeneration
                     )
                 } == true
-                guard pathMatches || endpointTarget != nil else { return nil }
-                return (presentation, endpointTarget ?? selection)
+                if pathMatches {
+                    guard let path = selection.worktreePath,
+                          let pathTarget = event.removalPresentationTargets
+                          .first(where: {
+                              $0.hostID == selection.hostID
+                                  && $0.worktreePath == path
+                          })
+                    else { return nil }
+                    return (presentation, pathTarget)
+                }
+                guard let endpointTarget else { return nil }
+                return (presentation, endpointTarget)
             }
         for (presentation, restorationSelection) in presentations {
             let key = TmuxPresentationKey(presentation.selection)
@@ -4274,14 +4285,24 @@ final class WorkspaceSceneModel: ObservableObject {
             context: context
         )
         guard !Task.isCancelled else { return .retry }
-        guard presentation.reconnectContext == context,
+        guard let currentContext = presentation.reconnectContext else {
+            return .stop
+        }
+        let confirmedEstablishment =
+            context.phase == .establishingWorkspace
+                && currentContext.phase == .attachOnly
+                && currentContext.selection == context.selection
+                && currentContext.handleID == context.handleID
+                && currentContext.host == context.host
+                && currentContext.surfaceExitCode == context.surfaceExitCode
+        guard currentContext == context || confirmedEstablishment,
               presentation.handle.id == context.handleID,
               retainedTmuxPresentation(for: presentation.handle)
               === presentation
         else { return .stop }
         return reconnectDecision(
             for: presentation,
-            context: context,
+            context: currentContext,
             outcome: outcome
         )
     }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2238,8 +2238,7 @@ final class WorkspaceSceneModel: ObservableObject {
         generation: String?
     ) -> Bool {
         tombstones.contains { tombstone in
-            tombstone.path == path
-                && generation.map { tombstone.generation == $0 } ?? true
+            tombstone.matches(path: path, generation: generation)
         }
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -220,7 +220,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private var confirmedEndedTmuxSessionHandles: Set<UUID> = []
     private let createdSessionDiscoveryDelays: [Duration]
     private let tmuxSessionProbeBroker: TmuxSessionProbeBroker
-    private let tmuxReconnectSupervisor: TmuxSessionReconnectSupervisor
+    private let tmuxReconnectIntervals: [Duration]
+    private let tmuxReconnectProbeDeadline: Duration
     @Published private(set) var workspaceInventoryState:
         WorkspaceInventoryState = .loading
     @Published private(set) var workspaceInventoryWarning: String?
@@ -298,15 +299,52 @@ final class WorkspaceSceneModel: ObservableObject {
         case establishingWorkspace
         case attachOnly
     }
-    private struct ActiveTmuxReconnectContext: Equatable {
+    private struct TmuxReconnectContext: Equatable {
         var selection: WorkspaceTmuxSessionSelection
         var handleID: UUID
         var host: TmuxHost
         var phase: RemoteTmuxEstablishmentPhase
         var surfaceExitCode: UInt32?
     }
-    private var activeTmuxReconnectContext: ActiveTmuxReconnectContext?
-    private var establishmentConfirmationTask: Task<Void, Never>?
+    private struct TmuxPresentationKey: Hashable {
+        var hostID: UUID
+        var name: String
+        var socketName: String?
+
+        init(_ selection: WorkspaceTmuxSessionSelection) {
+            hostID = selection.hostID
+            name = selection.name
+            socketName = selection.socketName
+        }
+    }
+    private final class RetainedTmuxPresentation {
+        var selection: WorkspaceTmuxSessionSelection
+        var handle: BorrowedTmuxSessionHandle
+        var launchMode: TmuxAttachmentLaunchMode
+        var reconnectContext: TmuxReconnectContext?
+        var recoveryState: BorrowedTmuxRecoveryState?
+        var recoveryRequest: TmuxConnectionRecoveryRequest?
+        let reconnectSupervisor: TmuxSessionReconnectSupervisor
+        var establishmentConfirmationTask: Task<Void, Never>?
+
+        init(
+            selection: WorkspaceTmuxSessionSelection,
+            handle: BorrowedTmuxSessionHandle,
+            launchMode: TmuxAttachmentLaunchMode,
+            reconnectContext: TmuxReconnectContext?,
+            reconnectSupervisor: TmuxSessionReconnectSupervisor
+        ) {
+            self.selection = selection
+            self.handle = handle
+            self.launchMode = launchMode
+            self.reconnectContext = reconnectContext
+            self.reconnectSupervisor = reconnectSupervisor
+        }
+    }
+    private var retainedTmuxPresentations:
+        [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
+    private var retainedTmuxPresentationKeysByHandle:
+        [UUID: TmuxPresentationKey] = [:]
     @Published private(set) var isWorkspaceRestorationPending = false
     @Published private(set) var suppressesAutomaticWorktreeSessionOpen = false
     private var pendingRestoration: WorkspaceWindowState?
@@ -708,10 +746,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
             }
         )
-        tmuxReconnectSupervisor = TmuxSessionReconnectSupervisor(
-            intervals: tmuxReconnectIntervals,
-            probeDeadline: tmuxReconnectProbeDeadline
-        )
+        self.tmuxReconnectIntervals = tmuxReconnectIntervals
+        self.tmuxReconnectProbeDeadline = tmuxReconnectProbeDeadline
         self.tmuxSessionKiller = tmuxSessionKiller
         self.tmuxSessionIdentityReader = tmuxSessionIdentityReader
         self.tmuxSessionStyler = tmuxSessionStyler
@@ -792,10 +828,12 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         nativeTmuxSessionCoordinatorBacking?.onSurfaceReady = {
             [weak self] handle in
-            guard self?.activeBorrowedTmuxHandle == handle else { return }
-            self?.objectWillChange.send()
-            if self?.activeBorrowedTmuxRecoveryState != nil {
-                self?.prepareActiveBorrowedTmuxSurface()
+            guard let self,
+                  retainedTmuxPresentation(for: handle) != nil
+            else { return }
+            _ = nativeTmuxSessionCoordinator.surface(handle: handle)
+            if activeBorrowedTmuxHandle == handle {
+                objectWillChange.send()
             }
         }
         activityControllerBacking = ActivityMonitoringController(
@@ -1031,6 +1069,7 @@ final class WorkspaceSceneModel: ObservableObject {
               ),
               generation != activeGeneration
         else { return }
+        closeBorrowedTmuxSession(active)
         openBorrowedTmuxSession(replacement)
     }
 
@@ -1167,7 +1206,14 @@ final class WorkspaceSceneModel: ObservableObject {
     /// tmux server sessions they attach to. Called by `WorkspaceWindow` before
     /// the scene model leaves the app-level window registry.
     func shutdown() async {
-        cancelTmuxReconnect()
+        for presentation in retainedTmuxPresentations.values {
+            cancelTmuxReconnect(presentation)
+        }
+        retainedTmuxPresentations.removeAll()
+        retainedTmuxPresentationKeysByHandle.removeAll()
+        activeBorrowedTmuxSelection = nil
+        activeBorrowedTmuxHandle = nil
+        activeBorrowedTmuxLaunchMode = nil
         kwtInventoryTask?.cancel()
         tmuxDiscoveryTask?.cancel()
         createdSessionDiscoveryTasks.values.forEach { $0.cancel() }
@@ -2250,25 +2296,25 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         applyInventoryOverlayIfNeeded()
         updateWorkspaceInventoryState()
-        applyDeferredTmuxPresentationIfReady()
+        applyDeferredTmuxPresentationsIfReady()
     }
 
     private func reconcileEndedTmuxSession(
         _ discovered: [DiscoveredTmuxSession],
         hostID: UUID
     ) {
-        guard let selection = activeBorrowedTmuxSelection,
-              selection.hostID == hostID,
-              selection.socketName == nil,
-              let handle = activeBorrowedTmuxHandle,
-              nativeTmuxSessionCoordinator.hasClosedAttachment(handle)
-        else {
-            return
-        }
-        if discovered.contains(where: { $0.name == selection.name }) {
-            confirmedEndedTmuxSessionHandles.remove(handle.id)
-        } else {
-            confirmedEndedTmuxSessionHandles.insert(handle.id)
+        for presentation in retainedTmuxPresentations.values {
+            let selection = presentation.selection
+            let handle = presentation.handle
+            guard selection.hostID == hostID,
+                  selection.socketName == nil,
+                  nativeTmuxSessionCoordinator.hasClosedAttachment(handle)
+            else { continue }
+            if discovered.contains(where: { $0.name == selection.name }) {
+                confirmedEndedTmuxSessionHandles.remove(handle.id)
+            } else {
+                confirmedEndedTmuxSessionHandles.insert(handle.id)
+            }
         }
     }
 
@@ -2449,6 +2495,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 hostID: hostID
             )
             for handle in handles {
+                if let key = retainedTmuxPresentationKeysByHandle
+                    .removeValue(forKey: handle.id),
+                    let presentation = retainedTmuxPresentations
+                    .removeValue(forKey: key) {
+                    cancelTmuxReconnect(presentation)
+                }
                 cancelTmuxPresentationTasks(handleID: handle.id)
                 borrowedTmuxConnectionStates.removeValue(forKey: handle.id)
                 createdSessionDiscoveryTasks.removeValue(
@@ -2460,10 +2512,11 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         guard let active = activeBorrowedTmuxSelection,
               hostIDs.contains(active.hostID) else { return }
-        cancelTmuxReconnect()
         activeBorrowedTmuxSelection = nil
         activeBorrowedTmuxHandle = nil
         activeBorrowedTmuxLaunchMode = nil
+        activeBorrowedTmuxRecoveryState = nil
+        tmuxConnectionRecoveryRequest = nil
     }
 
     func pendingSSHHostKeyConfirmation(
@@ -3318,8 +3371,29 @@ final class WorkspaceSceneModel: ObservableObject {
             selection.socketName != nil && launchMode == .create
                 ? .attach
                 : launchMode
-        if let active = activeBorrowedTmuxSelection, active != selection {
-            closeBorrowedTmuxSession(active)
+        let key = TmuxPresentationKey(selection)
+        if let retained = retainedTmuxPresentations[key] {
+            let generationChanged = if let retainedGeneration =
+                retained.selection.worktreeGeneration,
+                let selectionGeneration = selection.worktreeGeneration {
+                retainedGeneration != selectionGeneration
+            } else {
+                false
+            }
+            let recreatesClosedAttachment = effectiveLaunchMode == .create
+                && nativeTmuxSessionCoordinator.hasClosedAttachment(
+                    retained.handle
+                )
+            if generationChanged || recreatesClosedAttachment {
+                closeBorrowedTmuxSession(retained.selection)
+            } else {
+                if retained.selection.worktreeGeneration == nil,
+                   selection.worktreeGeneration != nil {
+                    retained.selection = selection
+                }
+                activateTmuxPresentation(retained)
+                return retained.handle
+            }
         }
         guard let host = snapshot.host(id: selection.hostID),
               let attachmentHost = TmuxHostResolver.resolve(host)
@@ -3327,6 +3401,8 @@ final class WorkspaceSceneModel: ObservableObject {
             activeBorrowedTmuxSelection = selection
             activeBorrowedTmuxHandle = nil
             activeBorrowedTmuxLaunchMode = effectiveLaunchMode
+            activeBorrowedTmuxRecoveryState = nil
+            tmuxConnectionRecoveryRequest = nil
             return nil
         }
         let knownSessions = tmuxSessionsByHost[selection.hostID]
@@ -3354,12 +3430,8 @@ final class WorkspaceSceneModel: ObservableObject {
             workingDirectory: selection.worktreePath,
             openWorkspace: openWorkspace
         )
-        activeBorrowedTmuxSelection = selection
-        activeBorrowedTmuxHandle = handle
-        activeBorrowedTmuxLaunchMode = effectiveLaunchMode
-        borrowedTmuxConnectionStates[handle.id] = .connecting
-        if attachmentHost.isRemote {
-            activeTmuxReconnectContext = ActiveTmuxReconnectContext(
+        let reconnectContext = attachmentHost.isRemote
+            ? TmuxReconnectContext(
                 selection: selection,
                 handleID: handle.id,
                 host: attachmentHost,
@@ -3368,13 +3440,88 @@ final class WorkspaceSceneModel: ObservableObject {
                     : .attachOnly,
                 surfaceExitCode: nil
             )
-        } else {
-            activeTmuxReconnectContext = nil
-        }
+            : nil
+        let presentation = RetainedTmuxPresentation(
+            selection: selection,
+            handle: handle,
+            launchMode: effectiveLaunchMode,
+            reconnectContext: reconnectContext,
+            reconnectSupervisor: TmuxSessionReconnectSupervisor(
+                intervals: tmuxReconnectIntervals,
+                probeDeadline: tmuxReconnectProbeDeadline
+            )
+        )
+        retainedTmuxPresentations[key] = presentation
+        retainedTmuxPresentationKeysByHandle[handle.id] = key
+        activateTmuxPresentation(presentation)
+        borrowedTmuxConnectionStates[handle.id] = .connecting
         if effectiveLaunchMode == .create {
             transferPendingCreation(for: selection, to: handle)
         }
         return handle
+    }
+
+    private func retainedTmuxPresentation(
+        for handle: BorrowedTmuxSessionHandle
+    ) -> RetainedTmuxPresentation? {
+        retainedTmuxPresentationKeysByHandle[handle.id].flatMap {
+            retainedTmuxPresentations[$0]
+        }
+    }
+
+    private func retainedTmuxPresentation(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> RetainedTmuxPresentation? {
+        retainedTmuxPresentations[TmuxPresentationKey(selection)]
+    }
+
+    private func activateTmuxPresentation(
+        _ presentation: RetainedTmuxPresentation
+    ) {
+        activeBorrowedTmuxSelection = presentation.selection
+        activeBorrowedTmuxHandle = presentation.handle
+        activeBorrowedTmuxLaunchMode = presentation.launchMode
+        activeBorrowedTmuxRecoveryState = presentation.recoveryState
+        tmuxConnectionRecoveryRequest = presentation.recoveryRequest
+        applyDeferredTmuxPresentationIfReady(presentation)
+    }
+
+    private func publishActiveState(
+        for presentation: RetainedTmuxPresentation
+    ) {
+        guard activeBorrowedTmuxHandle == presentation.handle else { return }
+        activeBorrowedTmuxLaunchMode = presentation.launchMode
+        activeBorrowedTmuxRecoveryState = presentation.recoveryState
+        tmuxConnectionRecoveryRequest = presentation.recoveryRequest
+    }
+
+    func hideBorrowedTmuxSession(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) {
+        guard activeBorrowedTmuxSelection == selection else { return }
+        activeBorrowedTmuxSelection = nil
+        activeBorrowedTmuxHandle = nil
+        activeBorrowedTmuxLaunchMode = nil
+        activeBorrowedTmuxRecoveryState = nil
+        tmuxConnectionRecoveryRequest = nil
+    }
+
+    var retainedBorrowedTmuxPresentationCount: Int {
+        retainedTmuxPresentations.count
+    }
+
+    func retainedBorrowedTmuxHandle(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> BorrowedTmuxSessionHandle? {
+        retainedTmuxPresentation(for: selection)?.handle
+    }
+
+    func retainedBorrowedTmuxSessionIsConnected(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        guard let handle = retainedTmuxPresentation(for: selection)?.handle
+        else { return false }
+        return borrowedTmuxConnectionStates[handle.id] == .connected
     }
 
     private static func sameTmuxSession(
@@ -3421,30 +3568,45 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
-        guard activeBorrowedTmuxSelection == selection else { return }
-        cancelTmuxReconnect()
-        if let handle = activeBorrowedTmuxHandle {
-            cancelTmuxPresentationTasks(handleID: handle.id)
-            confirmedEndedTmuxSessionHandles.remove(handle.id)
-            borrowedTmuxConnectionStates.removeValue(forKey: handle.id)
-            if pendingCreatedTmuxSessions[handle.id] != nil,
-               nativeTmuxSessionCoordinator.hasLaunched(handle) {
-                endedCreatedTmuxSessionHandles.insert(handle.id)
-                reconcileCreatedTmuxSession(
-                    handleID: handle.id,
-                    immediately: true
-                )
-            } else if pendingCreatedTmuxSessions[handle.id] != nil {
-                discardPendingTmuxSession(handleID: handle.id)
-            }
+        let key = TmuxPresentationKey(selection)
+        guard let presentation = retainedTmuxPresentations.removeValue(
+            forKey: key
+        ) else {
+            guard activeBorrowedTmuxSelection == selection else { return }
+            activeBorrowedTmuxSelection = nil
+            activeBorrowedTmuxHandle = nil
+            activeBorrowedTmuxLaunchMode = nil
+            activeBorrowedTmuxRecoveryState = nil
+            tmuxConnectionRecoveryRequest = nil
+            return
         }
-        activeBorrowedTmuxSelection = nil
-        activeBorrowedTmuxHandle = nil
-        activeBorrowedTmuxLaunchMode = nil
+        let handle = presentation.handle
+        retainedTmuxPresentationKeysByHandle.removeValue(forKey: handle.id)
+        cancelTmuxReconnect(presentation)
+        cancelTmuxPresentationTasks(handleID: handle.id)
+        confirmedEndedTmuxSessionHandles.remove(handle.id)
+        borrowedTmuxConnectionStates.removeValue(forKey: handle.id)
+        if pendingCreatedTmuxSessions[handle.id] != nil,
+           nativeTmuxSessionCoordinator.hasLaunched(handle) {
+            endedCreatedTmuxSessionHandles.insert(handle.id)
+            reconcileCreatedTmuxSession(
+                handleID: handle.id,
+                immediately: true
+            )
+        } else if pendingCreatedTmuxSessions[handle.id] != nil {
+            discardPendingTmuxSession(handleID: handle.id)
+        }
+        if activeBorrowedTmuxHandle == handle {
+            activeBorrowedTmuxSelection = nil
+            activeBorrowedTmuxHandle = nil
+            activeBorrowedTmuxLaunchMode = nil
+            activeBorrowedTmuxRecoveryState = nil
+            tmuxConnectionRecoveryRequest = nil
+        }
         nativeTmuxSessionCoordinator.detach(
-            hostID: selection.hostID,
-            name: selection.name,
-            socketName: selection.socketName
+            hostID: presentation.selection.hostID,
+            name: presentation.selection.name,
+            socketName: presentation.selection.socketName
         )
     }
 
@@ -3520,8 +3682,12 @@ final class WorkspaceSceneModel: ObservableObject {
         let activeTargetAfterKill = activeBorrowedTmuxSelection.flatMap {
             Self.sameTmuxEndpoint($0, tmuxSelection) ? $0 : nil
         }
-        if let activeTargetAfterKill {
-            closeBorrowedTmuxSession(activeTargetAfterKill)
+        if let retainedTarget = retainedTmuxPresentations.values.first(
+            where: {
+                Self.sameTmuxEndpoint($0.selection, tmuxSelection)
+            }
+        )?.selection {
+            closeBorrowedTmuxSession(retainedTarget)
         }
         if tmuxSelection.socketName == nil {
             tmuxSessionsByHost[tmuxSelection.hostID]?.removeAll {
@@ -3656,38 +3822,42 @@ final class WorkspaceSceneModel: ObservableObject {
         state: ConnectionState
     ) {
         borrowedTmuxConnectionStates[handle.id] = state
+        guard let presentation = retainedTmuxPresentation(for: handle) else {
+            return
+        }
         if state == .connected {
             confirmedEndedTmuxSessionHandles.remove(handle.id)
-            activeBorrowedTmuxRecoveryState = nil
-            tmuxConnectionRecoveryRequest = nil
-            if activeTmuxReconnectContext?.handleID == handle.id {
-                activeTmuxReconnectContext?.surfaceExitCode = nil
-                startEstablishmentConfirmationIfNeeded(handle: handle)
+            presentation.recoveryState = nil
+            presentation.recoveryRequest = nil
+            if presentation.reconnectContext?.handleID == handle.id {
+                presentation.reconnectContext?.surfaceExitCode = nil
+                startEstablishmentConfirmationIfNeeded(
+                    presentation: presentation
+                )
             }
-            applyDeferredTmuxPresentationIfReady()
+            publishActiveState(for: presentation)
+            applyDeferredTmuxPresentationIfReady(presentation)
         }
         if case .disconnected = state,
-           activeBorrowedTmuxHandle == handle,
-           activeBorrowedTmuxRecoveryState != nil,
+           presentation.recoveryState != nil,
            nativeTmuxSessionCoordinator.attachmentClosure(handle)
            == .launchFailed {
-            cancelTmuxReconnect()
+            cancelTmuxReconnect(presentation)
             return
         }
         if case .disconnected = state,
            nativeTmuxSessionCoordinator.hasLaunched(handle) {
             cancelTmuxPresentationTasks(handleID: handle.id)
-            if activeBorrowedTmuxHandle == handle,
-               var context = activeTmuxReconnectContext,
+            if var context = presentation.reconnectContext,
                context.handleID == handle.id,
                context.host.isRemote,
                case let .processExited(code) =
                nativeTmuxSessionCoordinator.attachmentClosure(handle) {
-                establishmentConfirmationTask?.cancel()
-                establishmentConfirmationTask = nil
+                presentation.establishmentConfirmationTask?.cancel()
+                presentation.establishmentConfirmationTask = nil
                 context.surfaceExitCode = code
-                activeTmuxReconnectContext = context
-                startTmuxReconnect(context)
+                presentation.reconnectContext = context
+                startTmuxReconnect(presentation, context: context)
                 return
             }
             scheduleTmuxSessionDiscovery()
@@ -3713,37 +3883,60 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
-    private func startTmuxReconnect(_ context: ActiveTmuxReconnectContext) {
-        guard activeTmuxReconnectContext == context,
-              activeBorrowedTmuxHandle?.id == context.handleID
+    private func startTmuxReconnect(
+        _ presentation: RetainedTmuxPresentation,
+        context: TmuxReconnectContext
+    ) {
+        guard presentation.reconnectContext == context,
+              presentation.handle.id == context.handleID,
+              retainedTmuxPresentation(for: presentation.handle)
+              === presentation
         else { return }
-        activeBorrowedTmuxRecoveryState = .reconnecting(
+        presentation.recoveryState = .reconnecting(
             message: "Waiting for \(hostName(for: context.selection.hostID)). "
                 + "Ghosthub will reconnect automatically."
         )
-        tmuxConnectionRecoveryRequest = nil
-        tmuxReconnectSupervisor.start { [weak self] in
+        presentation.recoveryRequest = nil
+        publishActiveState(for: presentation)
+        presentation.reconnectSupervisor.start { [weak self, weak presentation] in
+            guard let presentation else { return .stop }
             guard let self else { return .stop }
-            return await attemptTmuxReconnect(context)
+            return await attemptTmuxReconnect(
+                presentation,
+                context: context
+            )
         }
     }
 
     private func attemptTmuxReconnect(
-        _ context: ActiveTmuxReconnectContext
+        _ presentation: RetainedTmuxPresentation,
+        context: TmuxReconnectContext
     ) async -> TmuxReconnectDecision {
-        guard activeTmuxReconnectContext == context,
-              activeBorrowedTmuxHandle?.id == context.handleID
+        guard presentation.reconnectContext == context,
+              presentation.handle.id == context.handleID,
+              retainedTmuxPresentation(for: presentation.handle)
+              === presentation
         else { return .stop }
-        let outcome = await tmuxProbeOutcome(for: context)
+        let outcome = await tmuxProbeOutcome(
+            for: presentation,
+            context: context
+        )
         guard !Task.isCancelled else { return .retry }
-        guard activeTmuxReconnectContext == context,
-              activeBorrowedTmuxHandle?.id == context.handleID
+        guard presentation.reconnectContext == context,
+              presentation.handle.id == context.handleID,
+              retainedTmuxPresentation(for: presentation.handle)
+              === presentation
         else { return .stop }
-        return reconnectDecision(for: context, outcome: outcome)
+        return reconnectDecision(
+            for: presentation,
+            context: context,
+            outcome: outcome
+        )
     }
 
     private func tmuxProbeOutcome(
-        for context: ActiveTmuxReconnectContext
+        for presentation: RetainedTmuxPresentation,
+        context: TmuxReconnectContext
     ) async -> TmuxSessionProbeOutcome {
         guard case let .ssh(host) = context.host else {
             return .failure(.sessionContextUnavailable)
@@ -3757,8 +3950,10 @@ final class WorkspaceSceneModel: ObservableObject {
                     shell: context.host.displayName
                 ))
             }
-            guard activeTmuxReconnectContext == context,
-                  activeBorrowedTmuxHandle?.id == context.handleID,
+            guard presentation.reconnectContext == context,
+                  presentation.handle.id == context.handleID,
+                  retainedTmuxPresentation(for: presentation.handle)
+                  === presentation,
                   snapshot.host(id: context.selection.hostID)
                   .flatMap(TmuxHostResolver.resolve) == context.host
             else {
@@ -3791,24 +3986,28 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func reconnectDecision(
-        for context: ActiveTmuxReconnectContext,
+        for presentation: RetainedTmuxPresentation,
+        context: TmuxReconnectContext,
         outcome: TmuxSessionProbeOutcome
     ) -> TmuxReconnectDecision {
         guard !Task.isCancelled else { return .retry }
-        guard activeTmuxReconnectContext == context,
-              activeBorrowedTmuxHandle?.id == context.handleID
+        guard presentation.reconnectContext == context,
+              presentation.handle.id == context.handleID,
+              retainedTmuxPresentation(for: presentation.handle)
+              === presentation
         else { return .stop }
         switch outcome {
         case .present:
             guard context.surfaceExitCode == 255 else {
                 stopTmuxReconnectWithUnableToAttach(
+                    presentation,
                     "The remote tmux client exited before it could attach."
                 )
                 return .stop
             }
             confirmedEndedTmuxSessionHandles.remove(context.handleID)
             relaunchTmuxSession(
-                context.selection,
+                presentation,
                 launchMode: .attachOnly,
                 intent: .restoreOnly
             )
@@ -3816,18 +4015,20 @@ final class WorkspaceSceneModel: ObservableObject {
         case .absent:
             guard context.phase == .establishingWorkspace else {
                 confirmedEndedTmuxSessionHandles.insert(context.handleID)
-                activeBorrowedTmuxRecoveryState = nil
-                tmuxConnectionRecoveryRequest = nil
+                presentation.recoveryState = nil
+                presentation.recoveryRequest = nil
+                publishActiveState(for: presentation)
                 return .stop
             }
             guard context.surfaceExitCode == 255 else {
                 stopTmuxReconnectWithUnableToAttach(
+                    presentation,
                     "The remote workspace could not be established."
                 )
                 return .stop
             }
             relaunchTmuxSession(
-                context.selection,
+                presentation,
                 launchMode: .attach,
                 intent: .userInitiated
             )
@@ -3837,66 +4038,124 @@ final class WorkspaceSceneModel: ObservableObject {
         case let .failure(.sshConnectionFailed(_, classification)):
             switch classification.kind {
             case .transport:
-                activeBorrowedTmuxRecoveryState = .reconnecting(
+                presentation.recoveryState = .reconnecting(
                     message: classification.diagnostic.summary + " "
                         + "Ghosthub will reconnect automatically."
                 )
+                publishActiveState(for: presentation)
                 return .retry
             case .authenticationRequired, .hostKeyReviewRequired:
                 let message = classification.diagnostic.summary + " "
                     + classification.diagnostic.recoverySuggestion
-                activeBorrowedTmuxRecoveryState = .needsAttention(
+                presentation.recoveryState = .needsAttention(
                     message: message,
                     canReviewConnection: true
                 )
-                if tmuxConnectionRecoveryRequest == nil {
-                    tmuxConnectionRecoveryRequest =
+                if presentation.recoveryRequest == nil {
+                    presentation.recoveryRequest =
                         TmuxConnectionRecoveryRequest(
                             hostID: context.selection.hostID,
                             message: message
                         )
                 }
+                publishActiveState(for: presentation)
                 return .stop
             case .hostKeyChanged:
-                activeBorrowedTmuxRecoveryState = .needsAttention(
+                presentation.recoveryState = .needsAttention(
                     message: classification.diagnostic.summary + " "
                         + classification.diagnostic.recoverySuggestion,
                     canReviewConnection: false
                 )
-                tmuxConnectionRecoveryRequest = nil
+                presentation.recoveryRequest = nil
+                publishActiveState(for: presentation)
                 return .stop
             }
         case let .failure(error):
-            stopTmuxReconnectWithUnableToAttach(error.localizedDescription)
+            stopTmuxReconnectWithUnableToAttach(
+                presentation,
+                error.localizedDescription
+            )
             return .stop
         }
     }
 
     private func relaunchTmuxSession(
-        _ selection: WorkspaceTmuxSessionSelection,
+        _ presentation: RetainedTmuxPresentation,
         launchMode: TmuxAttachmentLaunchMode,
         intent: TmuxPresentationIntent
     ) {
-        guard presentTmuxSession(
-            selection,
-            launchMode: launchMode,
-            intent: intent
-        ) != nil else {
+        let selection = presentation.selection
+        guard let host = snapshot.host(id: selection.hostID),
+              let attachmentHost = TmuxHostResolver.resolve(host)
+        else {
             stopTmuxReconnectWithUnableToAttach(
+                presentation,
                 "The remote host is no longer available."
             )
             return
         }
-        prepareActiveBorrowedTmuxSurface()
+        let knownSessions = tmuxSessionsByHost[selection.hostID]
+            ?? host.tmuxSessions
+        let sessionIsDiscovered = selection.socketName == nil
+            && knownSessions.contains { $0.name == selection.name }
+        let managedKwtUnavailable = host.remoteDiagnostics.contains {
+            $0.code == .missingKwt
+        }
+        let openWorkspace = intent == .userInitiated
+            && launchMode == .attach
+            && selection.socketName == nil
+            && selection.worktreePath != nil
+            && (!sessionIsDiscovered || !managedKwtUnavailable)
+        let protectedSessionNeedsEstablishment = intent == .userInitiated
+            && launchMode == .attach
+            && selection.socketName != nil
+            && selection.worktreePath != nil
+        let previousHandle = presentation.handle
+        let handle = nativeTmuxSessionCoordinator.attach(
+            hostID: selection.hostID,
+            name: selection.name,
+            host: attachmentHost,
+            socketName: selection.socketName,
+            launchMode: launchMode,
+            workingDirectory: selection.worktreePath,
+            openWorkspace: openWorkspace
+        )
+        if handle.id != previousHandle.id {
+            retainedTmuxPresentationKeysByHandle.removeValue(
+                forKey: previousHandle.id
+            )
+            retainedTmuxPresentationKeysByHandle[handle.id] =
+                TmuxPresentationKey(selection)
+        }
+        presentation.handle = handle
+        presentation.launchMode = launchMode
+        presentation.reconnectContext = TmuxReconnectContext(
+            selection: selection,
+            handleID: handle.id,
+            host: attachmentHost,
+            phase: openWorkspace || protectedSessionNeedsEstablishment
+                ? .establishingWorkspace
+                : .attachOnly,
+            surfaceExitCode: nil
+        )
+        borrowedTmuxConnectionStates[handle.id] = .connecting
+        if activeBorrowedTmuxHandle == previousHandle {
+            activeBorrowedTmuxHandle = handle
+            publishActiveState(for: presentation)
+        }
+        _ = nativeTmuxSessionCoordinator.surface(handle: handle)
     }
 
-    private func stopTmuxReconnectWithUnableToAttach(_ reason: String) {
-        activeBorrowedTmuxRecoveryState = nil
-        tmuxConnectionRecoveryRequest = nil
-        guard let handle = activeBorrowedTmuxHandle else { return }
-        borrowedTmuxConnectionStates[handle.id] = .disconnected(
+    private func stopTmuxReconnectWithUnableToAttach(
+        _ presentation: RetainedTmuxPresentation,
+        _ reason: String
+    ) {
+        presentation.recoveryState = nil
+        presentation.recoveryRequest = nil
+        borrowedTmuxConnectionStates[presentation.handle.id] = .disconnected(
             reason: reason
         )
+        publishActiveState(for: presentation)
     }
 
     private func hostName(for hostID: UUID) -> String {
@@ -3904,78 +4163,94 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func reconnectActiveTmuxSessionNow() {
-        guard let recoveryState = activeBorrowedTmuxRecoveryState,
+        guard let handle = activeBorrowedTmuxHandle,
+              let presentation = retainedTmuxPresentation(for: handle),
+              let recoveryState = presentation.recoveryState,
               recoveryState.allowsReconnectNow
         else { return }
         if recoveryState.isReconnecting {
-            tmuxReconnectSupervisor.reconnectNow()
+            presentation.reconnectSupervisor.reconnectNow()
             return
         }
-        guard let context = activeTmuxReconnectContext,
-              activeBorrowedTmuxHandle?.id == context.handleID
+        guard let context = presentation.reconnectContext,
+              handle.id == context.handleID
         else { return }
-        startTmuxReconnect(context)
+        startTmuxReconnect(presentation, context: context)
     }
 
-    func resumeTmuxReconnectAfterSSHRecovery(hostID: UUID) {
-        guard case .needsAttention(_, true) = activeBorrowedTmuxRecoveryState,
-              let request = tmuxConnectionRecoveryRequest,
-              request.hostID == hostID,
-              var context = activeTmuxReconnectContext,
-              context.selection.hostID == hostID,
-              activeBorrowedTmuxHandle?.id == context.handleID
+    func resumeTmuxReconnectAfterSSHRecovery(
+        _ recoveryRequest: TmuxConnectionRecoveryRequest
+    ) {
+        guard let presentation = retainedTmuxPresentations.values.first(
+            where: { $0.recoveryRequest?.id == recoveryRequest.id }
+        ),
+            case .needsAttention(_, true) = presentation.recoveryState,
+            let request = presentation.recoveryRequest,
+            request == recoveryRequest,
+            var context = presentation.reconnectContext,
+            context.selection.hostID == request.hostID,
+            presentation.handle.id == context.handleID
         else { return }
         context.surfaceExitCode = 255
-        activeTmuxReconnectContext = context
-        tmuxConnectionRecoveryRequest = nil
-        startTmuxReconnect(context)
+        presentation.reconnectContext = context
+        presentation.recoveryRequest = nil
+        publishActiveState(for: presentation)
+        startTmuxReconnect(presentation, context: context)
     }
 
-    private func cancelTmuxReconnect() {
-        tmuxReconnectSupervisor.cancel()
-        establishmentConfirmationTask?.cancel()
-        establishmentConfirmationTask = nil
-        activeTmuxReconnectContext = nil
-        activeBorrowedTmuxRecoveryState = nil
-        tmuxConnectionRecoveryRequest = nil
+    private func cancelTmuxReconnect(
+        _ presentation: RetainedTmuxPresentation
+    ) {
+        presentation.reconnectSupervisor.cancel()
+        presentation.establishmentConfirmationTask?.cancel()
+        presentation.establishmentConfirmationTask = nil
+        presentation.reconnectContext = nil
+        presentation.recoveryState = nil
+        presentation.recoveryRequest = nil
+        publishActiveState(for: presentation)
     }
 
     private func startEstablishmentConfirmationIfNeeded(
-        handle: BorrowedTmuxSessionHandle
+        presentation: RetainedTmuxPresentation
     ) {
-        guard let context = activeTmuxReconnectContext,
+        let handle = presentation.handle
+        guard let context = presentation.reconnectContext,
               context.handleID == handle.id,
               context.phase == .establishingWorkspace
         else { return }
-        establishmentConfirmationTask?.cancel()
+        presentation.establishmentConfirmationTask?.cancel()
         let delays = [.zero] + createdSessionDiscoveryDelays
-        establishmentConfirmationTask = Task { [weak self] in
+        presentation.establishmentConfirmationTask = Task {
+            [weak self, weak presentation] in
             for delay in delays {
                 do {
                     try await Task.sleep(for: delay)
                 } catch {
                     return
                 }
-                guard let self,
+                guard let self, let presentation,
                       !Task.isCancelled,
-                      activeTmuxReconnectContext == context,
+                      presentation.reconnectContext == context,
                       borrowedTmuxConnectionStates[handle.id] == .connected
                 else { return }
-                let outcome = await tmuxProbeOutcome(for: context)
+                let outcome = await tmuxProbeOutcome(
+                    for: presentation,
+                    context: context
+                )
                 guard !Task.isCancelled,
-                      activeTmuxReconnectContext == context,
+                      presentation.reconnectContext == context,
                       borrowedTmuxConnectionStates[handle.id] == .connected
                 else { return }
                 if outcome == .present {
-                    activeTmuxReconnectContext?.phase = .attachOnly
-                    establishmentConfirmationTask = nil
+                    presentation.reconnectContext?.phase = .attachOnly
+                    presentation.establishmentConfirmationTask = nil
                     return
                 }
             }
-            guard let self,
-                  activeTmuxReconnectContext == context
+            guard let presentation,
+                  presentation.reconnectContext == context
             else { return }
-            establishmentConfirmationTask = nil
+            presentation.establishmentConfirmationTask = nil
         }
     }
 
@@ -3999,10 +4274,13 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func terminalPresentationStyleDidChange() {
         objectWillChange.send()
-        if let handle = activeBorrowedTmuxHandle {
-            cancelTmuxPresentationTasks(handleID: handle.id)
+        let presentations = Array(retainedTmuxPresentations.values)
+        for presentation in presentations {
+            cancelTmuxPresentationTasks(handleID: presentation.handle.id)
         }
-        applyDeferredTmuxPresentationIfReady()
+        for presentation in presentations {
+            applyDeferredTmuxPresentationIfReady(presentation)
+        }
     }
 
     /// A cancelled ladder keeps draining until its in-flight tmux command
@@ -4036,24 +4314,32 @@ final class WorkspaceSceneModel: ObservableObject {
     /// kwt finishes creating or repairing the session, revalidates the style
     /// policy before every attempt, and otherwise leaves the explicit
     /// Apply Theme action as the recovery path.
-    private func applyDeferredTmuxPresentationIfReady() {
-        guard let handle = activeBorrowedTmuxHandle,
-              nativeTmuxSessionCoordinator.hasDeferredPresentationStyle(
-                  handle
-              ),
-              nativeTmuxSessionCoordinator.shouldApplyPresentationStyle(
-                  handle
-              ),
-              deferredTmuxPresentationTasks[handle.id] == nil,
-              pendingCreatedTmuxSessions[handle.id] == nil,
-              borrowedTmuxConnectionStates[handle.id] == .connected,
-              let selection = activeBorrowedTmuxSelection,
-              let hostSummary = snapshot.host(id: selection.hostID),
-              let host = TmuxHostResolver.resolve(hostSummary),
-              Self.supportsTmuxSessionStyling(host),
-              let surfaceIdentity = nativeTmuxSessionCoordinator
-              .surfaceIdentity(handle: handle),
-              let style = tmuxPresentationStyleProvider(surfaceIdentity)
+    private func applyDeferredTmuxPresentationsIfReady() {
+        for presentation in retainedTmuxPresentations.values {
+            applyDeferredTmuxPresentationIfReady(presentation)
+        }
+    }
+
+    private func applyDeferredTmuxPresentationIfReady(
+        _ presentation: RetainedTmuxPresentation
+    ) {
+        let handle = presentation.handle
+        let selection = presentation.selection
+        guard nativeTmuxSessionCoordinator.hasDeferredPresentationStyle(
+            handle
+        ),
+            nativeTmuxSessionCoordinator.shouldApplyPresentationStyle(
+                handle
+            ),
+            deferredTmuxPresentationTasks[handle.id] == nil,
+            pendingCreatedTmuxSessions[handle.id] == nil,
+            borrowedTmuxConnectionStates[handle.id] == .connected,
+            let hostSummary = snapshot.host(id: selection.hostID),
+            let host = TmuxHostResolver.resolve(hostSummary),
+            Self.supportsTmuxSessionStyling(host),
+            let surfaceIdentity = nativeTmuxSessionCoordinator
+            .surfaceIdentity(handle: handle),
+            let style = tmuxPresentationStyleProvider(surfaceIdentity)
         else { return }
         let capturedIdentity = Self.discoveredTmuxSessionIdentity(
             selection,
@@ -4070,14 +4356,14 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             // Success and exhaustion both consume the deferred marker so a
             // persistently failing session cannot re-run the ladder on every
-            // later trigger. An interrupted ladder (cancellation, switch-away,
-            // disconnect) leaves the marker for the next visit.
+            // later trigger. An interrupted ladder (cancellation or
+            // disconnect) leaves the marker for the next eligible trigger.
             var consumesMarker = false
             var expectedIdentity = capturedIdentity
             for attempt in 0 ... retryDelays.count {
                 guard let self,
                       !Task.isCancelled,
-                      activeBorrowedTmuxHandle == handle,
+                      retainedTmuxPresentation(for: handle) === presentation,
                       borrowedTmuxConnectionStates[handle.id] == .connected,
                       nativeTmuxSessionCoordinator
                       .hasDeferredPresentationStyle(handle),
@@ -4194,7 +4480,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     applyInventoryOverlayIfNeeded()
                     updateWorkspaceInventoryState()
                     if found {
-                        applyDeferredTmuxPresentationIfReady()
+                        applyDeferredTmuxPresentationsIfReady()
                     }
                     if found || isLastAttempt {
                         createdSessionDiscoveryTasks.removeValue(
@@ -4246,11 +4532,11 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         for (handleID, pending) in pendingForHost {
             if discoveredNames.contains(pending.name) {
-                if activeBorrowedTmuxHandle?.id == handleID,
-                   activeBorrowedTmuxSelection.map({
-                       Self.sameTmuxSession($0, pending)
-                   }) == true {
-                    activeBorrowedTmuxLaunchMode = .attach
+                if let key = retainedTmuxPresentationKeysByHandle[handleID],
+                   let presentation = retainedTmuxPresentations[key],
+                   Self.sameTmuxSession(presentation.selection, pending) {
+                    presentation.launchMode = .attach
+                    publishActiveState(for: presentation)
                 }
                 pendingCreatedTmuxSessions.removeValue(forKey: handleID)
                 createdSessionDiscoveryTasks.removeValue(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1647,6 +1647,7 @@ final class WorkspaceSceneModel: ObservableObject {
         _ worktree: WorktreeSummary,
         hostID: UUID
     ) {
+        closeRetainedTmuxPresentations(forWorktreeIDs: [worktree.id])
         if let inventory = kwtInventoriesByHost[hostID] {
             kwtInventoriesByHost[hostID] =
                 inventory.removingWorktree(atPath: worktree.path)
@@ -2134,6 +2135,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 return worktree.id
             }
         )
+        closeRetainedTmuxPresentations(forWorktreeIDs: removedIDs)
         snapshot.worktrees.removeAll { removedIDs.contains($0.id) }
         snapshot.sessions.removeAll {
             guard let worktreeID = $0.worktreeID else { return false }
@@ -3491,6 +3493,22 @@ final class WorkspaceSceneModel: ObservableObject {
         for selection: WorkspaceTmuxSessionSelection
     ) -> RetainedTmuxPresentation? {
         retainedTmuxPresentations[TmuxPresentationKey(selection)]
+    }
+
+    private func closeRetainedTmuxPresentations(
+        forWorktreeIDs worktreeIDs: Set<UUID>
+    ) {
+        guard !worktreeIDs.isEmpty else { return }
+        let selections: [WorkspaceTmuxSessionSelection] =
+            retainedTmuxPresentations.values.compactMap { presentation in
+                guard let worktreeID = presentation.selection.worktreeID,
+                      worktreeIDs.contains(worktreeID)
+                else { return nil }
+                return presentation.selection
+            }
+        for selection in selections {
+            closeBorrowedTmuxSession(selection)
+        }
     }
 
     private func activateTmuxPresentation(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -368,6 +368,11 @@ final class WorkspaceSceneModel: ObservableObject {
             self.reconnectSupervisor = reconnectSupervisor
         }
     }
+    private struct PendingRemovalPresentation {
+        var selection: WorkspaceTmuxSessionSelection
+        var launchMode: TmuxAttachmentLaunchMode
+        var wasActive: Bool
+    }
     private var retainedTmuxPresentations:
         [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
     private var retainedTmuxPresentationKeysByHandle:
@@ -380,6 +385,11 @@ final class WorkspaceSceneModel: ObservableObject {
         [
             WorktreeMutationCoordinator.Scope:
                 Set<WorktreeMutationCoordinator.RemovalTombstone>
+        ] = [:]
+    private var pendingRemovalPresentationRestorations:
+        [
+            WorktreeMutationCoordinator.Scope:
+                [TmuxPresentationKey: PendingRemovalPresentation]
         ] = [:]
     var suppressesSelectedWorktreeSessionOpen: Bool {
         suppressesAutomaticWorktreeSessionOpen
@@ -1256,6 +1266,7 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         retainedTmuxPresentations.removeAll()
         retainedTmuxPresentationKeysByHandle.removeAll()
+        pendingRemovalPresentationRestorations.removeAll()
         activeBorrowedTmuxSelection = nil
         activeBorrowedTmuxHandle = nil
         activeBorrowedTmuxLaunchMode = nil
@@ -1333,13 +1344,10 @@ final class WorkspaceSceneModel: ObservableObject {
             cancelPendingRestoration()
 
             let refreshed = try await kwtInventoryLoader(host)
-            let previous = kwtInventoriesByHost[project.hostID]
-            kwtInventoriesByHost[project.hostID] =
-                refreshed.retainingFailedProjectWorktrees(from: previous)
-            kwtAvailabilityByHost[project.hostID] = true
-            kwtInventoryFailuresByHost.removeValue(forKey: project.hostID)
-            applyInventoryOverlayIfNeeded()
-            updateWorkspaceInventoryState()
+            applyAuthoritativeKwtInventory(
+                refreshed,
+                hostID: project.hostID
+            )
             scheduleTmuxSessionDiscovery()
         } catch {
             if isRemoteKwtUnavailable(error, hostID: project.hostID) {
@@ -1575,21 +1583,16 @@ final class WorkspaceSceneModel: ObservableObject {
 
         do {
             let refreshed = try await kwtInventoryLoader(confirmedHost)
-            let previous = kwtInventoriesByHost[project.hostID]
-            kwtInventoriesByHost[project.hostID] =
-                refreshed.retainingFailedProjectWorktrees(
-                    from: previous,
-                    excludingWorktrees: [
-                        KwtWorktreeIdentity(
-                            path: worktree.path,
-                            generation: generation
-                        ),
-                    ]
-                )
-            kwtAvailabilityByHost[project.hostID] = true
-            kwtInventoryFailuresByHost.removeValue(forKey: project.hostID)
-            applyInventoryOverlayIfNeeded()
-            updateWorkspaceInventoryState()
+            applyAuthoritativeKwtInventory(
+                refreshed,
+                hostID: project.hostID,
+                excludingWorktrees: [
+                    KwtWorktreeIdentity(
+                        path: worktree.path,
+                        generation: generation
+                    ),
+                ]
+            )
         } catch {
             if isRemoteKwtUnavailable(error, hostID: project.hostID) {
                 kwtAvailabilityByHost[project.hostID] = false
@@ -1622,13 +1625,7 @@ final class WorkspaceSceneModel: ObservableObject {
         }) else {
             return nil
         }
-        let previous = kwtInventoriesByHost[hostID]
-        kwtInventoriesByHost[hostID] =
-            inventory.retainingFailedProjectWorktrees(from: previous)
-        kwtAvailabilityByHost[hostID] = true
-        kwtInventoryFailuresByHost.removeValue(forKey: hostID)
-        applyInventoryOverlayIfNeeded()
-        updateWorkspaceInventoryState()
+        applyAuthoritativeKwtInventory(inventory, hostID: hostID)
         guard record.repository == request.project.scopedKey,
               record.branch == request.worktree.branch,
               record.isMain == request.worktree.isPrimary,
@@ -1820,10 +1817,10 @@ final class WorkspaceSceneModel: ObservableObject {
 
         do {
             let refreshed = try await kwtInventoryLoader(host)
-            let previous = kwtInventoriesByHost[project.hostID]
-            kwtInventoriesByHost[project.hostID] =
-                refreshed.retainingFailedProjectWorktrees(from: previous)
-            kwtInventoryFailuresByHost.removeValue(forKey: project.hostID)
+            applyAuthoritativeKwtInventory(
+                refreshed,
+                hostID: project.hostID
+            )
         } catch {
             kwtInventoryFailuresByHost[project.hostID] =
                 error.localizedDescription
@@ -2078,23 +2075,15 @@ final class WorkspaceSceneModel: ObservableObject {
                     }
                     switch result {
                     case let .success(inventory):
-                        let previous = self.kwtInventoriesByHost[hostID]
                         let tombstones =
                             self.activeRemovalTombstones(
                                 after: inventory,
                                 hostID: hostID
                             )
-                        self.kwtInventoriesByHost[hostID] =
-                            inventory.retainingFailedProjectWorktrees(
-                                from: previous,
-                                excludingWorktrees: tombstones
-                            )
-                        self.kwtAvailabilityByHost[hostID] = true
-                        // A host inventory is useful even when one project
-                        // cannot be read. Retain that project's cached
-                        // worktrees and keep other hosts available.
-                        self.kwtInventoryFailuresByHost.removeValue(
-                            forKey: hostID
+                        self.applyAuthoritativeKwtInventory(
+                            inventory,
+                            hostID: hostID,
+                            excludingWorktrees: tombstones
                         )
                     case let .failure(error):
                         if self.isRemoteKwtUnavailable(
@@ -2114,13 +2103,10 @@ final class WorkspaceSceneModel: ObservableObject {
                                 error.localizedDescription
                         }
                     }
-                    self.applyInventoryOverlayIfNeeded()
-                    if case .success = result {
-                        self.reconcileRetainedTmuxPresentations(
-                            afterAuthoritativeInventoryFor: hostID
-                        )
+                    if case .failure = result {
+                        self.applyInventoryOverlayIfNeeded()
+                        self.updateWorkspaceInventoryState()
                     }
-                    self.updateWorkspaceInventoryState()
                 }
             }
             guard let self, !Task.isCancelled,
@@ -2149,16 +2135,15 @@ final class WorkspaceSceneModel: ObservableObject {
         case .willRemove:
             pendingWorktreeRemovals[event.scope, default: []]
                 .formUnion(event.removalTombstones)
-            closeRetainedTmuxPresentations(
-                forWorktreeIDs: worktreeIDs(
-                    matching: event.removalTombstones,
-                    hostID: event.scope.hostID
-                )
-            )
+            retainPresentationsForFailedRemoval(event)
             return
         case .ended:
             fencedWorktreeMutationScopes.remove(event.scope)
             pendingWorktreeRemovals.removeValue(forKey: event.scope)
+            let pendingRestorations =
+                pendingRemovalPresentationRestorations.removeValue(
+                    forKey: event.scope
+                )
             if !event.removalTombstones.isEmpty {
                 worktreeRemovalTombstones[event.scope, default: []]
                     .formUnion(event.removalTombstones)
@@ -2166,6 +2151,8 @@ final class WorkspaceSceneModel: ObservableObject {
                     event.removalTombstones,
                     hostID: event.scope.hostID
                 )
+            } else if let pendingRestorations {
+                restorePresentationsAfterFailedRemoval(pendingRestorations)
             }
         }
         guard inventoryHosts[event.scope.hostID] != nil else { return }
@@ -2213,6 +2200,47 @@ final class WorkspaceSceneModel: ObservableObject {
             visibility: worktreeVisibility
         )
         updateWorkspaceInventoryState()
+    }
+
+    private func retainPresentationsForFailedRemoval(
+        _ event: WorktreeMutationCoordinator.Event
+    ) {
+        let presentations = retainedTmuxPresentations.values.filter {
+            presentation in
+            let selection = presentation.selection
+            guard selection.hostID == event.scope.hostID,
+                  let path = selection.worktreePath
+            else { return false }
+            return Self.removalTombstones(
+                event.removalTombstones,
+                matchPath: path,
+                generation: selection.worktreeGeneration
+            )
+        }
+        for presentation in presentations {
+            let key = TmuxPresentationKey(presentation.selection)
+            pendingRemovalPresentationRestorations[event.scope, default: [:]][
+                key
+            ] = PendingRemovalPresentation(
+                selection: presentation.selection,
+                launchMode: presentation.launchMode,
+                wasActive: activeBorrowedTmuxHandle == presentation.handle
+            )
+            invalidateBorrowedTmuxSession(presentation.selection)
+        }
+    }
+
+    private func restorePresentationsAfterFailedRemoval(
+        _ presentations: [TmuxPresentationKey: PendingRemovalPresentation]
+    ) {
+        for presentation in presentations.values {
+            _ = presentTmuxSession(
+                presentation.selection,
+                launchMode: presentation.launchMode,
+                intent: .restoreOnly,
+                activatesPresentation: presentation.wasActive
+            )
+        }
     }
 
     private func worktreeIDs(
@@ -2278,6 +2306,26 @@ final class WorkspaceSceneModel: ObservableObject {
             }
         }
         return activeTombstones
+    }
+
+    private func applyAuthoritativeKwtInventory(
+        _ inventory: KwtHostInventory,
+        hostID: UUID,
+        excludingWorktrees: Set<KwtWorktreeIdentity> = []
+    ) {
+        let previous = kwtInventoriesByHost[hostID]
+        kwtInventoriesByHost[hostID] =
+            inventory.retainingFailedProjectWorktrees(
+                from: previous,
+                excludingWorktrees: excludingWorktrees
+            )
+        kwtAvailabilityByHost[hostID] = true
+        kwtInventoryFailuresByHost.removeValue(forKey: hostID)
+        applyInventoryOverlayIfNeeded()
+        reconcileRetainedTmuxPresentations(
+            afterAuthoritativeInventoryFor: hostID
+        )
+        updateWorkspaceInventoryState()
     }
 
     private func isRemoteKwtUnavailable(
@@ -3461,7 +3509,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private func presentTmuxSession(
         _ selection: WorkspaceTmuxSessionSelection,
         launchMode: TmuxAttachmentLaunchMode,
-        intent: TmuxPresentationIntent = .userInitiated
+        intent: TmuxPresentationIntent = .userInitiated,
+        activatesPresentation: Bool = true
     ) -> BorrowedTmuxSessionHandle? {
         var selection = selection
         if let worktreeID = selection.worktreeID,
@@ -3513,18 +3562,22 @@ final class WorkspaceSceneModel: ObservableObject {
                    selection.worktreeGeneration != nil {
                     retained.selection = selection
                 }
-                activateTmuxPresentation(retained)
+                if activatesPresentation {
+                    activateTmuxPresentation(retained)
+                }
                 return retained.handle
             }
         }
         guard let host = snapshot.host(id: selection.hostID),
               let attachmentHost = TmuxHostResolver.resolve(host)
         else {
-            activeBorrowedTmuxSelection = selection
-            activeBorrowedTmuxHandle = nil
-            activeBorrowedTmuxLaunchMode = effectiveLaunchMode
-            activeBorrowedTmuxRecoveryState = nil
-            tmuxConnectionRecoveryRequest = nil
+            if activatesPresentation {
+                activeBorrowedTmuxSelection = selection
+                activeBorrowedTmuxHandle = nil
+                activeBorrowedTmuxLaunchMode = effectiveLaunchMode
+                activeBorrowedTmuxRecoveryState = nil
+                tmuxConnectionRecoveryRequest = nil
+            }
             return nil
         }
         let knownSessions = tmuxSessionsByHost[selection.hostID]
@@ -3575,7 +3628,9 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         retainedTmuxPresentations[key] = presentation
         retainedTmuxPresentationKeysByHandle[handle.id] = key
-        activateTmuxPresentation(presentation)
+        if activatesPresentation {
+            activateTmuxPresentation(presentation)
+        }
         borrowedTmuxConnectionStates[handle.id] = .connecting
         if effectiveLaunchMode == .create {
             transferPendingCreation(for: selection, to: handle)

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -104,6 +104,7 @@ final class WorktreeMutationCoordinator {
     static let shared = WorktreeMutationCoordinator()
 
     private var activeScopes: Set<Scope> = []
+    private var pendingRemovalsByScope: [Scope: Set<RemovalTombstone>] = [:]
     private let eventSubject = PassthroughSubject<Event, Never>()
 
     var events: AnyPublisher<Event, Never> {
@@ -112,6 +113,10 @@ final class WorktreeMutationCoordinator {
 
     var scopes: Set<Scope> {
         activeScopes
+    }
+
+    var pendingRemovals: [Scope: Set<RemovalTombstone>] {
+        pendingRemovalsByScope
     }
 
     func acquire(
@@ -145,6 +150,7 @@ final class WorktreeMutationCoordinator {
             projectIdentity: projectIdentity
         )
         if activeScopes.remove(scope) != nil {
+            pendingRemovalsByScope.removeValue(forKey: scope)
             eventSubject.send(
                 Event(
                     phase: .ended,
@@ -165,6 +171,7 @@ final class WorktreeMutationCoordinator {
             projectIdentity: projectIdentity
         )
         guard activeScopes.contains(scope), !worktrees.isEmpty else { return }
+        pendingRemovalsByScope[scope, default: []].formUnion(worktrees)
         eventSubject.send(
             Event(
                 phase: .willRemove,
@@ -369,11 +376,17 @@ final class WorkspaceSceneModel: ObservableObject {
     @Published private(set) var suppressesAutomaticWorktreeSessionOpen = false
     @Published private var explicitlyDismissedWorktreePresentationIDs:
         Set<UUID> = []
+    @Published private var pendingWorktreeRemovals:
+        [
+            WorktreeMutationCoordinator.Scope:
+                Set<WorktreeMutationCoordinator.RemovalTombstone>
+        ] = [:]
     var suppressesSelectedWorktreeSessionOpen: Bool {
         suppressesAutomaticWorktreeSessionOpen
             || selection.selectedWorktreeID.map {
                 explicitlyDismissedWorktreePresentationIDs.contains($0)
             } == true
+            || selectedWorktreeRemovalIsPending
     }
     private var pendingRestoration: WorkspaceWindowState?
     private var protectedRestorationProbeTask: Task<Void, Never>?
@@ -984,6 +997,7 @@ final class WorkspaceSceneModel: ObservableObject {
             self?.worktreeMutationEvent(event)
         }
         fencedWorktreeMutationScopes = worktreeMutationCoordinator.scopes
+        pendingWorktreeRemovals = worktreeMutationCoordinator.pendingRemovals
         let sshHostsPublisher = configuredSSHHostsPublisher
             ?? SettingsStore.shared.$sshHosts.eraseToAnyPublisher()
         // Defer post-init work that mutates @Published state to
@@ -2133,6 +2147,8 @@ final class WorkspaceSceneModel: ObservableObject {
         case .began:
             fencedWorktreeMutationScopes.insert(event.scope)
         case .willRemove:
+            pendingWorktreeRemovals[event.scope, default: []]
+                .formUnion(event.removalTombstones)
             closeRetainedTmuxPresentations(
                 forWorktreeIDs: worktreeIDs(
                     matching: event.removalTombstones,
@@ -2142,6 +2158,7 @@ final class WorkspaceSceneModel: ObservableObject {
             return
         case .ended:
             fencedWorktreeMutationScopes.remove(event.scope)
+            pendingWorktreeRemovals.removeValue(forKey: event.scope)
             if !event.removalTombstones.isEmpty {
                 worktreeRemovalTombstones[event.scope, default: []]
                     .formUnion(event.removalTombstones)
@@ -3437,6 +3454,7 @@ final class WorkspaceSceneModel: ObservableObject {
            WorktreeGeneration.isCanonical(generation) {
             selection.worktreeGeneration = generation
         }
+        guard !worktreeRemovalIsPending(for: selection) else { return nil }
         let effectiveLaunchMode: TmuxAttachmentLaunchMode =
             selection.socketName != nil && launchMode == .create
                 ? .attach
@@ -3561,6 +3579,33 @@ final class WorkspaceSceneModel: ObservableObject {
         for selection: WorkspaceTmuxSessionSelection
     ) -> RetainedTmuxPresentation? {
         retainedTmuxPresentations[TmuxPresentationKey(selection)]
+    }
+
+    private var selectedWorktreeRemovalIsPending: Bool {
+        guard let worktreeID = selection.selectedWorktreeID,
+              let worktree = snapshot.worktree(id: worktreeID),
+              let tmuxSelection = WorkspaceSidebarModel
+              .tmuxSessionSelection(for: worktree)
+        else { return false }
+        return worktreeRemovalIsPending(for: tmuxSelection)
+    }
+
+    private func worktreeRemovalIsPending(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        guard selection.worktreeID != nil,
+              let path = selection.worktreePath,
+              let generation = selection.worktreeGeneration
+        else { return false }
+        return pendingWorktreeRemovals.contains { scope, tombstones in
+            scope.hostID == selection.hostID
+                && tombstones.contains(
+                    WorktreeMutationCoordinator.RemovalTombstone(
+                        path: path,
+                        generation: generation
+                    )
+                )
+        }
     }
 
     private func reconcileRetainedTmuxPresentations(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3371,20 +3371,38 @@ final class WorkspaceSceneModel: ObservableObject {
             selection.socketName != nil && launchMode == .create
                 ? .attach
                 : launchMode
+        if let worktreeID = selection.worktreeID {
+            let replacedSelections: [WorkspaceTmuxSessionSelection] =
+                retainedTmuxPresentations.values.compactMap { presentation in
+                    let retained = presentation.selection
+                    guard retained.worktreeID == worktreeID else { return nil }
+                    let endpointChanged = !Self.sameTmuxEndpoint(
+                        retained,
+                        selection
+                    )
+                    let generationChanged = if let retainedGeneration =
+                        retained.worktreeGeneration,
+                        let selectionGeneration = selection
+                        .worktreeGeneration {
+                        retainedGeneration != selectionGeneration
+                    } else {
+                        false
+                    }
+                    return endpointChanged || generationChanged
+                        ? retained
+                        : nil
+                }
+            for replaced in replacedSelections {
+                closeBorrowedTmuxSession(replaced)
+            }
+        }
         let key = TmuxPresentationKey(selection)
         if let retained = retainedTmuxPresentations[key] {
-            let generationChanged = if let retainedGeneration =
-                retained.selection.worktreeGeneration,
-                let selectionGeneration = selection.worktreeGeneration {
-                retainedGeneration != selectionGeneration
-            } else {
-                false
-            }
             let recreatesClosedAttachment = effectiveLaunchMode == .create
                 && nativeTmuxSessionCoordinator.hasClosedAttachment(
                     retained.handle
                 )
-            if generationChanged || recreatesClosedAttachment {
+            if recreatesClosedAttachment {
                 closeBorrowedTmuxSession(retained.selection)
             } else {
                 if retained.selection.worktreeGeneration == nil,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -99,6 +99,7 @@ final class WorktreeMutationCoordinator {
         let phase: Phase
         let scope: Scope
         let removalTombstones: Set<RemovalTombstone>
+        let requiresWorkspaceReestablishment: Bool
     }
 
     static let shared = WorktreeMutationCoordinator()
@@ -133,7 +134,8 @@ final class WorktreeMutationCoordinator {
                 Event(
                     phase: .began,
                     scope: scope,
-                    removalTombstones: []
+                    removalTombstones: [],
+                    requiresWorkspaceReestablishment: false
                 )
             )
         }
@@ -143,7 +145,8 @@ final class WorktreeMutationCoordinator {
     func release(
         hostID: UUID,
         projectIdentity: String,
-        removalTombstones: Set<RemovalTombstone> = []
+        removalTombstones: Set<RemovalTombstone> = [],
+        requiresWorkspaceReestablishment: Bool = false
     ) {
         let scope = Scope(
             hostID: hostID,
@@ -155,7 +158,9 @@ final class WorktreeMutationCoordinator {
                 Event(
                     phase: .ended,
                     scope: scope,
-                    removalTombstones: removalTombstones
+                    removalTombstones: removalTombstones,
+                    requiresWorkspaceReestablishment:
+                    requiresWorkspaceReestablishment
                 )
             )
         }
@@ -176,7 +181,8 @@ final class WorktreeMutationCoordinator {
             Event(
                 phase: .willRemove,
                 scope: scope,
-                removalTombstones: worktrees
+                removalTombstones: worktrees,
+                requiresWorkspaceReestablishment: false
             )
         )
     }
@@ -372,6 +378,7 @@ final class WorkspaceSceneModel: ObservableObject {
         var selection: WorkspaceTmuxSessionSelection
         var launchMode: TmuxAttachmentLaunchMode
         var wasActive: Bool
+        var userNavigationRevision: UInt64
     }
     private var retainedTmuxPresentations:
         [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
@@ -391,6 +398,7 @@ final class WorkspaceSceneModel: ObservableObject {
             WorktreeMutationCoordinator.Scope:
                 [TmuxPresentationKey: PendingRemovalPresentation]
         ] = [:]
+    private var userNavigationRevision: UInt64 = 0
     var suppressesSelectedWorktreeSessionOpen: Bool {
         suppressesAutomaticWorktreeSessionOpen
             || selection.selectedWorktreeID.map {
@@ -624,6 +632,9 @@ final class WorkspaceSceneModel: ObservableObject {
         nativeTmuxSurfaceStore: (any TmuxSurfaceStoring)? = nil,
         nativeTmuxPathProvider:
         (@Sendable () -> Result<String, TmuxBinaryError>)? = nil,
+        localKwtPathProvider: @escaping @Sendable () -> String? = {
+            KwtBinaryLocator.bundledPath()
+        },
         remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
             -> Result<String, TmuxBinaryError> = {
                 TmuxBinaryResolver().resolveTmuxPath(on: $0)
@@ -866,6 +877,7 @@ final class WorkspaceSceneModel: ObservableObject {
             tmuxPathProvider: {
                 tmuxPathCache.resolveTmuxPath()
             },
+            localKwtPathProvider: localKwtPathProvider,
             presentationStyleProvider: {
                 tmuxPresentationStyleProvider(nil)
             },
@@ -1100,6 +1112,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func selectFromUser(_ newSelection: WorkspaceSelection) {
         cancelPendingRestoration()
+        userNavigationRevision &+= 1
         if let worktreeID = newSelection.selectedWorktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
@@ -1490,13 +1503,17 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         var removalTombstones:
             Set<WorktreeMutationCoordinator.RemovalTombstone> = []
+        var requiresWorkspaceReestablishment = false
+        var terminatedSession = false
         invalidateKwtInventoryRefresh()
         defer {
             ownsWorktreeMutation = false
             worktreeMutationCoordinator.release(
                 hostID: mutationHostID,
                 projectIdentity: mutationProjectIdentity,
-                removalTombstones: removalTombstones
+                removalTombstones: removalTombstones,
+                requiresWorkspaceReestablishment:
+                requiresWorkspaceReestablishment
             )
         }
 
@@ -1555,17 +1572,23 @@ final class WorkspaceSceneModel: ObservableObject {
         do {
             if let sessionKillRequest = request.sessionKillRequest {
                 try await killTmuxSession(sessionKillRequest)
+                terminatedSession = true
             }
             guard removalHostEndpointMatches(request) else {
                 throw KwtWorktreeError.removalTargetChanged
             }
             if !checkoutAlreadyAbsent {
-                try await kwtWorktreeRemover(
-                    worktree.path,
-                    generation,
-                    project.rootPath,
-                    confirmedHost
-                )
+                do {
+                    try await kwtWorktreeRemover(
+                        worktree.path,
+                        generation,
+                        project.rootPath,
+                        confirmedHost
+                    )
+                } catch {
+                    requiresWorkspaceReestablishment = terminatedSession
+                    throw error
+                }
             }
             cancelPendingRestoration()
             removalTombstones.insert(removalTombstone)
@@ -2152,7 +2175,11 @@ final class WorkspaceSceneModel: ObservableObject {
                     hostID: event.scope.hostID
                 )
             } else if let pendingRestorations {
-                restorePresentationsAfterFailedRemoval(pendingRestorations)
+                restorePresentationsAfterFailedRemoval(
+                    pendingRestorations,
+                    requiresWorkspaceReestablishment:
+                    event.requiresWorkspaceReestablishment
+                )
             }
         }
         guard inventoryHosts[event.scope.hostID] != nil else { return }
@@ -2224,21 +2251,27 @@ final class WorkspaceSceneModel: ObservableObject {
             ] = PendingRemovalPresentation(
                 selection: presentation.selection,
                 launchMode: presentation.launchMode,
-                wasActive: activeBorrowedTmuxHandle == presentation.handle
+                wasActive: activeBorrowedTmuxHandle == presentation.handle,
+                userNavigationRevision: userNavigationRevision
             )
             invalidateBorrowedTmuxSession(presentation.selection)
         }
     }
 
     private func restorePresentationsAfterFailedRemoval(
-        _ presentations: [TmuxPresentationKey: PendingRemovalPresentation]
+        _ presentations: [TmuxPresentationKey: PendingRemovalPresentation],
+        requiresWorkspaceReestablishment: Bool
     ) {
         for presentation in presentations.values {
             _ = presentTmuxSession(
                 presentation.selection,
-                launchMode: presentation.launchMode,
-                intent: .restoreOnly,
+                launchMode: requiresWorkspaceReestablishment
+                    ? .attach : presentation.launchMode,
+                intent: requiresWorkspaceReestablishment
+                    ? .userInitiated : .restoreOnly,
                 activatesPresentation: presentation.wasActive
+                    && presentation.userNavigationRevision
+                    == userNavigationRevision
             )
         }
     }
@@ -3455,6 +3488,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func openBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
+        userNavigationRevision &+= 1
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
@@ -3471,6 +3505,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func createTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
+        userNavigationRevision &+= 1
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
@@ -3680,7 +3715,7 @@ final class WorkspaceSceneModel: ObservableObject {
     ) {
         let invalidSelections: [WorkspaceTmuxSessionSelection] =
             retainedTmuxPresentations.values.compactMap { presentation in
-                let retained = presentation.selection
+                var retained = presentation.selection
                 guard retained.hostID == hostID,
                       let worktreeID = retained.worktreeID
                 else { return nil }
@@ -3690,6 +3725,16 @@ final class WorkspaceSceneModel: ObservableObject {
                       .tmuxSessionSelection(for: worktree),
                       Self.sameTmuxEndpoint(retained, current)
                 else { return retained }
+                if retained.worktreeGeneration == nil,
+                   let canonicalGeneration = WorktreeGeneration.canonical(
+                       current.worktreeGeneration
+                   ) {
+                    retained.worktreeGeneration = canonicalGeneration
+                    presentation.selection = retained
+                    if activeBorrowedTmuxHandle == presentation.handle {
+                        activeBorrowedTmuxSelection = retained
+                    }
+                }
                 if let retainedGeneration = retained.worktreeGeneration,
                    let currentGeneration = current.worktreeGeneration,
                    retainedGeneration != currentGeneration {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -99,6 +99,7 @@ final class WorktreeMutationCoordinator {
         let phase: Phase
         let scope: Scope
         let removalTombstones: Set<RemovalTombstone>
+        let removalPresentationTargets: Set<WorkspaceTmuxSessionSelection>
         let requiresWorkspaceReestablishment: Bool
     }
 
@@ -135,6 +136,7 @@ final class WorktreeMutationCoordinator {
                     phase: .began,
                     scope: scope,
                     removalTombstones: [],
+                    removalPresentationTargets: [],
                     requiresWorkspaceReestablishment: false
                 )
             )
@@ -159,6 +161,7 @@ final class WorktreeMutationCoordinator {
                     phase: .ended,
                     scope: scope,
                     removalTombstones: removalTombstones,
+                    removalPresentationTargets: [],
                     requiresWorkspaceReestablishment:
                     requiresWorkspaceReestablishment
                 )
@@ -169,7 +172,8 @@ final class WorktreeMutationCoordinator {
     func prepareRemoval(
         hostID: UUID,
         projectIdentity: String,
-        worktrees: Set<RemovalTombstone>
+        worktrees: Set<RemovalTombstone>,
+        presentationTargets: Set<WorkspaceTmuxSessionSelection>
     ) {
         let scope = Scope(
             hostID: hostID,
@@ -182,6 +186,7 @@ final class WorktreeMutationCoordinator {
                 phase: .willRemove,
                 scope: scope,
                 removalTombstones: worktrees,
+                removalPresentationTargets: presentationTargets,
                 requiresWorkspaceReestablishment: false
             )
         )
@@ -1567,7 +1572,11 @@ final class WorkspaceSceneModel: ObservableObject {
         worktreeMutationCoordinator.prepareRemoval(
             hostID: mutationHostID,
             projectIdentity: mutationProjectIdentity,
-            worktrees: [removalTombstone]
+            worktrees: [removalTombstone],
+            presentationTargets: Set(
+                WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+                    .map { [$0] } ?? []
+            )
         )
 
         do {
@@ -2233,35 +2242,34 @@ final class WorkspaceSceneModel: ObservableObject {
     private func retainPresentationsForFailedRemoval(
         _ event: WorktreeMutationCoordinator.Event
     ) {
-        let presentations = retainedTmuxPresentations.values.filter {
-            presentation in
-            let selection = presentation.selection
-            guard selection.hostID == event.scope.hostID,
-                  let path = selection.worktreePath
-            else { return false }
-            return Self.removalTombstones(
-                event.removalTombstones,
-                matchPath: path,
-                generation: selection.worktreeGeneration
-            )
-        }
-        for presentation in presentations {
+        let presentations:
+            [(RetainedTmuxPresentation, WorkspaceTmuxSessionSelection)] =
+            retainedTmuxPresentations.values.compactMap { presentation in
+                let selection = presentation.selection
+                guard selection.hostID == event.scope.hostID else { return nil }
+                let endpointTarget = event.removalPresentationTargets.first {
+                    Self.sameTmuxEndpoint(selection, $0)
+                }
+                let pathMatches = selection.worktreePath.map { path in
+                    Self.removalTombstones(
+                        event.removalTombstones,
+                        matchPath: path,
+                        generation: selection.worktreeGeneration
+                    )
+                } == true
+                guard pathMatches || endpointTarget != nil else { return nil }
+                return (presentation, endpointTarget ?? selection)
+            }
+        for (presentation, restorationSelection) in presentations {
             let key = TmuxPresentationKey(presentation.selection)
             pendingRemovalPresentationRestorations[event.scope, default: [:]][
                 key
             ] = PendingRemovalPresentation(
-                selection: presentation.selection,
+                selection: restorationSelection,
                 launchMode: presentation.launchMode,
                 requiresWorkspaceEstablishment:
                 presentation.reconnectContext?.phase
-                    == .establishingWorkspace
-                    || (
-                        presentation.launchMode == .attach
-                            && presentation.selection.worktreePath != nil
-                            && !nativeTmuxSessionCoordinator.hasLaunched(
-                                presentation.handle
-                            )
-                    ),
+                    == .establishingWorkspace,
                 wasActive: activeBorrowedTmuxHandle == presentation.handle,
                 userNavigationRevision: userNavigationRevision
             )
@@ -2485,6 +2493,20 @@ final class WorkspaceSceneModel: ObservableObject {
             discovered,
             hostID: hostID
         )
+        for presentation in retainedTmuxPresentations.values {
+            guard var context = presentation.reconnectContext,
+                  context.phase == .establishingWorkspace,
+                  context.selection.hostID == hostID,
+                  context.selection.socketName == nil,
+                  discovered.contains(where: {
+                      $0.name == context.selection.name
+                  })
+            else { continue }
+            context.phase = .attachOnly
+            presentation.reconnectContext = context
+            presentation.establishmentConfirmationTask?.cancel()
+            presentation.establishmentConfirmationTask = nil
+        }
         applyInventoryOverlayIfNeeded()
         updateWorkspaceInventoryState()
         applyDeferredTmuxPresentationsIfReady()
@@ -3658,6 +3680,8 @@ final class WorkspaceSceneModel: ObservableObject {
             openWorkspace: openWorkspace
         )
         let reconnectContext = attachmentHost.isRemote
+            || openWorkspace
+            || protectedSessionNeedsEstablishment
             ? TmuxReconnectContext(
                 selection: selection,
                 handleID: handle.id,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -91,6 +91,7 @@ final class WorktreeMutationCoordinator {
 
     enum Phase: Sendable {
         case began
+        case willRemove
         case ended
     }
 
@@ -152,6 +153,25 @@ final class WorktreeMutationCoordinator {
                 )
             )
         }
+    }
+
+    func prepareRemoval(
+        hostID: UUID,
+        projectIdentity: String,
+        worktrees: Set<RemovalTombstone>
+    ) {
+        let scope = Scope(
+            hostID: hostID,
+            projectIdentity: projectIdentity
+        )
+        guard activeScopes.contains(scope), !worktrees.isEmpty else { return }
+        eventSubject.send(
+            Event(
+                phase: .willRemove,
+                scope: scope,
+                removalTombstones: worktrees
+            )
+        )
     }
 }
 
@@ -347,6 +367,14 @@ final class WorkspaceSceneModel: ObservableObject {
         [UUID: TmuxPresentationKey] = [:]
     @Published private(set) var isWorkspaceRestorationPending = false
     @Published private(set) var suppressesAutomaticWorktreeSessionOpen = false
+    @Published private var explicitlyDismissedWorktreePresentationIDs:
+        Set<UUID> = []
+    var suppressesSelectedWorktreeSessionOpen: Bool {
+        suppressesAutomaticWorktreeSessionOpen
+            || selection.selectedWorktreeID.map {
+                explicitlyDismissedWorktreePresentationIDs.contains($0)
+            } == true
+    }
     private var pendingRestoration: WorkspaceWindowState?
     private var protectedRestorationProbeTask: Task<Void, Never>?
     private var protectedRestorationProbeID: UUID?
@@ -1048,6 +1076,9 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func selectFromUser(_ newSelection: WorkspaceSelection) {
         cancelPendingRestoration()
+        if let worktreeID = newSelection.selectedWorktreeID {
+            explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
+        }
         selection = newSelection
         attachReplacedWorktreeSessionIfNeeded()
     }
@@ -1069,7 +1100,7 @@ final class WorkspaceSceneModel: ObservableObject {
               ),
               generation != activeGeneration
         else { return }
-        closeBorrowedTmuxSession(active)
+        invalidateBorrowedTmuxSession(active)
         openBorrowedTmuxSession(replacement)
     }
 
@@ -1470,6 +1501,11 @@ final class WorkspaceSceneModel: ObservableObject {
         guard let generation = worktree.generation else {
             throw KwtWorktreeError.removalTargetChanged
         }
+        let removalTombstone =
+            WorktreeMutationCoordinator.RemovalTombstone(
+                path: worktree.path,
+                generation: generation
+            )
 
         if request.sessionKillRequest == nil,
            let session = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -1488,6 +1524,12 @@ final class WorkspaceSceneModel: ObservableObject {
             }
         }
 
+        worktreeMutationCoordinator.prepareRemoval(
+            hostID: mutationHostID,
+            projectIdentity: mutationProjectIdentity,
+            worktrees: [removalTombstone]
+        )
+
         do {
             if let sessionKillRequest = request.sessionKillRequest {
                 try await killTmuxSession(sessionKillRequest)
@@ -1504,12 +1546,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 )
             }
             cancelPendingRestoration()
-            removalTombstones.insert(
-                WorktreeMutationCoordinator.RemovalTombstone(
-                    path: worktree.path,
-                    generation: generation
-                )
-            )
+            removalTombstones.insert(removalTombstone)
         } catch {
             recordKwtUnavailability(error, hostID: project.hostID)
             throw error
@@ -1648,6 +1685,7 @@ final class WorkspaceSceneModel: ObservableObject {
         hostID: UUID
     ) {
         closeRetainedTmuxPresentations(forWorktreeIDs: [worktree.id])
+        explicitlyDismissedWorktreePresentationIDs.remove(worktree.id)
         if let inventory = kwtInventoriesByHost[hostID] {
             kwtInventoriesByHost[hostID] =
                 inventory.removingWorktree(atPath: worktree.path)
@@ -1660,7 +1698,7 @@ final class WorkspaceSceneModel: ObservableObject {
             in: snapshot,
             visibility: worktreeVisibility
         )
-        selectFromUser(removalSelection)
+        synchronizeSelection(removalSelection)
         updateWorkspaceInventoryState()
     }
 
@@ -2063,6 +2101,11 @@ final class WorkspaceSceneModel: ObservableObject {
                         }
                     }
                     self.applyInventoryOverlayIfNeeded()
+                    if case .success = result {
+                        self.reconcileRetainedTmuxPresentations(
+                            afterAuthoritativeInventoryFor: hostID
+                        )
+                    }
                     self.updateWorkspaceInventoryState()
                 }
             }
@@ -2089,6 +2132,14 @@ final class WorkspaceSceneModel: ObservableObject {
         switch event.phase {
         case .began:
             fencedWorktreeMutationScopes.insert(event.scope)
+        case .willRemove:
+            closeRetainedTmuxPresentations(
+                forWorktreeIDs: worktreeIDs(
+                    matching: event.removalTombstones,
+                    hostID: event.scope.hostID
+                )
+            )
+            return
         case .ended:
             fencedWorktreeMutationScopes.remove(event.scope)
             if !event.removalTombstones.isEmpty {
@@ -2125,17 +2176,12 @@ final class WorkspaceSceneModel: ObservableObject {
             }
             kwtInventoriesByHost[hostID] = inventory
         }
-        let removedIDs = Set<UUID>(
-            snapshot.worktrees.compactMap { worktree in
-                guard worktree.hostID == hostID,
-                      matches(worktree.path, worktree.generation)
-                else {
-                    return nil
-                }
-                return worktree.id
-            }
+        let removedIDs = worktreeIDs(
+            matching: tombstones,
+            hostID: hostID
         )
         closeRetainedTmuxPresentations(forWorktreeIDs: removedIDs)
+        explicitlyDismissedWorktreePresentationIDs.subtract(removedIDs)
         snapshot.worktrees.removeAll { removedIDs.contains($0.id) }
         snapshot.sessions.removeAll {
             guard let worktreeID = $0.worktreeID else { return false }
@@ -2148,6 +2194,22 @@ final class WorkspaceSceneModel: ObservableObject {
             visibility: worktreeVisibility
         )
         updateWorkspaceInventoryState()
+    }
+
+    private func worktreeIDs(
+        matching tombstones:
+        Set<WorktreeMutationCoordinator.RemovalTombstone>,
+        hostID: UUID
+    ) -> Set<UUID> {
+        Set(snapshot.worktrees.compactMap { worktree in
+            guard worktree.hostID == hostID,
+                  tombstones.contains(where: {
+                      $0.path == worktree.path
+                          && $0.generation == worktree.generation
+                  })
+            else { return nil }
+            return worktree.id
+        })
     }
 
     private func activeRemovalTombstones(
@@ -3312,6 +3374,9 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func openBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
+        if let worktreeID = selection.worktreeID {
+            explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
+        }
         let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
             Self.sameTmuxSession($0, selection)
         }
@@ -3325,6 +3390,9 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func createTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
+        if let worktreeID = selection.worktreeID {
+            explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
+        }
         let hasPendingCreation = pendingCreatedTmuxSessions.values.contains {
             Self.sameTmuxSession($0, selection)
         }
@@ -3395,7 +3463,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         : nil
                 }
             for replaced in replacedSelections {
-                closeBorrowedTmuxSession(replaced)
+                invalidateBorrowedTmuxSession(replaced)
             }
         }
         let key = TmuxPresentationKey(selection)
@@ -3405,7 +3473,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     retained.handle
                 )
             if recreatesClosedAttachment {
-                closeBorrowedTmuxSession(retained.selection)
+                invalidateBorrowedTmuxSession(retained.selection)
             } else {
                 if retained.selection.worktreeGeneration == nil,
                    selection.worktreeGeneration != nil {
@@ -3495,6 +3563,36 @@ final class WorkspaceSceneModel: ObservableObject {
         retainedTmuxPresentations[TmuxPresentationKey(selection)]
     }
 
+    private func reconcileRetainedTmuxPresentations(
+        afterAuthoritativeInventoryFor hostID: UUID
+    ) {
+        let invalidSelections: [WorkspaceTmuxSessionSelection] =
+            retainedTmuxPresentations.values.compactMap { presentation in
+                let retained = presentation.selection
+                guard retained.hostID == hostID,
+                      let worktreeID = retained.worktreeID
+                else { return nil }
+                guard let worktree = snapshot.worktree(id: worktreeID),
+                      worktree.hostID == hostID,
+                      let current = WorkspaceSidebarModel
+                      .tmuxSessionSelection(for: worktree),
+                      Self.sameTmuxEndpoint(retained, current)
+                else { return retained }
+                if let retainedGeneration = retained.worktreeGeneration,
+                   let currentGeneration = current.worktreeGeneration,
+                   retainedGeneration != currentGeneration {
+                    return retained
+                }
+                return nil
+            }
+        for selection in invalidSelections {
+            invalidateBorrowedTmuxSession(selection)
+        }
+        explicitlyDismissedWorktreePresentationIDs.formIntersection(
+            Set(snapshot.worktrees.map(\.id))
+        )
+    }
+
     private func closeRetainedTmuxPresentations(
         forWorktreeIDs worktreeIDs: Set<UUID>
     ) {
@@ -3507,7 +3605,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 return presentation.selection
             }
         for selection in selections {
-            closeBorrowedTmuxSession(selection)
+            invalidateBorrowedTmuxSession(selection)
         }
     }
 
@@ -3603,7 +3701,23 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        closeBorrowedTmuxSession(selection, recordsExplicitDismissal: true)
+    }
+
+    private func invalidateBorrowedTmuxSession(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) {
+        closeBorrowedTmuxSession(selection, recordsExplicitDismissal: false)
+    }
+
+    private func closeBorrowedTmuxSession(
+        _ selection: WorkspaceTmuxSessionSelection,
+        recordsExplicitDismissal: Bool
+    ) {
         cancelPendingRestoration()
+        if recordsExplicitDismissal, let worktreeID = selection.worktreeID {
+            explicitlyDismissedWorktreePresentationIDs.insert(worktreeID)
+        }
         let key = TmuxPresentationKey(selection)
         guard let presentation = retainedTmuxPresentations.removeValue(
             forKey: key
@@ -3723,7 +3837,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 Self.sameTmuxEndpoint($0.selection, tmuxSelection)
             }
         )?.selection {
-            closeBorrowedTmuxSession(retainedTarget)
+            invalidateBorrowedTmuxSession(retainedTarget)
         }
         if tmuxSelection.socketName == nil {
             tmuxSessionsByHost[tmuxSelection.hostID]?.removeAll {
@@ -4651,7 +4765,7 @@ final class WorkspaceSceneModel: ObservableObject {
             current: activeBorrowedTmuxLaunchMode,
             sessionConfirmedEnded: sessionConfirmedEnded
         )
-        closeBorrowedTmuxSession(selection)
+        invalidateBorrowedTmuxSession(selection)
         if recreateEndedNamedSession {
             guard let handle = presentTmuxSession(
                 selection,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2181,9 +2181,11 @@ final class WorkspaceSceneModel: ObservableObject {
         hostID: UUID
     ) {
         let matches: (String, String?) -> Bool = { path, generation in
-            tombstones.contains {
-                $0.path == path && $0.generation == generation
-            }
+            Self.removalTombstones(
+                tombstones,
+                matchPath: path,
+                generation: generation
+            )
         }
         if var inventory = kwtInventoriesByHost[hostID] {
             for index in inventory.projects.indices {
@@ -2220,13 +2222,25 @@ final class WorkspaceSceneModel: ObservableObject {
     ) -> Set<UUID> {
         Set(snapshot.worktrees.compactMap { worktree in
             guard worktree.hostID == hostID,
-                  tombstones.contains(where: {
-                      $0.path == worktree.path
-                          && $0.generation == worktree.generation
-                  })
+                  Self.removalTombstones(
+                      tombstones,
+                      matchPath: worktree.path,
+                      generation: worktree.generation
+                  )
             else { return nil }
             return worktree.id
         })
+    }
+
+    private static func removalTombstones(
+        _ tombstones: Set<WorktreeMutationCoordinator.RemovalTombstone>,
+        matchPath path: String,
+        generation: String?
+    ) -> Bool {
+        tombstones.contains { tombstone in
+            tombstone.path == path
+                && generation.map { tombstone.generation == $0 } ?? true
+        }
     }
 
     private func activeRemovalTombstones(
@@ -2250,8 +2264,11 @@ final class WorkspaceSceneModel: ObservableObject {
                     return true
                 }
                 return project.worktrees.contains {
-                    $0.path == tombstone.path
-                        && $0.generation == tombstone.generation
+                    Self.removalTombstones(
+                        [tombstone],
+                        matchPath: $0.path,
+                        generation: $0.generation
+                    )
                 }
             }
             if active.isEmpty {
@@ -3593,17 +3610,13 @@ final class WorkspaceSceneModel: ObservableObject {
     private func worktreeRemovalIsPending(
         for selection: WorkspaceTmuxSessionSelection
     ) -> Bool {
-        guard selection.worktreeID != nil,
-              let path = selection.worktreePath,
-              let generation = selection.worktreeGeneration
-        else { return false }
+        guard let path = selection.worktreePath else { return false }
         return pendingWorktreeRemovals.contains { scope, tombstones in
             scope.hostID == selection.hostID
-                && tombstones.contains(
-                    WorktreeMutationCoordinator.RemovalTombstone(
-                        path: path,
-                        generation: generation
-                    )
+                && Self.removalTombstones(
+                    tombstones,
+                    matchPath: path,
+                    generation: selection.worktreeGeneration
                 )
         }
     }
@@ -3630,8 +3643,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
                 return nil
             }
-        for selection in invalidSelections {
-            invalidateBorrowedTmuxSession(selection)
+        for invalidSelection in invalidSelections {
+            if let worktreeID = invalidSelection.worktreeID,
+               selection.selectedWorktreeID == worktreeID {
+                explicitlyDismissedWorktreePresentationIDs.insert(worktreeID)
+            }
+            invalidateBorrowedTmuxSession(invalidSelection)
         }
         explicitlyDismissedWorktreePresentationIDs.formIntersection(
             Set(snapshot.worktrees.map(\.id))

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -637,7 +637,7 @@ struct WorkspaceWindow: View {
                 isWorkspaceRestorationPending:
                 sceneModel.isWorkspaceRestorationPending,
                 suppressesAutomaticWorktreeSessionOpen:
-                sceneModel.suppressesAutomaticWorktreeSessionOpen,
+                sceneModel.suppressesSelectedWorktreeSessionOpen,
                 activeTmuxSession:
                 sceneModel.activeBorrowedTmuxSelection,
                 activeTmuxSessionIsConnected:

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -767,6 +767,9 @@ struct WorkspaceWindow: View {
                 openTmuxSession: { [sceneModel] selection in
                     sceneModel.openBorrowedTmuxSession(selection)
                 },
+                hideTmuxSession: { [sceneModel] selection in
+                    sceneModel.hideBorrowedTmuxSession(selection)
+                },
                 closeTmuxSession: { [sceneModel] selection in
                     sceneModel.closeBorrowedTmuxSession(selection)
                 },
@@ -789,9 +792,9 @@ struct WorkspaceWindow: View {
                     sceneModel.reconnectActiveTmuxSessionNow()
                 },
                 resumeTmuxReconnectAfterSSHRecovery: {
-                    [sceneModel] hostID in
+                    [sceneModel] request in
                     sceneModel.resumeTmuxReconnectAfterSSHRecovery(
-                        hostID: hostID
+                        request
                     )
                 },
                 reviewSSHHostKey: { [sceneModel] hostID, inventoryWarning in

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -231,8 +231,7 @@ public struct RootView: View {
                     selection: selection,
                     selectionBaseline: tmuxSelectionBaseline,
                     activeSession: activeTmuxSession,
-                    isWorkspaceVisible: true,
-                    deactivate: deactivateTmuxSession
+                    hide: hideTmuxSession
                 )
             )
             .onAppear {
@@ -471,7 +470,7 @@ public struct RootView: View {
                 activateTmuxSession(session)
             },
             onNavigateAwayFromTmuxSession: {
-                deactivateTmuxSession()
+                hideTmuxSession()
             },
             onRequestKillTmuxSession: requestSessionKill,
             onRequestRemoveWorktree: requestWorktreeRemoval,
@@ -558,19 +557,17 @@ public struct RootView: View {
     }
 
     private func retrySSHRecovery() {
-        let recoveryHostID =
+        let recoveryRequest =
             sshHostKeyReview.presentation == .inventoryIssue
-                ? tmuxRecoveryRequestRouter.recoveryHostIDToResume(
+                ? tmuxRecoveryRequestRouter.recoveryRequestToResume(
                     reviewedHostID: sshHostKeyReview.hostID,
-                    reviewRequestID:
-                    sshHostKeyReview.tmuxRecoveryRequestID,
-                    activeRequest: display.tmuxConnectionRecoveryRequest
+                    reviewRequestID: sshHostKeyReview.tmuxRecoveryRequestID
                 )
                 : nil
         cancelSSHAuthenticationIfNeeded()
         sshHostKeyReview.dismiss()
-        if let recoveryHostID {
-            handlers.resumeTmuxReconnectAfterSSHRecovery?(recoveryHostID)
+        if let recoveryRequest {
+            handlers.resumeTmuxReconnectAfterSSHRecovery?(recoveryRequest)
         }
         handlers.refreshWorkspaceInventory?()
     }
@@ -624,19 +621,16 @@ public struct RootView: View {
                 )
                 return
             case .connected:
-                let recoveryHostID =
-                    tmuxRecoveryRequestRouter.recoveryHostIDToResume(
+                let recoveryRequest =
+                    tmuxRecoveryRequestRouter.recoveryRequestToResume(
                         reviewedHostID: hostID,
-                        reviewRequestID:
-                        sshHostKeyReview.tmuxRecoveryRequestID,
-                        activeRequest:
-                        display.tmuxConnectionRecoveryRequest
+                        reviewRequestID: sshHostKeyReview.tmuxRecoveryRequestID
                     )
                 handlers.cancelSSHAuthentication?(hostID)
                 sshHostKeyReview.authenticationSucceeded {
-                    if let recoveryHostID {
+                    if let recoveryRequest {
                         handlers.resumeTmuxReconnectAfterSSHRecovery?(
-                            recoveryHostID
+                            recoveryRequest
                         )
                     }
                 }
@@ -673,9 +667,6 @@ public struct RootView: View {
             handlers.openTmuxSession?(session)
             return
         }
-        if let previous = activeTmuxSession {
-            handlers.closeTmuxSession?(previous)
-        }
         tmuxSelectionBaseline = selection
         handlers.openTmuxSession?(session)
     }
@@ -691,9 +682,6 @@ public struct RootView: View {
             hostID: host.id,
             name: name
         )
-        if let previous = activeTmuxSession {
-            handlers.closeTmuxSession?(previous)
-        }
         selectWorkspace(Self.selectionForHostTmuxSession(
             session,
             from: selection,
@@ -876,6 +864,12 @@ public struct RootView: View {
         handlers.closeTmuxSession?(previous)
     }
 
+    private func hideTmuxSession() {
+        guard let previous = activeTmuxSession else { return }
+        tmuxSelectionBaseline = nil
+        handlers.hideTmuxSession?(previous)
+    }
+
     private var selectedWorktreeTmuxSession:
         WorkspaceTmuxSessionSelection? {
         let selected = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -910,7 +904,7 @@ public struct RootView: View {
         guard !display.suppressesAutomaticWorktreeSessionOpen else { return }
         guard let session = selectedWorktreeTmuxSession else {
             if activeTmuxSession?.worktreeID != nil {
-                deactivateTmuxSession()
+                hideTmuxSession()
             }
             return
         }
@@ -1327,15 +1321,15 @@ public struct RootView: View {
 
 }
 
-/// Keeps a borrowed tmux attachment scoped to the workspace presentation.
-/// Kept as a small modifier so route and removal lifecycle behavior can be
-/// exercised without constructing the entire sidebar hierarchy.
+/// Hides the active tmux presentation when navigation leaves its route while
+/// retaining the underlying attachment for a later return. Kept as a small
+/// modifier so route behavior can be exercised without constructing the
+/// entire sidebar hierarchy.
 struct TmuxSessionPresentationLifecycleModifier: ViewModifier {
     let selection: WorkspaceSelection
     let selectionBaseline: WorkspaceSelection?
     let activeSession: WorkspaceTmuxSessionSelection?
-    let isWorkspaceVisible: Bool
-    let deactivate: () -> Void
+    let hide: () -> Void
 
     func body(content: Content) -> some View {
         content
@@ -1343,16 +1337,8 @@ struct TmuxSessionPresentationLifecycleModifier: ViewModifier {
                 if activeSession != nil,
                    let selectionBaseline,
                    newSelection != selectionBaseline {
-                    deactivate()
+                    hide()
                 }
-            }
-            .onChange(of: isWorkspaceVisible) { _, isVisible in
-                if !isVisible {
-                    deactivate()
-                }
-            }
-            .onDisappear {
-                deactivate()
             }
     }
 }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -90,6 +90,7 @@ public struct RootView: View {
             }
             .onChange(of: sshHostKeyReview.isPresented) { wasPresented, isPresented in
                 guard wasPresented, !isPresented else { return }
+                tmuxRecoveryRequestRouter.reviewDidDismiss()
                 reviewTmuxConnectionRequestIfNeeded()
             }
             .sheet(isPresented: $isCommandPalettePresented) {

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -193,15 +193,15 @@ public struct TmuxConnectionRecoveryRequest:
 }
 
 struct TmuxConnectionRecoveryRequestRouter {
-    private(set) var reviewedRequestID: UUID?
+    private(set) var reviewedRequest: TmuxConnectionRecoveryRequest?
 
     mutating func take(
         _ request: TmuxConnectionRecoveryRequest?,
         whileReviewIsPresented: Bool
     ) -> TmuxConnectionRecoveryRequest? {
-        guard let request, reviewedRequestID != request.id else { return nil }
+        guard let request, reviewedRequest?.id != request.id else { return nil }
         guard !whileReviewIsPresented else { return nil }
-        reviewedRequestID = request.id
+        reviewedRequest = request
         return request
     }
 
@@ -210,25 +210,23 @@ struct TmuxConnectionRecoveryRequestRouter {
         activeRequest: TmuxConnectionRecoveryRequest?
     ) -> UUID? {
         guard let activeRequest,
-              activeRequest.id == reviewedRequestID,
+              activeRequest.id == reviewedRequest?.id,
               activeRequest.hostID == hostID
         else { return nil }
         return activeRequest.id
     }
 
-    func recoveryHostIDToResume(
+    func recoveryRequestToResume(
         reviewedHostID: UUID?,
-        reviewRequestID: UUID?,
-        activeRequest: TmuxConnectionRecoveryRequest?
-    ) -> UUID? {
+        reviewRequestID: UUID?
+    ) -> TmuxConnectionRecoveryRequest? {
         guard let reviewedHostID,
               let reviewRequestID,
-              recoveryRequestID(
-                  for: reviewedHostID,
-                  activeRequest: activeRequest
-              ) == reviewRequestID
+              let reviewedRequest,
+              reviewedRequest.hostID == reviewedHostID,
+              reviewedRequest.id == reviewRequestID
         else { return nil }
-        return reviewedHostID
+        return reviewedRequest
     }
 }
 
@@ -238,6 +236,7 @@ public struct InteractionHandlers {
     public let reloadTerminalConfig: (() -> Void)?
     public let selectWorkspace: ((WorkspaceSelection) -> Void)?
     public let openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
+    public let hideTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let prepareTmuxSessionKill:
         ((WorkspaceTmuxSessionSelection) async throws
@@ -249,7 +248,8 @@ public struct InteractionHandlers {
     public let createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let refreshWorkspaceInventory: (() -> Void)?
     public let reconnectActiveTmuxSessionNow: (() -> Void)?
-    public let resumeTmuxReconnectAfterSSHRecovery: ((UUID) -> Void)?
+    public let resumeTmuxReconnectAfterSSHRecovery:
+        ((TmuxConnectionRecoveryRequest) -> Void)?
     public let reviewSSHHostKey:
         ((UUID, String) async -> SSHConnectionRecoveryResult)?
     public let trustSSHHostKey:
@@ -280,6 +280,7 @@ public struct InteractionHandlers {
         reloadTerminalConfig: (() -> Void)? = nil,
         selectWorkspace: ((WorkspaceSelection) -> Void)? = nil,
         openTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
+        hideTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         prepareTmuxSessionKill:
         ((WorkspaceTmuxSessionSelection) async throws
@@ -291,7 +292,8 @@ public struct InteractionHandlers {
         createTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         refreshWorkspaceInventory: (() -> Void)? = nil,
         reconnectActiveTmuxSessionNow: (() -> Void)? = nil,
-        resumeTmuxReconnectAfterSSHRecovery: ((UUID) -> Void)? = nil,
+        resumeTmuxReconnectAfterSSHRecovery:
+        ((TmuxConnectionRecoveryRequest) -> Void)? = nil,
         reviewSSHHostKey:
         ((UUID, String) async -> SSHConnectionRecoveryResult)? = nil,
         trustSSHHostKey:
@@ -321,6 +323,7 @@ public struct InteractionHandlers {
         self.reloadTerminalConfig = reloadTerminalConfig
         self.selectWorkspace = selectWorkspace
         self.openTmuxSession = openTmuxSession
+        self.hideTmuxSession = hideTmuxSession
         self.closeTmuxSession = closeTmuxSession
         self.prepareTmuxSessionKill = prepareTmuxSessionKill
         self.killTmuxSession = killTmuxSession

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -193,27 +193,36 @@ public struct TmuxConnectionRecoveryRequest:
 }
 
 struct TmuxConnectionRecoveryRequestRouter {
-    private(set) var reviewedRequest: TmuxConnectionRecoveryRequest?
+    private(set) var reviewedRequestIDs: Set<UUID> = []
+    private(set) var currentReviewRequest: TmuxConnectionRecoveryRequest?
 
     mutating func take(
         _ request: TmuxConnectionRecoveryRequest?,
         whileReviewIsPresented: Bool
     ) -> TmuxConnectionRecoveryRequest? {
-        guard let request, reviewedRequest?.id != request.id else { return nil }
+        guard let request, !reviewedRequestIDs.contains(request.id) else {
+            return nil
+        }
         guard !whileReviewIsPresented else { return nil }
-        reviewedRequest = request
+        reviewedRequestIDs.insert(request.id)
+        currentReviewRequest = request
         return request
     }
 
-    func recoveryRequestID(
+    mutating func recoveryRequestID(
         for hostID: UUID,
         activeRequest: TmuxConnectionRecoveryRequest?
     ) -> UUID? {
         guard let activeRequest,
-              activeRequest.id == reviewedRequest?.id,
+              reviewedRequestIDs.contains(activeRequest.id),
               activeRequest.hostID == hostID
         else { return nil }
+        currentReviewRequest = activeRequest
         return activeRequest.id
+    }
+
+    mutating func reviewDidDismiss() {
+        currentReviewRequest = nil
     }
 
     func recoveryRequestToResume(
@@ -222,11 +231,11 @@ struct TmuxConnectionRecoveryRequestRouter {
     ) -> TmuxConnectionRecoveryRequest? {
         guard let reviewedHostID,
               let reviewRequestID,
-              let reviewedRequest,
-              reviewedRequest.hostID == reviewedHostID,
-              reviewedRequest.id == reviewRequestID
+              let currentReviewRequest,
+              currentReviewRequest.hostID == reviewedHostID,
+              currentReviewRequest.id == reviewRequestID
         else { return nil }
-        return reviewedRequest
+        return currentReviewRequest
     }
 }
 

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -296,6 +296,9 @@ func makeModel(
     nativeTmuxSurfaceStore: (any TmuxSurfaceStoring)? = nil,
     nativeTmuxPathProvider:
     (@Sendable () -> Result<String, TmuxBinaryError>)? = nil,
+    localKwtPathProvider: @escaping @Sendable () -> String? = {
+        KwtBinaryLocator.bundledPath()
+    },
     remoteTmuxPathProvider: @escaping @Sendable (SSHHostInfo)
         -> Result<String, TmuxBinaryError> = { _ in
             .failure(.notFound(shell: "test"))
@@ -413,6 +416,7 @@ func makeModel(
         notificationService: notificationService,
         nativeTmuxSurfaceStore: nativeTmuxSurfaceStore,
         nativeTmuxPathProvider: nativeTmuxPathProvider,
+        localKwtPathProvider: localKwtPathProvider,
         remoteTmuxPathProvider: remoteTmuxPathProvider,
         tmuxPresentationStyleProvider: tmuxPresentationStyleProvider,
         appliesTmuxPresentationStyleToExistingSessionsProvider:

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2866,6 +2866,7 @@ struct WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: environment.snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
             remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
             tmuxExactSessionProbe: { _ in probes.removeFirst() },
             tmuxReconnectIntervals: [.milliseconds(1)]

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2991,6 +2991,62 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("recovery continues when discovery confirms establishment")
+    func discoveryConfirmationContinuesEstablishmentRecovery() async throws {
+        let environment = try setupRemoteEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionName = "kwt-ghosthub-main"
+        let discoveries = TmuxDiscoveryResultQueue([
+            .success([]),
+            .success([
+                DiscoveredTmuxSession(
+                    name: sessionName,
+                    windowCount: 1,
+                    createdAt: nil,
+                    managed: true
+                ),
+            ]),
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            createdSessionDiscoveryDelays: [.seconds(10)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { discoveries.count == 1 }
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            discoveries.count == 2
+                && surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        #expect(
+            surfaceStore.lastConfiguration?.command?
+                .contains("attach-session") == true
+        )
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == false
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("a failed replacement stops promising automatic recovery")
     func failedReplacementStopsAutomaticRecovery() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -706,8 +706,17 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("returning to a replaced worktree invalidates its retained client")
-    func returningToReplacedWorktreeInvalidatesRetainedClient() async throws {
+    @Test(
+        "returning to an inactive replaced worktree invalidates its old endpoint",
+        arguments: [
+            ("kwt-ghosthub-replacement", String?.none),
+            ("kwt-ghosthub-main", Optional("replacement-socket")),
+        ]
+    )
+    func returningToReplacedWorktreeInvalidatesRetainedClient(
+        replacementName: String,
+        replacementSocket: String?
+    ) async throws {
         let environment = try setupStandardEnvironment()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
@@ -717,7 +726,7 @@ struct WorkspaceTmuxDiscoveryTests {
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
         )
-        var worktree = WorkspaceTmuxSessionSelection(
+        let worktree = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
@@ -739,18 +748,22 @@ struct WorkspaceTmuxDiscoveryTests {
             return surfaceStore.requestCount == 2
         }
 
-        worktree.worktreeGeneration =
+        var replacement = worktree
+        replacement.name = replacementName
+        replacement.socketName = replacementSocket
+        replacement.worktreeGeneration =
             "fedcba9876543210fedcba9876543210"
-        model.openBorrowedTmuxSession(worktree)
+        model.openBorrowedTmuxSession(replacement)
         await waitUntilMainActor {
             model.prepareActiveBorrowedTmuxSurface()
             return surfaceStore.requestCount == 3
         }
 
         #expect(
-            model.retainedBorrowedTmuxHandle(for: worktree) != originalHandle
+            model.retainedBorrowedTmuxHandle(for: replacement) != originalHandle
         )
-        #expect(model.activeBorrowedTmuxSelection == worktree)
+        #expect(model.retainedBorrowedTmuxHandle(for: worktree) == nil)
+        #expect(model.activeBorrowedTmuxSelection == replacement)
         #expect(model.retainedBorrowedTmuxPresentationCount == 2)
         #expect(surfaceStore.removedKeys.count == 1)
         await model.shutdown()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -61,6 +61,75 @@ struct WorkspaceTmuxDiscoveryTests {
         await model.shutdown()
     }
 
+    @MainActor
+    @Test("authoritative inventory removal closes retained presentation")
+    func authoritativeInventoryRemovalClosesRetainedPresentation() async throws {
+        let environment = try setupStandardEnvironment()
+        let generation = "0123456789abcdef0123456789abcdef"
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation = generation
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        let inventoryRemoved = LockedValue(false)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in
+                KwtHostInventory(projects: [
+                    KwtProjectInventory(
+                        project: KwtProjectRecord(
+                            repository: environment.project.scopedKey,
+                            name: environment.project.name,
+                            path: environment.project.rootPath,
+                            lastTouched: nil
+                        ),
+                        worktrees: inventoryRemoved.load() ? [] : [
+                            KwtWorktreeRecord(
+                                path: environment.worktree.path,
+                                branch: environment.worktree.branch,
+                                commitHash: "",
+                                isMain: true,
+                                createdAt: nil,
+                                generation: generation,
+                                repository: environment.project.scopedKey,
+                                sessionName: "kwt-ghosthub-main",
+                                tmuxSocketName: nil
+                            ),
+                        ],
+                        warning: nil
+                    ),
+                ])
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            startServices: true
+        )
+        await waitUntilMainActor {
+            model.isWorkspaceInventoryRefreshComplete
+                && model.snapshot.worktrees.count == 1
+        }
+        let worktree = try #require(model.snapshot.worktrees.first)
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+
+        inventoryRemoved.withLock { $0 = true }
+        model.refreshKwtInventory()
+
+        await waitUntilMainActor {
+            model.snapshot.worktree(id: worktree.id) == nil
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+        #expect(surfaceStore.removedKeys.count == 1)
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        await model.shutdown()
+    }
+
     private enum CreationKwtFailurePhase: CaseIterable, Sendable {
         case command
         case inventoryRefresh
@@ -578,6 +647,53 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(model.activeBorrowedTmuxSelection == second)
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("closed worktree waits for explicit selection before reopening")
+    func closedWorktreeWaitsForExplicitSelection() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        var userSelection = model.selection
+        userSelection.select(
+            .worktree(environment.worktree.id),
+            in: model.snapshot
+        )
+        model.selectFromUser(userSelection)
+        let tmuxSelection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: userSelection,
+                in: model.snapshot
+            )
+        )
+        model.openBorrowedTmuxSession(tmuxSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        model.closeBorrowedTmuxSession(tmuxSelection)
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.suppressesSelectedWorktreeSessionOpen)
+
+        model.synchronizeSelection(userSelection)
+        #expect(model.suppressesSelectedWorktreeSessionOpen)
+        #expect(surfaceStore.requestCount == 1)
+
+        model.selectFromUser(userSelection)
+        #expect(!model.suppressesSelectedWorktreeSessionOpen)
+        model.openBorrowedTmuxSession(tmuxSelection)
+        await waitUntilMainActor { surfaceStore.requestCount == 2 }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -444,6 +444,208 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("switching sessions retains and reuses each presentation")
+    func switchingSessionsReusesRetainedPresentations() async throws {
+        let environment = try setupHostEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "first"
+        )
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "second"
+        )
+
+        model.openBorrowedTmuxSession(first)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let firstHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: first)
+        )
+
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        let secondHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: second)
+        )
+
+        model.openBorrowedTmuxSession(first)
+        model.prepareActiveBorrowedTmuxSurface()
+
+        #expect(model.activeBorrowedTmuxSelection == first)
+        #expect(model.retainedBorrowedTmuxHandle(for: first) == firstHandle)
+        #expect(firstHandle.surfaceID != secondHandle.surfaceID)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(surfaceStore.requestCount == 2)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("switching between remote hosts retains both presentations")
+    func switchingRemoteHostsRetainsPresentations() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        var snapshot = environment.snapshot
+        let secondHost = HostSummary(
+            id: UUID(),
+            configKey: "second-builder",
+            name: "Second Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "wesm@second-builder",
+            preferredTransport: .ssh,
+            lastKnownReachable: true
+        )
+        snapshot.hosts.append(secondHost)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") }
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: secondHost.id,
+            name: "deploy-work"
+        )
+
+        model.openBorrowedTmuxSession(first)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let firstHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: first)
+        )
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        model.openBorrowedTmuxSession(first)
+
+        #expect(model.retainedBorrowedTmuxHandle(for: first) == firstHandle)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(surfaceStore.requestCount == 2)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("explicit close detaches only its retained presentation")
+    func explicitCloseDetachesOnlyTargetPresentation() async throws {
+        let environment = try setupHostEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "first"
+        )
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "second"
+        )
+        model.openBorrowedTmuxSession(first)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        model.closeBorrowedTmuxSession(first)
+
+        #expect(model.retainedBorrowedTmuxHandle(for: first) == nil)
+        #expect(model.retainedBorrowedTmuxHandle(for: second) != nil)
+        #expect(model.activeBorrowedTmuxSelection == second)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("explicit close dismisses an unresolved-host presentation")
+    func explicitCloseDismissesUnresolvedHostPresentation() throws {
+        let environment = try setupStandardEnvironment()
+        let unresolvedHost = HostSummary(
+            id: UUID(),
+            configKey: "unresolved-builder",
+            name: "Unresolved Builder",
+            kind: .remote,
+            platform: .linux,
+            preferredTransport: .ssh
+        )
+        var snapshot = environment.snapshot
+        snapshot.hosts.append(unresolvedHost)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: unresolvedHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.activeBorrowedTmuxLaunchMode == .attach)
+
+        model.closeBorrowedTmuxSession(selection)
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.activeBorrowedTmuxLaunchMode == nil)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+    }
+
+    @MainActor
+    @Test("workspace shutdown detaches every retained presentation")
+    func shutdownDetachesEveryRetainedPresentation() async throws {
+        let environment = try setupHostEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        for name in ["first", "second"] {
+            model.openBorrowedTmuxSession(.init(
+                hostID: environment.host.id,
+                name: name
+            ))
+            await waitUntilMainActor {
+                model.prepareActiveBorrowedTmuxSurface()
+                return surfaceStore.requestCount ==
+                    model.retainedBorrowedTmuxPresentationCount
+            }
+        }
+
+        await model.shutdown()
+
+        #expect(surfaceStore.removedKeys.count == 2)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+    }
+
+    @MainActor
     @Test("reopening an ended worktree restores establishment mode")
     func endedWorktreeRetryRestoresEstablishmentMode() {
         let selection = WorkspaceTmuxSessionSelection(
@@ -501,6 +703,57 @@ struct WorkspaceTmuxDiscoveryTests {
                 == "fedcba9876543210fedcba9876543210"
         )
         #expect(model.activeBorrowedTmuxLaunchMode == .attach)
+    }
+
+    @MainActor
+    @Test("returning to a replaced worktree invalidates its retained client")
+    func returningToReplacedWorktreeInvalidatesRetainedClient() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") }
+        )
+        var worktree = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef"
+        )
+        let other = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other"
+        )
+        model.openBorrowedTmuxSession(worktree)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let originalHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: worktree)
+        )
+        model.openBorrowedTmuxSession(other)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        worktree.worktreeGeneration =
+            "fedcba9876543210fedcba9876543210"
+        model.openBorrowedTmuxSession(worktree)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 3
+        }
+
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: worktree) != originalHandle
+        )
+        #expect(model.activeBorrowedTmuxSelection == worktree)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
     }
 
     @MainActor
@@ -1185,6 +1438,46 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("creating a closed retained session launches a replacement")
+    func creatingClosedRetainedSessionLaunchesReplacement() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let closedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+        surfaceStore.surface.closeObservers[closedHandle.id]?(false, 0)
+
+        model.createTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        let replacementHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+
+        #expect(replacementHandle != closedHandle)
+        #expect(model.activeBorrowedTmuxLaunchMode == .create)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(command.contains("new-session"))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("reopening an optimistic session preserves creation intent")
     func reopeningCreatedSessionPreservesCreateMode() throws {
         let environment = try setupStandardEnvironment()
@@ -1340,17 +1633,20 @@ struct WorkspaceTmuxDiscoveryTests {
         model.openBorrowedTmuxSession(protectedSelection)
 
         #expect(model.activeBorrowedTmuxLaunchMode == .attach)
-        #expect(model.pendingCreatedTmuxSessionCount == 0)
+        #expect(model.pendingCreatedTmuxSessionCount == 1)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
     }
 
     @MainActor
-    @Test("creation discovery waits for terminal command launch")
-    func createdSessionDoesNotReconcileBeforeLaunch() async throws {
+    @Test("creation discovery follows automatic terminal command launch")
+    func createdSessionDiscoveryFollowsAutomaticLaunch() async throws {
         let environment = try setupStandardEnvironment()
         let attempts = Counter()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { .success("/opt/homebrew/bin/tmux") },
             kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
             tmuxSessionDiscovery: { _ in
@@ -1370,14 +1666,44 @@ struct WorkspaceTmuxDiscoveryTests {
             hostID: environment.host.id,
             name: "release-work"
         ))
-        try await Task.sleep(for: .milliseconds(100))
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 1
+                && attempts.count > baselineAttempts
+        }
 
-        #expect(attempts.count == baselineAttempts)
         #expect(model.pendingCreatedTmuxSessionCount == 1)
         #expect(
             model.snapshot.host(id: environment.host.id)?
                 .tmuxSessions.map(\.name) == ["release-work"]
         )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("inactive presentation launches when binary resolution completes")
+    func inactivePresentationLaunchesAfterPathResolution() async throws {
+        let environment = try setupStandardEnvironment()
+        let path = DelayedTmuxPathState()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: path.resolve
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "release-work"
+        )
+
+        model.createTmuxSession(selection)
+        await waitUntilMainActor { path.didStart }
+        model.hideBorrowedTmuxSession(selection)
+        path.release()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) != nil)
         await model.shutdown()
     }
 
@@ -1574,6 +1900,84 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("endpoint change invalidates only that host's retained presentations")
+    func endpointChangeInvalidatesOnlyAffectedHostPresentations()
+        async throws {
+        let environment = try setupStandardEnvironment()
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            SSHHost(
+                configKey: "first-builder",
+                name: "First Builder",
+                platform: .linux,
+                sshDestination: "wesm@first-builder"
+            ),
+            SSHHost(
+                configKey: "second-builder",
+                name: "Second Builder",
+                platform: .linux,
+                sshDestination: "wesm@second-builder"
+            ),
+        ])
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            configuredSSHHostsProvider: { configuredHosts.value }
+        )
+        model.refreshHosts()
+        let firstHost = try #require(
+            model.snapshot.hosts.first { $0.configKey == "first-builder" }
+        )
+        let secondHost = try #require(
+            model.snapshot.hosts.first { $0.configKey == "second-builder" }
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: firstHost.id,
+            name: "first"
+        )
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: secondHost.id,
+            name: "second"
+        )
+        model.openBorrowedTmuxSession(first)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        let secondHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: second)
+        )
+
+        configuredHosts.value = [
+            SSHHost(
+                configKey: "first-builder",
+                name: "First Builder",
+                platform: .linux,
+                sshDestination: "wesm@replacement-builder"
+            ),
+            SSHHost(
+                configKey: "second-builder",
+                name: "Second Builder",
+                platform: .linux,
+                sshDestination: "wesm@second-builder"
+            ),
+        ]
+        model.refreshHosts()
+
+        #expect(model.retainedBorrowedTmuxHandle(for: first) == nil)
+        #expect(model.retainedBorrowedTmuxHandle(for: second) == secondHandle)
+        #expect(model.activeBorrowedTmuxSelection == second)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("shutdown cancels detached creation discovery")
     func shutdownCancelsDetachedCreationDiscovery() async throws {
         let environment = try setupStandardEnvironment()
@@ -1715,6 +2119,79 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(
             surfaceStore.lastConfiguration?.command?.contains("'open'") == false
         )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("inactive retained presentation continues automatic recovery")
+    func inactivePresentationContinuesAutomaticRecovery() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "local-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { host in
+                if host.isRemote {
+                    return .success([
+                        DiscoveredTmuxSession(
+                            name: "release-work",
+                            windowCount: 1,
+                            createdAt: nil,
+                            managed: false
+                        ),
+                    ])
+                }
+                return .success([])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remote = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        let local = WorkspaceTmuxSessionSelection(
+            hostID: environment.localHostID,
+            name: "local-work"
+        )
+        model.openBorrowedTmuxSession(remote)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let remoteHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: remote)
+        )
+        let remoteClose = try #require(
+            surfaceStore.surface.closeObservers[remoteHandle.id]
+        )
+        model.openBorrowedTmuxSession(local)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        remoteClose(false, 255)
+
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 3
+                && model.retainedBorrowedTmuxSessionIsConnected(remote)
+        }
+        #expect(model.activeBorrowedTmuxSelection == local)
+        #expect(model.retainedBorrowedTmuxHandle(for: remote) == remoteHandle)
+
+        model.openBorrowedTmuxSession(remote)
+        model.prepareActiveBorrowedTmuxSurface()
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(surfaceStore.requestCount == 3)
         await model.shutdown()
     }
 
@@ -2255,6 +2732,9 @@ struct WorkspaceTmuxDiscoveryTests {
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        let endedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
         surfaceStore.surface.closeObservers.values.first?(false, 255)
 
         await waitUntilMainActor {
@@ -2262,6 +2742,22 @@ struct WorkspaceTmuxDiscoveryTests {
         }
         #expect(probes.count == 1)
         #expect(surfaceStore.requestCount == 1)
+
+        let local = WorkspaceTmuxSessionSelection(
+            hostID: environment.localHostID,
+            name: "local-work"
+        )
+        model.openBorrowedTmuxSession(local)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        model.openBorrowedTmuxSession(selection)
+        model.prepareActiveBorrowedTmuxSurface()
+
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) == endedHandle)
+        #expect(model.activeBorrowedTmuxSessionIsConfirmedEnded)
+        #expect(surfaceStore.requestCount == 2)
         await model.shutdown()
     }
 
@@ -2393,6 +2889,152 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("successful SSH recovery resumes its inactive presentation")
+    func sshRecoveryResumesInactivePresentation() async throws {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: "Permission denied (publickey,password)."
+        )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .failure(.sshConnectionFailed(
+                host: "build-box", classification: classification
+            )),
+            .success([
+                DiscoveredTmuxSession(
+                    name: "release-work", windowCount: 1,
+                    createdAt: nil, managed: false
+                ),
+            ]),
+        ])
+        let environment = try setupRemoteTmuxEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "local-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { host in
+                host.isRemote ? discoveries.removeFirst() : .success([])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remote = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        let local = WorkspaceTmuxSessionSelection(
+            hostID: environment.localHostID,
+            name: "local-work"
+        )
+        model.openBorrowedTmuxSession(remote)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let remoteHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: remote)
+        )
+        surfaceStore.surface.closeObservers[remoteHandle.id]?(false, 255)
+        await waitUntilMainActor {
+            model.tmuxConnectionRecoveryRequest != nil
+        }
+        let recoveryRequest = try #require(
+            model.tmuxConnectionRecoveryRequest
+        )
+
+        model.openBorrowedTmuxSession(local)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        model.resumeTmuxReconnectAfterSSHRecovery(recoveryRequest)
+
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 3
+                && model.retainedBorrowedTmuxSessionIsConnected(remote)
+        }
+        #expect(model.activeBorrowedTmuxSelection == local)
+        #expect(model.retainedBorrowedTmuxHandle(for: remote) == remoteHandle)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("unresolved host does not inherit retained recovery state")
+    func unresolvedHostDoesNotInheritRetainedRecoveryState() async throws {
+        let classification = SSHConnectionFailure.classify(
+            status: 255,
+            output: "Permission denied (publickey,password)."
+        )
+        let environment = try setupRemoteTmuxEnvironment()
+        let unresolvedHost = HostSummary(
+            id: UUID(),
+            configKey: "unresolved-builder",
+            name: "Unresolved Builder",
+            kind: .remote,
+            platform: .linux,
+            preferredTransport: .ssh
+        )
+        var snapshot = environment.snapshot
+        snapshot.hosts.append(unresolvedHost)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in
+                .failure(.sshConnectionFailed(
+                    host: "build-box",
+                    classification: classification
+                ))
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let retained = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(retained)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let retainedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: retained)
+        )
+        surfaceStore.surface.closeObservers[retainedHandle.id]?(false, 255)
+        await waitUntilMainActor {
+            model.tmuxConnectionRecoveryRequest != nil
+        }
+
+        let unresolved = WorkspaceTmuxSessionSelection(
+            hostID: unresolvedHost.id,
+            name: "unavailable-work"
+        )
+        model.openBorrowedTmuxSession(unresolved)
+
+        #expect(model.activeBorrowedTmuxSelection == unresolved)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        #expect(model.tmuxConnectionRecoveryRequest == nil)
+
+        model.openBorrowedTmuxSession(retained)
+        #expect(model.tmuxConnectionRecoveryRequest?.hostID == retained.hostID)
+        guard case .needsAttention(_, true) =
+            model.activeBorrowedTmuxRecoveryState
+        else {
+            Issue.record("Expected retained recovery state")
+            await model.shutdown()
+            return
+        }
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("changed host key can reconnect after manual remediation")
     func changedHostKeyRequiresManualRemediation() async throws {
         let classification = SSHConnectionFailure.classify(
@@ -2444,7 +3086,10 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(model.tmuxConnectionRecoveryRequest == nil)
 
         model.resumeTmuxReconnectAfterSSHRecovery(
-            hostID: environment.remoteHost.id
+            TmuxConnectionRecoveryRequest(
+                hostID: environment.remoteHost.id,
+                message: message
+            )
         )
         #expect(
             model.activeBorrowedTmuxRecoveryState == .needsAttention(
@@ -2488,6 +3133,50 @@ struct WorkspaceTmuxDiscoveryTests {
 
         #expect(model.activeBorrowedTmuxRecoveryState == nil)
         #expect(surfaceStore.requestCount == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("returning to a cleanly detached retained session does not reopen it")
+    func cleanlyDetachedRetainedSessionDoesNotReopen() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remote = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        let local = WorkspaceTmuxSessionSelection(
+            hostID: environment.localHostID,
+            name: "local-work"
+        )
+        model.openBorrowedTmuxSession(remote)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let remoteHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: remote)
+        )
+        surfaceStore.surface.closeObservers[remoteHandle.id]?(false, 0)
+        model.openBorrowedTmuxSession(local)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        model.openBorrowedTmuxSession(remote)
+        model.prepareActiveBorrowedTmuxSurface()
+
+        #expect(model.retainedBorrowedTmuxHandle(for: remote) == remoteHandle)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        #expect(surfaceStore.requestCount == 2)
         await model.shutdown()
     }
 
@@ -3450,17 +4139,26 @@ private final class SceneTmuxSurfaceStoreStub: TmuxSurfaceStoring {
     let surface = SceneTmuxPaneSurfaceStub()
     private(set) var requestCount = 0
     private(set) var lastConfiguration: TerminalSurfaceConfiguration?
+    private(set) var requestedKeys: [SurfaceKey] = []
+    private(set) var removedKeys: [SurfaceKey] = []
+    private var retainedKeys: Set<SurfaceKey> = []
 
     func paneSurface(
         for key: SurfaceKey,
         configuration: TerminalSurfaceConfiguration
     ) -> (any TmuxPaneSurfacing)? {
+        guard !retainedKeys.contains(key) else { return surface }
+        retainedKeys.insert(key)
         requestCount += 1
         lastConfiguration = configuration
+        requestedKeys.append(key)
         return surface
     }
 
-    func removeSurface(for key: SurfaceKey) {}
+    func removeSurface(for key: SurfaceKey) {
+        retainedKeys.remove(key)
+        removedKeys.append(key)
+    }
 }
 
 private final class TmuxDiscoveryResultQueue: @unchecked Sendable {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -707,15 +707,29 @@ struct WorkspaceTmuxDiscoveryTests {
 
     @MainActor
     @Test(
-        "returning to an inactive replaced worktree invalidates its old endpoint",
+        "returning to an inactive replaced worktree invalidates its retained client",
         arguments: [
-            ("kwt-ghosthub-replacement", String?.none),
-            ("kwt-ghosthub-main", Optional("replacement-socket")),
+            (
+                "kwt-ghosthub-replacement",
+                String?.none,
+                "0123456789abcdef0123456789abcdef"
+            ),
+            (
+                "kwt-ghosthub-main",
+                Optional("replacement-socket"),
+                "0123456789abcdef0123456789abcdef"
+            ),
+            (
+                "kwt-ghosthub-main",
+                String?.none,
+                "fedcba9876543210fedcba9876543210"
+            ),
         ]
     )
     func returningToReplacedWorktreeInvalidatesRetainedClient(
         replacementName: String,
-        replacementSocket: String?
+        replacementSocket: String?,
+        replacementGeneration: String
     ) async throws {
         let environment = try setupStandardEnvironment()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
@@ -751,8 +765,7 @@ struct WorkspaceTmuxDiscoveryTests {
         var replacement = worktree
         replacement.name = replacementName
         replacement.socketName = replacementSocket
-        replacement.worktreeGeneration =
-            "fedcba9876543210fedcba9876543210"
+        replacement.worktreeGeneration = replacementGeneration
         model.openBorrowedTmuxSession(replacement)
         await waitUntilMainActor {
             model.prepareActiveBorrowedTmuxSurface()
@@ -762,7 +775,10 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(
             model.retainedBorrowedTmuxHandle(for: replacement) != originalHandle
         )
-        #expect(model.retainedBorrowedTmuxHandle(for: worktree) == nil)
+        if replacement.name != worktree.name
+            || replacement.socketName != worktree.socketName {
+            #expect(model.retainedBorrowedTmuxHandle(for: worktree) == nil)
+        }
         #expect(model.activeBorrowedTmuxSelection == replacement)
         #expect(model.retainedBorrowedTmuxPresentationCount == 2)
         #expect(surfaceStore.removedKeys.count == 1)

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -130,6 +130,119 @@ struct WorkspaceTmuxDiscoveryTests {
         await model.shutdown()
     }
 
+    @MainActor
+    @Test(
+        "authoritative replacement waits for explicit reselection",
+        arguments: [
+            (
+                "kwt-ghosthub-replacement",
+                "0123456789abcdef0123456789abcdef"
+            ),
+            (
+                "kwt-ghosthub-main",
+                "fedcba9876543210fedcba9876543210"
+            ),
+        ]
+    )
+    func authoritativeReplacementWaitsForExplicitReselection(
+        replacementName: String,
+        replacementGeneration: String
+    ) async throws {
+        let environment = try setupStandardEnvironment()
+        let originalGeneration = "0123456789abcdef0123456789abcdef"
+        let replacementActive = LockedValue(false)
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation = originalGeneration
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in
+                KwtHostInventory(projects: [
+                    KwtProjectInventory(
+                        project: KwtProjectRecord(
+                            repository: environment.project.scopedKey,
+                            name: environment.project.name,
+                            path: environment.project.rootPath,
+                            lastTouched: nil
+                        ),
+                        worktrees: [
+                            KwtWorktreeRecord(
+                                path: environment.worktree.path,
+                                branch: environment.worktree.branch,
+                                commitHash: "",
+                                isMain: true,
+                                createdAt: nil,
+                                generation: replacementActive.load()
+                                    ? replacementGeneration
+                                    : originalGeneration,
+                                repository: environment.project.scopedKey,
+                                sessionName: replacementActive.load()
+                                    ? replacementName
+                                    : "kwt-ghosthub-main",
+                                tmuxSocketName: nil
+                            ),
+                        ],
+                        warning: nil
+                    ),
+                ])
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            startServices: true
+        )
+        await waitUntilMainActor {
+            model.isWorkspaceInventoryRefreshComplete
+                && model.snapshot.worktrees.count == 1
+        }
+        var userSelection = model.selection
+        userSelection.select(
+            .worktree(environment.worktree.id),
+            in: model.snapshot
+        )
+        model.selectFromUser(userSelection)
+        let original = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: userSelection,
+                in: model.snapshot
+            )
+        )
+        model.openBorrowedTmuxSession(original)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        replacementActive.withLock { $0 = true }
+        model.refreshKwtInventory()
+        await waitUntilMainActor {
+            guard let worktree = model.snapshot.worktree(
+                id: environment.worktree.id
+            ) else { return false }
+            return worktree.tmuxSessionName == replacementName
+                && worktree.generation == replacementGeneration
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+
+        #expect(model.suppressesSelectedWorktreeSessionOpen)
+        #expect(surfaceStore.requestCount == 1)
+
+        model.selectFromUser(userSelection)
+        #expect(!model.suppressesSelectedWorktreeSessionOpen)
+        let replacement = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: userSelection,
+                in: model.snapshot
+            )
+        )
+        model.openBorrowedTmuxSession(replacement)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        await model.shutdown()
+    }
+
     private enum CreationKwtFailurePhase: CaseIterable, Sendable {
         case command
         case inventoryRefresh
@@ -388,17 +501,14 @@ struct WorkspaceTmuxDiscoveryTests {
                 firstGate.wait()
                 return .success([])
             }
-            if call == 2 {
-                return .success([
-                    DiscoveredTmuxSession(
-                        name: "release-work",
-                        windowCount: 1,
-                        createdAt: "1721552400",
-                        managed: false
-                    ),
-                ])
-            }
-            return .failure(.shellFailed(status: 255))
+            return .success([
+                DiscoveredTmuxSession(
+                    name: "release-work",
+                    windowCount: 1,
+                    createdAt: "1721552400",
+                    managed: false
+                ),
+            ])
         }
 
         var firstStarted: Bool {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -131,6 +131,78 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("authoritative inventory latches a retained canonical generation")
+    func authoritativeInventoryLatchesRetainedGeneration() async throws {
+        let environment = try setupStandardEnvironment()
+        let firstGeneration = "0123456789abcdef0123456789abcdef"
+        let replacementGeneration = "fedcba9876543210fedcba9876543210"
+        let publishedGeneration = LockedValue(firstGeneration)
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation = nil
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in
+                KwtHostInventory(projects: [
+                    KwtProjectInventory(
+                        project: KwtProjectRecord(
+                            repository: environment.project.scopedKey,
+                            name: environment.project.name,
+                            path: environment.project.rootPath,
+                            lastTouched: nil
+                        ),
+                        worktrees: [
+                            KwtWorktreeRecord(
+                                path: environment.worktree.path,
+                                branch: environment.worktree.branch,
+                                commitHash: "",
+                                isMain: true,
+                                createdAt: nil,
+                                generation: publishedGeneration.load(),
+                                repository: environment.project.scopedKey,
+                                sessionName: "kwt-ghosthub-main",
+                                tmuxSocketName: nil
+                            ),
+                        ],
+                        warning: nil
+                    ),
+                ])
+            },
+            startServices: false
+        )
+        let initial = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
+        )
+        model.openBorrowedTmuxSession(initial)
+        let originalHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: initial)
+        )
+
+        model.startKwtInventory()
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection?.worktreeGeneration
+                == firstGeneration
+        }
+        let enriched = try #require(model.activeBorrowedTmuxSelection)
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: enriched) == originalHandle
+        )
+
+        publishedGeneration.withLock { $0 = replacementGeneration }
+        model.refreshKwtInventory()
+        await waitUntilMainActor {
+            model.snapshot.worktrees[0].generation == replacementGeneration
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test(
         "authoritative replacement waits for explicit reselection",
         arguments: [

--- a/Tests/App/WorkspaceTmuxThemeTests.swift
+++ b/Tests/App/WorkspaceTmuxThemeTests.swift
@@ -317,6 +317,77 @@ struct WorkspaceTmuxThemeTests {
     }
 
     @MainActor
+    @Test("inactive styling supersedes colors changed during an apply")
+    func inactiveStylingSupersedesChangedColors() async throws {
+        let environment = try setupHostEnvironment()
+        let store = ThemeTmuxSurfaceStoreStub(
+            surfaceIdentities: [42, 43]
+        )
+        var resolvedStyles: [UInt: TmuxPresentationStyle] = [:]
+        let appliedStyles = LockedValue<
+            [String: [TmuxPresentationStyle]]
+        >([:])
+        let gate = StylerGate()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: store,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            tmuxPresentationStyleProvider: { identity in
+                identity.flatMap { resolvedStyles[$0] }
+            },
+            appliesTmuxPresentationStyleToExistingSessionsProvider: { true },
+            tmuxSessionIdentityReader: { _, _ in sessionIdentity },
+            tmuxSessionStyler: { style, selection, _, _ in
+                appliedStyles.withLock {
+                    $0[selection.name, default: []].append(style)
+                }
+                if selection.name == "first", style == primaryStyle {
+                    await gate.blockUntilOpened()
+                    throw CancellationError()
+                }
+            }
+        )
+        let first = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "first"
+        )
+        let second = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "second"
+        )
+        model.openBorrowedTmuxSession(first)
+        await connectActiveTmuxSession(model, store: store)
+        model.openBorrowedTmuxSession(second)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return store.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        resolvedStyles = [42: primaryStyle, 43: newerStyle]
+        model.terminalPresentationStyleDidChange()
+        await gate.waitUntilBlocked()
+        await waitUntilMainActor {
+            appliedStyles.load()["second"] == [newerStyle]
+        }
+
+        resolvedStyles[42] = newerStyle
+        model.terminalPresentationStyleDidChange()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(appliedStyles.load()["first"] == [primaryStyle])
+
+        gate.open()
+        await waitUntilMainActor {
+            appliedStyles.load()["first"] == [primaryStyle, newerStyle]
+                && model.tmuxStylingQuiesced
+        }
+        #expect(model.activeBorrowedTmuxSelection == second)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("remote deferred kwt styling applies once with the read identity")
     func remoteDeferredKwtStylingAppliesOnce() async throws {
         let environment = try setupRemoteEnvironment()
@@ -848,23 +919,38 @@ private final class ThemeTmuxPaneSurfaceStub: TmuxPaneSurfacing {
 private final class ThemeTmuxSurfaceStoreStub: TmuxSurfaceStoring {
     private let surface = ThemeTmuxPaneSurfaceStub()
     private(set) var requestCount = 0
-    private let surfaceIdentity: UInt?
+    private let surfaceIdentities: [UInt?]
+    private var surfaceIdentitiesByKey: [SurfaceKey: UInt] = [:]
+    private var retainedKeys: Set<SurfaceKey> = []
 
     init(surfaceIdentity: UInt? = nil) {
-        self.surfaceIdentity = surfaceIdentity
+        surfaceIdentities = [surfaceIdentity]
+    }
+
+    init(surfaceIdentities: [UInt?]) {
+        self.surfaceIdentities = surfaceIdentities
     }
 
     func paneSurface(
-        for _: SurfaceKey,
+        for key: SurfaceKey,
         configuration _: TerminalSurfaceConfiguration
     ) -> (any TmuxPaneSurfacing)? {
+        guard !retainedKeys.contains(key) else { return surface }
+        retainedKeys.insert(key)
+        let identityIndex = min(requestCount, surfaceIdentities.count - 1)
+        if let identity = surfaceIdentities[identityIndex] {
+            surfaceIdentitiesByKey[key] = identity
+        }
         requestCount += 1
         return surface
     }
 
-    func removeSurface(for _: SurfaceKey) {}
+    func removeSurface(for key: SurfaceKey) {
+        retainedKeys.remove(key)
+        surfaceIdentitiesByKey.removeValue(forKey: key)
+    }
 
-    func surfaceIdentity(for _: SurfaceKey) -> UInt? {
-        surfaceIdentity
+    func surfaceIdentity(for key: SurfaceKey) -> UInt? {
+        surfaceIdentitiesByKey[key]
     }
 }

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -733,6 +733,151 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("failed removal preserves interrupted local establishment")
+    func failedRemovalPreservesInterruptedLocalEstablishment() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let surfaces = RecordingTmuxSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            localKwtPathProvider: { "/test/kwt" },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        #expect(surfaces.lastCommand?.contains("kwt") == true)
+        model.openBorrowedTmuxSession(WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other-session"
+        ))
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.self) {
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count > initialRequestCount
+        }
+
+        #expect(surfaces.lastCommand?.contains("kwt") == true)
+        #expect(surfaces.lastCommand?.contains("open") == true)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("failed removal restores a pathless matching endpoint")
+    func failedRemovalRestoresPathlessMatchingEndpoint() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        removable.tmuxSocketName = "kwt-pr-0123456789abcdef"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let surfaces = RecordingTmuxSurfaceStore()
+        let kills = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            localKwtPathProvider: { "/test/kwt" },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$8",
+                    createdAt: "1721552400"
+                )
+            }
+        )
+        let pathless = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-feature",
+            socketName: "kwt-pr-0123456789abcdef"
+        )
+        model.openBorrowedTmuxSession(pathless)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.self) {
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count > initialRequestCount
+        }
+
+        #expect(kills.load() == 1)
+        #expect(
+            model.activeBorrowedTmuxSelection?.worktreePath == removable.path
+        )
+        #expect(surfaces.lastCommand?.contains("kwt") == true)
+        #expect(surfaces.lastCommand?.contains("pr") == true)
+        #expect(surfaces.lastCommand?.contains("attach") == true)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("endpoint changes discard pending removal restoration")
     func endpointChangeDiscardsPendingRemovalRestoration() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosthubSettings
 import GhosthubTestSupport
 import GhosthubTmux
 import GhosthubUI
@@ -666,6 +667,159 @@ struct WorkspaceWorktreeRemovalTests {
         #expect(restoredCommand.contains("kwt"))
         #expect(restoredCommand.contains("open"))
         #expect(!restoredCommand.contains("attach-session"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("failed removal preserves pending workspace establishment")
+    func failedRemovalPreservesPendingEstablishment() async throws {
+        let environment = try setupRemoteEnvironment()
+        var removable = try #require(environment.snapshot.worktrees.first)
+        removable.generation = stableWorktreeGeneration
+        removable.scopedKey = removable.path
+        removable.tmuxSessionName = "kwt-ghosthub-main"
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [removable]
+        let beforeRemoval = inventory(environment, including: removable)
+        let surfaces = RecordingTmuxSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Office Linux",
+                    status: 1
+                )
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        #expect(surfaces.lastCommand?.contains("'open'") == true)
+        model.openBorrowedTmuxSession(WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other-session"
+        ))
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.self) {
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count > initialRequestCount
+        }
+
+        #expect(surfaces.lastCommand?.contains("'open'") == true)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("endpoint changes discard pending removal restoration")
+    func endpointChangeDiscardsPendingRemovalRestoration() async throws {
+        let environment = try setupRemoteEnvironment()
+        var removable = try #require(environment.snapshot.worktrees.first)
+        removable.generation = stableWorktreeGeneration
+        removable.scopedKey = removable.path
+        removable.tmuxSessionName = "kwt-ghosthub-main"
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [removable]
+        let beforeRemoval = inventory(environment, including: removable)
+        let surfaces = RecordingTmuxSurfaceStore()
+        let removerHold = RemovalPreflightHold()
+        let originalDestination = try #require(
+            environment.host.sshDestination
+        )
+        let configuredHosts = LockedValue([
+            SSHHost(
+                configKey: environment.host.configKey,
+                name: environment.host.name,
+                platform: .linux,
+                sshDestination: originalDestination
+            ),
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                _ = await removerHold.load(beforeRemoval)
+                throw KwtWorktreeError.removalFailed(
+                    host: "Office Linux",
+                    status: 1
+                )
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            },
+            configuredSSHHostsProvider: { configuredHosts.load() }
+        )
+        model.refreshHosts()
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        model.openBorrowedTmuxSession(WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other-session"
+        ))
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let removal = Task { @MainActor in
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor { await removerHold.started }
+        configuredHosts.withLock {
+            $0 = [
+                SSHHost(
+                    configKey: environment.host.configKey,
+                    name: environment.host.name,
+                    platform: .linux,
+                    sshDestination: "wesm@replacement.example.com"
+                ),
+            ]
+        }
+        model.refreshHosts()
+        await removerHold.release()
+        await #expect(throws: KwtWorktreeError.self) {
+            try await removal.value
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(
+            surfaces.requestedConfigurations.count == initialRequestCount
+        )
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -256,6 +256,7 @@ struct WorkspaceWorktreeRemovalTests {
         let afterRemoval = inventory(environment)
         let coordinator = WorktreeMutationCoordinator()
         let pathGate = DispatchSemaphore(value: 0)
+        let removerHold = RemovalPreflightHold()
         let pathResolutions = LockedValue(0)
         let completedPathResolutions = LockedValue(0)
         let resolveTmuxPath: @Sendable ()
@@ -285,7 +286,9 @@ struct WorkspaceWorktreeRemovalTests {
                     ? beforeRemoval
                     : afterRemoval
             },
-            kwtWorktreeRemover: { _, _, _, _ in },
+            kwtWorktreeRemover: { _, _, _, _ in
+                _ = await removerHold.load(afterRemoval)
+            },
             worktreeMutationCoordinator: coordinator,
             tmuxSessionIdentityReader: { selection, host in
                 throw TmuxSessionKillError.sessionNotRunning(
@@ -314,10 +317,17 @@ struct WorkspaceWorktreeRemovalTests {
         #expect(secondModel.retainedBorrowedTmuxPresentationCount == 1)
 
         let request = try await firstModel.prepareWorktreeRemoval(removable.id)
-        try await firstModel.removeWorktree(request)
+        let removal = Task { @MainActor in
+            try await firstModel.removeWorktree(request)
+        }
+        for _ in 0 ..< 1_000 {
+            if await removerHold.started {
+                break
+            }
+            await Task.yield()
+        }
+        #expect(await removerHold.started)
 
-        #expect(firstModel.snapshot.worktree(id: removable.id) == nil)
-        #expect(secondModel.snapshot.worktree(id: removable.id) == nil)
         #expect(firstModel.retainedBorrowedTmuxPresentationCount == 0)
         #expect(secondModel.retainedBorrowedTmuxPresentationCount == 0)
 
@@ -331,6 +341,11 @@ struct WorkspaceWorktreeRemovalTests {
         }
         #expect(firstSurfaces.requestedConfigurations.isEmpty)
         #expect(secondSurfaces.requestedConfigurations.isEmpty)
+
+        await removerHold.release()
+        try await removal.value
+        #expect(firstModel.snapshot.worktree(id: removable.id) == nil)
+        #expect(secondModel.snapshot.worktree(id: removable.id) == nil)
         await firstModel.shutdown()
         await secondModel.shutdown()
     }

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -377,6 +377,92 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("failed removal restores the canonical endpoint in a stale scene")
+    func failedRemovalRestoresCanonicalEndpointAcrossScenes() async throws {
+        let environment = try setupStandardEnvironment()
+        var stale = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        stale.tmuxSessionName = "kwt-ghosthub-stale"
+        var canonical = stale
+        canonical.tmuxSessionName = "kwt-ghosthub-canonical"
+        var currentSnapshot = environment.snapshot
+        currentSnapshot.worktrees.append(canonical)
+        var staleSnapshot = environment.snapshot
+        staleSnapshot.worktrees.append(stale)
+        let currentInventory = inventory(
+            environment,
+            including: canonical
+        )
+        let coordinator = WorktreeMutationCoordinator()
+        let staleSurfaces = RecordingTmuxSurfaceStore()
+        let currentModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: currentSnapshot,
+            kwtInventoryLoader: { _ in currentInventory },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: coordinator,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let staleModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: staleSnapshot,
+            nativeTmuxSurfaceStore: staleSurfaces,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            worktreeMutationCoordinator: coordinator
+        )
+        let staleSelection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: stale)
+        )
+        let canonicalSelection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: canonical)
+        )
+        staleModel.openBorrowedTmuxSession(staleSelection)
+        await waitUntilMainActor {
+            staleSurfaces.requestedConfigurations.count == 1
+        }
+
+        let request = try await currentModel.prepareWorktreeRemoval(
+            canonical.id
+        )
+        await #expect(throws: KwtWorktreeError.self) {
+            try await currentModel.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            staleSurfaces.requestedConfigurations.count == 2
+        }
+
+        #expect(
+            staleModel.retainedBorrowedTmuxHandle(for: staleSelection) == nil
+        )
+        #expect(
+            staleModel.retainedBorrowedTmuxHandle(for: canonicalSelection)
+                != nil
+        )
+        #expect(staleModel.activeBorrowedTmuxSelection == canonicalSelection)
+        await currentModel.shutdown()
+        await staleModel.shutdown()
+    }
+
+    @MainActor
     @Test("post-removal refresh ignores a generationless stale record")
     func postRemovalRefreshIgnoresGenerationlessRecord() async throws {
         let environment = try setupStandardEnvironment()
@@ -1445,6 +1531,71 @@ struct WorkspaceWorktreeRemovalTests {
             try await removal.value
         }
         #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("failed removal re-establishes after endpoint changes during kill")
+    func endpointChangeDuringKillReestablishesPresentation() async throws {
+        let environment = try setupRemoteEnvironment()
+        var worktree = try #require(environment.snapshot.worktrees.first)
+        worktree.generation = stableWorktreeGeneration
+        worktree.scopedKey = worktree.path
+        worktree.tmuxSessionName = "kwt-remote-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [worktree]
+        let beforeRemoval = inventory(environment, including: worktree)
+        let killHold = RemovalPreflightHold()
+        let surfaces = RecordingTmuxSurfaceStore()
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            remoteTmuxPathProvider: { _ in .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxSessionKiller: { _, _, _ in
+                _ = await killHold.load(beforeRemoval)
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$8",
+                    createdAt: "1721552400"
+                )
+            },
+            createdSessionDiscoveryDelays: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: try #require(worktree.tmuxSessionName)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+        let request = try await model.prepareWorktreeRemoval(worktree.id)
+        let removal = Task { @MainActor in
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor { await killHold.started }
+
+        model.snapshot.hosts[0].sshDestination = "replacement.example.com"
+        await killHold.release()
+        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+            try await removal.value
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+
+        #expect(removals.load() == 0)
+        #expect(surfaces.lastCommand?.contains("'open'") == true)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -527,6 +527,149 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("failed removal does not replace newer active presentation")
+    func failedRemovalPreservesNewerActivePresentation() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let removerHold = RemovalPreflightHold()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                _ = await removerHold.load(beforeRemoval)
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let removed = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let newer = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "newer"
+        )
+        model.openBorrowedTmuxSession(removed)
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let removal = Task { @MainActor in
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor { await removerHold.started }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+
+        model.openBorrowedTmuxSession(newer)
+        let newerHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: newer)
+        )
+        await removerHold.release()
+        await #expect(throws: KwtWorktreeError.self) {
+            try await removal.value
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(model.activeBorrowedTmuxSelection == newer)
+        #expect(model.retainedBorrowedTmuxHandle(for: newer) == newerHandle)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("failed removal re-establishes a terminated worktree session")
+    func failedRemovalReestablishesTerminatedSession() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let surfaces = RecordingTmuxSurfaceStore()
+        let kills = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            localKwtPathProvider: { "/test/kwt" },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$8",
+                    createdAt: "1721552400"
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.removalFailed(
+            host: "Local",
+            status: 1
+        )) {
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count > initialRequestCount
+        }
+
+        #expect(kills.load() == 1)
+        let restoredCommand = try #require(
+            surfaces.requestedConfigurations.last?.command
+        )
+        #expect(restoredCommand.contains("kwt"))
+        #expect(restoredCommand.contains("open"))
+        #expect(!restoredCommand.contains("attach-session"))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("removal preflight invalidates a replaced retained endpoint")
     func removalPreflightInvalidatesReplacedPresentation() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -251,6 +251,11 @@ struct WorkspaceWorktreeRemovalTests {
         removable.tmuxSessionName = "kwt-ghosthub-feature"
         var snapshot = environment.snapshot
         snapshot.worktrees.append(removable)
+        var staleSnapshot = snapshot
+        let staleIndex = try #require(
+            staleSnapshot.worktrees.firstIndex { $0.id == removable.id }
+        )
+        staleSnapshot.worktrees[staleIndex].generation = nil
 
         let beforeRemoval = inventory(environment, including: removable)
         let afterRemoval = inventory(environment)
@@ -300,7 +305,7 @@ struct WorkspaceWorktreeRemovalTests {
         let secondModel = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: snapshot,
+            snapshot: staleSnapshot,
             nativeTmuxSurfaceStore: secondSurfaces,
             nativeTmuxPathProvider: resolveTmuxPath,
             kwtInventoryLoader: { _ in beforeRemoval },
@@ -309,13 +314,18 @@ struct WorkspaceWorktreeRemovalTests {
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
         )
+        let staleSelection = try #require(
+            staleSnapshot.worktree(id: removable.id).flatMap(
+                WorkspaceSidebarModel.tmuxSessionSelection(for:)
+            )
+        )
         var navigation = firstModel.selection
         navigation.select(.worktree(removable.id), in: firstModel.snapshot)
         firstModel.selectFromUser(navigation)
         secondModel.selectFromUser(navigation)
 
         firstModel.openBorrowedTmuxSession(selection)
-        secondModel.openBorrowedTmuxSession(selection)
+        secondModel.openBorrowedTmuxSession(staleSelection)
         await waitUntilMainActor { pathResolutions.load() == 2 }
         #expect(firstModel.retainedBorrowedTmuxPresentationCount == 1)
         #expect(secondModel.retainedBorrowedTmuxPresentationCount == 1)
@@ -338,7 +348,7 @@ struct WorkspaceWorktreeRemovalTests {
         #expect(secondModel.suppressesSelectedWorktreeSessionOpen)
 
         firstModel.openBorrowedTmuxSession(selection)
-        secondModel.openBorrowedTmuxSession(selection)
+        secondModel.openBorrowedTmuxSession(staleSelection)
         for _ in 0 ..< 10 {
             await Task.yield()
         }

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -376,6 +376,61 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("post-removal refresh ignores a generationless stale record")
+    func postRemovalRefreshIgnoresGenerationlessRecord() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let staleRefresh = inventory(
+            environment,
+            including: removable,
+            generation: nil
+        )
+        let loads = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1 ? beforeRemoval : staleRefresh
+            },
+            kwtWorktreeRemover: { _, _, _, _ in },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        try await model.removeWorktree(request)
+        model.startKwtInventory()
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            loads.load() >= 3 && model.isWorkspaceInventoryRefreshComplete
+        }
+
+        #expect(loads.load() == 3)
+        #expect(!model.snapshot.worktrees.contains {
+            $0.hostID == removable.hostID && $0.path == removable.path
+        })
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("failed removal permits its worktree presentation to reopen")
     func failedRemovalPermitsPresentationReopen() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -236,6 +236,106 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("removal cancels pending presentations in every scene")
+    func removalCancelsPendingPresentationsInEveryScene() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+
+        let beforeRemoval = inventory(environment, including: removable)
+        let afterRemoval = inventory(environment)
+        let coordinator = WorktreeMutationCoordinator()
+        let pathGate = DispatchSemaphore(value: 0)
+        let pathResolutions = LockedValue(0)
+        let completedPathResolutions = LockedValue(0)
+        let resolveTmuxPath: @Sendable ()
+            -> Result<String, TmuxBinaryError> = {
+                pathResolutions.withLock { $0 += 1 }
+                pathGate.wait()
+                completedPathResolutions.withLock { $0 += 1 }
+                return .success("/usr/bin/tmux")
+            }
+        defer {
+            pathGate.signal()
+            pathGate.signal()
+        }
+
+        let firstLoads = LockedValue(0)
+        let firstSurfaces = RecordingTmuxSurfaceStore()
+        let secondSurfaces = RecordingTmuxSurfaceStore()
+        let firstModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: firstSurfaces,
+            nativeTmuxPathProvider: resolveTmuxPath,
+            kwtInventoryLoader: { _ in
+                firstLoads.withLock { $0 += 1 }
+                return firstLoads.load() == 1
+                    ? beforeRemoval
+                    : afterRemoval
+            },
+            kwtWorktreeRemover: { _, _, _, _ in },
+            worktreeMutationCoordinator: coordinator,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let secondModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: secondSurfaces,
+            nativeTmuxPathProvider: resolveTmuxPath,
+            kwtInventoryLoader: { _ in beforeRemoval },
+            worktreeMutationCoordinator: coordinator
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+
+        firstModel.openBorrowedTmuxSession(selection)
+        secondModel.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { pathResolutions.load() == 2 }
+        #expect(firstModel.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(secondModel.retainedBorrowedTmuxPresentationCount == 1)
+
+        let request = try await firstModel.prepareWorktreeRemoval(removable.id)
+        try await firstModel.removeWorktree(request)
+
+        #expect(firstModel.snapshot.worktree(id: removable.id) == nil)
+        #expect(secondModel.snapshot.worktree(id: removable.id) == nil)
+        #expect(firstModel.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(secondModel.retainedBorrowedTmuxPresentationCount == 0)
+
+        pathGate.signal()
+        pathGate.signal()
+        await waitUntilMainActor {
+            completedPathResolutions.load() == 2
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(firstSurfaces.requestedConfigurations.isEmpty)
+        #expect(secondSurfaces.requestedConfigurations.isEmpty)
+        await firstModel.shutdown()
+        await secondModel.shutdown()
+    }
+
+    @MainActor
     @Test(
         "live session removal leaves a same-path worktree on another host"
     )

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -309,6 +309,10 @@ struct WorkspaceWorktreeRemovalTests {
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
         )
+        var navigation = firstModel.selection
+        navigation.select(.worktree(removable.id), in: firstModel.snapshot)
+        firstModel.selectFromUser(navigation)
+        secondModel.selectFromUser(navigation)
 
         firstModel.openBorrowedTmuxSession(selection)
         secondModel.openBorrowedTmuxSession(selection)
@@ -330,6 +334,17 @@ struct WorkspaceWorktreeRemovalTests {
 
         #expect(firstModel.retainedBorrowedTmuxPresentationCount == 0)
         #expect(secondModel.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(firstModel.suppressesSelectedWorktreeSessionOpen)
+        #expect(secondModel.suppressesSelectedWorktreeSessionOpen)
+
+        firstModel.openBorrowedTmuxSession(selection)
+        secondModel.openBorrowedTmuxSession(selection)
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(firstModel.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(secondModel.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(pathResolutions.load() == 2)
 
         pathGate.signal()
         pathGate.signal()
@@ -348,6 +363,86 @@ struct WorkspaceWorktreeRemovalTests {
         #expect(secondModel.snapshot.worktree(id: removable.id) == nil)
         await firstModel.shutdown()
         await secondModel.shutdown()
+    }
+
+    @MainActor
+    @Test("failed removal permits its worktree presentation to reopen")
+    func failedRemovalPermitsPresentationReopen() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let beforeRemoval = inventory(environment, including: removable)
+        let removerHold = RemovalPreflightHold()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                _ = await removerHold.load(beforeRemoval)
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        var navigation = model.selection
+        navigation.select(.worktree(removable.id), in: model.snapshot)
+        model.selectFromUser(navigation)
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let removal = Task { @MainActor in
+            try await model.removeWorktree(request)
+        }
+        for _ in 0 ..< 1_000 {
+            if await removerHold.started {
+                break
+            }
+            await Task.yield()
+        }
+        #expect(await removerHold.started)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.suppressesSelectedWorktreeSessionOpen)
+
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+
+        await removerHold.release()
+        await #expect(
+            throws: KwtWorktreeError.removalFailed(
+                host: "Local",
+                status: 1
+            )
+        ) {
+            try await removal.value
+        }
+        #expect(!model.suppressesSelectedWorktreeSessionOpen)
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        await model.shutdown()
     }
 
     @MainActor

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -431,8 +431,8 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
-    @Test("failed removal permits its worktree presentation to reopen")
-    func failedRemovalPermitsPresentationReopen() async throws {
+    @Test("failed removal restores an inactive retained presentation")
+    func failedRemovalRestoresInactivePresentation() async throws {
         let environment = try setupStandardEnvironment()
         var removable = WorktreeSummary.fixture(
             hostID: environment.host.id,
@@ -475,8 +475,20 @@ struct WorkspaceWorktreeRemovalTests {
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
         )
+        let other = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other"
+        )
         model.openBorrowedTmuxSession(selection)
-        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        let removedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+        model.openBorrowedTmuxSession(other)
+        let activeHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: other)
+        )
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(model.activeBorrowedTmuxSelection == other)
 
         let request = try await model.prepareWorktreeRemoval(removable.id)
         let removal = Task { @MainActor in
@@ -489,11 +501,11 @@ struct WorkspaceWorktreeRemovalTests {
             await Task.yield()
         }
         #expect(await removerHold.started)
-        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(model.suppressesSelectedWorktreeSessionOpen)
 
         model.openBorrowedTmuxSession(selection)
-        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
 
         await removerHold.release()
         await #expect(
@@ -505,8 +517,62 @@ struct WorkspaceWorktreeRemovalTests {
             try await removal.value
         }
         #expect(!model.suppressesSelectedWorktreeSessionOpen)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: selection) != removedHandle
+        )
+        #expect(model.retainedBorrowedTmuxHandle(for: other) == activeHandle)
+        #expect(model.activeBorrowedTmuxSelection == other)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("removal preflight invalidates a replaced retained endpoint")
+    func removalPreflightInvalidatesReplacedPresentation() async throws {
+        let environment = try setupStandardEnvironment()
+        var removable = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            scopedKey: "/tmp/ghosthub-feature",
+            name: "feature/remove",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature/remove",
+            generation: stableWorktreeGeneration
+        )
+        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        var replacement = removable
+        replacement.tmuxSessionName = "kwt-ghosthub-replacement"
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removable)
+        let replacementInventory = inventory(
+            environment,
+            including: replacement
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxPathProvider: { .success("/usr/bin/tmux") },
+            kwtInventoryLoader: { _ in replacementInventory },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
         model.openBorrowedTmuxSession(selection)
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+            try await model.removeWorktree(request)
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
         await model.shutdown()
     }
 

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -80,23 +80,37 @@ struct TmuxSessionPresentationLifecycleTests {
         #expect(router.take(request, whileReviewIsPresented: false) == nil)
     }
 
-    @Test("a new tmux recovery request can open after dismissal")
-    func newTmuxRecoveryRequestCanReopen() {
-        let hostID = UUID()
+    @Test("alternating dismissed tmux recovery requests stay dismissed")
+    func alternatingDismissedTmuxRecoveryRequestsStayDismissed() {
+        let firstHostID = UUID()
+        let secondHostID = UUID()
         let first = TmuxConnectionRecoveryRequest(
-            hostID: hostID,
+            hostID: firstHostID,
             message: "SSH authentication is required."
         )
         let second = TmuxConnectionRecoveryRequest(
-            hostID: hostID,
+            hostID: secondHostID,
             message: "The SSH host key needs review."
         )
         var router = TmuxConnectionRecoveryRequestRouter()
 
         #expect(router.take(first, whileReviewIsPresented: false) == first)
-        #expect(router.take(nil, whileReviewIsPresented: false) == nil)
-        #expect(router.take(first, whileReviewIsPresented: false) == nil)
+        router.reviewDidDismiss()
         #expect(router.take(second, whileReviewIsPresented: false) == second)
+        router.reviewDidDismiss()
+        #expect(router.take(first, whileReviewIsPresented: false) == nil)
+        #expect(router.take(second, whileReviewIsPresented: false) == nil)
+
+        let manualReviewRequestID = router.recoveryRequestID(
+            for: firstHostID,
+            activeRequest: first
+        )
+        #expect(
+            router.recoveryRequestToResume(
+                reviewedHostID: firstHostID,
+                reviewRequestID: manualReviewRequestID
+            ) == first
+        )
     }
 
     @Test("tmux recovery waits for an existing SSH review to dismiss")

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -126,11 +126,10 @@ struct TmuxSessionPresentationLifecycleTests {
         _ = router.take(request, whileReviewIsPresented: false)
 
         #expect(
-            router.recoveryHostIDToResume(
+            router.recoveryRequestToResume(
                 reviewedHostID: hostID,
-                reviewRequestID: request.id,
-                activeRequest: request
-            ) == hostID
+                reviewRequestID: request.id
+            ) == request
         )
     }
 
@@ -145,10 +144,9 @@ struct TmuxSessionPresentationLifecycleTests {
         _ = router.take(request, whileReviewIsPresented: false)
 
         #expect(
-            router.recoveryHostIDToResume(
+            router.recoveryRequestToResume(
                 reviewedHostID: hostID,
-                reviewRequestID: nil,
-                activeRequest: request
+                reviewRequestID: nil
             ) == nil
         )
     }
@@ -168,11 +166,10 @@ struct TmuxSessionPresentationLifecycleTests {
         )
 
         #expect(
-            router.recoveryHostIDToResume(
+            router.recoveryRequestToResume(
                 reviewedHostID: hostID,
-                reviewRequestID: manualReviewRequestID,
-                activeRequest: request
-            ) == hostID
+                reviewRequestID: manualReviewRequestID
+            ) == request
         )
     }
 
@@ -366,8 +363,8 @@ struct TmuxSessionPresentationLifecycleTests {
         withExtendedLifetime(hostingView) {}
     }
 
-    @Test("navigation detaches an initially restored unbound session")
-    func navigationDetachesInitiallyRestoredUnboundSession() {
+    @Test("navigation hides an initially restored unbound session")
+    func navigationHidesInitiallyRestoredUnboundSession() {
         let hostID = UUID()
         let model = EndpointChangePresentationModel(
             hostID: hostID,
@@ -385,8 +382,9 @@ struct TmuxSessionPresentationLifecycleTests {
         hostingView.layoutSubtreeIfNeeded()
         RunLoop.main.run(until: Date().addingTimeInterval(0.1))
 
-        #expect(model.closedSessions.count == 1)
-        #expect(model.closedSessions.first?.name == "docbank")
+        #expect(model.hiddenSessions.count == 1)
+        #expect(model.hiddenSessions.first?.name == "docbank")
+        #expect(model.closedSessions.isEmpty)
         withExtendedLifetime(hostingView) {}
     }
 }
@@ -395,6 +393,7 @@ struct TmuxSessionPresentationLifecycleTests {
 private final class EndpointChangePresentationModel: ObservableObject {
     @Published var display: WorkspaceDisplayState
     @Published var selection: WorkspaceSelection
+    private(set) var hiddenSessions: [WorkspaceTmuxSessionSelection] = []
     private(set) var closedSessions: [WorkspaceTmuxSessionSelection] = []
     private let alternateHostID = UUID()
     let hostID: UUID
@@ -428,6 +427,16 @@ private final class EndpointChangePresentationModel: ObservableObject {
 
     func recordClosedSession(_ session: WorkspaceTmuxSessionSelection) {
         closedSessions.append(session)
+    }
+
+    func recordHiddenSession(_ session: WorkspaceTmuxSessionSelection) {
+        hiddenSessions.append(session)
+        display = Self.display(
+            hostID: hostID,
+            alternateHostID: alternateHostID,
+            destination: "old-builder",
+            activeSession: nil
+        )
     }
 
     private static func display(
@@ -478,6 +487,7 @@ private struct EndpointChangePresentationHarness: View {
                 }
             ),
             handlers: InteractionHandlers(
+                hideTmuxSession: model.recordHiddenSession,
                 closeTmuxSession: model.recordClosedSession
             ),
             selection: $model.selection

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,11 +58,15 @@ still owns geometry and tab grouping without dropping or duplicating a session.
 After assignment, the scene model owns the complete logical descriptor; delayed
 native payloads that share its window UUID but contain stale navigation or tmux
 data are rewritten before they can become persisted scene state.
-An active tmux presentation retains the worktree generation observed when it
-was established; a later non-nil generation change is a replacement even when
-inventory reuses the same runtime UUID. Scene persistence observes the complete
-captured restoration value so later generation enrichment is written without
-requiring another navigation event.
+Every explicitly opened tmux presentation is retained by that workspace scene,
+keyed by exact host, socket, and session identity. Active selection determines
+which retained surface is mounted in the visible hierarchy; navigation only
+hides the previous surface and does not terminate its tmux/SSH client or stop
+its recovery supervisor. A retained worktree presentation keeps the generation
+observed when it was established; a later non-nil generation change is a
+replacement even when inventory reuses the same runtime UUID. Scene persistence
+captures only the active presentation, while later generation enrichment is
+written without requiring another navigation event.
 Once a restored scene has current inventory, Ghosthub resolves the descriptor
 back to live models and reattaches only to the confirmed exact session.
 Missing or offline targets fail soft and remain pending across later inventory
@@ -78,7 +82,8 @@ surface when needed. Restoring the same session in more than one window may
 reproduce the existing shared-presentation behavior tracked by kata `s75s`;
 restoration does not add a separate collision policy.
 
-Closing a native tab or window closes only that workspace presentation. Closing
+Closing a native tab or window closes every retained presentation owned by that
+workspace scene. Closing
 the final workspace window leaves Ghosthub running, matching ordinary macOS
 terminal behavior; Cmd-Q remains the explicit app-termination path. Ghosthub
 confirms app termination by default, and users can disable that confirmation in
@@ -366,8 +371,10 @@ remain visible, and explicit reloads publish a user-visible result.
 
 Kwt workspaces and otherwise-unbound host sessions use the same native tmux
 client. Ghosthub never projects tmux windows or panes into a Swift split tree.
-Closing the app, changing selection, or pressing Cmd-W closes only the client;
-it never runs `kill-session`. An explicit, confirmed Kill Session action
+Changing selection only hides the previous retained client. Pressing Cmd-W
+closes the active client, while closing its workspace window or the app closes
+every client retained by that scene; none of these paths runs `kill-session`.
+An explicit, confirmed Kill Session action
 targets the exact session (`=<name>:`) on its selected default or protected
 socket only when discovery or a currently connected active attachment
 establishes that it is running. Confirmation captures the selected host
@@ -380,9 +387,10 @@ operation can fail. After success, Ghosthub closes the matching current active
 selection and navigates away only when the killed target is active at
 completion time, so switching sessions during the command is preserved. The
 action terminates all of that session's windows, panes, and processes. For SSH,
-Ghosthub supplies keepalives. Remote shell commands are one-shot; the active
-scene owns transport-status-255 recovery, probe scheduling, authentication and
-host-key escalation, and attach-only client replacement. Tmux owns all windows,
+Ghosthub supplies keepalives. Remote shell commands are one-shot; each retained
+presentation owns its own transport-status-255 recovery, probe scheduling,
+authentication and host-key escalation state, and attach-only client
+replacement. Inactive presentations remain supervised. Tmux owns all windows,
 panes, history, input, rendering, and server-side lifetime.
 
 Ghosthub applies the selected Tmux Theme when it creates a new bare session.
@@ -436,7 +444,7 @@ exhaustion and command termination may retire it. Confirmation permanently
 demotes later retries to attach-only. Host endpoint changes and scene shutdown
 cancel pending probes.
 
-Each active remote tmux presentation owns at most one native reconnect
+Each retained remote tmux presentation owns at most one native reconnect
 supervisor. It uses the host's shared in-flight default-socket inventory probe,
 or an exact headless `has-session` probe for a protected socket. Attempt starts
 follow 1, 2, 4, 8, 16, and 30-second intervals, include probe runtime, and are
@@ -444,8 +452,9 @@ bounded by a 15-second probe deadline. Transport failures continue
 automatically and **Reconnect Now** advances the existing schedule;
 authentication or host-key failures pause it and route through native SSH
 recovery. Exact absence ends an established presentation, while reachable
-non-transport failures become an unable-to-attach state. Navigation, endpoint
-changes, replacement presentations, and scene shutdown cancel stale work.
+non-transport failures become an unable-to-attach state. Endpoint changes,
+explicit closure, replacement presentations, and scene shutdown cancel stale
+work. Navigation does not cancel recovery.
 Each complete remote establishment or attachment command records its final
 status through an app-owned per-launch temporary file because libghostty's
 outer macOS login process does not reliably preserve a nested command's status.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -39,10 +39,16 @@ map, split-tree projection, or Ghosthub tab bar. Tmux owns:
 - pane processes and session lifetime
 - tmux-native key bindings and mouse behavior
 
-Ghosthub owns only inventory presentation, the disposable terminal client,
-and connection state. Navigating away, pressing Cmd-W, closing a window, or
-quitting Ghosthub detaches the client and never destroys server-side state.
-The separate Kill Session action is the only destructive lifecycle operation.
+Ghosthub owns inventory presentation, terminal clients, and connection state.
+Each workspace window retains every presentation it explicitly opens, keyed by
+the exact host, tmux socket, and session name. Navigating to another host,
+worktree, or session removes the previous surface from the visible hierarchy
+and marks it occluded without freeing the surface or terminating its tmux/SSH
+client. Returning to it reuses the same handle and surface. Cmd-W or a
+pane-originated close request detaches only the active presentation; closing a
+workspace window or quitting Ghosthub detaches every presentation owned by
+that window and never destroys server-side state. The separate Kill Session
+action is the only destructive lifecycle operation.
 It is offered only when direct discovery or a currently connected active
 attachment establishes that the session is running. Before displaying
 confirmation, Ghosthub captures tmux's server PID, `session_id`, and
@@ -99,7 +105,7 @@ by kwt, so removing and recreating a worktree at the same path cannot inherit a
 saved presentation; a missing generation restores only as far as the project.
 Once a worktree presentation has observed a generation, incomplete inventory
 cannot erase it and a different non-nil generation is treated as a replacement;
-explicitly reselecting the worktree detaches the observed presentation and
+explicitly reselecting the worktree invalidates the observed presentation and
 attaches the replacement session.
 For **Install and Relaunch**, Ghosthub also writes a one-shot ordered window
 manifest under `~/.ghosthub/` before Sparkle terminates the app. On the next
@@ -221,10 +227,11 @@ coordinator consumes that status instead of relying on libghostty's outer macOS
 login process, whose reported status may be zero even when nested OpenSSH
 exited 255.
 After a confirmed attachment exits with OpenSSH's transport/setup status 255,
-the scene's native supervisor probes the real SSH and tmux path at attempt-start
-intervals of 1, 2, 4, 8, 16, and then 30 seconds. Each probe has a 15-second
-end-to-end deadline; its runtime counts against the interval, and an overrun
-clamps the next delay to zero. Attempts never overlap. **Reconnect Now** wakes
+that retained presentation's native supervisor probes the real SSH and tmux
+path at attempt-start intervals of 1, 2, 4, 8, 16, and then 30 seconds. Each
+probe has a 15-second end-to-end deadline; its runtime counts against the
+interval, and an overrun clamps the next delay to zero. Attempts never overlap.
+**Reconnect Now** wakes
 the same supervisor immediately instead of starting a parallel path.
 
 Default-socket recovery shares the host's in-flight `list-sessions` probe with
@@ -238,13 +245,14 @@ A reachable non-transport tmux failure is presented as unable to attach rather
 than retried indefinitely. A clean detach does not start recovery.
 
 Transport failures continue retrying automatically, with no more than 30
-seconds between attempt starts. Authentication and host-key review failures
-pause automatic retry and open the existing native recovery flow. Successful
-recovery resumes the same supervisor. If SSH is already reachable when that
-flow checks again, **Retry** resumes the supervisor as well as refreshing host
-inventory. Only the recovery flow opened for that active tmux request may
-resume it; authentication started from ordinary host inventory never reopens a
-session. Dismissing it leaves an honest
+seconds between attempt starts, even while their retained presentation is
+inactive. Authentication and host-key review failures pause that presentation's
+automatic retry and appear in the existing native recovery flow when it is
+active. Successful recovery resumes the same supervisor. If SSH is already
+reachable when that flow checks again, **Retry** resumes the supervisor as well
+as refreshing host inventory. Only the recovery flow opened for that tmux
+request may resume it; authentication started from ordinary host inventory
+never reopens a session. Dismissing it leaves an honest
 **Connection needs attention** presentation with **Review Connection** when
 native review is available; reopening that review retains the active recovery
 request and can resume its supervisor after success. **Host Settings** remains

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -24,14 +24,23 @@ Select a session in the sidebar or search for it in the Command Palette with
 ++shift+cmd+p++. Ghosthub opens it through a normal local or SSH tmux
 client.
 
-Closing a tab, closing a window, switching sessions, or quitting Ghosthub only
-detaches the presentation. Tmux keeps the session and its processes alive.
+Switching to another host, worktree, or session hides the previous terminal
+without detaching it. Each workspace keeps every session you explicitly open
+connected, and returning to one reuses the same terminal and tmux client.
+
+Press ++cmd+w++ to detach only the active presentation. Closing a workspace
+tab or window detaches every presentation it owns, and quitting Ghosthub
+detaches them all. None of these actions ends a tmux session; tmux keeps the
+session and its processes alive.
 
 ## Reopen an exited standalone session
 
 If a standalone session exits while its presentation is still open, Ghosthub
 shows a **Reopen** action. Reopening creates a new tmux session with the exact
 previous name. It cannot restore processes from the exited session.
+
+A clean detach or a confirmed ended session stays closed until you explicitly
+open or reopen it.
 
 ## End a session deliberately
 

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -5,15 +5,17 @@ icon: lucide/panels-top-left
 
 # Windows and navigation
 
-Each Ghosthub workspace presentation can attach to one tmux session. Native
-macOS tabs group complete Ghosthub workspaces; they do not replace tmux windows
-or panes inside a session.
+Each Ghosthub workspace can keep multiple tmux presentations connected while
+showing one at a time. Native macOS tabs group complete Ghosthub workspaces;
+they do not replace tmux windows or panes inside a session.
 
 ## Use the sidebar
 
 The sidebar groups projects, worktrees, and standalone tmux sessions under each
-host. Select an item to attach. Expand a host to see its current inventory and
-connection diagnostics.
+host. Select an item to attach or return to its retained terminal. Moving to
+another host, worktree, or session hides the previous terminal without
+detaching its local or SSH tmux client. Expand a host to see its current
+inventory and connection diagnostics.
 
 Press ++cmd+b++ to hide or show the sidebar. Hiding it gives the terminal
 the full window while preserving its session attachment.
@@ -40,8 +42,10 @@ tab group.
 
 ## Close a presentation
 
-++cmd+w++ closes the current session presentation. ++shift+cmd+w++
-closes the containing window. Both detach from tmux; neither ends the session.
+++cmd+w++ closes and detaches only the active session presentation. Other
+sessions opened in that workspace remain connected. ++shift+cmd+w++ closes the
+containing workspace window and detaches every presentation it owns. Neither
+action ends a tmux session.
 
 Closing the final workspace leaves Ghosthub running. Use ++cmd+q++ to quit.
 Quit confirmation is enabled by default and can be changed under

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -92,9 +92,11 @@ const imageAlt = {
             plus commands to open any discovered session.
           </p>
           <p>
-            Closing a Ghosthub presentation only detaches; your work keeps
+            Switching between hosts, worktrees, and sessions keeps each opened
+            terminal connected, so returning picks up where you left off. Press
+            <kbd>⌘W</kbd> to detach only the active terminal; your work keeps
             running in tmux. See <a href="/docs/sessions/">Sessions</a> for
-            session lifecycle, hiding, and confirmed kill controls.
+            session lifecycle and confirmed kill controls.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Navigating between hosts, worktrees, or standalone tmux sessions currently shares the closure lifecycle, so Ghosthub destroys the previous libghostty surface and SSH/tmux client even though the workspace window still owns that presentation. That makes ordinary navigation unnecessarily expensive, changes attachment identity, and stops supervising the connection that the user explicitly opened.

Separate active selection from each window’s retained presentation registry. Hidden surfaces and their endpoint-specific clients remain alive and independently supervised until explicit close, endpoint invalidation, replacement of a recreated worktree, or window/app shutdown. Cmd-W still detaches only the active presentation, and Kill Session remains the only operation that destroys server-side state.

Validated with focused lifecycle suites, `make test-essential-workflows`, `make test-libghostty-bootstrap`, 132 Python tests, the full Swift and libghostty smoke suite, `make build`, formatting, and commit hooks.