### PR TITLE
Publish comprehensive user documentation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -39,9 +39,6 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          cache-dependency-glob: website/docs/uv.lock
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm lint

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -39,6 +39,9 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache-dependency-glob: website/docs/uv.lock
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm lint

--- a/.vercelignore
+++ b/.vercelignore
@@ -6,6 +6,7 @@
 website/node_modules
 website/dist
 website/.astro
+website/.cache
 website/.env*
 website/**/.env*
 website/.vercel

--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ docs-serve:
 	@cd docs && $(UV) run --frozen ./zensical-docs.sh serve
 
 site-docs-serve:
-	@cd website && $(UV) run --project docs --frozen zensical serve --config-file zensical.toml
+	@cd website && ./scripts/run-uv.sh run --project docs --frozen zensical serve --config-file zensical.toml
 
 site-deploy:
 	@cd website && $(PNPM) build

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ KWT_SOURCE_REVISION ?= unpinned
 endif
 SWIFT_TEST_FILTER ?=
 
-.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows test-ssh-authentication-live build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach purge-test-tmux python-test test smoke-test docs-build docs-serve site-deploy reset-app-state install-hooks format format-check
+.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows test-ssh-authentication-live build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach purge-test-tmux python-test test smoke-test docs-build docs-serve site-docs-serve site-deploy reset-app-state install-hooks format format-check
 
 help:
 	@printf '%s\n' \
@@ -114,7 +114,9 @@ help:
 		'  make docs-build' \
 		'      Build the Zensical documentation site under docs/site.' \
 		'  make docs-serve' \
-		'      Serve the Zensical documentation site locally.' \
+		'      Serve the internal Zensical engineering documentation locally.' \
+		'  make site-docs-serve' \
+		'      Serve the public Zensical user documentation locally.' \
 		'  make site-deploy' \
 		'      Build the marketing site and deploy it to production with Vercel.' \
 		'  make reset-app-state' \
@@ -427,6 +429,9 @@ docs-build:
 
 docs-serve:
 	@cd docs && $(UV) run --frozen ./zensical-docs.sh serve
+
+site-docs-serve:
+	@cd website && $(UV) run --project docs --frozen zensical serve --config-file zensical.toml
 
 site-deploy:
 	@cd website && $(PNPM) build

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
   ·
   <a href="https://ghosthub.ai/guide/"><strong>Guide</strong></a>
   ·
+  <a href="https://ghosthub.ai/docs/"><strong>Docs</strong></a>
+  ·
   <a href="CHANGELOG.md"><strong>Changelog</strong></a>
   ·
   <a href="https://discord.gg/nEB7VaAnU9"><strong>Discord</strong></a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,9 @@
 The maintained docs are a Zensical site rooted in this directory. They are for
 Kenn engineers and approved contributors who build, operate, and release
 Ghosthub. Public product guidance lives on
