### PR TITLE
Surface kwt session state and provision remote helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,10 @@ layer, as subject to direct iteration.
   and exact tmux session names. Direct `tmux list-sessions` discovery supplies
   every otherwise-unbound session on each configured host.
 - Packaged builds invoke their revision-pinned bundled kwt for local operations.
-  After explicit user permission, remote hosts invoke Ghosthub's matching
-  revision-pinned managed helper from `~/.ghosthub/`.
+  Configured remote macOS and Linux hosts automatically install or update
+  Ghosthub's matching revision-pinned managed helper under `~/.ghosthub/`.
+  Windows helper installation remains explicit until the kwt executables are
+  Authenticode-signed.
 - Fresh remote hosts gain project context through the explicit Host Settings
   **Add Project** action, which delegates one absolute repository path to kwt;
   Ghosthub never scans the remote filesystem or edits kwt configuration.
@@ -89,7 +91,12 @@ layer, as subject to direct iteration.
   account, host, project, or session data. Publish required refreshed binaries
   to the orphan `website-assets` branch so ghosthub.ai does not ship stale
   product views.
-- Pull request descriptions should be concise, rationale-first prose. Do not add boilerplate or navel-gazing sections like "Changes", "Tests", or "Verification"; mention validation only when it is genuinely useful reviewer context.
+- Pull request descriptions must be concise and optimized for human scanning:
+  lead with a short rationale, then use bullets for the material behavior,
+  constraints, and reviewer-relevant consequences. Do not add boilerplate or
+  navel-gazing sections such as "Changes", "Validation", "Tests", or
+  "Verification". Mention unusual validation only inline when it is genuinely
+  useful reviewer context.
 - The canonical repository is `https://github.com/kenn-io/ghosthub`. Only push
   or open pull requests when the user explicitly asks.
 - The public repository does not accept unsolicited pull requests. Direct bug

--- a/README.md
+++ b/README.md
@@ -141,16 +141,17 @@ Open **Settings → Hosts**, add an SSH address such as `devbox`,
 **Test Connection**. If your OpenSSH policy prompts for a new host key, verify
 the host once with system `ssh` first.
 
-Tmux-only hosts need no other setup. For project and worktree context, choose
-**Install kwt Worktree Helper** in Host Settings. Ghosthub copies the pinned
-helper for that host's operating system and CPU; it does not install or replace
-a system kwt.
+Tmux-only hosts need no other setup. For project and worktree context on remote
+macOS and Linux hosts, Ghosthub automatically installs and updates the pinned
+helper for that host's operating system and CPU. It stores the helper under the
+remote user's `~/.ghosthub/` directory and does not install or replace a system
+kwt.
 
 Native Windows support is experimental. Select **Windows (psmux)** for a
 Windows OpenSSH host with PowerShell and psmux installed. Ghosthub can upload
 its matching AMD64 or ARM64 kwt helper after explicit confirmation, but the
-Windows helper is currently unsigned and project registration is not yet
-available on Windows.
+Windows helper is currently unsigned, so it is not installed automatically;
+project registration is not yet available on Windows.
 
 ### Add projects and worktrees
 
@@ -183,7 +184,9 @@ Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd> to open the **Command Palette** a
 search across hosts, projects, worktrees, sessions, settings, and actions.
 Use **Settings → Worktrees** to hide tool-owned standalone tmux sessions with
 case-sensitive `*` and `?` patterns. Kwt workspaces always remain visible under
-their projects.
+their projects, show a status glyph while their tmux session is live, and hide
+their duplicate entries under **Tmux Sessions** by default. The same settings
+page can expose those duplicate session rows.
 
 | Shortcut | Action |
 | --- | --- |