-[ghosthub.ai](https://ghosthub.ai/guide/).
+[ghosthub.ai](https://ghosthub.ai/guide/), and comprehensive public user
+documentation lives in [`../website/docs`](../website/docs/README.md) for
+publication at [ghosthub.ai/docs](https://ghosthub.ai/docs/).
 
 ## Site Pages
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,6 +1,10 @@
 node_modules/
 dist/
 .astro/
+.cache/
+public/docs/
+public/docs.md
+public/llms.txt
 # Synced from the orphan website-assets branch by scripts/sync-assets.sh
 src/assets/*.png
 src/assets/*.png.placeholder

--- a/website/README.md
+++ b/website/README.md
@@ -17,11 +17,12 @@ documentation and has a separate build.
     pnpm test       # vitest unit tests
     pnpm build      # production build to dist/
 
-The website build uses `uv` for Zensical. CI installs it directly; other clean
-build environments use the checksum-pinned bootstrap in `scripts/run-uv.sh`.
-To preview only the public docs:
+The website build uses the checksum-pinned `uv` bootstrap in
+`scripts/run-uv.sh` in local, CI, and deployment environments. The pinned
+binary is cached under `website/.cache/` after its first verified install. To
+preview only the public docs:
 
-    uv run --project docs zensical serve --config-file zensical.toml
+    ./scripts/run-uv.sh run --project docs --frozen zensical serve --config-file zensical.toml
 
 Constants (repo slug, Discord invite) live in `src/config.ts`.
 

--- a/website/README.md
+++ b/website/README.md
@@ -17,10 +17,11 @@ documentation and has a separate build.
     pnpm test       # vitest unit tests
     pnpm build      # production build to dist/
 
-The website build uses the checksum-pinned `uv` bootstrap in
-`scripts/run-uv.sh` in local, CI, and deployment environments. The pinned
-binary is cached under `website/.cache/` after its first verified install. To
-preview only the public docs:
+The website build downloads repository-supported `uv` platform archives with
+repository-pinned archive and executable checksums through `scripts/run-uv.sh`
+in local, CI, and deployment environments. The verified binary is cached under
+`website/.cache/` and rechecked before every use. To preview only the public
+docs:
 
     ./scripts/run-uv.sh run --project docs --frozen zensical serve --config-file zensical.toml
 

--- a/website/README.md
+++ b/website/README.md
@@ -4,12 +4,24 @@ Marketing site for Ghosthub. Astro static site, deployed through Vercel's
 CLI. `.github/workflows/website.yml` is CI only (check, lint, test, build); it
 does not deploy.
 
+The public, task-oriented Zensical documentation lives in `docs/` and is
+published under `/docs/` by the same build. Each documentation page is also
+published as Markdown at its sibling `.md` URL, and `docs/llms.txt` becomes
+`/llms.txt`. The repository-root `docs/` directory remains internal engineering
+documentation and has a separate build.
+
     pnpm install
     pnpm dev        # local dev server
     pnpm check      # type-check templates
     pnpm lint       # oxlint
     pnpm test       # vitest unit tests
     pnpm build      # production build to dist/
+
+The website build uses `uv` for Zensical. CI installs it directly; other clean
+build environments use the checksum-pinned bootstrap in `scripts/run-uv.sh`.
+To preview only the public docs:
+
+    uv run --project docs zensical serve --config-file zensical.toml
 
 Constants (repo slug, Discord invite) live in `src/config.ts`.
 

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -1,0 +1,23 @@
+# Ghosthub User Documentation
+
+This directory contains the public, task-oriented documentation published at
+[ghosthub.ai/docs](https://ghosthub.ai/docs/). The visual
+[Guide](https://ghosthub.ai/guide/) remains a short product tour; detailed
+instructions belong here.
+
+Build the complete website from `website/`:
+
+```bash
+corepack pnpm build
+```
+
+Preview only the Zensical documentation while editing:
+
+```bash
+uv run --project docs zensical serve --config-file zensical.toml
+```
+
+Keep page sources flat in `content/`. A source named `sessions.md` is published
+as both `/docs/sessions/` and `/docs/sessions.md`. The landing page is published
+as `/docs/` and `/docs.md`. Add every public page to `zensical.toml` and
+`llms.txt`.

--- a/website/docs/content/getting-started.md
+++ b/website/docs/content/getting-started.md
@@ -1,0 +1,75 @@
+---
+description: Install Ghosthub and attach to your first local tmux session.
+icon: lucide/rocket
+---
+
+# Getting started
+
+## Requirements
+
+Ghosthub currently requires:
+
+- an Apple Silicon Mac
+- macOS 26 (Tahoe) or newer
+- tmux 3.2 or newer on the local Mac and on each remote macOS or Linux host
+
+Native Windows hosts are experimental and have additional requirements. See
+[Remote Hosts](remote-hosts.md#experimental-windows-hosts).
+
+## Install Ghosthub
+
+Install the signed, notarized app from the Kenn Homebrew tap:
+
+```sh
+brew install kenn-io/tap/ghosthub
+```
+
+Then launch **Ghosthub** from **Applications**.
+
+As a manual alternative, download the latest DMG from
+[GitHub Releases](https://github.com/kenn-io/ghosthub/releases), open it, and
+drag **Ghosthub** to **Applications**.
+
+If tmux is not installed locally:
+
+```sh
+brew install tmux
+```
+
+Verify it with:
+
+```sh
+tmux -V
+```
+
+## Open an existing session
+
+1. Launch Ghosthub.
+2. Expand your Mac under **Hosts** in the sidebar.
+3. Select an existing tmux session.
+
+Ghosthub attaches an ordinary tmux client to that session. Existing tmux
+windows, panes, processes, history, key bindings, and plugins stay under tmux's
+control.
+
+## Create a session
+
+1. Open the **+** menu beside your Mac in the sidebar.
+2. Choose **New Session**.
+3. Enter a tmux session name and create it.
+
+The session is not tied to a Git repository. Close the Ghosthub window or tab
+to detach; your shell and other processes continue running in tmux.
+
+## What to do next
+
+- Learn the full session lifecycle in [Sessions](sessions.md).
+- Add a machine over SSH in [Remote Hosts](remote-hosts.md).
+- Add Git repository context in [Projects and Worktrees](projects-worktrees.md).
+- Learn the main navigation commands in
+  [Windows and Navigation](windows-navigation.md).
+
+!!! note "Worktrees are optional"
+
+    You do not need kwt, a Git repository, or a worktree to use Ghosthub as a
+    local and remote tmux session switcher.

--- a/website/docs/content/index.md
+++ b/website/docs/content/index.md
@@ -41,7 +41,8 @@ Ghosthub is a tmux client, not a replacement for tmux.
 
 Tmux continues to own windows, panes, layout, history, and running processes.
 Closing a Ghosthub presentation detaches from a session; it does not end the
-session. Only an explicit, confirmed kill action ends one.
+session. A session ends only through an explicit, confirmed **Kill Session**
+action or removal of a worktree whose verified live session must be terminated.
 
 Ghosthub uses an ordinary local or SSH tmux client for every attachment. It
 does not use tmux control mode and it does not reconstruct terminal state in

--- a/website/docs/content/index.md
+++ b/website/docs/content/index.md
@@ -1,0 +1,58 @@
+---
+description: Comprehensive user documentation for Ghosthub.
+icon: lucide/book-open
+---
+
+# Ghosthub documentation
+
+Ghosthub is a native macOS terminal for your local and remote tmux sessions. It
+can attach to any ordinary tmux session without Git setup. When you want
+project context, it can also create and manage tmux sessions bound to Git
+worktrees.
+
+These docs explain how to operate Ghosthub. For a shorter, visual introduction,
+start with the [five-minute Guide](https://ghosthub.ai/guide/).
+
+## Start here
+
+| If you want to… | Read… |
+| --- | --- |
+| Install Ghosthub and open a first session | [Getting Started](/docs/getting-started/) |
+| Create, attach to, detach from, or end a tmux session | [Sessions](/docs/sessions/) |
+| Connect a Mac, Linux, or experimental Windows host | [Remote Hosts](/docs/remote-hosts/) |
+| Register a Git repository or create a worktree | [Projects and Worktrees](/docs/projects-worktrees/) |
+| Use windows, tabs, the sidebar, or the Command Palette | [Windows and Navigation](/docs/windows-navigation/) |
+| Change fonts, colors, shell behavior, or tmux themes | [Terminal Configuration](/docs/terminal-configuration/) |
+| Find an application shortcut | [Keyboard Shortcuts](/docs/keyboard-shortcuts/) |
+| Understand anonymous usage reporting and stored data | [Privacy](/docs/privacy/) |
+| Diagnose a connection, tmux, or worktree problem | [Troubleshooting](/docs/troubleshooting/) |
+
+## The important mental model
+
+Ghosthub is a tmux client, not a replacement for tmux.
+
+- **Hosts** are the local Mac or machines reached over SSH.
+- **Sessions** are ordinary tmux sessions on a host. They do not need a Git
+  repository.
+- **Projects** are Git repositories registered with
+  [kwt](https://kwt.sh) on a particular host.
+- **Worktrees** are project checkouts with an exact, canonical tmux session
+  name supplied by kwt.
+
+Tmux continues to own windows, panes, layout, history, and running processes.
+Closing a Ghosthub presentation detaches from a session; it does not end the
+session. Only an explicit, confirmed kill action ends one.
+
+Ghosthub uses an ordinary local or SSH tmux client for every attachment. It
+does not use tmux control mode and it does not reconstruct terminal state in
+Swift.
+
+## Human and machine-readable pages
+
+Every page has an HTML URL and a Markdown twin. For example:
+
+- `https://ghosthub.ai/docs/sessions/`
+- `https://ghosthub.ai/docs/sessions.md`
+
+The complete machine-readable index is available at
+[`https://ghosthub.ai/llms.txt`](https://ghosthub.ai/llms.txt).

--- a/website/docs/content/keyboard-shortcuts.md
+++ b/website/docs/content/keyboard-shortcuts.md
@@ -1,0 +1,26 @@
+---
+description: Keyboard shortcuts for Ghosthub application and workspace actions.
+icon: lucide/keyboard
+---
+
+# Keyboard shortcuts
+
+| Action | Shortcut |
+| --- | --- |
+| Open Settings | ++cmd+comma++ |
+| Reload terminal configuration | ++shift+cmd+comma++ |
+| Open Command Palette | ++shift+cmd+p++ |
+| Hide or show the sidebar | ++cmd+b++ |
+| Select worktree 1–9 | ++cmd+1++ through ++cmd+9++ |
+| Select previous worktree | ++option+cmd+up++ |
+| Select next worktree | ++option+cmd+down++ |
+| Create or import a worktree | ++shift+cmd+n++ |
+| New window | ++cmd+n++ |
+| New tab | ++cmd+t++ |
+| Close session presentation | ++cmd+w++ |
+| Close window | ++shift+cmd+w++ |
+| Open application log | ++option+cmd+l++ |
+| Quit Ghosthub | ++cmd+q++ |
+
+Closing a presentation, window, or the app detaches from tmux. It does not end
+the session.

--- a/website/docs/content/privacy.md
+++ b/website/docs/content/privacy.md
@@ -1,0 +1,51 @@
+---
+description: Understand Ghosthub anonymous usage reporting and local state.
+icon: lucide/shield-check
+---
+
+# Privacy
+
+## Anonymous usage data
+
+Packaged Ghosthub releases send at most one anonymous `application active`
+event per day. The event contains:
+
+- a random installation ID
+- the Ghosthub version
+- the build number
+
+It does not contain repository, worktree, host, session, path, command, or
+terminal data. PostHog person profiles and GeoIP enrichment are disabled.
+
+Turn reporting off at any time under **Settings → Privacy → Share anonymous
+usage data**.
+
+## Local state
+
+Ghosthub's mutable application state lives under:
+
+```text
+~/.ghosthub/
+```
+
+Ghosthub-owned terminal configuration lives separately at:
+
+```text
+~/.config/ghosthub/ghostty.conf
+```
+
+Other Ghosthub preferences, including hidden standalone tmux session patterns,
+live in:
+
+```text
+~/.config/ghosthub/config.toml
+```
+
+## Remote state
+
+Ghosthub does not scan remote filesystems. **Add Project** delegates only the
+absolute repository path you explicitly provide. When you approve installation
+of a managed kwt helper, Ghosthub stores its matching revision-pinned helper
+under the remote user's `~/.ghosthub/` directory.
+
+Interactive SSH responses are retained only for the running app session.

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -1,0 +1,90 @@
+---
+description: Register Git projects and create, import, use, and remove worktrees.
+icon: lucide/git-branch
+---
+
+# Projects and worktrees
+
+Projects and worktrees add Git context to Ghosthub's ordinary tmux workflow.
+They are optional.
+
+Ghosthub delegates repository and worktree identity to
+[kwt](https://kwt.sh). Packaged builds use their revision-pinned bundled kwt
+locally and a matching managed helper on remote macOS or Linux hosts.
+
+## Register a project
+
+Start with an existing Git checkout on the target host.
+
+1. Open the **+** menu beside the local Mac or a remote macOS or Linux host.
+2. Choose **Add Project**.
+3. Enter the checkout's absolute path on that host.
+4. Confirm the registration.
+
+Ghosthub registers that one path through kwt and refreshes inventory. It does
+not scan the machine or edit kwt configuration itself.
+
+Remote hosts need the [managed kwt helper](remote-hosts.md#install-the-managed-kwt-helper)
+first. Project registration is not yet available for native Windows hosts.
+
+If the SSH destination changes while the Add Project sheet is open, close the
+sheet and start again so the confirmation applies to the current host.
+
+## Open a project checkout
+
+Select the project's primary checkout or any linked worktree in the sidebar.
+Kwt supplies the exact canonical tmux session name. Ghosthub creates or repairs
+that session when necessary and then attaches an ordinary tmux client.
+
+## Create a worktree from a branch
+
+1. Select the project.
+2. Press ++shift+cmd+n++ or choose the new-worktree action.
+3. Select **Branch**.
+4. Search local and remote branches that are not already checked out, or type a
+   new branch name.
+5. Confirm the worktree.
+
+Selecting a remote source creates a local tracking branch when needed. The
+picker distinguishes same-named sources. Input that does not match an existing
+branch creates a new branch.
+
+## Import a GitHub pull request
+
+Pull-request import requires the [GitHub CLI](https://cli.github.com/) on the
+host that contains the project—not merely on the Mac running Ghosthub.
+
+On that host:
+
+```sh
+gh auth login
+```
+
+For an HTTPS Git remote, Git authentication must also work there. GitHub CLI
+can configure itself as the credential helper:
+
+```sh
+gh auth setup-git
+```
+
+Then select the project, press ++shift+cmd+n++, choose **Pull Request**, and
+search for an open pull request. Ghosthub asks kwt to import it and selects the
+resulting worktree session.
+
+## Remove a worktree
+
+Hover over a non-primary worktree in the sidebar and choose **×**. After you
+confirm the exact worktree and host, Ghosthub:
+
+1. ends that worktree's verified live tmux session when necessary; and
+2. asks kwt to remove the checkout.
+
+The Git branch is kept. If the checkout is already absent, Ghosthub skips the
+redundant filesystem removal but still reconciles the exact live session
+covered by the confirmation.
+
+## Rearrange worktrees
+
+Drag worktrees within a project to set their display order. The insertion line
+shows the destination. This changes Ghosthub's navigation only; it does not
+rename or reorder anything in Git, kwt, or tmux.

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -1,0 +1,115 @@
+---
+description: Configure SSH hosts, trust, authentication, remote helpers, and reconnect behavior.
+icon: lucide/server
+---
+
+# Remote hosts
+
+Ghosthub can discover and attach to tmux sessions on remote macOS and Linux
+machines over SSH. Native Windows hosts using psmux are experimental.
+
+## Before you add a host
+
+A macOS or Linux host needs:
+
+- a working OpenSSH server
+- tmux 3.2 or newer
+- a destination that your Mac's OpenSSH configuration can resolve
+
+Test the same destination in Terminal first when diagnosing configuration or
+authentication:
+
+```sh
+ssh devbox
+```
+
+Ghosthub follows OpenSSH configuration for users, ports, identity files,
+agents, host-key policies, and supported jump routing.
+
+## Add and test a host
+
+1. Open **Settings → Hosts**.
+2. Add a destination such as `devbox`, `alice@build-server`, or a configured SSH
+   alias.
+3. Choose the host platform.
+4. Select **Test Connection**.
+
+An unreachable host does not block discovery or use of the rest of the fleet.
+An expanded, reachable host with no projects or tmux sessions says so in the
+sidebar.
+
+## Host-key trust
+
+When OpenSSH encounters an unseen key under an interactive trust policy,
+Ghosthub presents the exact destination and fingerprint for review. Approve it
+only after comparing the fingerprint through a trusted channel.
+
+ProxyJump routes are reviewed one hop at a time, and every trust or credential
+prompt identifies the machine that controls it. Ghosthub rejects opaque
+`ProxyCommand` routes and jump hosts that themselves use another proxy because
+it cannot safely present the intermediate trust boundaries.
+
+## Authentication
+
+Ghosthub uses your OpenSSH identities and agent configuration. When SSH asks an
+interactive question, Ghosthub presents a native secure-entry sheet naming the
+host that requested the response. The response is kept only for the running app
+session. **Continue** can intentionally submit an empty response when the
+challenge requires one.
+
+If a host shows a caution icon, select it to review trust, authenticate, or
+retry. A successful ordinary host-inventory authentication refreshes inventory;
+it does not open a tmux session by itself.
+
+## Automatic reconnect
+
+If an active SSH connection drops, Ghosthub shows **Connection interrupted**
+and retries automatically, with no more than 30 seconds between attempts.
+Choose **Reconnect Now** to try immediately. When the connection returns,
+Ghosthub reattaches to the same exact tmux session; the server-side processes
+were never moved into Ghosthub.
+
+If SSH needs authentication or host-key review, the presentation changes to
+**Connection needs attention**. Complete the native recovery flow to resume the
+same reconnect supervisor. If you dismiss it, choose **Review Connection** to
+open it again.
+
+## Install the managed kwt helper
+
+Tmux-only hosts do not need kwt. To show projects and worktrees on a remote
+macOS or Linux host:
+
+1. Test the host connection successfully.
+2. Choose **Install kwt Worktree Helper** in Host Settings.
+3. Confirm the upload.
+
+Ghosthub copies its matching revision-pinned helper for the remote operating
+system and CPU, verifies it, and stores it under `~/.ghosthub/`. It does not
+install or replace a system-wide kwt.
+
+Register individual repositories with the explicit **Add Project** action.
+Ghosthub never scans a remote filesystem. See
+[Projects and Worktrees](projects-worktrees.md).
+
+## Tailscale hosts
+
+Importing a Tailscale peer preserves its full MagicDNS name. Ghosthub uses the
+user selected by OpenSSH configuration and falls back to the local macOS user
+name when none is configured.
+
+## Experimental Windows hosts
+
+Native Windows support requires:
+
+- Windows 11 build 22523 or newer
+- Windows OpenSSH
+- Windows PowerShell 5.1 or newer
+- [psmux](https://github.com/marlocarlo/psmux) with its `tmux.exe`
+  compatibility alias available
+
+Choose **Windows (psmux)** when adding the host. After a successful connection
+test, **Install Bundled kwt** can upload the matching AMD64 or ARM64 helper for
+that user. The Windows helper is currently unsigned, so this path is intended
+for development machines and power users. Adding a new project from Ghosthub is
+not yet supported on Windows, although already registered project inventory can
+be shown.

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -1,0 +1,75 @@
+---
+description: Create, attach to, detach from, reopen, hide, and end tmux sessions.
+icon: lucide/square-terminal
+---
+
+# Sessions
+
+Ghosthub discovers every tmux session on each reachable configured host.
+Sessions that are not bound to a kwt workspace appear directly under the host.
+Worktree-backed sessions appear inside their project.
+
+## Create a standalone session
+
+1. Open the **+** menu beside a host.
+2. Choose **New Session**.
+3. Enter the tmux session name.
+
+The new session is an ordinary tmux session. It remains usable from the `tmux`
+CLI and other tmux clients.
+
+## Attach and detach
+
+Select a session in the sidebar or search for it in the Command Palette with
+++shift+cmd+p++. Ghosthub opens it through a normal local or SSH tmux
+client.
+
+Closing a tab, closing a window, switching sessions, or quitting Ghosthub only
+detaches the presentation. Tmux keeps the session and its processes alive.
+
+## Reopen an exited standalone session
+
+If a standalone session exits while its presentation is still open, Ghosthub
+shows a **Reopen** action. Reopening creates a new tmux session with the exact
+previous name. It cannot restore processes from the exited session.
+
+## End a session deliberately
+
+To end a standalone session that Ghosthub knows is running, hover over its
+sidebar row and choose the subtle **×** control. For a worktree-backed session,
+use **Kill Session…** in the worktree action menu.
+
+Ghosthub confirms the host and exact tmux session before it sends
+`kill-session`. Ending a session terminates all of its windows, panes, and
+processes and cannot be undone.
+
+Ghosthub cancels the operation if the host connection changes, or if the
+original session disappears and another session appears under the same name.
+If the command fails, the active attachment remains open.
+
+!!! warning "Killing a session is different from removing a worktree"
+
+    **Kill Session…** ends tmux processes but keeps the checkout. Removing a
+    worktree ends its verified live session when necessary and then removes the
+    checkout, while keeping the Git branch. See
+    [Remove a worktree](projects-worktrees.md#remove-a-worktree).
+
+## Hide standalone sessions
+
+To keep tool-owned or noisy standalone sessions out of the sidebar:
+
+1. Open **Settings → Worktrees**.
+2. Add hidden tmux session patterns, one per line.
+
+Patterns are case-sensitive. `*` matches any number of characters and `?`
+matches one character. Ghosthub stores these patterns in
+`~/.config/ghosthub/config.toml`.
+
+The patterns apply only to standalone sessions. A matching kwt workspace stays
+visible under its project.
+
+## Ownership and safety
+
+Ghosthub does not infer that closing a presentation means ending work. It only
+destroys a session after the explicit, confirmed kill action. Sessions created
+outside Ghosthub receive the same protection as sessions created inside it.

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -70,6 +70,8 @@ visible under its project.
 
 ## Ownership and safety
 
-Ghosthub does not infer that closing a presentation means ending work. It only
-destroys a session after the explicit, confirmed kill action. Sessions created
-outside Ghosthub receive the same protection as sessions created inside it.
+Ghosthub does not infer that closing a presentation means ending work. It
+destroys a session only after an explicit, confirmed **Kill Session** action or
+as part of confirmed worktree removal when that worktree has a verified live
+session. Sessions created outside Ghosthub receive the same protection as
+sessions created inside it.

--- a/website/docs/content/stylesheets/extra.css
+++ b/website/docs/content/stylesheets/extra.css
@@ -1,0 +1,16 @@
+:root {
+  --md-primary-fg-color: #00a884;
+  --md-accent-fg-color: #00cfa3;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #0b1012;
+  --md-default-fg-color: #e8f0ee;
+  --md-primary-fg-color: #00cfa3;
+  --md-accent-fg-color: #44dfbd;
+}
+
+.md-header__topic:first-child {
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+}

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -1,0 +1,64 @@
+---
+description: Configure Ghosthub's libghostty terminal and tmux session themes.
+icon: lucide/settings-2
+---
+
+# Terminal configuration
+
+Ghosthub embeds libghostty for terminal rendering. It does not embed or run
+Ghostty.app, and Ghostty.app is not a runtime dependency.
+
+## Configuration file
+
+Ghosthub's terminal configuration lives at:
+
+```text
+~/.config/ghosthub/ghostty.conf
+```
+
+The file uses [Ghostty's configuration format](https://ghostty.org/docs/config/reference),
+but it is owned and loaded independently by Ghosthub. Global Ghostty.app
+configuration does not affect Ghosthub.
+
+Ghosthub reloads terminal configuration after the file changes. Use
+++shift+cmd+comma++ to request a reload immediately.
+
+## Shell startup
+
+For local shells, Ghosthub preserves libghostty's normal macOS login-shell and
+shell-integration behavior. It does not force a custom shell command by
+default. Your ordinary zsh startup files and key bindings should load as they
+do in a native macOS terminal.
+
+Ghosthub avoids inheriting launcher-terminal `EDITOR` and `VISUAL` values that
+can unexpectedly change zsh keymaps. It sets `TERM_PROGRAM` to `ghosthub`.
+
+## Tmux themes
+
+The **Tmux Theme** picker in Settings supplies colors for new sessions created
+by Ghosthub. When **Follow ghostty.conf** is selected, the effective foreground
+and background follow the current light or dark appearance.
+
+Existing tmux sessions keep their own appearance by default. This avoids
+silently repainting a shared session for every attached client.
+
+To change the active connected session once, choose **Session → Apply Theme to
+Current Session** or the matching Command Palette action. It updates the
+session's existing windows and tmux chrome for all attached clients.
+
+To style future attachments to shared sessions automatically, enable **Apply
+theme to shared tmux sessions** in Settings. This is an explicit opt-in.
+
+Theme application is not available for the Console Panel or native Windows
+sessions.
+
+## Clipboard behavior
+
+Remote tmux copy mode can copy text to the Mac clipboard through OSC 52. Paste
+uses the configured terminal shortcut and libghostty's safe paste path.
+
+## Quit behavior
+
+**Confirm before quitting Ghosthub** is enabled by default under
+**Settings → Terminal**. Quitting the app or closing its windows detaches from
+tmux and leaves sessions running.

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -1,0 +1,83 @@
+---
+description: Diagnose common Ghosthub installation, SSH, tmux, and worktree problems.
+icon: lucide/life-buoy
+---
+
+# Troubleshooting
+
+## A host does not connect
+
+Test the exact destination outside Ghosthub:
+
+```sh
+ssh devbox
+```
+
+Resolve OpenSSH configuration, routing, agent, or server problems there first.
+Then open **Settings → Hosts**, test the connection, and address any trust or
+authentication prompt naming the failing host or ProxyJump hop.
+
+Ghosthub does not support opaque `ProxyCommand` routes or a jump host that
+itself uses another proxy.
+
+## A remote host connects but shows no sessions
+
+Confirm tmux is installed on the remote host:
+
+```sh
+tmux -V
+tmux list-sessions
+```
+
+An expanded host with no discovered tmux sessions or projects reports that it
+is empty. Project inventory is separate from SSH reachability, so a reachable
+host can also show a separate kwt diagnostic.
+
+## Reconnect needs attention
+
+Automatic retry pauses for action when SSH requires a credential or host-key
+decision. Choose **Review Connection**, complete the native prompt, and let the
+existing presentation resume. **Reconnect Now** performs an immediate retry
+when no review is pending.
+
+## A project does not appear
+
+For a remote macOS or Linux host, first install the managed kwt helper from
+Host Settings. Then use the host's **Add Project** action and provide the
+absolute path to an existing checkout on that host. Ghosthub does not discover
+repositories by scanning.
+
+Project registration is not yet supported for native Windows hosts.
+
+## Pull-request import fails
+
+Run these checks on the machine that contains the project:
+
+```sh
+gh auth status
+git remote -v
+git fetch --dry-run
+```
+
+For HTTPS GitHub remotes, `gh auth setup-git` can configure GitHub CLI as the
+Git credential helper. Installing or authenticating `gh` only on the local Mac
+does not help a project stored on a remote host.
+
+## A shell key binding behaves differently
+
+Check `~/.config/ghosthub/ghostty.conf` and your normal shell startup files.
+Ghosthub uses libghostty's macOS login-shell path and shell integration. Do not
+disable shell integration as a key-binding workaround.
+
+If Ghosthub was launched from another terminal, quit and reopen it from
+**Applications** to eliminate unusual launcher environment as a diagnostic
+step.
+
+## Find the application log
+
+Press ++option+cmd+l++ to open the application log. Include the relevant
+diagnostic text, Ghosthub version, macOS version, and reproducible steps when
+filing a [GitHub issue](https://github.com/kenn-io/ghosthub/issues).
+
+Do not publish passwords, private keys, session output, repository secrets, or
+private hostnames in a public issue.

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -1,0 +1,65 @@
+---
+description: Navigate hosts and sessions with the sidebar, Command Palette, windows, and tabs.
+icon: lucide/panels-top-left
+---
+
+# Windows and navigation
+
+Each Ghosthub workspace presentation can attach to one tmux session. Native
+macOS tabs group complete Ghosthub workspaces; they do not replace tmux windows
+or panes inside a session.
+
+## Use the sidebar
+
+The sidebar groups projects, worktrees, and standalone tmux sessions under each
+host. Select an item to attach. Expand a host to see its current inventory and
+connection diagnostics.
+
+Press ++cmd+b++ to hide or show the sidebar. Hiding it gives the terminal
+the full window while preserving its session attachment.
+
+## Use the Command Palette
+
+Press ++shift+cmd+p++ and type to search:
+
+- hosts, projects, worktrees, and standalone sessions
+- settings pages
+- session lifecycle commands
+- appearance and theme commands
+
+Press Return to perform the selected action.
+
+## Open tabs and windows
+
+- ++cmd+t++ opens a workspace tab in the current window.
+- ++cmd+n++ opens a separate workspace window.
+
+Each can attach to a different local or remote tmux session. Use the macOS
+**Window** menu to move a tab into its own window or merge windows into a native
+tab group.
+
+## Close a presentation
+
+++cmd+w++ closes the current session presentation. ++shift+cmd+w++
+closes the containing window. Both detach from tmux; neither ends the session.
+
+Closing the final workspace leaves Ghosthub running. Use ++cmd+q++ to quit.
+Quit confirmation is enabled by default and can be changed under
+**Settings → Terminal**.
+
+## Restore workspaces after launch or update
+
+Ghosthub asks macOS to restore native windows and tabs. It reconnects each
+saved presentation only when it can confirm the exact tmux session. Offline SSH
+hosts continue retrying as inventory refreshes.
+
+During an update relaunch, Ghosthub recreates saved windows if macOS does not
+return them. A window that previously had no terminal attached restores its
+navigation state without creating a worktree session. Select the worktree when
+you are ready to attach.
+
+## Rearrange navigation
+
+Drag worktrees within a project or standalone tmux sessions within a host. The
+insertion line previews the destination. Ghosthub remembers this display order
+without changing anything in Git, kwt, or tmux.

--- a/website/docs/llms.txt
+++ b/website/docs/llms.txt
@@ -1,0 +1,24 @@
+# Ghosthub
+
+> Ghosthub is a native macOS terminal for creating and attaching to local and remote tmux sessions, with optional git worktree management.
+
+Ghosthub is alpha software. The Guide is a short visual tour; the Docs links below are comprehensive task-oriented references. Markdown versions are canonical for machine readers.
+
+## Docs
+
+- [Documentation overview](https://ghosthub.ai/docs.md): Mental model and documentation map
+- [Getting started](https://ghosthub.ai/docs/getting-started.md): Requirements, installation, and first session
+- [Sessions](https://ghosthub.ai/docs/sessions.md): Create, attach, detach, reopen, hide, and kill tmux sessions
+- [Remote hosts](https://ghosthub.ai/docs/remote-hosts.md): SSH setup, trust, authentication, reconnect, and supported hosts
+- [Projects and worktrees](https://ghosthub.ai/docs/projects-worktrees.md): Register repositories and manage branch- or pull-request-backed worktrees
+- [Windows and navigation](https://ghosthub.ai/docs/windows-navigation.md): Sidebar, Command Palette, windows, tabs, and restoration
+- [Terminal configuration](https://ghosthub.ai/docs/terminal-configuration.md): Ghosthub-owned libghostty configuration and tmux themes
+- [Keyboard shortcuts](https://ghosthub.ai/docs/keyboard-shortcuts.md): Application and workspace shortcuts
+- [Privacy](https://ghosthub.ai/docs/privacy.md): Anonymous usage data and local state
+- [Troubleshooting](https://ghosthub.ai/docs/troubleshooting.md): Common local, SSH, tmux, and worktree problems
+
+## Other
+
+- [Five-minute Guide](https://ghosthub.ai/guide/): High-level visual product tour
+- [Source repository](https://github.com/kenn-io/ghosthub): Source, releases, changelog, and issue tracker
+- [kwt](https://kwt.sh): Git worktree manager used for optional project and worktree workflows

--- a/website/docs/pyproject.toml
+++ b/website/docs/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "ghosthub-user-documentation"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "zensical==0.0.43",
+]
+
+[tool.uv]
+package = false

--- a/website/docs/uv.lock
+++ b/website/docs/uv.lock
@@ -1,0 +1,271 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
+]
+
+[[package]]
+name = "ghosthub-user-documentation"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "zensical" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "zensical", specifier = "==0.0.43" }]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/85/ec45162e7824a8f879d887ef0774ee65926bf7d1064e2eebccc7eaee3378/zensical-0.0.43.tar.gz", hash = "sha256:dc2d3804ff562795c1024130e0c3ce79736467930729dda314f096d0e35b98c8", size = 3932396, upload-time = "2026-05-19T09:44:07.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/c2/55e0709607ae41c266987c3b91a1a9702b37fbbef0d07eddfe5e25c2d823/zensical-0.0.43-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:17c335362b6bac3a50178181694a964f6d9f0c516fc532129ba5a0a5c4103fb6", size = 12706531, upload-time = "2026-05-19T09:43:32.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/64/ce8627bc5ea30556162b29b041fe97d6a6aef2a87b51f12def628e4fa608/zensical-0.0.43-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8fe97f185194215f6193af45a17d2b30ebd72c8113e3650f2d7d6767b9c2206", size = 12563012, upload-time = "2026-05-19T09:43:35.962Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d1/533bc9454f0e06b3d9d8bd2e7ac405308c3d4dee6572acab98f0ed6d1c07/zensical-0.0.43-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c4c85978c765b3e7f347e8102dfe1373d4bbe4229d7008b6bdbf352f1fbcd7f", size = 12947599, upload-time = "2026-05-19T09:43:38.754Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a0/94f47d6fb592997be7ab9526938c929f0199adf2637c3c2b2b9b2101b28e/zensical-0.0.43-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:90d7c06ffd07b2bdf78bef041d541baba8a3ea51fd2dd84dbdbc5b0229076524", size = 12904911, upload-time = "2026-05-19T09:43:42.434Z" },
+    { url = "https://files.pythonhosted.org/packages/96/fb/1db3ad9a86ff772f74a8bc60ad5b447aa02a158e70f94adacf50bdd5c40f/zensical-0.0.43-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:60022f4a6b95e46ec0023f51052fcd491743b3ebd08c0066b22a5cf1e741fecd", size = 13269386, upload-time = "2026-05-19T09:43:45.387Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ee/b24fd0f94885519d851c35615b086d069a1077b0198021a56755395a4633/zensical-0.0.43-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e278eb948a0b7545d50609d713c7c27e366dade4523ff73a311a5d5f136518a", size = 12999364, upload-time = "2026-05-19T09:43:48.549Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/401ccd7afd9d2690f81b5319b7f1eed05108154ce20e4207053914518c1c/zensical-0.0.43-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b85e5ab99fbda13823e67c43a4be6e5ebda6600602969c6575e143f20ac203fd", size = 13124392, upload-time = "2026-05-19T09:43:50.965Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b3/9af6eba5826b0ef143fc8308bd1e219e221441e307a958e39f824ba9ab53/zensical-0.0.43-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:751385accc92cccfd4560dabed7c423870686ef6ede244a67e5c96286af25e8f", size = 13177538, upload-time = "2026-05-19T09:43:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6b/cd090bd6659d32692487206469988ee84d41aa6de4cdf9e380f847da90e2/zensical-0.0.43-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:dd3ff5bfa6e65cf3d2550dc639c3da2a3bfa11087b83d57e06623c4c1607d583", size = 13327086, upload-time = "2026-05-19T09:43:56.8Z" },
+    { url = "https://files.pythonhosted.org/packages/79/5b/ac2555354b5a53cb9c2c942811905c47be0b9f5603d3c1328ee8564333eb/zensical-0.0.43-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:85055a115b12f49c6ab194dcf04f966fc06b690ed6a8ddddd819929fc5f340e6", size = 13284645, upload-time = "2026-05-19T09:43:59.329Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/1688ec6e5be15e3ab367d7804753291bfbdff3109b06e20c19ce30a7129c/zensical-0.0.43-cp310-abi3-win32.whl", hash = "sha256:8a75ddd4bb3cd3c4a8e71d2ebae44c5611fd636c1d355c6124dd96e2f9c52838", size = 12256740, upload-time = "2026-05-19T09:44:02.102Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a8/d967e70eac810a7e9eb8c5150d6d02848a1f42260f42977c71debed3cb02/zensical-0.0.43-cp310-abi3-win_amd64.whl", hash = "sha256:03a9d1744a6394ad66c355d6f1de04cfd92efa525b0b94bf6dbf6971c5cd2c6b", size = 12496166, upload-time = "2026-05-19T09:44:04.915Z" },
+]

--- a/website/package.json
+++ b/website/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "bash scripts/sync-assets.sh && astro dev",
-    "build": "bash scripts/sync-assets.sh && astro build",
+    "dev": "bash scripts/sync-assets.sh && bash scripts/build-docs.sh && astro dev",
+    "build": "bash scripts/sync-assets.sh && bash scripts/build-docs.sh && astro build",
     "preview": "astro preview",
     "check": "bash scripts/sync-assets.sh && astro check",
     "lint": "oxlint src",

--- a/website/scripts/build-docs.sh
+++ b/website/scripts/build-docs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+website_root="$(cd "$script_dir/.." && pwd)"
+docs_root="$website_root/docs"
+output_root="$website_root/public"
+
+(
+  cd "$website_root"
+  "$script_dir/run-uv.sh" \
+    run --project docs --frozen \
+    zensical build --strict --config-file zensical.toml
+)
+
+cp -f "$docs_root/content/index.md" "$output_root/docs.md"
+
+for source in "$docs_root"/content/*.md; do
+  name="$(basename "$source")"
+  if [[ "$name" == "index.md" ]]; then
+    continue
+  fi
+  cp -f "$source" "$output_root/docs/$name"
+done
+
+cp -f "$docs_root/llms.txt" "$output_root/llms.txt"
+
+for source in "$docs_root"/content/*.md; do
+  name="$(basename "$source" .md)"
+  if [[ "$name" == "index" ]]; then
+    html="$output_root/docs/index.html"
+    markdown="$output_root/docs.md"
+  else
+    html="$output_root/docs/$name/index.html"
+    markdown="$output_root/docs/$name.md"
+  fi
+
+  if [[ ! -s "$html" || ! -s "$markdown" ]]; then
+    printf 'missing generated documentation pair for %s\n' "$source" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -s "$output_root/llms.txt" ]]; then
+  printf 'missing generated llms.txt\n' >&2
+  exit 1
+fi

--- a/website/scripts/run-uv.sh
+++ b/website/scripts/run-uv.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v uv >/dev/null 2>&1; then
-  exec uv "$@"
-fi
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 website_root="$(cd "$script_dir/.." && pwd)"
 uv_version="0.9.5"
 uv_cache="$website_root/.cache/uv-$uv_version"
+uv_bin="$uv_cache/bin/uv"
 installer="$uv_cache/install.sh"
 installer_sha256="8402ab80d2ef54d7044a71ea4e4e1e8db3b20c87c7bffbc30bff59f1e80ebbd5"
+
+if [[ -x "$uv_bin" ]]; then
+  exec "$uv_bin" "$@"
+fi
 
 mkdir -p "$uv_cache"
 curl \
@@ -35,7 +36,6 @@ else
 fi
 env UV_UNMANAGED_INSTALL="$uv_cache/bin" sh "$installer" >/dev/null
 
-uv_bin="$uv_cache/bin/uv"
 if [[ ! -x "$uv_bin" ]]; then
   printf 'uv installer did not create the expected executable: %s\n' "$uv_bin" >&2
   exit 1

--- a/website/scripts/run-uv.sh
+++ b/website/scripts/run-uv.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v uv >/dev/null 2>&1; then
+  exec uv "$@"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+website_root="$(cd "$script_dir/.." && pwd)"
+uv_version="0.9.5"
+uv_cache="$website_root/.cache/uv-$uv_version"
+installer="$uv_cache/install.sh"
+installer_sha256="8402ab80d2ef54d7044a71ea4e4e1e8db3b20c87c7bffbc30bff59f1e80ebbd5"
+
+mkdir -p "$uv_cache"
+curl \
+  --proto '=https' \
+  --tlsv1.2 \
+  --fail \
+  --location \
+  --silent \
+  --show-error \
+  "https://astral.sh/uv/$uv_version/install.sh" \
+  --output "$installer"
+
+if command -v shasum >/dev/null 2>&1; then
+  printf '%s  %s\n' "$installer_sha256" "$installer" \
+    | shasum -a 256 --check --status
+elif command -v sha256sum >/dev/null 2>&1; then
+  printf '%s  %s\n' "$installer_sha256" "$installer" \
+    | sha256sum --check --status
+else
+  printf 'a SHA-256 checksum tool is required to bootstrap uv\n' >&2
+  exit 1
+fi
+env UV_UNMANAGED_INSTALL="$uv_cache/bin" sh "$installer" >/dev/null
+
+uv_bin="$uv_cache/bin/uv"
+if [[ ! -x "$uv_bin" ]]; then
+  printf 'uv installer did not create the expected executable: %s\n' "$uv_bin" >&2
+  exit 1
+fi
+
+exec "$uv_bin" "$@"

--- a/website/scripts/run-uv.sh
+++ b/website/scripts/run-uv.sh
@@ -4,16 +4,70 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 website_root="$(cd "$script_dir/.." && pwd)"
 uv_version="0.9.5"
-uv_cache="$website_root/.cache/uv-$uv_version"
-uv_bin="$uv_cache/bin/uv"
-installer="$uv_cache/install.sh"
-installer_sha256="8402ab80d2ef54d7044a71ea4e4e1e8db3b20c87c7bffbc30bff59f1e80ebbd5"
 
-if [[ -x "$uv_bin" ]]; then
+os_name="$(uname -s)"
+machine_arch="$(uname -m)"
+case "$os_name:$machine_arch" in
+  Darwin:arm64)
+    uv_target="uv-aarch64-apple-darwin"
+    archive_sha256="dc098ff224d78ed418e121fd374f655949d2c7031a70f6f6604eaf016a130433"
+    binary_sha256="d54989c0037e115f53c34a5658c2cc0ff5c44e35b5635ed9a5463b9caa364f81"
+    ;;
+  Linux:aarch64 | Linux:arm64)
+    uv_target="uv-aarch64-unknown-linux-gnu"
+    archive_sha256="9db0c2f6683099f86bfeea47f4134e915f382512278de95b2a0e625957594ff3"
+    binary_sha256="b880aad13554f4eb7815f962b4f40e3f94fb2f86cae4b98afa0906324b61f754"
+    ;;
+  Linux:x86_64 | Linux:amd64)
+    uv_target="uv-x86_64-unknown-linux-gnu"
+    archive_sha256="2cf10babba653310606f8b49876cfb679928669e7ddaa1fb41fb00ce73e64f66"
+    binary_sha256="d3dc3ca8e29337dd602a9a4df9e6edb15ebc52aed91461debeedb96939dc4ce0"
+    ;;
+  *)
+    printf 'unsupported uv bootstrap platform: %s %s\n' "$os_name" "$machine_arch" >&2
+    exit 1
+    ;;
+esac
+
+verify_sha256() {
+  local expected_sha="$1"
+  local file_abs="$2"
+  local checksum_line=""
+  local actual_sha=""
+
+  if command -v shasum >/dev/null 2>&1; then
+    checksum_line="$(shasum -a 256 "$file_abs")"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    checksum_line="$(sha256sum "$file_abs")"
+  else
+    printf 'a SHA-256 checksum tool is required to bootstrap uv\n' >&2
+    return 1
+  fi
+
+  actual_sha="${checksum_line%% *}"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    printf 'SHA-256 mismatch for %s: expected %s, got %s\n' \
+      "$file_abs" "$expected_sha" "$actual_sha" >&2
+    return 1
+  fi
+}
+
+uv_cache="$website_root/.cache/uv-$uv_version/$uv_target"
+uv_bin="$uv_cache/uv"
+
+if [[ -e "$uv_bin" ]]; then
+  if [[ -L "$uv_bin" || ! -f "$uv_bin" || ! -x "$uv_bin" ]]; then
+    printf 'cached uv is not a regular executable: %s\n' "$uv_bin" >&2
+    exit 1
+  fi
+  verify_sha256 "$binary_sha256" "$uv_bin"
   exec "$uv_bin" "$@"
 fi
 
 mkdir -p "$uv_cache"
+archive_abs="$(mktemp "$uv_cache/archive.XXXXXX")"
+extract_abs="$(mktemp -d "$uv_cache/extract.XXXXXX")"
+archive_name="$uv_target.tar.gz"
 curl \
   --proto '=https' \
   --tlsv1.2 \
@@ -21,24 +75,24 @@ curl \
   --location \
   --silent \
   --show-error \
-  "https://astral.sh/uv/$uv_version/install.sh" \
-  --output "$installer"
+  "https://github.com/astral-sh/uv/releases/download/$uv_version/$archive_name" \
+  --output "$archive_abs"
 
-if command -v shasum >/dev/null 2>&1; then
-  printf '%s  %s\n' "$installer_sha256" "$installer" \
-    | shasum -a 256 --check --status
-elif command -v sha256sum >/dev/null 2>&1; then
-  printf '%s  %s\n' "$installer_sha256" "$installer" \
-    | sha256sum --check --status
-else
-  printf 'a SHA-256 checksum tool is required to bootstrap uv\n' >&2
+verify_sha256 "$archive_sha256" "$archive_abs"
+tar -xzf "$archive_abs" -C "$extract_abs" "$uv_target/uv"
+
+extracted_uv_abs="$extract_abs/$uv_target/uv"
+if [[ -L "$extracted_uv_abs" || ! -f "$extracted_uv_abs" || ! -x "$extracted_uv_abs" ]]; then
+  printf 'uv archive did not contain the expected executable: %s\n' "$extracted_uv_abs" >&2
   exit 1
 fi
-env UV_UNMANAGED_INSTALL="$uv_cache/bin" sh "$installer" >/dev/null
+verify_sha256 "$binary_sha256" "$extracted_uv_abs"
+mv -f "$extracted_uv_abs" "$uv_bin"
 
-if [[ ! -x "$uv_bin" ]]; then
-  printf 'uv installer did not create the expected executable: %s\n' "$uv_bin" >&2
+if [[ -L "$uv_bin" || ! -f "$uv_bin" || ! -x "$uv_bin" ]]; then
+  printf 'uv bootstrap did not create the expected executable: %s\n' "$uv_bin" >&2
   exit 1
 fi
+verify_sha256 "$binary_sha256" "$uv_bin"
 
 exec "$uv_bin" "$@"

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -11,6 +11,7 @@ import { DISCORD_URL, GITHUB_URL } from '../config';
     </p>
     <nav aria-label="Footer links">
       <a href="/guide/">Guide</a>
+      <a href="/docs/">Docs</a>
       <a href={GITHUB_URL}>GitHub</a>
       <a href={DISCORD_URL}>Discord</a>
     </nav>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -7,7 +7,8 @@ import AppIcon from './AppIcon.astro';
   <div class="container bar">
     <a class="brand" href="/"><AppIcon prefix="gh-ic-hdr" /><span>Ghosthub</span></a>
     <nav aria-label="Primary navigation">
-      <a class="guide" href="/guide/">Guide</a>
+      <a class="site-link" href="/guide/">Guide</a>
+      <a class="site-link" href="/docs/">Docs</a>
       <a class="repo" href={GITHUB_URL}>
         <span class="sr-only">Ghosthub on GitHub:</span>
         <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true" fill="currentColor">
@@ -147,14 +148,14 @@ import AppIcon from './AppIcon.astro';
     gap: 1rem;
   }
 
-  .guide {
+  .site-link {
     color: var(--text-dim);
     font-family: var(--font-mono);
     font-size: 0.82rem;
     transition: color 0.15s;
   }
 
-  .guide:hover {
+  .site-link:hover {
     color: var(--text);
   }
 

--- a/website/src/pages/guide.astro
+++ b/website/src/pages/guide.astro
@@ -14,7 +14,7 @@ import { RELEASES_URL } from '../config';
 
 const title = 'How to use Ghosthub';
 const description =
-  'A visual guide to connected tmux sessions, automatic SSH reconnect, '
+  'A visual tour of connected tmux sessions, automatic SSH reconnect, '
   + 'worktrees, the Command Palette, native tabs and windows, and terminal configuration.';
 
 const imageWidths = [640, 960, 1280, 1600];
@@ -45,6 +45,10 @@ const imageAlt = {
         SSH hosts, with no Git setup required. It also manages worktree-bound
         sessions created from branches and GitHub pull requests. If SSH drops,
         it retries and reattaches to the same exact session automatically.
+      </p>
+      <p class="docs-callout">
+        Looking for detailed setup and reference material? Visit the{' '}
+        <a href="/docs/">Ghosthub Docs</a>.
       </p>
       <p class="promise" aria-label="Automatic SSH reconnect plus tmux reattach">
         <span class="promise-icon" aria-hidden="true">↻</span>
@@ -88,28 +92,9 @@ const imageAlt = {
             plus commands to open any discovered session.
           </p>
           <p>
-            To keep tool-owned standalone sessions out of navigation, open{' '}
-            <strong>Settings → Worktrees</strong> and add hidden tmux session
-            patterns, one per line. Patterns are case-sensitive and support{' '}
-            <code>*</code> for any number of characters and <code>?</code> for
-            one character. Ghosthub stores them in{' '}
-            <code>~/.config/ghosthub/config.toml</code>; matching kwt workspaces
-            remain visible under their projects.
-          </p>
-          <p>
-            Closing the Ghosthub window only detaches. Your work keeps running
-            in tmux. To end a standalone session Ghosthub knows is running,
-            hover its row and click the subtle <strong>×</strong>. A
-            worktree-backed session keeps <strong>Kill Session…</strong> in
-            its action menu, beside the separate worktree-removal control.
-            Ghosthub confirms the host and exact tmux instance before
-            terminating its windows, panes, and processes. It cancels the
-            action if that host’s connection changes or if the session
-            disappears and is replaced under the same name, and keeps an
-            active attachment open if the kill fails. Switching to another
-            session while the command completes does not navigate away from
-            the new selection. The same command is available in the command
-            palette.
+            Closing a Ghosthub presentation only detaches; your work keeps
+            running in tmux. See <a href="/docs/sessions/">Sessions</a> for
+            session lifecycle, hiding, and confirmed kill controls.
           </p>
         </div>
       </div>
@@ -134,63 +119,15 @@ const imageAlt = {
           <p>
             Open <strong>Settings → Hosts</strong> and add any destination
             accepted by your SSH configuration, such as{' '}
-            <code>devbox</code> or <code>alice@build-server</code>.
-            Importing from Tailscale uses the user resolved by your OpenSSH
-            configuration (falling back to your local username) and preserves
-            each host’s full MagicDNS name.
+            <code>devbox</code> or <code>alice@build-server</code>. Ghosthub
+            follows OpenSSH configuration for users, ports, keys, and routing.
           </p>
           <p>
-            Remote hosts need tmux. Ghosthub follows your OpenSSH configuration
-            for users, ports, keys, and routing. If OpenSSH encounters an unseen
-            key under an interactive trust policy, Ghosthub shows the exact
-            destination and fingerprint for approval. Passwords and other
-            interactive challenges use a native secure-entry sheet that names
-            the host requesting the response. Responses are kept only for the
-            app session, and <strong>Continue</strong> can deliberately send an
-            empty response when a challenge requires one.
-          </p>
-          <p>
-            ProxyJump routes are handled one host at a time, with every trust
-            and credential prompt naming the hop that controls it. Ghosthub
-            refuses opaque ProxyCommand routes and jump hosts that themselves
-            use another proxy because it cannot safely review those intermediate
-            policies. An unreachable machine never blocks the rest of your
-            fleet.
-          </p>
-          <p>
-            Native Windows support is experimental. Choose{' '}
-            <strong>Windows (psmux)</strong> for a Windows OpenSSH host with
-            PowerShell and <a href="https://github.com/marlocarlo/psmux">psmux</a>{' '}
-            installed, including its <code>tmux.exe</code> alias. After
-            testing the connection, <strong>Install Bundled kwt</strong>{' '}
-            uploads Ghosthub’s matching AMD64 or ARM64 helper for that user.
-            The Windows helper is currently unsigned, so this path is intended
-            for development machines and power users until Authenticode
-            signing is available.
-          </p>
-          <p>
-            To add project and worktree context without installing{' '}
-            <a href="https://kwt.sh">kwt, a Git worktree manager</a>,
-            system-wide, test the connection and choose{' '}
-            <strong>Install kwt Worktree Helper</strong>. Ghosthub asks through that
-            explicit action, then copies its pinned build for the host’s OS and
-            CPU, verifies it, and keeps it under <code>~/.ghosthub/</code>.
-            On a fresh macOS or Linux host, open the <strong>+</strong> menu
-            beside it, choose <strong>Add Project</strong>, and enter each
-            existing checkout’s absolute path. Ghosthub delegates registration
-            to kwt and refreshes inventory without scanning the machine.
-            Project registration is not yet available for Windows hosts. If the
-            host’s SSH address changes while Add Project is open, close the
-            sheet and try again against the updated host. Tmux-only hosts do not
-            need either step.
-          </p>
-          <p>
-            If a host shows a caution icon, click it to review trust,
-            authenticate, or retry the connection. Ghosthub confirms success
-            before dismissing the sheet and retries inventory automatically.
-            Reachable hosts keep any separate inventory diagnostic visible so
-            you can retry it without repeating SSH setup. An expanded host with
-            no projects or tmux sessions says so in the sidebar.
+            Trust and credential prompts name the exact host or jump hop that
+            controls them. Tmux-only hosts need no helper; project context can
+            use Ghosthub’s managed kwt helper. Native Windows support through
+            psmux is experimental. See <a href="/docs/remote-hosts/">Remote Hosts</a>{' '}
+            for requirements, trust, authentication, Tailscale, and helper setup.
           </p>
           <aside class="reconnect">
             <span aria-hidden="true">↻</span>
@@ -200,16 +137,7 @@ const imageAlt = {
               with no more than 30 seconds between attempts. Choose
               <strong>Reconnect Now</strong> to try immediately. When
               connectivity returns, Ghosthub reattaches to the same exact tmux
-              session with the server-side process state still intact. If SSH
-              needs authentication or host-key review, the screen changes to
-              <strong>Connection needs attention</strong> and opens the native
-              recovery flow. If the connection has recovered before that check
-              finishes, <strong>Retry</strong> resumes the same automatic
-              reconnect supervisor immediately. Authentication opened from an
-              ordinary host inventory warning only refreshes that inventory;
-              it never reopens a tmux session. If you dismiss a session’s
-              recovery sheet, <strong>Review Connection</strong> reopens the
-              same recovery request so successful review can resume it.
+              session with the server-side process state still intact.
             </p>
           </aside>
         </div>
@@ -237,41 +165,15 @@ const imageAlt = {
             the absolute path to an existing checkout. Ghosthub registers that
             repository through its bundled or managed{' '}
             <a href="https://kwt.sh">kwt</a> helper without scanning the machine.
-            Windows project registration is not yet supported.
-          </p>
-          <p>
-            Pull-request import requires the{' '}
-            <a href="https://cli.github.com/">GitHub CLI (<code>gh</code>)</a>{' '}
-            on the host containing the project: your Mac for a local project
-            or the SSH machine for a remote one. Install it there and run{' '}
-            <code>gh auth login</code> on that same host before importing. For
-            an HTTPS Git remote, ordinary Git authentication must also work on
-            that host; <code>gh auth setup-git</code> configures GitHub CLI as
-            a Git credential helper.
           </p>
           <p>
             Select a project and press <kbd>⌘⇧N</kbd>. Use
             <strong>Branch</strong> to search local and remote branches that
-            are not already checked out. Pick one to create its worktree,
-            including a local tracking branch when the source is remote, or
-            type a new branch name. Use
+            are not already checked out, or type a new branch name. Use
             <strong>Pull Request</strong> to find and import an open GitHub
-            pull request. You do not need to install or run kwt separately.
-            Selecting a listed worktree creates or repairs its canonical tmux
-            session when needed, then attaches an ordinary tmux client.
-            Kwt remains optional if you only want a local and remote tmux
-            session switcher. Remote tmux copy-mode can write copied text to
-            the Mac clipboard through OSC 52, while paste follows the
-            configured terminal shortcut and libghostty’s safe paste path.
-          </p>
-          <p>
-            To remove a non-primary worktree, hover its sidebar row and click
-            the <strong>×</strong>. After confirmation, Ghosthub terminates
-            that worktree’s live tmux session if necessary and asks kwt to
-            remove the checkout. If the checkout is already gone, Ghosthub
-            skips the redundant kwt removal but still reconciles the exact
-            live tmux session covered by the confirmation. The Git branch is
-            kept.
+            pull request. See <a href="/docs/projects-worktrees/">Projects and
+              Worktrees</a> for host-side GitHub CLI setup, branch behavior,
+            and safe worktree removal.
           </p>
         </div>
       </div>
@@ -295,9 +197,9 @@ const imageAlt = {
           <p>
             Press <kbd>⌘⇧P</kbd> for the Command Palette. Search across hosts,
             projects, worktrees, appearance, settings, and common actions,
-            then press Return to go. When an attached tmux session is active,
-            <strong>Apply Theme to Current Session</strong> rethemes it without
-            detaching or enabling the persistent shared-session override.
+            then press Return to go. The{' '}
+            <a href="/docs/keyboard-shortcuts/">keyboard shortcut reference</a>{' '}
+            covers the rest of the app.
           </p>
           <div class="shortcuts" aria-label="Useful keyboard shortcuts">
             <span><kbd>⌘B</kbd> Hide/show sidebar</span>
@@ -342,11 +244,9 @@ const imageAlt = {
           </div>
           <p>
             Press <kbd>⌘B</kbd> in any window to hide its sidebar and give
-            the terminal the full frame. Press it again whenever you need
-            fleet navigation back. Drag worktrees within a project or standalone
-            tmux sessions within a host to arrange them; the insertion line
-            previews the destination. Ghosthub remembers these display orders
-            without changing anything in kwt, git, or tmux.
+            the terminal the full frame. See{' '}
+            <a href="/docs/windows-navigation/">Windows and Navigation</a> for
+            restoration, detachment, and display ordering.
           </p>
         </div>
       </div>
@@ -383,28 +283,13 @@ const imageAlt = {
             <code>~/.config/ghosthub/ghostty.conf</code>.
           </p>
           <p>
-            Quit confirmation is on by default. Change it at{' '}
-            <strong>Settings → Terminal → Confirm before quitting Ghosthub</strong>.
-            Closing the final workspace leaves Ghosthub running; use Command-Q to
-            quit. Quitting or closing windows only detaches and leaves every tmux
-            session running.
-          </p>
-          <p>
-            The file uses{' '}<a href="https://ghostty.org/docs/config/reference">Ghostty’s
-              configuration format</a>, but is isolated from Ghostty.app.
+            The file uses Ghostty’s configuration format but is isolated from
+            Ghostty.app.{' '}
             The Tmux Theme picker supplies colors for new sessions created by
             Ghosthub. Existing sessions keep their own appearance by default;
-            Ghosthub does not place a local palette over them. An explicit
-            <strong>Apply theme to shared tmux sessions</strong> opt-in applies
-            the selected colors before future attachments. Follow ghostty.conf
-            uses the effective foreground and background for the current light
-            or dark appearance, just like the built-in themes. To update only
-            the connected active session immediately, choose{' '}
-            <strong>Session → Apply Theme to Current Session</strong> or the
-            matching Command Palette action. Both choices update the session’s
-            existing windows and chrome for every attached terminal; they do
-            not target the Console Panel and are unavailable for native Windows
-            sessions. Ghosthub reloads terminal configuration when it changes.
+            shared-session styling is explicit. See{' '}
+            <a href="/docs/terminal-configuration/">Terminal Configuration</a>{' '}
+            for shell startup, themes, clipboard behavior, and quit settings.
           </p>
         </div>
       </div>
@@ -433,6 +318,8 @@ const imageAlt = {
         PostHog person profiles and GeoIP enrichment are disabled. Turn
         reporting off at any time in{' '}
         <strong>Settings → Privacy → Share anonymous usage data</strong>.
+        The <a href="/docs/privacy/">Privacy docs</a> also describe local and
+        remote state.
       </p>
     </div>
   </section>
@@ -445,11 +332,7 @@ const imageAlt = {
         Ghosthub never replaces tmux windows, panes, history, or plugins.
         Quit the app or install an update and the sessions remain where you
         left them. Ghosthub restores each exact session it can confirm and
-        keeps retrying offline SSH hosts as inventory refreshes. During an
-        update relaunch, it also recreates your saved windows if macOS does not
-        return them. A window that had no terminal attached restores its
-        navigation without creating a worktree session; select the worktree
-        when you want to attach again.
+        keeps retrying offline SSH hosts as inventory refreshes.
       </p>
       <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
     </div>
@@ -496,6 +379,15 @@ const imageAlt = {
     margin: 1rem auto 0;
     max-width: 64ch;
     text-wrap: balance;
+  }
+
+  .docs-callout {
+    color: var(--text-dim);
+    margin: 1rem 0 0;
+  }
+
+  .docs-callout a {
+    color: var(--accent);
   }
 
   .promise {

--- a/website/zensical.toml
+++ b/website/zensical.toml
@@ -1,0 +1,91 @@
+[project]
+site_name = "Ghosthub Docs"
+site_description = "Comprehensive user documentation for Ghosthub."
+site_author = "Kenn Software LLC"
+site_url = "https://ghosthub.ai/docs/"
+copyright = "Copyright &copy; 2026 Kenn Software LLC. AGPL-3.0."
+docs_dir = "docs/content"
+site_dir = "public/docs"
+use_directory_urls = true
+repo_url = "https://github.com/kenn-io/ghosthub"
+repo_name = "kenn-io/ghosthub"
+extra_css = ["stylesheets/extra.css"]
+nav = [
+  {"Overview" = "index.md"},
+  {"Getting Started" = "getting-started.md"},
+  {"Sessions" = "sessions.md"},
+  {"Remote Hosts" = "remote-hosts.md"},
+  {"Projects and Worktrees" = "projects-worktrees.md"},
+  {"Windows and Navigation" = "windows-navigation.md"},
+  {"Terminal Configuration" = "terminal-configuration.md"},
+  {"Keyboard Shortcuts" = "keyboard-shortcuts.md"},
+  {"Privacy" = "privacy.md"},
+  {"Troubleshooting" = "troubleshooting.md"},
+]
+
+[project.extra]
+homepage = "/"
+
+[project.theme]
+variant = "modern"
+features = [
+  "content.code.copy",
+  "navigation.footer",
+  "navigation.instant",
+  "navigation.instant.progress",
+  "navigation.path",
+  "navigation.sections",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+]
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
+scheme = "default"
+primary = "custom"
+accent = "custom"
+
+  [project.theme.palette.toggle]
+  icon = "lucide/sun"
+  name = "Switch to dark mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
+scheme = "slate"
+primary = "custom"
+accent = "custom"
+
+  [project.theme.palette.toggle]
+  icon = "lucide/moon"
+  name = "Switch to light mode"
+
+[project.theme.icon]
+logo = "lucide/terminal-square"
+repo = "fontawesome/brands/github"
+
+[project.markdown_extensions.admonition]
+
+[project.markdown_extensions.attr_list]
+
+[project.markdown_extensions.md_in_html]
+
+[project.markdown_extensions.pymdownx.details]
+
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+pygments_lang_class = true
+
+[project.markdown_extensions.pymdownx.inlinehilite]
+
+[project.markdown_extensions.pymdownx.keys]
+
+[project.markdown_extensions.pymdownx.superfences]
+
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+
+[project.markdown_extensions.tables]
+
+[project.markdown_extensions.toc]
+permalink = true


### PR DESCRIPTION
The visual Guide has accumulated enough operational detail that it no longer works cleanly as a concise product tour. A dedicated `/docs/` surface gives users a searchable, task-oriented home for installation, sessions, SSH hosts, worktrees, navigation, terminal configuration, privacy, and troubleshooting while letting the Guide return to a higher-level role.

Zensical now publishes the public docs with the Astro site, including sibling Markdown URLs and a curated `/llms.txt` generated from the same maintained source. This keeps human and machine-readable documentation aligned without exposing the separate internal engineering-docs navigation.

Strict Zensical validation, Astro type-checking, lint, all 16 website tests, and the production build pass. A local production preview also returned HTML for directory routes, `text/markdown` for `.md` twins, and `text/plain` for `/llms.txt`; automated visual-browser inspection was unavailable in the local browser runtime.