--- a/Sources/App/KwtRemoteInstaller.swift
+++ b/Sources/App/KwtRemoteInstaller.swift
@@ -85,6 +85,7 @@ struct KwtRemoteInstaller: Sendable {
 
     private static let targetMarker = "GHOSTHUB_KWT_TARGET\t"
     private static let uploadMarker = "GHOSTHUB_KWT_UPLOAD\t"
+    private static let readyMarker = "GHOSTHUB_KWT_READY"
     private static let installedMarker = "GHOSTHUB_KWT_INSTALLED"
 
     private let revision: String?
@@ -121,6 +122,17 @@ struct KwtRemoteInstaller: Sendable {
     }
 
     func install(on host: SSHHost) async throws {
+        try await install(on: host, ifNeeded: false)
+    }
+
+    func ensureInstalled(on host: SSHHost) async throws {
+        try await install(on: host, ifNeeded: true)
+    }
+
+    private func install(
+        on host: SSHHost,
+        ifNeeded: Bool
+    ) async throws {
         guard let info = TmuxHostResolver.parseSSHDestination(
             host.sshDestination
         ) else {
@@ -130,7 +142,8 @@ struct KwtRemoteInstaller: Sendable {
         let remoteRunner = remoteRunner
         let uploadRunner = uploadRunner
         let resourceProvider = resourceProvider
-        try await Task.detached(priority: .userInitiated) {
+        let operation = Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
             guard let revision,
                   KwtBinaryLocator.remoteManagedPath(
                       revision: revision
@@ -139,7 +152,21 @@ struct KwtRemoteInstaller: Sendable {
                 throw KwtRemoteInstallError.bundleIncomplete
             }
 
+            if ifNeeded {
+                let ready = remoteRunner(
+                    info,
+                    Self.readyProbeCommand(revision: revision)
+                )
+                try Task.checkCancellation()
+                if ready.status == 0,
+                   ready.stdout.split(whereSeparator: \.isNewline)
+                   .contains(Substring(Self.readyMarker)) {
+                    return
+                }
+            }
+
             let probe = remoteRunner(info, Self.targetProbeCommand)
+            try Task.checkCancellation()
             guard probe.status == 0 else {
                 throw KwtRemoteInstallError.targetProbeFailed(
                     status: probe.status
@@ -166,6 +193,7 @@ struct KwtRemoteInstaller: Sendable {
                 .map { String(format: "%02x", $0) }
                 .joined()
             let incomingName = ".incoming-\(UUID().uuidString.lowercased())"
+            try Task.checkCancellation()
             let prepare = remoteRunner(
                 info,
                 Self.prepareCommand(
@@ -173,6 +201,7 @@ struct KwtRemoteInstaller: Sendable {
                     incomingName: incomingName
                 )
             )
+            try Task.checkCancellation()
             guard prepare.status == 0 else {
                 throw KwtRemoteInstallError.prepareFailed(
                     status: prepare.status
@@ -180,6 +209,7 @@ struct KwtRemoteInstaller: Sendable {
             }
             do {
                 let uploadPath = try Self.parseUploadPath(prepare.stdout)
+                try Task.checkCancellation()
                 let upload = uploadRunner(info, helperURL, uploadPath)
                 guard upload.status == 0 else {
                     let message = upload.output.trimmingCharacters(
@@ -190,6 +220,7 @@ struct KwtRemoteInstaller: Sendable {
                         message: message.isEmpty ? nil : message
                     )
                 }
+                try Task.checkCancellation()
                 let install = remoteRunner(
                     info,
                     Self.installCommand(
@@ -199,6 +230,7 @@ struct KwtRemoteInstaller: Sendable {
                         digest: digest
                     )
                 )
+                try Task.checkCancellation()
                 guard install.status == 0 else {
                     throw KwtRemoteInstallError.installFailed(
                         status: install.status
@@ -219,7 +251,12 @@ struct KwtRemoteInstaller: Sendable {
                 )
                 throw error
             }
-        }.value
+        }
+        try await withTaskCancellationHandler {
+            try await operation.value
+        } onCancel: {
+            operation.cancel()
+        }
     }
 
     static let targetProbeCommand =
@@ -227,6 +264,19 @@ struct KwtRemoteInstaller: Sendable {
             + "ghosthub_kwt_arch=$(uname -m) || exit $?; "
             + "printf 'GHOSTHUB_KWT_TARGET\\t%s\\t%s\\n' "
             + "\"$ghosthub_kwt_os\" \"$ghosthub_kwt_arch\""
+
+    static func readyProbeCommand(revision: String) -> String {
+        let path = "$HOME/.ghosthub/helpers/kwt/\(revision)/kwt"
+        return "ghosthub_kwt_path=\"\(path)\"; "
+            + "[ -x \"$ghosthub_kwt_path\" ] || exit 1; "
+            + "ghosthub_kwt_version=$(\"$ghosthub_kwt_path\" version) "
+            + "|| exit $?; "
+            + "ghosthub_kwt_version_first=$(printf '%s\\n' "
+            + "\"$ghosthub_kwt_version\" | sed -n '1p') || exit $?; "
+            + "[ \"$ghosthub_kwt_version_first\" = "
+            + shellQuotedCommandArgument("kwt version \(revision)")
+            + " ] || exit 1; printf 'GHOSTHUB_KWT_READY\\n'"
+    }
 
     static func prepareCommand(
         revision: String,
@@ -365,5 +415,79 @@ struct KwtRemoteInstaller: Sendable {
         arguments.append(source.path)
         arguments.append("\(target):\(destination)")
         return arguments
+    }
+}
+
+actor KwtRemoteProvisioningCoordinator {
+    static let shared = KwtRemoteProvisioningCoordinator()
+
+    private struct HostKey: Hashable {
+        let configKey: String
+        let platform: String
+        let sshDestination: String
+    }
+
+    private struct InFlight {
+        let task: Task<Void, Error>
+        var waiters: Set<UUID>
+    }
+
+    private var inFlight: [HostKey: InFlight] = [:]
+    private let installer: KwtRemoteInstaller
+
+    init(installer: KwtRemoteInstaller = KwtRemoteInstaller()) {
+        self.installer = installer
+    }
+
+    func ensureInstalled(on host: SSHHost) async throws {
+        let key = HostKey(
+            configKey: host.configKey,
+            platform: host.platform.rawValue,
+            sshDestination: host.sshDestination
+        )
+        let waiterID = UUID()
+        let task: Task<Void, Error>
+        if var existing = inFlight[key] {
+            existing.waiters.insert(waiterID)
+            inFlight[key] = existing
+            task = existing.task
+        } else {
+            let installer = installer
+            task = Task {
+                try await installer.ensureInstalled(on: host)
+            }
+            inFlight[key] = InFlight(
+                task: task,
+                waiters: [waiterID]
+            )
+        }
+
+        do {
+            try await withTaskCancellationHandler {
+                try Task.checkCancellation()
+                try await task.value
+                try Task.checkCancellation()
+            } onCancel: {
+                Task {
+                    await self.releaseWaiter(waiterID, for: key)
+                }
+            }
+            releaseWaiter(waiterID, for: key)
+        } catch {
+            releaseWaiter(waiterID, for: key)
+            throw error
+        }
+    }
+
+    private func releaseWaiter(_ waiterID: UUID, for key: HostKey) {
+        guard var existing = inFlight[key],
+              existing.waiters.remove(waiterID) != nil
+        else { return }
+        guard !existing.waiters.isEmpty else {
+            inFlight.removeValue(forKey: key)
+            existing.task.cancel()
+            return
+        }
+        inFlight[key] = existing
     }
 }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -160,6 +160,9 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias KwtInventoryLoader = @Sendable (
         TmuxHost
     ) async throws -> KwtHostInventory
+    typealias KwtRemoteProvisioner = @Sendable (
+        SSHHost
+    ) async throws -> Void
     typealias KwtWorktreeCreator = @Sendable (
         WorktreeCreateRequest, String, TmuxHost
     ) async throws -> Void
@@ -413,6 +416,7 @@ final class WorkspaceSceneModel: ObservableObject {
     let localHostID: UUID
     private let notificationService: NotificationService
     private let kwtInventoryLoader: KwtInventoryLoader
+    private let kwtRemoteProvisioner: KwtRemoteProvisioner
     private let kwtWorktreeCreator: KwtWorktreeCreator
     private let kwtWorktreeRemover: KwtWorktreeRemover
     private let kwtBranchLister: KwtBranchLister
@@ -549,6 +553,10 @@ final class WorkspaceSceneModel: ObservableObject {
         @escaping () -> Bool = { false },
         kwtInventoryLoader: @escaping KwtInventoryLoader = { host in
             try await KwtInventoryClient().load(from: host)
+        },
+        kwtRemoteProvisioner: @escaping KwtRemoteProvisioner = { host in
+            try await KwtRemoteProvisioningCoordinator.shared
+                .ensureInstalled(on: host)
         },
         kwtWorktreeCreator: @escaping KwtWorktreeCreator = {
             request, projectPath, host in
@@ -694,6 +702,7 @@ final class WorkspaceSceneModel: ObservableObject {
         self.sceneSettings = sceneSettings
         self.terminalRuntime = terminalRuntime
         self.kwtInventoryLoader = kwtInventoryLoader
+        self.kwtRemoteProvisioner = kwtRemoteProvisioner
         self.kwtWorktreeCreator = kwtWorktreeCreator
         self.kwtWorktreeRemover = kwtWorktreeRemover
         self.kwtBranchLister = kwtBranchLister
@@ -1979,6 +1988,20 @@ final class WorkspaceSceneModel: ObservableObject {
         let targets = inventoryHosts.filter {
             !fencedHostIDs.contains($0.key)
         }
+        let configuredHosts = Dictionary(
+            configuredSSHHostsProvider().map { ($0.configKey, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let automaticProvisioningHosts: [UUID: SSHHost] = Dictionary(
+            uniqueKeysWithValues: targets.compactMap { hostID, target in
+                guard case .ssh = target,
+                      let summary = snapshot.host(id: hostID),
+                      let host = configuredHosts[summary.configKey],
+                      host.platform == .macOS || host.platform == .linux
+                else { return nil }
+                return (hostID, host)
+            }
+        )
         kwtInventoryGeneration += 1
         let generation = kwtInventoryGeneration
         kwtInventoryTask?.cancel()
@@ -1993,6 +2016,7 @@ final class WorkspaceSceneModel: ObservableObject {
         isKwtInventoryLoading = true
         updateWorkspaceInventoryState()
         let kwtInventoryLoader = kwtInventoryLoader
+        let kwtRemoteProvisioner = kwtRemoteProvisioner
         kwtInventoryTask = Task { [weak self] in
             await withTaskGroup(
                 of: (UUID, Result<KwtHostInventory, Error>).self
@@ -2000,6 +2024,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 for (hostID, host) in targets {
                     group.addTask {
                         do {
+                            if let remoteHost =
+                                automaticProvisioningHosts[hostID] {
+                                try await kwtRemoteProvisioner(remoteHost)
+                            }
                             return await (
                                 hostID,
                                 .success(
@@ -2038,7 +2066,14 @@ final class WorkspaceSceneModel: ObservableObject {
                             forKey: hostID
                         )
                     case let .failure(error):
-                        if self.isRemoteKwtUnavailable(
+                        if error is KwtRemoteInstallError {
+                            // Provisioning failures disable worktree actions
+                            // but remain visible because they require a
+                            // packaging, transport, or remote-host repair.
+                            self.kwtAvailabilityByHost[hostID] = false
+                            self.kwtInventoryFailuresByHost[hostID] =
+                                error.localizedDescription
+                        } else if self.isRemoteKwtUnavailable(
                             error,
                             hostID: hostID
                         ) {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1989,7 +1989,9 @@ final class WorkspaceSceneModel: ObservableObject {
             !fencedHostIDs.contains($0.key)
         }
         let configuredHosts = Dictionary(
-            configuredSSHHostsProvider().map { ($0.configKey, $0) },
+            (configuredSSHHostsProvider()
+                + configuredExeHostsProvider().map(\.sshHost))
+                .map { ($0.configKey, $0) },
             uniquingKeysWith: { first, _ in first }
         )
         let automaticProvisioningHosts: [UUID: SSHHost] = Dictionary(

--- a/Sources/Settings/SettingsPreferences.swift
+++ b/Sources/Settings/SettingsPreferences.swift
@@ -4,13 +4,16 @@ import GhosthubWorkspace
 public struct WorktreePreferences: Equatable, Sendable {
     public var hideRootCheckout: Bool
     public var showHiddenWorktreesByDefault: Bool
+    public var hideKwtManagedSessions: Bool
 
     public init(
         hideRootCheckout: Bool,
-        showHiddenWorktreesByDefault: Bool
+        showHiddenWorktreesByDefault: Bool,
+        hideKwtManagedSessions: Bool
     ) {
         self.hideRootCheckout = hideRootCheckout
         self.showHiddenWorktreesByDefault = showHiddenWorktreesByDefault
+        self.hideKwtManagedSessions = hideKwtManagedSessions
     }
 }
 

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -18,6 +18,8 @@ public final class SettingsStore: ObservableObject {
             "ghosthub.settings.application.confirmBeforeQuitting"
         static let hideRootCheckout = "ghosthub.settings.worktrees.hideRootCheckout"
         static let showHiddenWorktreesByDefault = "ghosthub.settings.worktrees.showHiddenWorktreesByDefault"
+        static let hideKwtManagedSessions =
+            "ghosthub.settings.worktrees.hideKwtManagedSessions"
         static let interfaceAppearance = "ghosthub.settings.appearance.interfaceAppearance"
         static let showMacOSNotifications =
             "ghosthub.settings.notifications.showMacOSNotifications"
@@ -67,7 +69,8 @@ public final class SettingsStore: ObservableObject {
 
     public static let defaultWorktreePreferences = WorktreePreferences(
         hideRootCheckout: false,
-        showHiddenWorktreesByDefault: false
+        showHiddenWorktreesByDefault: false,
+        hideKwtManagedSessions: true
     )
 
     public static let defaultTmuxSessionPreferences = TmuxSessionPreferences()
@@ -390,6 +393,13 @@ public final class SettingsStore: ObservableObject {
             preferences.showHiddenWorktreesByDefault = enabled
         }
         userDefaults.set(enabled, forKey: DefaultsKey.showHiddenWorktreesByDefault)
+    }
+
+    public func setHideKwtManagedSessions(_ enabled: Bool) {
+        updateWorktreePreferences { preferences in
+            preferences.hideKwtManagedSessions = enabled
+        }
+        userDefaults.set(enabled, forKey: DefaultsKey.hideKwtManagedSessions)
     }
 
     @discardableResult
@@ -750,7 +760,10 @@ public final class SettingsStore: ObservableObject {
             ) as? Bool ?? defaults.hideRootCheckout,
             showHiddenWorktreesByDefault: userDefaults.object(
                 forKey: DefaultsKey.showHiddenWorktreesByDefault
-            ) as? Bool ?? defaults.showHiddenWorktreesByDefault
+            ) as? Bool ?? defaults.showHiddenWorktreesByDefault,
+            hideKwtManagedSessions: userDefaults.object(
+                forKey: DefaultsKey.hideKwtManagedSessions
+            ) as? Bool ?? defaults.hideKwtManagedSessions
         )
     }
 

--- a/Sources/Settings/SettingsViewDraft.swift
+++ b/Sources/Settings/SettingsViewDraft.swift
@@ -31,6 +31,7 @@ public struct SettingsViewDraft: Equatable {
     public var copySelectionToClipboard: Bool
     public var hideRootCheckout: Bool
     public var showHiddenWorktreesByDefault: Bool
+    public var hideKwtManagedSessions: Bool
     public var hiddenTmuxSessionPatterns: [String]
     public var showMacOSNotifications: Bool
     public var attentionSound: WorkspaceNotificationSound
@@ -62,6 +63,8 @@ public struct SettingsViewDraft: Equatable {
         hideRootCheckout = store.worktreePreferences.hideRootCheckout
         showHiddenWorktreesByDefault = store.worktreePreferences
             .showHiddenWorktreesByDefault
+        hideKwtManagedSessions = store.worktreePreferences
+            .hideKwtManagedSessions
         hiddenTmuxSessionPatterns = store.tmuxSessionPreferences
             .hiddenSessionPatterns
         showMacOSNotifications = store.notificationConfiguration
@@ -117,6 +120,7 @@ public struct SettingsViewDraft: Equatable {
         store.setShowHiddenWorktreesByDefault(
             showHiddenWorktreesByDefault
         )
+        store.setHideKwtManagedSessions(hideKwtManagedSessions)
         let didPersistTmuxSessionPatterns = store
             .setHiddenTmuxSessionPatterns(hiddenTmuxSessionPatterns)
         store.setShowMacOSNotifications(showMacOSNotifications)

--- a/Sources/UI/CommandPaletteModel.swift
+++ b/Sources/UI/CommandPaletteModel.swift
@@ -468,7 +468,12 @@ public enum CommandPaletteModel {
                     )
                 }
             }
-            return discovered + worktrees
+            let worktreeSessionIDs = Set(
+                worktrees.map { $0.session.id }
+            )
+            return worktrees + discovered.filter {
+                !worktreeSessionIDs.contains($0.session.id)
+            }
         }
 
         return sessions.flatMap {

--- a/Sources/UI/HostsSettingsView.swift
+++ b/Sources/UI/HostsSettingsView.swift
@@ -826,8 +826,8 @@ public struct HostsSettingsView: View {
             $0.code == .missingKwt
         } == true
         return isMissing
-            ? "Install kwt Worktree Helper"
-            : "Update kwt Worktree Helper"
+            ? "Retry kwt Worktree Helper"
+            : "Reinstall kwt Worktree Helper"
     }
 
     private var isHostActionInProgress: Bool {

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -1029,7 +1029,9 @@ public struct RootView: View {
     private var tmuxSessionVisibility: TmuxSessionVisibility {
         TmuxSessionVisibility(
             hiddenPatterns: settingsStore.tmuxSessionPreferences
-                .hiddenSessionPatterns
+                .hiddenSessionPatterns,
+            hideKwtManagedSessions: settingsStore.worktreePreferences
+                .hideKwtManagedSessions
         )
     }
 

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -457,10 +457,15 @@ public struct SettingsView: View {
                     "Show hidden worktrees by default",
                     isOn: $draft.showHiddenWorktreesByDefault
                 )
+                Toggle(
+                    "Hide kwt-managed sessions from Tmux Sessions",
+                    isOn: $draft.hideKwtManagedSessions
+                )
 
                 Text(
-                    "Kwt remains authoritative for registered projects,"
-                        + " worktrees, and tmux session names."
+                    "Kwt-managed sessions remain available through their"
+                        + " worktrees when hidden from the separate tmux"
+                        + " session list."
                 )
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -394,7 +394,8 @@ public enum WorkspaceSidebarModel {
                 tmuxSessionRows: tmuxSessionOrder.ordered(
                     host.tmuxSessions
                         .filter {
-                            !defaultServerSessionNames.contains($0.name)
+                            (!tmuxSessionVisibility.hideKwtManagedSessions
+                                || !defaultServerSessionNames.contains($0.name))
                                 && !tmuxSessionVisibility.isHidden($0.name)
                         }
                         .sorted {
@@ -448,7 +449,19 @@ public enum WorkspaceSidebarModel {
         snapshot: WorkspaceSnapshot
     ) -> WorkspaceSidebarRow {
         let sessions = snapshot.sessions(for: worktree.id)
-        let status = WorktreeRowStatus.make(for: worktree, sessions: sessions)
+        let host = snapshot.host(id: worktree.hostID)
+        let hasLiveTmuxSession = worktree.tmuxSocketName == nil
+            && host?.lastKnownReachable == true
+            && worktree.tmuxSessionName.map { sessionName in
+                host?.tmuxSessions.contains {
+                    $0.name == sessionName
+                } == true
+            } == true
+        let status = WorktreeRowStatus.make(
+            for: worktree,
+            sessions: sessions,
+            hasLiveTmuxSession: hasLiveTmuxSession
+        )
         // The branch/PR lives in the status's second line and the detail
         // card, so worktree rows carry no subtitle. Command-palette search
         // reads worktree.sidebarSubtitle directly instead.

--- a/Sources/UI/WorktreeRowStatus.swift
+++ b/Sources/UI/WorktreeRowStatus.swift
@@ -41,16 +41,19 @@ public struct WorktreeRowStatus: Equatable, Sendable {
     /// - Parameters:
     ///   - w: The worktree summary to derive status from.
     ///   - sessions: The active sessions associated with this worktree.
+    ///   - hasLiveTmuxSession: Whether direct discovery found the worktree's
+    ///     canonical tmux session.
     /// - Returns: A fully derived `WorktreeRowStatus`.
     public static func make(
         for w: WorktreeSummary,
-        sessions: [TerminalSessionSummary]
+        sessions: [TerminalSessionSummary],
+        hasLiveTmuxSession: Bool = false
     ) -> WorktreeRowStatus {
         let added = (w.diffAdded ?? 0) > 0 ? w.diffAdded : nil
         let removed = (w.diffRemoved ?? 0) > 0 ? w.diffRemoved : nil
         let ahead = (w.syncAhead ?? 0) > 0 ? w.syncAhead : nil
         let behind = (w.syncBehind ?? 0) > 0 ? w.syncBehind : nil
-        let running = sessions.contains { $0.isAlive }
+        let running = hasLiveTmuxSession || sessions.contains { $0.isAlive }
         let agentRunning = sessions.contains { $0.isAlive && $0.runtimeKind == .agent }
         let checksGlyph = checksGlyph(from: w.checksStatus)
 

--- a/Sources/Workspace/HostModels.swift
+++ b/Sources/Workspace/HostModels.swift
@@ -204,10 +204,9 @@ public struct RemoteHostDiagnostic: Codable, Equatable, Sendable, Identifiable {
         RemoteHostDiagnostic(
             code: .missingKwt,
             severity: .warning,
-            summary: "Git worktree support is not installed (optional).",
+            summary: "Git worktree support is unavailable (optional).",
             recoverySuggestion:
-            "Use Install kwt Worktree Helper in Host Settings to show "
-                + "projects and worktrees from this host. "
+            "Open Host Settings to install or repair the kwt helper. "
                 + "Tmux sessions remain available."
         )
     }

--- a/Sources/Workspace/TmuxSessionVisibility.swift
+++ b/Sources/Workspace/TmuxSessionVisibility.swift
@@ -2,9 +2,14 @@ import Foundation
 
 public struct TmuxSessionVisibility: Equatable, Sendable {
     public var hiddenPatterns: [String]
+    public var hideKwtManagedSessions: Bool
 
-    public init(hiddenPatterns: [String] = []) {
+    public init(
+        hiddenPatterns: [String] = [],
+        hideKwtManagedSessions: Bool = true
+    ) {
         self.hiddenPatterns = hiddenPatterns
+        self.hideKwtManagedSessions = hideKwtManagedSessions
     }
 
     public func isHidden(_ sessionName: String) -> Bool {

--- a/Tests/App/KwtRemoteInstallerTests.swift
+++ b/Tests/App/KwtRemoteInstallerTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 @Suite("Managed remote kwt installation")
 struct KwtRemoteInstallerTests {
-    @Test("Linux arm64 helper is verified and installed by exact revision")
+    @Test("missing Linux arm64 helper is installed by exact revision")
     func installsLinuxARM64Helper() async throws {
         let revision = String(repeating: "d", count: 40)
         let helperURL = FileManager.default.temporaryDirectory
@@ -19,6 +19,11 @@ struct KwtRemoteInstallerTests {
             revision: revision,
             remoteRunner: { _, command in
                 recorder.record(command: command)
+                if command == KwtRemoteInstaller.readyProbeCommand(
+                    revision: revision
+                ) {
+                    return (1, "")
+                }
                 if command == KwtRemoteInstaller.targetProbeCommand {
                     return (
                         0,
@@ -48,7 +53,7 @@ struct KwtRemoteInstallerTests {
             }
         )
 
-        try await installer.install(on: SSHHost(
+        try await installer.ensureInstalled(on: SSHHost(
             configKey: "spark",
             name: "DGX Spark",
             platform: .linux,
@@ -70,6 +75,168 @@ struct KwtRemoteInstallerTests {
         #expect(installCommand.contains("mv -f"))
         #expect(installCommand.contains(revision))
         #expect(installCommand.contains("kwt version \(revision)"))
+    }
+
+    @Test("exact installed helper skips upload")
+    func exactInstalledHelperSkipsUpload() async throws {
+        let revision = String(repeating: "c", count: 40)
+        let recorder = KwtInstallRecorder()
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, command in
+                recorder.record(command: command)
+                return (0, "banner\nGHOSTHUB_KWT_READY\n")
+            },
+            uploadRunner: { host, source, destination in
+                recorder.record(
+                    host: host,
+                    source: source,
+                    destination: destination
+                )
+                return (0, "")
+            },
+            resourceProvider: { _ in nil }
+        )
+
+        try await installer.ensureInstalled(on: SSHHost(
+            configKey: "mbp",
+            name: "MacBook Pro",
+            platform: .macOS,
+            sshDestination: "wesm@mbp"
+        ))
+
+        #expect(recorder.commands == [
+            KwtRemoteInstaller.readyProbeCommand(revision: revision),
+        ])
+        #expect(recorder.destination == nil)
+    }
+
+    @Test("cancelling the last provisioning waiter stops before upload")
+    func cancellationStopsProvisioningBeforeUpload() async throws {
+        let revision = String(repeating: "b", count: 40)
+        let probeStarted = AsyncStream<Void>.makeStream()
+        let recorder = KwtInstallRecorder()
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, command in
+                recorder.record(command: command)
+                if command == KwtRemoteInstaller.readyProbeCommand(
+                    revision: revision
+                ) {
+                    return (1, "")
+                }
+                if command == KwtRemoteInstaller.targetProbeCommand {
+                    probeStarted.continuation.yield()
+                    let deadline = Date().addingTimeInterval(2)
+                    while !Task.isCancelled, Date() < deadline {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                    return (
+                        0,
+                        "GHOSTHUB_KWT_TARGET\tLinux\taarch64\n"
+                    )
+                }
+                return (0, "")
+            },
+            uploadRunner: { host, source, destination in
+                recorder.record(
+                    host: host,
+                    source: source,
+                    destination: destination
+                )
+                return (0, "")
+            },
+            resourceProvider: { _ in nil }
+        )
+        let coordinator = KwtRemoteProvisioningCoordinator(
+            installer: installer
+        )
+        let task = Task {
+            try await coordinator.ensureInstalled(on: SSHHost(
+                configKey: "spark",
+                name: "DGX Spark",
+                platform: .linux,
+                sshDestination: "wesm@spark"
+            ))
+        }
+
+        var probeEvents = probeStarted.stream.makeAsyncIterator()
+        _ = await probeEvents.next()
+        task.cancel()
+        await #expect {
+            try await task.value
+        } throws: {
+            $0 is CancellationError
+        }
+        #expect(recorder.destination == nil)
+    }
+
+    @Test("cancellation after upload prevents helper activation")
+    func cancellationAfterUploadPreventsActivation() async throws {
+        let revision = String(repeating: "9", count: 40)
+        let helperURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try Data("pinned kwt".utf8).write(to: helperURL)
+        defer { try? FileManager.default.removeItem(at: helperURL) }
+        let uploadStarted = AsyncStream<Void>.makeStream()
+        let recorder = KwtInstallRecorder()
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, command in
+                recorder.record(command: command)
+                if command == KwtRemoteInstaller.targetProbeCommand {
+                    return (
+                        0,
+                        "GHOSTHUB_KWT_TARGET\tLinux\taarch64\n"
+                    )
+                }
+                if command.contains("GHOSTHUB_KWT_UPLOAD") {
+                    return (
+                        0,
+                        "GHOSTHUB_KWT_UPLOAD\t/home/wesm/.ghosthub/"
+                            + "helpers/kwt/\(revision)/.incoming-test\n"
+                    )
+                }
+                return (0, "GHOSTHUB_KWT_INSTALLED\n")
+            },
+            uploadRunner: { host, source, destination in
+                recorder.record(
+                    host: host,
+                    source: source,
+                    destination: destination
+                )
+                uploadStarted.continuation.yield()
+                let deadline = Date().addingTimeInterval(2)
+                while !Task.isCancelled, Date() < deadline {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return (0, "")
+            },
+            resourceProvider: { _ in helperURL }
+        )
+        let task = Task {
+            try await installer.install(on: SSHHost(
+                configKey: "spark",
+                name: "DGX Spark",
+                platform: .linux,
+                sshDestination: "wesm@spark"
+            ))
+        }
+
+        var uploadEvents = uploadStarted.stream.makeAsyncIterator()
+        _ = await uploadEvents.next()
+        task.cancel()
+        await #expect {
+            try await task.value
+        } throws: {
+            $0 is CancellationError
+        }
+        #expect(recorder.destination != nil)
+        #expect(!recorder.commands.contains {
+            $0.contains("GHOSTHUB_KWT_INSTALLED")
+        })
+        let cleanupCommand = try #require(recorder.commands.last)
+        #expect(cleanupCommand.contains("rm -f"))
     }
 
     @Test("uploaded helper must report the exact pinned revision")

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -308,6 +308,8 @@ func makeModel(
         host in
         try await KwtInventoryClient().load(from: host)
     },
+    kwtRemoteProvisioner:
+    @escaping WorkspaceSceneModel.KwtRemoteProvisioner = { _ in },
     kwtWorktreeCreator: @escaping WorkspaceSceneModel.KwtWorktreeCreator = {
         request, projectPath, host in
         try await KwtWorktreeClient().create(
@@ -419,6 +421,7 @@ func makeModel(
         appliesTmuxPresentationStyleToExistingSessionsProvider:
         appliesTmuxPresentationStyleToExistingSessionsProvider,
         kwtInventoryLoader: kwtInventoryLoader,
+        kwtRemoteProvisioner: kwtRemoteProvisioner,
         kwtWorktreeCreator: kwtWorktreeCreator,
         kwtWorktreeRemover: kwtWorktreeRemover,
         worktreeMutationCoordinator: worktreeMutationCoordinator,

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -387,6 +387,9 @@ func makeModel(
     configuredSSHHostsProvider: @escaping () -> [SSHHost] = { [] },
     configuredSSHHostsPublisher: AnyPublisher<[SSHHost], Never> =
         Empty(completeImmediately: false).eraseToAnyPublisher(),
+    configuredExeHostsProvider: @escaping () -> [ExeConfiguredHost] = { [] },
+    configuredExeHostsPublisher: AnyPublisher<[ExeConfiguredHost], Never> =
+        Empty(completeImmediately: false).eraseToAnyPublisher(),
     refreshExeHosts: @escaping () -> Void = {},
     terminalColorsPublisher:
     AnyPublisher<[UInt: TerminalResolvedColors], Never>? = nil,
@@ -436,6 +439,8 @@ func makeModel(
         sshHostProbeRunner: sshHostProbeRunner,
         configuredSSHHostsProvider: configuredSSHHostsProvider,
         configuredSSHHostsPublisher: configuredSSHHostsPublisher,
+        configuredExeHostsProvider: configuredExeHostsProvider,
+        configuredExeHostsPublisher: configuredExeHostsPublisher,
         refreshExeHosts: refreshExeHosts,
         terminalColorsPublisher: terminalColorsPublisher,
         sceneSettings: sceneSettings,

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2602,6 +2602,103 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("automatic kwt provisioning includes exe.dev hosts")
+    func automaticKwtProvisioningIncludesExeHosts() async throws {
+        let environment = try setupStandardEnvironment()
+        let exeHost = ExeConfiguredHost(
+            sshHost: SSHHost(
+                configKey: "exe-dev.personal.build",
+                name: "build",
+                platform: .linux,
+                sshDestination: "vm+build@exe.dev"
+            ),
+            metadata: ExeVMMetadata(
+                accountConfigKey: "personal",
+                accountName: "Personal",
+                vmName: "build"
+            )
+        )
+        let provisionedHost = LockedValue<SSHHost?>(nil)
+        let remoteInventoryLoads = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { host in
+                if host.isRemote {
+                    _ = remoteInventoryLoads.increment()
+                }
+                return KwtHostInventory(projects: [])
+            },
+            kwtRemoteProvisioner: { host in
+                provisionedHost.store(host)
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            configuredExeHostsProvider: { [exeHost] },
+            startServices: true
+        )
+
+        await waitUntilMainActor {
+            remoteInventoryLoads.count > 0
+                && model.isWorkspaceInventoryRefreshComplete
+        }
+
+        #expect(provisionedHost.load() == exeHost.sshHost)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("manual SSH hosts retain kwt provisioning precedence")
+    func manualHostsRetainKwtProvisioningPrecedence() async throws {
+        let environment = try setupStandardEnvironment()
+        let manualHost = SSHHost(
+            configKey: "manual-build",
+            name: "Manual Build",
+            platform: .linux,
+            sshDestination: "build.exe.xyz"
+        )
+        let exeHost = ExeConfiguredHost(
+            sshHost: SSHHost(
+                configKey: "exe-dev.personal.build",
+                name: "build",
+                platform: .linux,
+                sshDestination: manualHost.sshDestination
+            ),
+            metadata: ExeVMMetadata(
+                accountConfigKey: "personal",
+                accountName: "Personal",
+                vmName: "build"
+            )
+        )
+        let provisionedHost = LockedValue<SSHHost?>(nil)
+        let remoteInventoryLoads = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { host in
+                if host.isRemote {
+                    _ = remoteInventoryLoads.increment()
+                }
+                return KwtHostInventory(projects: [])
+            },
+            kwtRemoteProvisioner: { host in
+                provisionedHost.store(host)
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            configuredSSHHostsProvider: { [manualHost] },
+            configuredExeHostsProvider: { [exeHost] },
+            startServices: true
+        )
+
+        await waitUntilMainActor {
+            remoteInventoryLoads.count > 0
+                && model.isWorkspaceInventoryRefreshComplete
+        }
+
+        #expect(provisionedHost.load() == manualHost)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("kwt provisioning failure leaves remote tmux inventory available")
     func provisioningFailureDoesNotBlockTmux() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2549,6 +2549,117 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test(
+        "automatic kwt provisioning follows the remote platform policy",
+        arguments: [
+            (HostPlatform.macOS, true),
+            (HostPlatform.linux, true),
+            (HostPlatform.windows, false),
+        ]
+    )
+    func automaticKwtProvisioning(
+        platform: HostPlatform,
+        expected: Bool
+    ) async throws {
+        let environment = try setupStandardEnvironment()
+        let remote = SSHHost(
+            configKey: "remote",
+            name: "Remote",
+            platform: platform,
+            sshDestination: "remote"
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
+        let provisioningAttempts = Counter()
+        let remoteInventoryLoads = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { host in
+                if host.isRemote {
+                    _ = remoteInventoryLoads.increment()
+                    #expect((provisioningAttempts.count > 0) == expected)
+                }
+                return KwtHostInventory(projects: [])
+            },
+            kwtRemoteProvisioner: { host in
+                #expect(host.platform == platform)
+                _ = provisioningAttempts.increment()
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            configuredSSHHostsPublisher:
+            configuredHosts.eraseToAnyPublisher(),
+            startServices: true
+        )
+
+        await waitUntilMainActor {
+            remoteInventoryLoads.count > 0
+                && model.isWorkspaceInventoryRefreshComplete
+        }
+
+        #expect((provisioningAttempts.count > 0) == expected)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("kwt provisioning failure leaves remote tmux inventory available")
+    func provisioningFailureDoesNotBlockTmux() async throws {
+        let environment = try setupStandardEnvironment()
+        let remote = SSHHost(
+            configKey: "build-box",
+            name: "Build Box",
+            platform: .linux,
+            sshDestination: "build-box"
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
+        let remoteInventoryLoads = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { host in
+                if host.isRemote {
+                    _ = remoteInventoryLoads.increment()
+                }
+                return KwtHostInventory(projects: [])
+            },
+            kwtRemoteProvisioner: { _ in
+                throw KwtRemoteInstallError.bundleIncomplete
+            },
+            tmuxSessionDiscovery: { host in
+                .success(host.isRemote ? [
+                    DiscoveredTmuxSession(
+                        name: "build",
+                        windowCount: 1,
+                        createdAt: "1721552400",
+                        managed: false
+                    ),
+                ] : [])
+            },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            configuredSSHHostsPublisher:
+            configuredHosts.eraseToAnyPublisher(),
+            startServices: true
+        )
+
+        await waitUntilMainActor {
+            model.workspaceInventoryState == .loaded
+                && model.snapshot.hosts.contains {
+                    $0.configKey == remote.configKey
+                        && $0.tmuxSessions.map(\.name) == ["build"]
+                }
+                && !model.workspaceInventoryWarningsByHost.isEmpty
+        }
+
+        #expect(remoteInventoryLoads.count == 0)
+        let remoteSummary = try #require(
+            model.snapshot.hosts.first { $0.configKey == remote.configKey }
+        )
+        #expect(remoteSummary.primaryDiagnostic?.code == .missingKwt)
+        #expect(!remoteSummary.canCreateWorktree)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("an unreachable SSH host does not block local inventory")
     func unreachableRemoteDoesNotBlockLocalInventory() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -158,6 +158,7 @@ final class SettingsStoreTests {
                 .appliesThemeToTmuxSessions
         )
         #expect(!store.worktreePreferences.hideRootCheckout)
+        #expect(store.worktreePreferences.hideKwtManagedSessions)
         #expect(store.tmuxSessionPreferences.hiddenSessionPatterns.isEmpty)
         #expect(store.shareAnonymousUsageData)
     }
@@ -390,6 +391,7 @@ final class SettingsStoreTests {
         store.setShareAnonymousUsageData(false)
         store.setHideRootCheckout(true)
         store.setShowHiddenWorktreesByDefault(true)
+        store.setHideKwtManagedSessions(false)
         store.setShowPaneResourceUsage(false)
         store.setTerminalTheme(.clearDark)
         store.setTerminalThemeAppliesToTmuxSessions(true)
@@ -407,6 +409,7 @@ final class SettingsStoreTests {
         #expect(!reloaded.shareAnonymousUsageData)
         #expect(reloaded.worktreePreferences.hideRootCheckout)
         #expect(reloaded.worktreePreferences.showHiddenWorktreesByDefault)
+        #expect(!reloaded.worktreePreferences.hideKwtManagedSessions)
         #expect(!reloaded.terminalPreferences.showPaneResourceUsage)
         #expect(reloaded.terminalAppearancePreferences.theme == .clearDark)
         #expect(

--- a/Tests/Settings/SettingsViewDraftTests.swift
+++ b/Tests/Settings/SettingsViewDraftTests.swift
@@ -15,6 +15,7 @@ struct SettingsViewDraftTests {
         store.setTerminalThemeAppliesToTmuxSessions(true)
         store.setHideRootCheckout(true)
         store.setShowHiddenWorktreesByDefault(true)
+        store.setHideKwtManagedSessions(false)
         store.setHiddenTmuxSessionPatterns(["forge-*", "scratch-?"])
         store.setShowMacOSNotifications(false)
         store.setNotificationAttentionSound(.glass)
@@ -35,6 +36,7 @@ struct SettingsViewDraftTests {
         #expect(draft.appliesTerminalThemeToTmuxSessions)
         #expect(draft.hideRootCheckout)
         #expect(draft.showHiddenWorktreesByDefault)
+        #expect(!draft.hideKwtManagedSessions)
         #expect(
             draft.hiddenTmuxSessionPatterns == ["forge-*", "scratch-?"]
         )
@@ -69,6 +71,7 @@ struct SettingsViewDraftTests {
         var draft = SettingsViewDraft(store: store)
         draft.hideRootCheckout = true
         draft.showHiddenWorktreesByDefault = true
+        draft.hideKwtManagedSessions = false
         draft.hiddenTmuxSessionPatterns = ["forge-*", "scratch-?"]
         draft.showMacOSNotifications = false
         draft.attentionSound = .ping
@@ -77,6 +80,7 @@ struct SettingsViewDraftTests {
 
         #expect(store.worktreePreferences.hideRootCheckout)
         #expect(store.worktreePreferences.showHiddenWorktreesByDefault)
+        #expect(!store.worktreePreferences.hideKwtManagedSessions)
         #expect(
             store.tmuxSessionPreferences.hiddenSessionPatterns
                 == ["forge-*", "scratch-?"]

--- a/Tests/UI/CommandPaletteModelTests.swift
+++ b/Tests/UI/CommandPaletteModelTests.swift
@@ -685,6 +685,61 @@ struct CommandPaletteModelTests {
         commands.expectCommandContains(title: "Open tmux session: homelab")
     }
 
+    @Test("exposed kwt session keeps one worktree-aware lifecycle command")
+    func exposedKwtSessionDeduplicatesLifecycleCommands() throws {
+        let host = HostSummary.fixture(
+            tmuxSessions: [
+                TmuxSessionSummary(
+                    name: "kwt-ghosthub-main",
+                    managed: false,
+                    windows: [],
+                    serverPID: "4242",
+                    sessionID: "$3",
+                    createdAt: "1785190000"
+                ),
+            ]
+        )
+        let project = ProjectSummary.fixture(hostID: host.id)
+        var worktree = WorktreeSummary.fixture(
+            hostID: host.id,
+            projectID: project.id
+        )
+        worktree.tmuxSessionName = "kwt-ghosthub-main"
+        let commands = makeCommandPaletteCommands(
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [project],
+                worktrees: [worktree]
+            ),
+            selection: WorkspaceSelection(selectedHostID: host.id),
+            tmuxSessionVisibility: TmuxSessionVisibility(
+                hideKwtManagedSessions: false
+            )
+        )
+
+        let openCommands = commands.filter {
+            if case let .openTmuxSession(session) = $0.action {
+                return session.name == "kwt-ghosthub-main"
+            }
+            return false
+        }
+        let killCommands = commands.filter {
+            if case let .killTmuxSession(session) = $0.action {
+                return session.name == "kwt-ghosthub-main"
+            }
+            return false
+        }
+        let open = try #require(openCommands.first)
+        let kill = try #require(killCommands.first)
+        let expected = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+        #expect(openCommands.count == 1)
+        #expect(killCommands.count == 1)
+        #expect(open.action == .openTmuxSession(expected))
+        #expect(kill.action == .killTmuxSession(expected))
+    }
+
     @Test("import PR command hidden without GitHub-linked projects")
     func importPRCommandHiddenWithoutGitHubLink() {
         let host = HostSummary.fixture(

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -552,6 +552,31 @@ struct WorkspaceSidebarModelTests {
 
         #expect(sections[0].tmuxSessionRows.map(\.title) == ["external-agent"])
         #expect(sections[0].projects[0].worktrees.map(\.id) == [worktree.id])
+        #expect(
+            sections[0].projects[0].worktreeRows[0]
+                .worktreeStatus?.isRunning == true
+        )
+
+        let showingKwtSessions = WorkspaceSidebarModel.sections(
+            in: snapshot,
+            tmuxSessionVisibility: TmuxSessionVisibility(
+                hideKwtManagedSessions: false
+            )
+        )
+
+        #expect(showingKwtSessions[0].tmuxSessionRows.map(\.title) == [
+            "external-agent", "kwt-docbank-main",
+        ])
+
+        var unreachableSnapshot = snapshot
+        unreachableSnapshot.hosts[0].lastKnownReachable = false
+        let unreachableSections = WorkspaceSidebarModel.sections(
+            in: unreachableSnapshot
+        )
+        #expect(
+            unreachableSections[0].projects[0].worktreeRows[0]
+                .worktreeStatus?.isRunning == false
+        )
     }
 
     @Test("hidden patterns remove only standalone tmux session rows")
@@ -652,6 +677,10 @@ struct WorkspaceSidebarModelTests {
 
         #expect(
             sections[0].tmuxSessionRows.map(\.title) == ["kwt-docbank-pr-32"]
+        )
+        #expect(
+            sections[0].projects[0].worktreeRows[0]
+                .worktreeStatus?.isRunning == false
         )
     }
 

--- a/Tests/UI/WorktreeRowStatusTests.swift
+++ b/Tests/UI/WorktreeRowStatusTests.swift
@@ -128,6 +128,18 @@ struct WorktreeRowStatusTests {
         #expect(!s.isAgentRunning)
     }
 
+    @Test func discoveredTmuxSessionIsRunningWithoutPresentation() {
+        let w = makeWorktree()
+        let s = WorktreeRowStatus.make(
+            for: w,
+            sessions: [],
+            hasLiveTmuxSession: true
+        )
+
+        #expect(s.isRunning)
+        #expect(!s.isAgentRunning)
+    }
+
     @Test func checksFailure() {
         let w = makeWorktree(linkedPR: 7, checks: .failure)
         let s = WorktreeRowStatus.make(for: w, sessions: [])

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,11 @@ The sidebar is a host-wide session navigator. It shows registered worktrees and
 directly discovered tmux sessions on each host, including sessions that were
 not created by Ghosthub or kwt. Users may hide matching standalone sessions
 from navigation with case-sensitive wildcard patterns; discovery retains the
-complete inventory so worktree status and session identity remain accurate.
+complete inventory so a kwt-owned session confirmed by current discovery is
+indicated on its worktree row. Cached sessions do not remain live while a host
+is unreachable. Kwt-owned sessions are hidden from the separate tmux session
+group by default, with a Worktrees setting that exposes those duplicate
+entries.
 General tmux sessions are presented as one ordinary native tmux client; tmux
 alone owns and renders their layout.
 
@@ -244,18 +248,23 @@ host-key policy.
 Ghosthub bundles revision-pinned kwt CLI builds for local project and worktree
 operations and for `darwin/{amd64,arm64}`, `linux/{amd64,arm64}`, and
 `windows/{amd64,arm64}` remote hosts. The local helper is signed as app code and invoked by its exact bundle
-path. Remote helpers are sealed resources in the signed app. After the user
-chooses **Install kwt Worktree Helper** for a host, Ghosthub selects the matching
-`uname` target, uploads it, verifies its SHA-256 on the host, and atomically
-installs it under `~/.ghosthub/helpers/kwt/<revision>/kwt`. Packaging verifies
-the six binaries' formats, architectures, and embedded revision; installation
-also requires the uploaded helper's `version` output to report that revision
-before promotion. Every remote kwt operation invokes that exact revisioned
-path; failed upload or installation attempts also best-effort remove their
-unique staged file. Neither local nor remote operations select an unrelated
-kwt from `PATH`. This is a CLI boundary, not a vendored daemon or submodule.
-Kwt's machine-readable CLI provides project identity, worktree metadata, and
-exact tmux session names.
+path. Remote helpers are sealed resources in the signed app. Before loading kwt
+inventory for a configured remote macOS or Linux host, Ghosthub checks the
+exact revisioned helper. If it is missing or stale, Ghosthub selects the
+matching `uname` target, uploads it, verifies its SHA-256 on the host, and
+atomically installs it under `~/.ghosthub/helpers/kwt/<revision>/kwt`.
+Concurrent scenes share one provisioning operation per exact host endpoint.
+When inventory cancellation removes the final caller, Ghosthub cancels that
+operation and rechecks cancellation before upload and helper activation so a
+removed or reconfigured host is not mutated by obsolete work.
+Packaging verifies the six binaries' formats, architectures, and embedded
+revision; installation also requires the uploaded helper's `version` output to
+report that revision before promotion. Every remote kwt operation invokes that
+exact revisioned path; failed upload or installation attempts also best-effort
+remove their unique staged file. Neither local nor remote operations select an
+unrelated kwt from `PATH`. This is a CLI boundary, not a vendored daemon or
+submodule. Kwt's machine-readable CLI provides project identity, worktree
+metadata, and exact tmux session names.
 On a macOS or Linux host with no existing kwt registry, the user adds one
 absolute repository path at a time through **Add Project**. Ghosthub delegates
 registration to `kwt projects add --json`, then refreshes ordinary kwt
@@ -310,13 +319,13 @@ then executes an ordinary client with environment updates disabled. The user
 may explicitly run project commands after attachment. Other workspaces and
 unbound sessions continue to attach directly to the host's normal tmux server.
 
-Remote kwt installation is never implicit. Ordinary inventory and tmux
-attachment remain non-mutating. Connection testing mutates host-key state only
-after the explicit fingerprint approval above, and a remote host without the
-managed helper remains tmux-only. Install and Update are explicit Settings
-actions and never replace a host's system kwt. Versioned directories retain
-older pinned helpers, so installing an older Ghosthub build can select and
-restore its own revision; reinstalling one revision also retains `kwt.previous`.
+Adding a remote macOS or Linux host authorizes Ghosthub to maintain its
+per-user managed kwt helper as part of inventory refresh. Provisioning failure
+disables that host's worktree actions and reports the error without blocking
+ordinary tmux discovery or attachment. The helper never replaces or resolves
+a host's system kwt. Versioned directories retain older pinned helpers, so an
+older Ghosthub build can select and restore its own revision; reinstalling one
+revision also retains `kwt.previous`.
 
 Native Windows installation uses a separate PowerShell boundary. The explicit
 **Install Bundled kwt** action probes the remote process architecture, uploads
@@ -324,8 +333,9 @@ the matching PE helper over OpenSSH, verifies its SHA-256 and exact pinned
 version at a managed staging path, and atomically installs it at
 `%USERPROFILE%\.ghosthub\helpers\kwt\<revision>\kwt.exe` without replacing or
 resolving a system `kwt.exe`. A failed activation restores the prior helper at
-that revision. The Windows helpers remain unsigned experimental payloads until
-the release pipeline adds an approved Authenticode/DigiCert signing step.
+that revision. Automatic Windows provisioning remains disabled while the
+Windows helpers are unsigned experimental payloads; it requires an approved
+Authenticode signing step first.
 
 ### Experimental native Windows hosts
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,13 +118,14 @@ hosts should provide:
 
 - `git` and `tmux` on the non-interactive SSH `PATH`
 
-Kwt does not need to be installed system-wide. After the connection succeeds,
-use **Install kwt Worktree Helper** in Host Settings to copy Ghosthub's pinned
-architecture-matched helper into the remote user's `~/.ghosthub/` directory.
-On a fresh host, enter each existing checkout's absolute path under **Add
-Project**. The managed helper records it through kwt's supported registry
-command and Ghosthub refreshes project/worktree inventory. Tmux-only discovery
-and attachment work without either optional action.
+Kwt does not need to be installed system-wide. Ghosthub automatically copies
+or updates its pinned architecture-matched helper in the remote user's
+`~/.ghosthub/` directory when it loads inventory for a configured macOS or
+Linux host. On a fresh host, enter each existing checkout's absolute path under
+**Add Project**. The managed helper records it through kwt's supported registry
+command and Ghosthub refreshes project/worktree inventory. Tmux discovery and
+attachment continue to work if helper provisioning fails. Windows provisioning
+remains explicit until its kwt executables are Authenticode-signed.
 
 Ghosthub uses the host's OpenSSH configuration directly and invokes an
 ordinary tmux client on the target host. Tmux owns windows, panes, layouts,

--- a/docs/release.md
+++ b/docs/release.md
@@ -249,8 +249,10 @@ locally built. Verify at minimum:
 - Local kwt projects and worktrees load without a system kwt on `PATH`.
 - Existing local tmux sessions remain discoverable and attach normally.
 - A configured SSH host discovers and attaches tmux without managed kwt.
-- Install kwt Worktree Helper selects the correct target, enables remote project
-  inventory, and leaves any system `kwt` untouched.
+- A configured macOS or Linux host automatically receives the correct pinned
+  kwt helper during inventory, while any system `kwt` remains untouched.
+- A configured Windows host does not install its unsigned kwt helper
+  automatically.
 - On a fresh macOS or Linux host, Add Project registers an absolute existing
   checkout through managed kwt and makes its worktrees available without a
   filesystem scan.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -290,10 +290,11 @@ inventory and exposes a clickable detail warning on that host without blocking
 the rest of the workspace. The detail offers a retry and a shortcut to Host
 Settings; OpenSSH status 255 is reported as an SSH connection failure instead
 of a login-shell or tmux failure. Remote hosts where Ghosthub's managed kwt is
-absent remain available for direct tmux discovery and attachment. Inventory
-never uploads the helper. The user grants permission with **Install kwt
-Worktree Helper** in Host Settings, after which inventory and protected
-attachment execute its exact revisioned path. On macOS and Linux, a fresh
+absent remain available for direct tmux discovery and attachment. Before kwt
+inventory runs for a configured macOS or Linux host, Ghosthub ensures its exact
+revisioned helper is installed under the remote user's `~/.ghosthub/`
+directory. A provisioning failure is reported for that host and disables its
+worktree actions without blocking tmux inventory. On macOS and Linux, a fresh
 helper has an empty project registry: **Add Project** in the host's **+** menu
 passes one user-supplied absolute checkout path to kwt's noninteractive
 registration command, then refreshes inventory. Immediately before
@@ -307,12 +308,17 @@ verifies its SHA-256 and exact revision, and activates it at
 workspace operations use only that exact per-user helper and never resolve
 `kwt.exe` from `PATH`.
 Project registration is not yet supported on Windows, so its Add Project
-actions are hidden. Discovery never installs or updates remote software
-implicitly.
+actions are hidden. Inventory never installs or updates the unsigned Windows
+helper automatically.
 
-Kwt session names are removed from the generic session group and rendered
-under their project/worktree. Every remaining tmux session is eligible for the
-host-level session group. Case-sensitive `*` and `?` wildcard patterns in
+Direct tmux discovery marks a default-server worktree session as running when
+its exact kwt session name is present and the host remains reachable. Cached
+inventory does not preserve the live indicator through a discovery failure.
+Kwt session names are removed from the generic session group by default and
+remain rendered under their project/worktree. Settings → Worktrees can expose
+those duplicate generic session entries. Every remaining tmux session is
+eligible for the host-level session group. Case-sensitive `*` and `?` wildcard
+patterns in
 `hidden_session_patterns` under `[tmux]` inside
 `~/.config/ghosthub/config.toml` hide matching standalone sessions from the
 sidebar and command palette. Settings → Worktrees edits the same list, one

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -108,9 +108,11 @@ state is outside the security model.
 
 Pull-request import is an explicit user mutation delegated to the bundled local
 kwt or Ghosthub's exact managed kwt revision on the selected remote host.
-Installing that remote helper is a separate explicit user action; Ghosthub
-selects a sealed app resource, verifies its SHA-256 after upload, and never
-replaces a system kwt. Adding a remote project is also explicit: Ghosthub
+Configuring a remote macOS or Linux host authorizes Ghosthub to install and
+update that per-user helper during inventory refresh. Ghosthub selects a sealed
+app resource, verifies its SHA-256 after upload, and never replaces a system
+kwt. Automatic provisioning is disabled for Windows until its kwt executables
+are Authenticode-signed. Adding a remote project is still explicit: Ghosthub
 shell-quotes one user-supplied absolute path and delegates registration to the
 managed kwt rather than scanning remote directories or editing configuration.
 Ghosthub passes kwt's opaque candidate identity back

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,11 +93,12 @@ keeps that OpenSSH control connection for the app session. The response is not
 saved.
 Use **Test Connection** to verify authentication and that `tmux` is on the
 remote login-shell `PATH`.
-Kwt does not need a system installation: follow a successful test with
-**Install kwt Worktree Helper** when project inventory is missing. If the host
-has never used kwt, enter an existing checkout's absolute path under **Add
-Project** from the **+** menu beside that host; repeat for each repository
-Ghosthub should display.
+Kwt does not need a system installation: Ghosthub automatically installs or
+updates its managed helper when it loads inventory for a configured remote
+macOS or Linux host. If provisioning fails, use the host warning to retry or
+open Host Settings. If the host has never used kwt, enter an existing
+checkout's absolute path under **Add Project** from the **+** menu beside that
+host; repeat for each repository Ghosthub should display.
 
 **Test Connection** follows your OpenSSH host-key policy. If the exact full
 destination has an unseen key, Ghosthub presents OpenSSH's fingerprint for

--- a/website/docs/content/privacy.md
+++ b/website/docs/content/privacy.md
@@ -44,8 +44,9 @@ live in:
 ## Remote state
 
 Ghosthub does not scan remote filesystems. **Add Project** delegates only the
-absolute repository path you explicitly provide. When you approve installation
-of a managed kwt helper, Ghosthub stores its matching revision-pinned helper
-under the remote user's `~/.ghosthub/` directory.
+absolute repository path you explicitly provide. For configured remote macOS
+and Linux hosts, Ghosthub automatically stores or updates its matching
+revision-pinned managed kwt helper under the remote user's `~/.ghosthub/`
+directory. Automatic Windows helper installation remains disabled.
 
 Interactive SSH responses are retained only for the running app session.

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -24,8 +24,10 @@ Start with an existing Git checkout on the target host.
 Ghosthub registers that one path through kwt and refreshes inventory. It does
 not scan the machine or edit kwt configuration itself.
 
-Remote hosts need the [managed kwt helper](remote-hosts.md#install-the-managed-kwt-helper)
-first. Project registration is not yet available for native Windows hosts.
+Ghosthub automatically maintains the
+[managed kwt helper](remote-hosts.md#managed-kwt-helper) on configured remote
+macOS and Linux hosts. Project registration is not yet available for native
+Windows hosts.
 
 If the SSH destination changes while the Add Project sheet is open, close the
 sheet and start again so the confirmation applies to the current host.
@@ -35,6 +37,14 @@ sheet and start again so the confirmation applies to the current host.
 Select the project's primary checkout or any linked worktree in the sidebar.
 Kwt supplies the exact canonical tmux session name. Ghosthub creates or repairs
 that session when necessary and then attaches an ordinary tmux client.
+A status glyph on the worktree row indicates when current discovery confirms
+its tmux session is live, including while Ghosthub is detached. Cached sessions
+do not remain marked live while the host is unreachable.
+
+By default, a live kwt-managed session appears only on its worktree row instead
+of being duplicated under **Tmux Sessions**. Open **Settings → Worktrees** and
+turn off **Hide kwt-managed sessions from Tmux Sessions** if you want both
+entries visible.
 
 ## Create a worktree from a branch
 

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -89,18 +89,14 @@ If SSH needs authentication or host-key review, the presentation changes to
 same reconnect supervisor. If you dismiss it, choose **Review Connection** to
 open it again.
 
-## Install the managed kwt helper
+## Managed kwt helper
 
 Tmux-only hosts do not need kwt. To show projects and worktrees on a remote
-macOS or Linux host:
-
-1. Test the host connection successfully.
-2. Choose **Install kwt Worktree Helper** in Host Settings.
-3. Confirm the upload.
-
-Ghosthub copies its matching revision-pinned helper for the remote operating
-system and CPU, verifies it, and stores it under `~/.ghosthub/`. It does not
-install or replace a system-wide kwt.
+macOS or Linux host, configure the host normally. Ghosthub automatically copies
+or updates its matching revision-pinned helper during project inventory. It
+verifies the helper, stores it under `~/.ghosthub/`, and does not install or
+replace a system-wide kwt. If provisioning fails, tmux sessions remain usable
+and the host warning offers a retry and a shortcut to Host Settings.
 
 Register individual repositories with the explicit **Add Project** action.
 Ghosthub never scans a remote filesystem. See
@@ -125,6 +121,7 @@ Native Windows support requires:
 Choose **Windows (psmux)** when adding the host. After a successful connection
 test, **Install Bundled kwt** can upload the matching AMD64 or ARM64 helper for
 that user. The Windows helper is currently unsigned, so this path is intended
-for development machines and power users. Adding a new project from Ghosthub is
-not yet supported on Windows, although already registered project inventory can
-be shown.
+for development machines and power users and is never run automatically.
+Automatic provisioning will remain disabled until the kwt executables are
+Authenticode-signed. Adding a new project from Ghosthub is not yet supported on
+Windows, although already registered project inventory can be shown.

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -68,6 +68,11 @@ matches one character. Ghosthub stores these patterns in
 The patterns apply only to standalone sessions. A matching kwt workspace stays
 visible under its project.
 
+Kwt-managed sessions are also omitted from the separate **Tmux Sessions** group
+by default because their worktrees remain the canonical entry. You can expose
+those duplicate session rows with the toggle in **Settings → Worktrees**. The
+worktree's status glyph continues to reflect the live tmux session either way.
+
 ## Ownership and safety
 
 Ghosthub does not infer that closing a presentation means ending work. It

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -42,9 +42,10 @@ when no review is pending.
 
 ## A project does not appear
 
-For a remote macOS or Linux host, first install the managed kwt helper from
-Host Settings. Then use the host's **Add Project** action and provide the
-absolute path to an existing checkout on that host. Ghosthub does not discover
+For a remote macOS or Linux host, Ghosthub installs its managed kwt helper
+automatically. If the host shows a provisioning warning, retry it or open Host
+Settings. Then use the host's **Add Project** action and provide the absolute
+path to an existing checkout on that host. Ghosthub does not discover
 repositories by scanning.
 
 Project registration is not yet supported for native Windows hosts.


### PR DESCRIPTION
Kwt worktrees could look idle despite having a live tmux session, appear twice in navigation, or disappear from remote inventory when Ghosthub’s pinned helper had not been installed or updated.

This PR:

- Shows a live status glyph when current tmux discovery confirms a reachable worktree session. Cached sessions are not shown as live while a host is unreachable.
- Hides kwt-managed duplicates from **Tmux Sessions** by default, with a **Settings → Worktrees** option to expose them. The command palette still keeps one worktree-aware lifecycle command per session.
- Automatically installs or updates Ghosthub’s exact pinned kwt helper on configured macOS and Linux hosts without replacing a system kwt.
- Keeps Windows helper installation explicit until the executables are Authenticode-signed.
- Cancels shared provisioning when its final inventory caller disappears, preventing removed or reconfigured hosts from continuing into upload or activation.
- Preserves ordinary tmux access when helper provisioning fails while disabling affected worktree actions and reporting the error.