### PR TITLE
Recover safely from stale worktree removal

### DIFF
--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -83,7 +83,7 @@ struct KwtHostInventory: Equatable, Sendable {
 
     func retainingFailedProjectWorktrees(
         from previous: KwtHostInventory?,
-        excludingWorktrees: Set<KwtWorktreeIdentity> = []
+        excludingWorktrees: [String: Set<KwtWorktreeIdentity>] = [:]
     ) -> KwtHostInventory {
         var retainedProjects = projects
         if projectsWarning != nil,
@@ -108,8 +108,10 @@ struct KwtHostInventory: Equatable, Sendable {
                    }) {
                     retained.worktrees = prior.worktrees
                 }
+                let exclusions =
+                    excludingWorktrees[item.project.repository] ?? []
                 retained.worktrees.removeAll { worktree in
-                    excludingWorktrees.contains {
+                    exclusions.contains {
                         $0.matches(
                             path: worktree.path,
                             generation: worktree.generation
@@ -507,16 +509,38 @@ enum KwtSnapshotMerger {
             return workspace
         }
 
+        let inventoryRepositories = Set(
+            inventory.projects.map(\.project.repository)
+        )
+        var reconciledProjectIDs = Set<UUID>()
         for item in inventory.projects {
             let record = item.project
-            let existingProject = existingProjects.first {
-                normalizedPath($0.rootPath) == normalizedPath(record.path)
-                    || (!$0.scopedKey.isEmpty
-                        && $0.scopedKey == record.repository)
+            let recordPath = normalizedPath(record.path)
+            let repositoryMatch = existingProjects.first {
+                !record.repository.isEmpty
+                    && !$0.scopedKey.isEmpty
+                    && $0.scopedKey == record.repository
+                    && !reconciledProjectIDs.contains($0.id)
             }
+            // Repository identity survives a move. Path is only a legacy
+            // fallback for transitional records or when it does not belong to
+            // a different repository, and an existing runtime ID can be
+            // consumed at most once.
+            let existingProject = repositoryMatch
+                ?? existingProjects.first { candidate in
+                    normalizedPath(candidate.rootPath) == recordPath
+                        && ((candidate.registryID != nil
+                                && !inventoryRepositories.contains(
+                                    candidate.scopedKey
+                                ))
+                            || candidate.scopedKey.isEmpty
+                            || candidate.scopedKey == record.repository)
+                        && !reconciledProjectIDs.contains(candidate.id)
+                }
             let projectID = existingProject?.id ?? stableID(
                 "project|\(hostID.uuidString)|\(record.repository)|\(record.path)"
             )
+            reconciledProjectIDs.insert(projectID)
             var project = existingProject ?? ProjectSummary(
                 id: projectID,
                 hostID: hostID,
@@ -550,8 +574,16 @@ enum KwtSnapshotMerger {
             }
 
             for record in item.worktrees {
+                let recordPath = normalizedPath(record.path)
                 let existing = existingWorktrees.first {
-                    normalizedPath($0.path) == normalizedPath(record.path)
+                    $0.projectID == projectID
+                        && normalizedPath($0.path) == recordPath
+                }
+                let consistentExisting = existing.flatMap { candidate in
+                    candidate.branch == record.branch
+                        && candidate.isPrimary == record.isMain
+                        && candidate.tmuxSessionName == record.sessionName
+                        ? candidate : nil
                 }
                 let worktreeID = existing?.id ?? stableID(
                     "worktree|\(hostID.uuidString)|\(record.repository)|\(record.path)"
@@ -576,16 +608,33 @@ enum KwtSnapshotMerger {
                 worktree.isStale = false
                 worktree.createdAt = record.createdAt
                 worktree.generation = record.generation
+                    ?? WorktreeGeneration.canonical(
+                        consistentExisting?.generation
+                    )
                 worktree.tmuxSessionName = record.sessionName
                 // The protected socket is a fail-closed marker: it keeps
                 // contributor-authored terminal configuration out of the app
                 // config and routes attachment through kwt's protected
-                // command. A refresh that omits it is never evidence that the
-                // workspace stopped being protected, so it cannot clear it.
+                // command. A refresh can omit it without unprotecting the same
+                // workspace. Its last canonical generation is retained when
+                // that same incomplete record also omits identity, but a new
+                // canonical generation must not inherit the socket from the
+                // prior owner of a reused path. Canonical generation therefore
+                // outranks path identity.
                 // Deleting the workspace drops the record entirely, which is
                 // how a protected marker is actually retired.
-                worktree.tmuxSocketName = record.tmuxSocketName
-                    ?? existing?.tmuxSocketName
+                if let generation = WorktreeGeneration.canonical(
+                    record.generation
+                ) {
+                    worktree.tmuxSocketName = record.tmuxSocketName
+                        ?? existingWorktrees.first {
+                            $0.projectID == projectID
+                                && $0.generation == generation
+                        }?.tmuxSocketName
+                } else {
+                    worktree.tmuxSocketName = record.tmuxSocketName
+                        ?? consistentExisting?.tmuxSocketName
+                }
                 worktree.sessionBackend = snapshot.host(id: hostID)?.kind == .remote
                     ? .remoteTmux : .localTmux
                 worktrees.append(worktree)

--- a/Sources/App/KwtWorktreeClient.swift
+++ b/Sources/App/KwtWorktreeClient.swift
@@ -12,6 +12,8 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
     case removalInProgress
     case removalIdentityUnavailable
     case removalTargetChanged
+    case removalHostChanged
+    case removalPreflightUnavailable(host: String, message: String)
     case sessionStartedAfterConfirmation(session: String)
     case commandFailed(host: String, status: Int32)
     case removalFailed(host: String, status: Int32)
@@ -38,6 +40,11 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
         case .removalTargetChanged:
             "The worktree or its tmux session changed after confirmation."
                 + " Review the refreshed workspace and try again."
+        case .removalHostChanged:
+            "The host destination changed after confirmation. Review the host"
+                + " settings and try again."
+        case let .removalPreflightUnavailable(host, message):
+            "kwt could not verify the worktree on \(host): \(message)"
         case let .sessionStartedAfterConfirmation(session):
             "Tmux session “\(session)” started after confirmation. Review the"
                 + " updated removal warning and try again."

--- a/Sources/App/TmuxSessionActivityController.swift
+++ b/Sources/App/TmuxSessionActivityController.swift
@@ -31,6 +31,11 @@ final class TmuxSessionActivityController: ObservableObject {
 
     @Published private(set) var workingSessionIDs: Set<String> = []
 
+    /// Session IDs currently enrolled for warm-activity sampling. Warm
+    /// enrollment completes asynchronously after identity verification, so
+    /// callers that need to sample deterministically wait on this set.
+    var warmSessionIDs: Set<String> { Set(entries.keys) }
+
     private let sampler: Sampler
     private let activityDuration: TimeInterval
     private let workingSampleInterval: TimeInterval

--- a/Sources/App/TmuxSessionKiller.swift
+++ b/Sources/App/TmuxSessionKiller.swift
@@ -40,6 +40,7 @@ struct TmuxSessionKiller: Sendable {
         "GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH"
     private static let identityMarker =
         "GHOSTHUB_TMUX_SESSION_IDENTITY\t"
+    static let diagnosticMarker = "GHOSTHUB_TMUX_DIAGNOSTIC\t"
 
     typealias PathResolver = @Sendable (CommandHost)
         -> Result<String, TmuxBinaryError>
@@ -107,13 +108,20 @@ struct TmuxSessionKiller: Sendable {
             runner(host, command)
         }.value
         guard result.status == 0 else {
+            if result.status == 1,
+               Self.isConfirmedAbsence(result.stdout) {
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
             throw TmuxSessionKillError.commandFailed(
                 host: host.displayName,
                 session: selection.name,
                 status: result.status
             )
         }
-        guard !result.stdout.contains(Self.identityMismatchMarker) else {
+        guard !Self.hasIdentityMismatch(result.stdout) else {
             throw TmuxSessionKillError.sessionChanged(
                 host: host.displayName,
                 session: selection.name
@@ -203,11 +211,13 @@ struct TmuxSessionKiller: Sendable {
                 "kill-session -t \(expectedIdentity.sessionID)"
             arguments[arguments.count - 1] =
                 "display-message -p \(identityMismatchMarker)"
-            return powerShellCommand(arguments)
+            return powerShellCommand(
+                arguments,
+                captureStandardError: true,
+                frameOutput: true
+            )
         }
-        return arguments
-            .map(shellQuotedCommandArgument)
-            .joined(separator: " ")
+        return framedPOSIXCommand(arguments)
     }
 
     private static func identityCommand(
@@ -253,34 +263,87 @@ struct TmuxSessionKiller: Sendable {
         if platform == .windows {
             return powerShellCommand(
                 arguments,
-                captureStandardError: true
+                captureStandardError: true,
+                frameOutput: true
             )
         }
-        return arguments
-            .map(shellQuotedCommandArgument)
-            .joined(separator: " ")
-            + " 2>&1"
+        return framedPOSIXCommand(arguments)
     }
 
     static func isConfirmedAbsence(_ output: String) -> Bool {
-        let normalized = output.lowercased()
-        return normalized.contains("can't find session:")
-            || normalized.contains("no server running on ")
+        output.split(whereSeparator: \.isNewline).contains { rawLine in
+            guard rawLine.hasPrefix(diagnosticMarker) else { return false }
+            let line = rawLine.dropFirst(diagnosticMarker.count)
+                .trimmingCharacters(in: .whitespaces)
+                .lowercased()
+            return line.hasPrefix("can't find session:")
+                || line.hasPrefix("no server running on ")
+                || line ==
+                "failed to connect to server: no such file or directory"
+                || (line.hasPrefix("error connecting to ")
+                    && line.hasSuffix("(no such file or directory)"))
+        }
+    }
+
+    private static func hasIdentityMismatch(_ output: String) -> Bool {
+        let expected = diagnosticMarker + identityMismatchMarker
+        return output.split(whereSeparator: \.isNewline).contains {
+            $0 == expected
+        }
+    }
+
+    private static func framedPOSIXCommand(
+        _ arguments: [String]
+    ) -> String {
+        let invocation = arguments
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let marker = shellQuotedCommandArgument(diagnosticMarker)
+        return """
+        GHOSTHUB_TMUX_OUTPUT=$(\(invocation) 2>&1)
+        GHOSTHUB_TMUX_STATUS=$?
+        if [ -n "$GHOSTHUB_TMUX_OUTPUT" ]; then
+            printf '%s\\n' "$GHOSTHUB_TMUX_OUTPUT" |
+                while IFS= read -r GHOSTHUB_TMUX_LINE; do
+                    printf '%s%s\\n' \(marker) "$GHOSTHUB_TMUX_LINE"
+                done
+        fi
+        exit "$GHOSTHUB_TMUX_STATUS"
+        """
     }
 
     private static func powerShellCommand(
         _ arguments: [String],
-        captureStandardError: Bool = false
+        captureStandardError: Bool = false,
+        frameOutput: Bool = false
     ) -> String {
         let invocation = "& "
             + arguments.map(powerShellEncodedArgument).joined(separator: " ")
             + (captureStandardError ? " 2>&1" : "")
+        let body: String
+        if frameOutput {
+            body = """
+            $GhosthubTmuxOutput = \(invocation)
+            $GhosthubTmuxStatus = $LASTEXITCODE
+            foreach ($GhosthubTmuxLine in $GhosthubTmuxOutput) {
+                [Console]::Out.WriteLine(
+                    \(powerShellEncodedArgument(diagnosticMarker))
+                        + [string]$GhosthubTmuxLine
+                )
+            }
+            exit $GhosthubTmuxStatus
+            """
+        } else {
+            body = """
+            \(invocation)
+            exit $LASTEXITCODE
+            """
+        }
         return """
         $ErrorActionPreference = 'Stop'
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $OutputEncoding = [Console]::OutputEncoding
-        \(invocation)
-        exit $LASTEXITCODE
+        \(body)
         """
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -266,7 +266,7 @@ final class WorkspaceSceneModel: ObservableObject {
     ) async throws -> KwtProjectRecord
     typealias TmuxSessionDiscovery = @Sendable (
         CommandHost
-    ) -> Result<[DiscoveredTmuxSession], TmuxBinaryError>
+    ) async -> Result<[DiscoveredTmuxSession], TmuxBinaryError>
     typealias HerdrSessionDiscovery = @Sendable (
         CommandHost
     ) -> HerdrDiscoveryResult
@@ -532,6 +532,11 @@ final class WorkspaceSceneModel: ObservableObject {
         var wasActive: Bool
         var userNavigationRevision: UInt64
     }
+    private struct PendingRemovalRestoration {
+        var presentations:
+            [TmuxPresentationKey: PendingRemovalPresentation] = [:]
+        var snapshotRefreshed = false
+    }
     private var retainedTmuxPresentations:
         [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
     private var retainedTmuxPresentationKeysByHandle:
@@ -555,10 +560,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 Set<WorktreeMutationCoordinator.RemovalTombstone>
         ] = [:]
     private var pendingRemovalPresentationRestorations:
-        [
-            WorktreeMutationCoordinator.Scope:
-                [TmuxPresentationKey: PendingRemovalPresentation]
-        ] = [:]
+        [WorktreeMutationCoordinator.Scope: PendingRemovalRestoration] = [:]
     private var userNavigationRevision: UInt64 = 0
     private var isShutDown = false
     private var sceneActivityGeneration: UInt64 = 0
@@ -1145,7 +1147,7 @@ final class WorkspaceSceneModel: ObservableObject {
         tmuxSessionProbeBroker = TmuxSessionProbeBroker(
             discover: { host in
                 let probe = Task.detached(priority: .utility) {
-                    tmuxSessionDiscovery(host)
+                    await tmuxSessionDiscovery(host)
                 }
                 return await withTaskCancellationHandler {
                     await probe.value
@@ -2001,7 +2003,8 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func prepareWorktreeRemoval(
-        _ worktreeID: UUID
+        _ worktreeID: UUID,
+        refreshSessionIdentity: Bool = false
     ) async throws -> WorktreeRemovalRequest {
         guard let worktree = snapshot.worktree(id: worktreeID),
               let project = snapshot.project(id: worktree.projectID),
@@ -2026,13 +2029,14 @@ final class WorkspaceSceneModel: ObservableObject {
         if let session = WorkspaceSidebarModel.tmuxSessionSelection(
             for: worktree
         ) {
-            if WorkspaceSidebarModel.canRequestKill(
-                session,
-                in: snapshot,
-                activeSelection: activeBorrowedTmuxSelection,
-                activeSelectionIsConnected:
-                activeBorrowedTmuxSessionIsConnected
-            ) {
+            if !refreshSessionIdentity,
+               WorkspaceSidebarModel.canRequestKill(
+                   session,
+                   in: snapshot,
+                   activeSelection: activeBorrowedTmuxSelection,
+                   activeSelectionIsConnected:
+                   activeBorrowedTmuxSessionIsConnected
+               ) {
                 sessionKillRequest = try await prepareTmuxSessionKill(session)
             } else {
                 do {
@@ -2065,26 +2069,36 @@ final class WorkspaceSceneModel: ObservableObject {
     func removeWorktree(
         _ request: WorktreeRemovalRequest
     ) async throws {
-        guard let requestedWorktree = snapshot.worktree(
-            id: request.worktree.id
+        guard let requestedWorktree = currentRemovalTarget(for: request) else {
+            if currentRemovalTmuxEndpointOwner(for: request) != nil {
+                throw KwtWorktreeError.removalTargetChanged
+            }
+            throw KwtWorktreeError.worktreeUnavailable
+        }
+        guard let requestedProject = snapshot.project(
+            id: requestedWorktree.projectID
         ),
-            requestedWorktree.path == request.worktree.path,
-            requestedWorktree.projectID == request.project.id,
-            snapshot.canRemoveWorktree(requestedWorktree),
-            let requestedProject = snapshot.project(id: request.project.id),
-            requestedProject.rootPath == request.project.rootPath,
             let hostSummary = snapshot.host(id: requestedWorktree.hostID),
-            let currentHost = CommandHostResolver.resolve(hostSummary)
+            CommandHostResolver.resolve(hostSummary) != nil
         else {
             throw KwtWorktreeError.worktreeUnavailable
         }
-        guard request.confirmedHost.id == requestedWorktree.hostID,
+        guard removalRequest(
+            request,
+            matches: requestedWorktree,
+            project: requestedProject
+        ) else {
+            throw KwtWorktreeError.removalTargetChanged
+        }
+        guard snapshot.canRemoveWorktree(requestedWorktree) else {
+            throw KwtWorktreeError.worktreeUnavailable
+        }
+        guard removalHostEndpointMatches(request),
               let confirmedHost = CommandHostResolver.resolve(
                   request.confirmedHost
-              ),
-              currentHost == confirmedHost
+              )
         else {
-            throw KwtWorktreeError.removalTargetChanged
+            throw KwtWorktreeError.removalHostChanged
         }
 
         let mutationHostID = requestedProject.hostID
@@ -2127,7 +2141,7 @@ final class WorkspaceSceneModel: ObservableObject {
             throw error
         }
         guard removalHostEndpointMatches(request) else {
-            throw KwtWorktreeError.removalTargetChanged
+            throw KwtWorktreeError.removalHostChanged
         }
         let preflightTarget = try reconcileRemovalPreflight(
             preflight,
@@ -2179,7 +2193,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 requiresWorkspaceReestablishment = true
             }
             guard removalHostEndpointMatches(request) else {
-                throw KwtWorktreeError.removalTargetChanged
+                throw KwtWorktreeError.removalHostChanged
             }
             if !checkoutAlreadyAbsent {
                 do {
@@ -2190,8 +2204,22 @@ final class WorkspaceSceneModel: ObservableObject {
                         confirmedHost
                     )
                 } catch {
+                    let removalError = error
                     requiresWorkspaceReestablishment = terminatedSession
-                    throw error
+                    let outcome = await classifyFailedRemoval(
+                        request,
+                        tombstone: removalTombstone,
+                        hostID: project.hostID,
+                        confirmedHost: confirmedHost
+                    )
+                    if outcome.identityRemoved {
+                        removalTombstones.insert(removalTombstone)
+                        requiresWorkspaceReestablishment = false
+                    }
+                    if outcome.targetChanged {
+                        throw KwtWorktreeError.removalTargetChanged
+                    }
+                    throw removalError
                 }
             }
             cancelPendingRestoration()
@@ -2214,10 +2242,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 refreshed,
                 hostID: project.hostID,
                 excludingWorktrees: [
-                    KwtWorktreeIdentity(
-                        path: worktree.path,
-                        generation: generation
-                    ),
+                    project.scopedKey: [
+                        KwtWorktreeIdentity(
+                            path: worktree.path,
+                            generation: generation
+                        ),
+                    ],
                 ]
             )
         } catch {
@@ -2232,36 +2262,215 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    func resolveWorktreeRemoval(
+        _ request: WorktreeRemovalRequest
+    ) async throws -> WorktreeRemovalResult {
+        do {
+            try await removeWorktree(request)
+            return .removed
+        } catch {
+            guard let recovery = Self.removalRecovery(for: error) else {
+                throw error
+            }
+            guard removalHostEndpointMatches(request) else {
+                throw KwtWorktreeError.removalHostChanged
+            }
+            switch recovery {
+            case .refreshSessionIdentity:
+                return await .confirmationRequired(
+                    try prepareWorktreeRemoval(
+                        request.worktree.id,
+                        refreshSessionIdentity: true
+                    )
+                )
+            case .reconfirmChangedTarget:
+                let updatedRequest = try await prepareCurrentWorktreeRemoval(
+                    request
+                )
+                guard removalConfirmationChanged(
+                    from: request,
+                    to: updatedRequest
+                ) else {
+                    throw KwtWorktreeError.removalTargetChanged
+                }
+                return .confirmationRequired(updatedRequest)
+            case .reconfirmStartedSession:
+                return await .confirmationRequired(
+                    try prepareWorktreeRemoval(request.worktree.id)
+                )
+            }
+        }
+    }
+
+    private enum RemovalRecovery {
+        case refreshSessionIdentity
+        case reconfirmChangedTarget
+        case reconfirmStartedSession
+    }
+
+    private static func removalRecovery(
+        for error: Error
+    ) -> RemovalRecovery? {
+        switch error {
+        case TmuxSessionKillError.sessionChanged,
+             TmuxSessionKillError.sessionNotRunning:
+            return .refreshSessionIdentity
+        case KwtWorktreeError.removalTargetChanged:
+            return .reconfirmChangedTarget
+        case KwtWorktreeError.sessionStartedAfterConfirmation:
+            return .reconfirmStartedSession
+        default:
+            return nil
+        }
+    }
+
+    /// Classifies a failed removal against a freshly loaded inventory so
+    /// the caller can decide between tombstoning the removed identity and
+    /// requiring a new confirmation. Refresh or reconciliation errors
+    /// leave both flags false to preserve the original removal failure.
+    private func classifyFailedRemoval(
+        _ request: WorktreeRemovalRequest,
+        tombstone: WorktreeMutationCoordinator.RemovalTombstone,
+        hostID: UUID,
+        confirmedHost: CommandHost
+    ) async -> (identityRemoved: Bool, targetChanged: Bool) {
+        do {
+            let refreshed = try await kwtInventoryLoader(confirmedHost)
+            guard removalHostEndpointMatches(request) else {
+                return (false, false)
+            }
+            do {
+                guard try reconcileRemovalPreflight(
+                    refreshed,
+                    request: request
+                ) == nil else {
+                    return (false, false)
+                }
+                applyAuthoritativeKwtInventory(
+                    refreshed,
+                    hostID: hostID,
+                    excludingWorktrees: [
+                        request.project.scopedKey: [tombstone],
+                    ]
+                )
+                return (true, false)
+            } catch KwtWorktreeError.removalTargetChanged {
+                // Survival is judged within the confirmed repository: the
+                // identity lives on when its path is still present or when
+                // its canonical generation reappears at a new path. The
+                // same path or generation under another repository is no
+                // longer this removal's target and must not keep stale
+                // presentations restorable.
+                let generation = WorktreeGeneration.canonical(
+                    tombstone.generation
+                )
+                let survives = refreshed.projects.first {
+                    $0.project.repository == request.project.scopedKey
+                }.map { item in
+                    // An incomplete worktree list cannot prove removal.
+                    item.warning != nil
+                        || item.worktrees.contains { record in
+                            tombstone.matches(
+                                path: record.path,
+                                generation: record.generation
+                            )
+                                || (generation != nil
+                                    && WorktreeGeneration.canonical(
+                                        record.generation
+                                    ) == generation)
+                        }
+                } ?? false
+                return (identityRemoved: !survives, targetChanged: true)
+            } catch {
+                return (false, false)
+            }
+        } catch {
+            return (false, false)
+        }
+    }
+
     private func reconcileRemovalPreflight(
         _ inventory: KwtHostInventory,
         request: WorktreeRemovalRequest
     ) throws -> (WorktreeSummary, ProjectSummary)? {
         let hostID = request.project.hostID
-        guard let item = inventory.projects.first(where: {
+        if let warning = inventory.projectsWarning {
+            throw KwtWorktreeError.removalPreflightUnavailable(
+                host: request.confirmedHost.name,
+                message: warning
+            )
+        }
+        let repositoryItem = inventory.projects.first {
             $0.project.repository == request.project.scopedKey
-                || $0.project.path == request.project.rootPath
-        }),
-            item.warning == nil,
-            item.project.repository == request.project.scopedKey,
-            item.project.path == request.project.rootPath
-        else {
+        }
+        let pathItem = inventory.projects.first {
+            $0.project.path == request.project.rootPath
+        }
+        // An incomplete owning repository cannot prove anything about the
+        // target, so its warning outranks every identity conclusion below,
+        // including a repository/path conflict.
+        if let repositoryItem, let warning = repositoryItem.warning {
+            throw KwtWorktreeError.removalPreflightUnavailable(
+                host: request.confirmedHost.name,
+                message: warning
+            )
+        }
+        if let repositoryItem,
+           let pathItem,
+           repositoryItem.project.repository != pathItem.project.repository {
+            applyAuthoritativeKwtInventory(inventory, hostID: hostID)
+            throw KwtWorktreeError.removalTargetChanged
+        }
+        guard let item = repositoryItem else {
+            // A path-only match is a different repository at the confirmed
+            // location; only its warning is worth surfacing before failing.
+            if let warning = pathItem?.warning {
+                throw KwtWorktreeError.removalPreflightUnavailable(
+                    host: request.confirmedHost.name,
+                    message: warning
+                )
+            }
+            applyAuthoritativeKwtInventory(inventory, hostID: hostID)
+            throw KwtWorktreeError.removalTargetChanged
+        }
+        guard item.project.path == request.project.rootPath else {
+            applyAuthoritativeKwtInventory(inventory, hostID: hostID)
             throw KwtWorktreeError.removalTargetChanged
         }
         guard let record = item.worktrees.first(where: {
             $0.path == request.worktree.path
         }) else {
+            let hostWorktrees = inventory.projects.flatMap(\.worktrees)
+            if let confirmedGeneration = request.worktree.generation,
+               hostWorktrees.contains(where: {
+                   $0.generation == confirmedGeneration
+               }) {
+                applyAuthoritativeKwtInventory(inventory, hostID: hostID)
+                throw KwtWorktreeError.removalTargetChanged
+            }
+            if hostWorktrees.contains(where: {
+                removalTmuxEndpoint(request.worktree, matches: $0)
+            }) {
+                applyAuthoritativeKwtInventory(inventory, hostID: hostID)
+                throw KwtWorktreeError.removalTargetChanged
+            }
+            if let warning = inventory.projects.compactMap(\.warning).first {
+                throw KwtWorktreeError.removalPreflightUnavailable(
+                    host: request.confirmedHost.name,
+                    message: warning
+                )
+            }
             return nil
         }
         applyAuthoritativeKwtInventory(inventory, hostID: hostID)
-        guard record.repository == request.project.scopedKey,
+        guard let worktree = snapshot.worktree(id: request.worktree.id),
+              let project = snapshot.project(id: request.project.id),
+              record.repository == request.project.scopedKey,
               record.branch == request.worktree.branch,
               record.isMain == request.worktree.isPrimary,
               let confirmedGeneration = request.worktree.generation,
               record.generation == confirmedGeneration,
               record.sessionName == request.worktree.tmuxSessionName,
-              record.tmuxSocketName == request.worktree.tmuxSocketName,
-              let worktree = snapshot.worktree(id: request.worktree.id),
-              let project = snapshot.project(id: request.project.id),
               removalRequest(
                   request,
                   matches: worktree,
@@ -2271,6 +2480,71 @@ final class WorkspaceSceneModel: ObservableObject {
             throw KwtWorktreeError.removalTargetChanged
         }
         return (worktree, project)
+    }
+
+    private func prepareCurrentWorktreeRemoval(
+        _ request: WorktreeRemovalRequest
+    ) async throws -> WorktreeRemovalRequest {
+        guard let worktree = currentRemovalTarget(for: request)
+            ?? currentRemovalTmuxEndpointOwner(for: request)
+        else {
+            throw KwtWorktreeError.worktreeUnavailable
+        }
+        return try await prepareWorktreeRemoval(worktree.id)
+    }
+
+    private func currentRemovalTarget(
+        for request: WorktreeRemovalRequest
+    ) -> WorktreeSummary? {
+        if let generation = WorktreeGeneration.canonical(
+            request.worktree.generation
+        ) {
+            return snapshot.worktrees.first {
+                $0.hostID == request.worktree.hostID
+                    && $0.projectID == request.project.id
+                    && $0.generation == generation
+            }
+        }
+        return snapshot.worktree(id: request.worktree.id)
+    }
+
+    private func currentRemovalTmuxEndpointOwner(
+        for request: WorktreeRemovalRequest
+    ) -> WorktreeSummary? {
+        guard let sessionName = request.worktree.tmuxSessionName else {
+            return nil
+        }
+        return snapshot.worktrees.first {
+            $0.hostID == request.worktree.hostID
+                && $0.projectID == request.project.id
+                && $0.tmuxSessionName == sessionName
+                && removalTmuxSocket(
+                    request.worktree.tmuxSocketName,
+                    matches: $0.tmuxSocketName
+                )
+        }
+    }
+
+    private func removalTmuxEndpoint(
+        _ worktree: WorktreeSummary,
+        matches record: KwtWorktreeRecord
+    ) -> Bool {
+        guard let sessionName = worktree.tmuxSessionName else { return false }
+        return record.sessionName == sessionName
+            && removalTmuxSocket(
+                worktree.tmuxSocketName,
+                matches: record.tmuxSocketName
+            )
+    }
+
+    private func removalTmuxSocket(
+        _ confirmedSocket: String?,
+        matches candidateSocket: String?
+    ) -> Bool {
+        // Missing inventory metadata cannot prove that a same-name session
+        // moved away from the confirmed protected server.
+        candidateSocket == confirmedSocket
+            || (confirmedSocket != nil && candidateSocket == nil)
     }
 
     private func removalRequest(
@@ -2299,6 +2573,17 @@ final class WorkspaceSceneModel: ObservableObject {
             && killRequest.session.worktreeID == worktree.id
             && killRequest.session.workspacePath == worktree.path
             && killRequest.session.socketName == worktree.tmuxSocketName
+    }
+
+    private func removalConfirmationChanged(
+        from request: WorktreeRemovalRequest,
+        to updatedRequest: WorktreeRemovalRequest
+    ) -> Bool {
+        !removalRequest(
+            request,
+            matches: updatedRequest.worktree,
+            project: updatedRequest.project
+        ) || updatedRequest.sessionKillRequest != request.sessionKillRequest
     }
 
     private func removalHostEndpointMatches(
@@ -2345,7 +2630,7 @@ final class WorkspaceSceneModel: ObservableObject {
         in snapshot: WorkspaceSnapshot,
         visibility: WorktreeVisibility
     ) -> WorkspaceSelection {
-        current.normalizedBySelectingVisibleFallback(
+        current.normalized(
             in: snapshot,
             visibility: visibility
         )
@@ -2819,7 +3104,7 @@ final class WorkspaceSceneModel: ObservableObject {
         case .ended:
             fencedWorktreeMutationScopes.remove(event.scope)
             pendingWorktreeRemovals.removeValue(forKey: event.scope)
-            let pendingRestorations =
+            let pendingRestoration =
                 pendingRemovalPresentationRestorations.removeValue(
                     forKey: event.scope
                 )
@@ -2828,11 +3113,12 @@ final class WorkspaceSceneModel: ObservableObject {
                     .formUnion(event.removalTombstones)
                 applyRemovalTombstones(
                     event.removalTombstones,
-                    hostID: event.scope.hostID
+                    scope: event.scope
                 )
-            } else if let pendingRestorations {
+            } else if let pendingRestoration {
                 restorePresentationsAfterFailedRemoval(
-                    pendingRestorations,
+                    pendingRestoration,
+                    scope: event.scope,
                     requiresWorkspaceReestablishment:
                     event.requiresWorkspaceReestablishment
                 )
@@ -3040,9 +3326,12 @@ final class WorkspaceSceneModel: ObservableObject {
         herdrSessionProbeBroker.invalidateSessions(on: host)
     }
 
+    /// Tombstones identify a removal within one repository; the same path
+    /// and generation under another repository is a different worktree and
+    /// must stay visible.
     private func applyRemovalTombstones(
         _ tombstones: Set<WorktreeMutationCoordinator.RemovalTombstone>,
-        hostID: UUID
+        scope: WorktreeMutationCoordinator.Scope
     ) {
         let matches: (String, String?) -> Bool = { path, generation in
             Self.removalTombstones(
@@ -3051,17 +3340,19 @@ final class WorkspaceSceneModel: ObservableObject {
                 generation: generation
             )
         }
-        if var inventory = kwtInventoriesByHost[hostID] {
-            for index in inventory.projects.indices {
+        if var inventory = kwtInventoriesByHost[scope.hostID] {
+            for index in inventory.projects.indices
+                where inventory.projects[index].project.repository
+                == scope.projectIdentity {
                 inventory.projects[index].worktrees.removeAll {
                     matches($0.path, $0.generation)
                 }
             }
-            kwtInventoriesByHost[hostID] = inventory
+            kwtInventoriesByHost[scope.hostID] = inventory
         }
         let removedIDs = worktreeIDs(
             matching: tombstones,
-            hostID: hostID
+            scope: scope
         )
         closeRetainedTmuxPresentations(forWorktreeIDs: removedIDs)
         explicitlyDismissedWorktreePresentationIDs.subtract(removedIDs)
@@ -3112,9 +3403,9 @@ final class WorkspaceSceneModel: ObservableObject {
             }
         for (presentation, restorationSelection) in presentations {
             let key = TmuxPresentationKey(presentation.selection)
-            pendingRemovalPresentationRestorations[event.scope, default: [:]][
-                key
-            ] = PendingRemovalPresentation(
+            pendingRemovalPresentationRestorations[
+                event.scope, default: PendingRemovalRestoration()
+            ].presentations[key] = PendingRemovalPresentation(
                 selection: restorationSelection,
                 launchMode: presentation.launchMode,
                 requiresWorkspaceEstablishment:
@@ -3128,14 +3419,20 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func restorePresentationsAfterFailedRemoval(
-        _ presentations: [TmuxPresentationKey: PendingRemovalPresentation],
+        _ restoration: PendingRemovalRestoration,
+        scope: WorktreeMutationCoordinator.Scope,
         requiresWorkspaceReestablishment: Bool
     ) {
-        for presentation in presentations.values {
+        for presentation in restoration.presentations.values {
+            guard let selection = currentRestorationSelection(
+                for: presentation.selection,
+                scope: scope,
+                snapshotRefreshed: restoration.snapshotRefreshed
+            ) else { continue }
             let establishesWorkspace = requiresWorkspaceReestablishment
                 || presentation.requiresWorkspaceEstablishment
             _ = presentTmuxSession(
-                presentation.selection,
+                selection,
                 launchMode: establishesWorkspace
                     ? .attach : presentation.launchMode,
                 intent: establishesWorkspace
@@ -3147,13 +3444,53 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    /// Reconciliation can refresh the surviving worktree's tmux session
+    /// name or socket between removal preflight and restoration; restoring
+    /// the saved endpoint would leave a presentation the next inventory
+    /// pass immediately invalidates. While this scene's snapshot was not
+    /// refreshed after the target was captured, the saved preflight
+    /// endpoint stays authoritative. When the refreshed snapshot no longer
+    /// holds the worktree within the removal's repository scope — for
+    /// example the same path and generation now belong to another project
+    /// — there is no trustworthy endpoint and restoration is skipped.
+    private func currentRestorationSelection(
+        for saved: WorkspaceTmuxSessionSelection,
+        scope: WorktreeMutationCoordinator.Scope,
+        snapshotRefreshed: Bool
+    ) -> WorkspaceTmuxSessionSelection? {
+        guard snapshotRefreshed,
+              let generation = WorktreeGeneration.canonical(
+                  saved.worktreeGeneration
+              )
+        else { return saved }
+        let projectIDs = Set(
+            snapshot.projects.filter {
+                $0.hostID == scope.hostID
+                    && $0.scopedKey == scope.projectIdentity
+            }.map(\.id)
+        )
+        guard let worktree = snapshot.worktrees.first(where: {
+            $0.hostID == scope.hostID
+                && projectIDs.contains($0.projectID)
+                && WorktreeGeneration.canonical($0.generation) == generation
+        }) else { return nil }
+        return WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+    }
+
     private func worktreeIDs(
         matching tombstones:
         Set<WorktreeMutationCoordinator.RemovalTombstone>,
-        hostID: UUID
+        scope: WorktreeMutationCoordinator.Scope
     ) -> Set<UUID> {
-        Set(snapshot.worktrees.compactMap { worktree in
-            guard worktree.hostID == hostID,
+        let projectIDs = Set(
+            snapshot.projects.filter {
+                $0.hostID == scope.hostID
+                    && $0.scopedKey == scope.projectIdentity
+            }.map(\.id)
+        )
+        return Set(snapshot.worktrees.compactMap { worktree in
+            guard worktree.hostID == scope.hostID,
+                  projectIDs.contains(worktree.projectID),
                   Self.removalTombstones(
                       tombstones,
                       matchPath: worktree.path,
@@ -3177,8 +3514,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private func activeRemovalTombstones(
         after inventory: KwtHostInventory,
         hostID: UUID
-    ) -> Set<KwtWorktreeIdentity> {
-        var activeTombstones: Set<KwtWorktreeIdentity> = []
+    ) -> [String: Set<KwtWorktreeIdentity>] {
+        var activeTombstones: [String: Set<KwtWorktreeIdentity>] = [:]
         let scopes = worktreeRemovalTombstones.keys.filter {
             $0.hostID == hostID
         }
@@ -3206,7 +3543,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 worktreeRemovalTombstones.removeValue(forKey: scope)
             } else {
                 worktreeRemovalTombstones[scope] = active
-                activeTombstones.formUnion(active)
+                activeTombstones[scope.projectIdentity, default: []]
+                    .formUnion(active)
             }
         }
         return activeTombstones
@@ -3215,7 +3553,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private func applyAuthoritativeKwtInventory(
         _ inventory: KwtHostInventory,
         hostID: UUID,
-        excludingWorktrees: Set<KwtWorktreeIdentity> = []
+        excludingWorktrees: [String: Set<KwtWorktreeIdentity>] = [:]
     ) {
         let previous = kwtInventoriesByHost[hostID]
         kwtInventoriesByHost[hostID] =
@@ -3225,6 +3563,11 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         kwtAvailabilityByHost[hostID] = true
         kwtInventoryFailuresByHost.removeValue(forKey: hostID)
+        for scope in pendingRemovalPresentationRestorations.keys
+            where scope.hostID == hostID {
+            pendingRemovalPresentationRestorations[scope]?
+                .snapshotRefreshed = true
+        }
         applyInventoryOverlayIfNeeded()
         reconcileRetainedTmuxPresentations(
             afterAuthoritativeInventoryFor: hostID
@@ -7235,7 +7578,7 @@ final class WorkspaceSceneModel: ObservableObject {
                       pendingCreatedTmuxSessions[handleID] == pending
                 else { return }
                 let probe = Task.detached(priority: .utility) {
-                    discovery(host)
+                    await discovery(host)
                 }
                 let result = await withTaskCancellationHandler {
                     await probe.value

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -145,6 +145,10 @@ final class WorktreeMutationCoordinator {
         let scope: Scope
         let removalTombstones: Set<RemovalTombstone>
         let removalPresentationTargets: Set<WorkspaceTmuxSessionSelection>
+        /// Endpoints the failed removal's recovery refresh confirmed for
+        /// the surviving target; `nil` when no authoritative refresh
+        /// reconciled the failure.
+        let reconciledRestorationTargets: Set<WorkspaceTmuxSessionSelection>?
         let requiresWorkspaceReestablishment: Bool
     }
 
@@ -182,6 +186,7 @@ final class WorktreeMutationCoordinator {
                     scope: scope,
                     removalTombstones: [],
                     removalPresentationTargets: [],
+                    reconciledRestorationTargets: nil,
                     requiresWorkspaceReestablishment: false
                 )
             )
@@ -193,6 +198,8 @@ final class WorktreeMutationCoordinator {
         hostID: UUID,
         projectIdentity: String,
         removalTombstones: Set<RemovalTombstone> = [],
+        reconciledRestorationTargets:
+        Set<WorkspaceTmuxSessionSelection>? = nil,
         requiresWorkspaceReestablishment: Bool = false
     ) {
         let scope = Scope(
@@ -207,6 +214,8 @@ final class WorktreeMutationCoordinator {
                     scope: scope,
                     removalTombstones: removalTombstones,
                     removalPresentationTargets: [],
+                    reconciledRestorationTargets:
+                    reconciledRestorationTargets,
                     requiresWorkspaceReestablishment:
                     requiresWorkspaceReestablishment
                 )
@@ -232,6 +241,7 @@ final class WorktreeMutationCoordinator {
                 scope: scope,
                 removalTombstones: worktrees,
                 removalPresentationTargets: presentationTargets,
+                reconciledRestorationTargets: nil,
                 requiresWorkspaceReestablishment: false
             )
         )
@@ -532,11 +542,6 @@ final class WorkspaceSceneModel: ObservableObject {
         var wasActive: Bool
         var userNavigationRevision: UInt64
     }
-    private struct PendingRemovalRestoration {
-        var presentations:
-            [TmuxPresentationKey: PendingRemovalPresentation] = [:]
-        var snapshotRefreshed = false
-    }
     private var retainedTmuxPresentations:
         [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
     private var retainedTmuxPresentationKeysByHandle:
@@ -560,7 +565,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 Set<WorktreeMutationCoordinator.RemovalTombstone>
         ] = [:]
     private var pendingRemovalPresentationRestorations:
-        [WorktreeMutationCoordinator.Scope: PendingRemovalRestoration] = [:]
+        [WorktreeMutationCoordinator.Scope:
+            [TmuxPresentationKey: PendingRemovalPresentation]] = [:]
     private var userNavigationRevision: UInt64 = 0
     private var isShutDown = false
     private var sceneActivityGeneration: UInt64 = 0
@@ -2116,6 +2122,8 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         var removalTombstones:
             Set<WorktreeMutationCoordinator.RemovalTombstone> = []
+        var reconciledRestorationTargets:
+            Set<WorkspaceTmuxSessionSelection>?
         var requiresWorkspaceReestablishment = false
         var terminatedSession = false
         invalidateKwtInventoryRefresh()
@@ -2125,6 +2133,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 hostID: mutationHostID,
                 projectIdentity: mutationProjectIdentity,
                 removalTombstones: removalTombstones,
+                reconciledRestorationTargets: reconciledRestorationTargets,
                 requiresWorkspaceReestablishment:
                 requiresWorkspaceReestablishment
             )
@@ -2212,6 +2221,8 @@ final class WorkspaceSceneModel: ObservableObject {
                         hostID: project.hostID,
                         confirmedHost: confirmedHost
                     )
+                    reconciledRestorationTargets =
+                        outcome.restorationTargets
                     if outcome.identityRemoved {
                         removalTombstones.insert(removalTombstone)
                         requiresWorkspaceReestablishment = false
@@ -2326,25 +2337,37 @@ final class WorkspaceSceneModel: ObservableObject {
 
     /// Classifies a failed removal against a freshly loaded inventory so
     /// the caller can decide between tombstoning the removed identity and
-    /// requiring a new confirmation. Refresh or reconciliation errors
-    /// leave both flags false to preserve the original removal failure.
+    /// requiring a new confirmation. When the refresh confirms a surviving
+    /// target, `restorationTargets` carries its current endpoints so every
+    /// scene restores against the reconciled state rather than a saved
+    /// preflight endpoint. Refresh or reconciliation errors leave both
+    /// flags false and the targets `nil` to preserve the original removal
+    /// failure and the saved endpoints.
     private func classifyFailedRemoval(
         _ request: WorktreeRemovalRequest,
         tombstone: WorktreeMutationCoordinator.RemovalTombstone,
         hostID: UUID,
         confirmedHost: CommandHost
-    ) async -> (identityRemoved: Bool, targetChanged: Bool) {
+    ) async -> (
+        identityRemoved: Bool,
+        targetChanged: Bool,
+        restorationTargets: Set<WorkspaceTmuxSessionSelection>?
+    ) {
         do {
             let refreshed = try await kwtInventoryLoader(confirmedHost)
             guard removalHostEndpointMatches(request) else {
-                return (false, false)
+                return (false, false, nil)
             }
             do {
-                guard try reconcileRemovalPreflight(
+                if let (intact, _) = try reconcileRemovalPreflight(
                     refreshed,
                     request: request
-                ) == nil else {
-                    return (false, false)
+                ) {
+                    return (false, false, Set(
+                        WorkspaceSidebarModel.tmuxSessionSelection(
+                            for: intact
+                        ).map { [$0] } ?? []
+                    ))
                 }
                 applyAuthoritativeKwtInventory(
                     refreshed,
@@ -2353,7 +2376,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         request.project.scopedKey: [tombstone],
                     ]
                 )
-                return (true, false)
+                return (true, false, nil)
             } catch KwtWorktreeError.removalTargetChanged {
                 // Survival is judged within the confirmed repository: the
                 // identity lives on when its path is still present or when
@@ -2364,29 +2387,65 @@ final class WorkspaceSceneModel: ObservableObject {
                 let generation = WorktreeGeneration.canonical(
                     tombstone.generation
                 )
-                let survives = refreshed.projects.first {
+                guard let item = refreshed.projects.first(where: {
                     $0.project.repository == request.project.scopedKey
-                }.map { item in
-                    // An incomplete worktree list cannot prove removal.
-                    item.warning != nil
-                        || item.worktrees.contains { record in
-                            tombstone.matches(
-                                path: record.path,
-                                generation: record.generation
-                            )
-                                || (generation != nil
-                                    && WorktreeGeneration.canonical(
-                                        record.generation
-                                    ) == generation)
-                        }
-                } ?? false
-                return (identityRemoved: !survives, targetChanged: true)
+                }) else {
+                    return (true, true, nil)
+                }
+                // An incomplete worktree list cannot prove removal, but it
+                // cannot vouch for a restoration endpoint either.
+                guard item.warning == nil else {
+                    return (false, true, nil)
+                }
+                let survives = item.worktrees.contains { record in
+                    tombstone.matches(
+                        path: record.path,
+                        generation: record.generation
+                    )
+                        || (generation != nil
+                            && WorktreeGeneration.canonical(
+                                record.generation
+                            ) == generation)
+                }
+                guard survives else {
+                    return (true, true, nil)
+                }
+                let target = generation.flatMap { generation in
+                    scopedRestorationTarget(
+                        generation: generation,
+                        hostID: hostID,
+                        projectIdentity: request.project.scopedKey
+                    )
+                }
+                return (false, true, Set(target.map { [$0] } ?? []))
             } catch {
-                return (false, false)
+                return (false, false, nil)
             }
         } catch {
-            return (false, false)
+            return (false, false, nil)
         }
+    }
+
+    /// Resolves the current tmux endpoint for a surviving generation
+    /// within the removal's repository scope after the snapshot was
+    /// refreshed by reconciliation.
+    private func scopedRestorationTarget(
+        generation: String,
+        hostID: UUID,
+        projectIdentity: String
+    ) -> WorkspaceTmuxSessionSelection? {
+        let projectIDs = Set(
+            snapshot.projects.filter {
+                $0.hostID == hostID
+                    && $0.scopedKey == projectIdentity
+            }.map(\.id)
+        )
+        guard let worktree = snapshot.worktrees.first(where: {
+            $0.hostID == hostID
+                && projectIDs.contains($0.projectID)
+                && WorktreeGeneration.canonical($0.generation) == generation
+        }) else { return nil }
+        return WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
     }
 
     private func reconcileRemovalPreflight(
@@ -3118,7 +3177,7 @@ final class WorkspaceSceneModel: ObservableObject {
             } else if let pendingRestoration {
                 restorePresentationsAfterFailedRemoval(
                     pendingRestoration,
-                    scope: event.scope,
+                    reconciledTargets: event.reconciledRestorationTargets,
                     requiresWorkspaceReestablishment:
                     event.requiresWorkspaceReestablishment
                 )
@@ -3404,8 +3463,8 @@ final class WorkspaceSceneModel: ObservableObject {
         for (presentation, restorationSelection) in presentations {
             let key = TmuxPresentationKey(presentation.selection)
             pendingRemovalPresentationRestorations[
-                event.scope, default: PendingRemovalRestoration()
-            ].presentations[key] = PendingRemovalPresentation(
+                event.scope, default: [:]
+            ][key] = PendingRemovalPresentation(
                 selection: restorationSelection,
                 launchMode: presentation.launchMode,
                 requiresWorkspaceEstablishment:
@@ -3419,15 +3478,14 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func restorePresentationsAfterFailedRemoval(
-        _ restoration: PendingRemovalRestoration,
-        scope: WorktreeMutationCoordinator.Scope,
+        _ restoration: [TmuxPresentationKey: PendingRemovalPresentation],
+        reconciledTargets: Set<WorkspaceTmuxSessionSelection>?,
         requiresWorkspaceReestablishment: Bool
     ) {
-        for presentation in restoration.presentations.values {
-            guard let selection = currentRestorationSelection(
+        for presentation in restoration.values {
+            guard let selection = Self.restorationSelection(
                 for: presentation.selection,
-                scope: scope,
-                snapshotRefreshed: restoration.snapshotRefreshed
+                reconciledTargets: reconciledTargets
             ) else { continue }
             let establishesWorkspace = requiresWorkspaceReestablishment
                 || presentation.requiresWorkspaceEstablishment
@@ -3447,34 +3505,23 @@ final class WorkspaceSceneModel: ObservableObject {
     /// Reconciliation can refresh the surviving worktree's tmux session
     /// name or socket between removal preflight and restoration; restoring
     /// the saved endpoint would leave a presentation the next inventory
-    /// pass immediately invalidates. While this scene's snapshot was not
-    /// refreshed after the target was captured, the saved preflight
-    /// endpoint stays authoritative. When the refreshed snapshot no longer
-    /// holds the worktree within the removal's repository scope — for
-    /// example the same path and generation now belong to another project
-    /// — there is no trustworthy endpoint and restoration is skipped.
-    private func currentRestorationSelection(
+    /// pass immediately invalidates. The reconciled targets carried on the
+    /// mutation event are authoritative for every scene, including scenes
+    /// whose own snapshot is stale. Without reconciled targets the saved
+    /// endpoint stands; with them, a saved endpoint whose generation no
+    /// longer resolves has no trustworthy target and is skipped.
+    private static func restorationSelection(
         for saved: WorkspaceTmuxSessionSelection,
-        scope: WorktreeMutationCoordinator.Scope,
-        snapshotRefreshed: Bool
+        reconciledTargets: Set<WorkspaceTmuxSessionSelection>?
     ) -> WorkspaceTmuxSessionSelection? {
-        guard snapshotRefreshed,
+        guard let reconciledTargets,
               let generation = WorktreeGeneration.canonical(
                   saved.worktreeGeneration
               )
         else { return saved }
-        let projectIDs = Set(
-            snapshot.projects.filter {
-                $0.hostID == scope.hostID
-                    && $0.scopedKey == scope.projectIdentity
-            }.map(\.id)
-        )
-        guard let worktree = snapshot.worktrees.first(where: {
-            $0.hostID == scope.hostID
-                && projectIDs.contains($0.projectID)
-                && WorktreeGeneration.canonical($0.generation) == generation
-        }) else { return nil }
-        return WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        return reconciledTargets.first {
+            WorktreeGeneration.canonical($0.worktreeGeneration) == generation
+        }
     }
 
     private func worktreeIDs(
@@ -3563,11 +3610,6 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         kwtAvailabilityByHost[hostID] = true
         kwtInventoryFailuresByHost.removeValue(forKey: hostID)
-        for scope in pendingRemovalPresentationRestorations.keys
-            where scope.hostID == hostID {
-            pendingRemovalPresentationRestorations[scope]?
-                .snapshotRefreshed = true
-        }
         applyInventoryOverlayIfNeeded()
         reconcileRetainedTmuxPresentations(
             afterAuthoritativeInventoryFor: hostID

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3401,8 +3401,10 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         if var inventory = kwtInventoriesByHost[scope.hostID] {
             for index in inventory.projects.indices
-                where inventory.projects[index].project.repository
-                == scope.projectIdentity {
+                where Self.removalScopeIncludesRepository(
+                    inventory.projects[index].project.repository,
+                    scope: scope
+                ) {
                 inventory.projects[index].worktrees.removeAll {
                     matches($0.path, $0.generation)
                 }
@@ -3524,6 +3526,18 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    /// A removed identity is stripped from its own repository and from
+    /// projects whose identity is legacy-empty, so scenes that have not
+    /// yet resolved a repository identity still drop the removed worktree.
+    /// A different non-empty repository identity is another project's
+    /// worktree — for example a reassignment — and stays visible.
+    private static func removalScopeIncludesRepository(
+        _ repository: String,
+        scope: WorktreeMutationCoordinator.Scope
+    ) -> Bool {
+        repository.isEmpty || repository == scope.projectIdentity
+    }
+
     private func worktreeIDs(
         matching tombstones:
         Set<WorktreeMutationCoordinator.RemovalTombstone>,
@@ -3532,7 +3546,10 @@ final class WorkspaceSceneModel: ObservableObject {
         let projectIDs = Set(
             snapshot.projects.filter {
                 $0.hostID == scope.hostID
-                    && $0.scopedKey == scope.projectIdentity
+                    && Self.removalScopeIncludesRepository(
+                        $0.scopedKey,
+                        scope: scope
+                    )
             }.map(\.id)
         )
         return Set(snapshot.worktrees.compactMap { worktree in

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -871,6 +871,9 @@ struct WorkspaceWindow: View {
                 createTmuxSession: { [sceneModel] request in
                     sceneModel.createTmuxSession(request)
                 },
+                currentWorkspaceSnapshot: { [sceneModel] in
+                    sceneModel.snapshot
+                },
                 refreshWorkspaceInventory: { [sceneModel] in
                     sceneModel.refreshWorkspaceInventory()
                 },
@@ -927,7 +930,7 @@ struct WorkspaceWindow: View {
                     try await sceneModel.prepareWorktreeRemoval(worktreeID)
                 },
                 removeWorktree: { [sceneModel] request in
-                    try await sceneModel.removeWorktree(request)
+                    try await sceneModel.resolveWorktreeRemoval(request)
                 }
             ),
             sidebarToggleTarget: sceneModel,

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -39,6 +39,11 @@ public struct RootView: View {
     @State private var herdrCreationRevision: UInt64 = 0
     @State private var addProjectHost: HostSummary?
     @State private var workspaceAlert: WorkspaceAlert?
+    @State private var pendingWorktreeRemoval: WorktreeRemovalRequest?
+    // Retain the first confirmed generation for every runtime ID encountered
+    // while reconfirming so ID reuse cannot disguise a displaced target.
+    @State private var pendingWorktreeRemovals:
+        [UUID: PendingWorktreeRemovalIdentity] = [:]
     @State private var sessionRecoveryRequestRouter =
         SessionConnectionRecoveryRequestRouter()
     @StateObject private var sshHostKeyReview =
@@ -259,9 +264,11 @@ public struct RootView: View {
                 )
             }
             .onChange(of: snapshot) { _, updatedSnapshot in
-                selection = selection.normalizedBySelectingVisibleFallback(
+                selection = Self.selectionAfterSnapshotChange(
+                    selection,
                     in: updatedSnapshot,
-                    visibility: worktreeVisibility
+                    visibility: worktreeVisibility,
+                    pendingRemovals: pendingWorktreeRemovals
                 )
                 synchronizeSelectedWorktreeSession()
             }
@@ -936,22 +943,22 @@ public struct RootView: View {
         _ tmuxSession: WorkspaceTmuxSessionSelection
     ) {
         guard let prepare = handlers.prepareTmuxSessionKill else {
-            workspaceAlert = .sessionKillFailure(
+            presentNonWorktreeWorkspaceAlert(.sessionKillFailure(
                 session: tmuxSession.name,
                 message: "Session termination is unavailable."
-            )
+            ))
             return
         }
         Task {
             do {
-                workspaceAlert = await .sessionKillConfirmation(
+                await presentNonWorktreeWorkspaceAlert(.sessionKillConfirmation(
                     try prepare(tmuxSession)
-                )
+                ))
             } catch {
-                workspaceAlert = .sessionKillFailure(
+                presentNonWorktreeWorkspaceAlert(.sessionKillFailure(
                     session: tmuxSession.name,
                     message: error.localizedDescription
-                )
+                ))
             }
         }
     }
@@ -968,12 +975,21 @@ public struct RootView: View {
                 }
                 try await applyTheme(tmuxSession)
             } catch {
-                workspaceAlert = .sessionThemeFailure(
+                presentNonWorktreeWorkspaceAlert(.sessionThemeFailure(
                     session: tmuxSession.name,
                     message: error.localizedDescription
-                )
+                ))
             }
         }
+    }
+
+    private func presentNonWorktreeWorkspaceAlert(_ alert: WorkspaceAlert) {
+        Self.presentNonWorktreeWorkspaceAlert(
+            alert,
+            workspaceAlert: &workspaceAlert,
+            pendingWorktreeRemoval: &pendingWorktreeRemoval,
+            pendingWorktrees: &pendingWorktreeRemovals
+        )
     }
 
     private func workspaceAlertView(
@@ -1001,10 +1017,10 @@ public struct RootView: View {
                             }
                             try await kill(request)
                         } catch {
-                            workspaceAlert = .sessionKillFailure(
+                            presentNonWorktreeWorkspaceAlert(.sessionKillFailure(
                                 session: tmuxSession.name,
                                 message: error.localizedDescription
-                            )
+                            ))
                         }
                     }
                 },
@@ -1074,13 +1090,38 @@ public struct RootView: View {
                         + " The Git branch will be kept."
                 ),
                 primaryButton: .destructive(Text("Remove Worktree")) {
+                    Self.beginWorktreeRemovalResolution(
+                        pendingWorktreeRemoval: &pendingWorktreeRemoval
+                    )
                     Task {
                         do {
                             guard let remove = handlers.removeWorktree else {
                                 throw WorktreeRemovalUnavailableError()
                             }
-                            try await remove(request)
+                            switch try await remove(request) {
+                            case .removed:
+                                pendingWorktreeRemoval = nil
+                                pendingWorktreeRemovals.removeAll()
+                            case let .confirmationRequired(updatedRequest):
+                                Self.transitionWorktreeRemovalConfirmation(
+                                    to: updatedRequest,
+                                    pendingWorktreeRemoval: &pendingWorktreeRemoval,
+                                    pendingWorktrees: &pendingWorktreeRemovals
+                                )
+                                workspaceAlert = .worktreeRemovalConfirmation(
+                                    updatedRequest
+                                )
+                            }
                         } catch {
+                            pendingWorktreeRemoval = nil
+                            selection = Self.finishFailedWorktreeRemoval(
+                                selection,
+                                in: snapshot,
+                                currentSnapshot:
+                                handlers.currentWorkspaceSnapshot,
+                                visibility: worktreeVisibility,
+                                pendingWorktrees: &pendingWorktreeRemovals
+                            )
                             workspaceAlert = .worktreeRemovalFailure(
                                 worktree: request.worktree.name,
                                 message: error.localizedDescription
@@ -1088,7 +1129,10 @@ public struct RootView: View {
                         }
                     }
                 },
-                secondaryButton: .cancel()
+                secondaryButton: .cancel(Text("Cancel")) {
+                    pendingWorktreeRemoval = nil
+                    pendingWorktreeRemovals.removeAll()
+                }
             )
         case let .worktreeRemovalFailure(worktree, message):
             return Alert(
@@ -1100,7 +1144,15 @@ public struct RootView: View {
     }
 
     private func requestWorktreeRemoval(_ worktree: WorktreeSummary) {
+        guard Self.reserveWorktreeRemovalPreparation(
+            worktree,
+            pendingWorktrees: &pendingWorktreeRemovals
+        ) else { return }
         guard let prepare = handlers.prepareWorktreeRemoval else {
+            Self.clearWorktreeRemovalPreparation(
+                worktree,
+                pendingWorktrees: &pendingWorktreeRemovals
+            )
             workspaceAlert = .worktreeRemovalFailure(
                 worktree: worktree.name,
                 message: "Worktree removal is unavailable."
@@ -1109,16 +1161,145 @@ public struct RootView: View {
         }
         Task {
             do {
-                workspaceAlert = await .worktreeRemovalConfirmation(
-                    try prepare(worktree.id)
+                let request = try await Self.prepareWorktreeRemoval(
+                    worktree,
+                    using: prepare
+                )
+                guard Self.holdsWorktreeRemovalReservation(
+                    worktree,
+                    pendingWorktrees: pendingWorktreeRemovals
+                ) else {
+                    return
+                }
+                pendingWorktreeRemoval = request
+                workspaceAlert = .worktreeRemovalConfirmation(
+                    request
                 )
             } catch {
-                workspaceAlert = .worktreeRemovalFailure(
-                    worktree: worktree.name,
-                    message: error.localizedDescription
+                guard Self.holdsWorktreeRemovalReservation(
+                    worktree,
+                    pendingWorktrees: pendingWorktreeRemovals
+                ) else { return }
+                selection = Self.finishFailedWorktreeRemoval(
+                    selection,
+                    in: snapshot,
+                    currentSnapshot: handlers.currentWorkspaceSnapshot,
+                    visibility: worktreeVisibility,
+                    pendingWorktrees: &pendingWorktreeRemovals
                 )
+                pendingWorktreeRemoval = nil
+                if !(error is CancellationError) {
+                    workspaceAlert = .worktreeRemovalFailure(
+                        worktree: worktree.name,
+                        message: error.localizedDescription
+                    )
+                }
             }
         }
+    }
+
+    @MainActor
+    static func prepareWorktreeRemoval(
+        _ worktree: WorktreeSummary,
+        using prepare: (UUID) async throws -> WorktreeRemovalRequest
+    ) async throws -> WorktreeRemovalRequest {
+        try await prepare(worktree.id)
+    }
+
+    struct PendingWorktreeRemovalIdentity: Equatable {
+        let generation: String?
+
+        init(_ worktree: WorktreeSummary) {
+            generation = worktree.generation
+        }
+    }
+
+    @MainActor
+    static func reserveWorktreeRemovalPreparation(
+        _ worktree: WorktreeSummary,
+        pendingWorktrees: inout [UUID: PendingWorktreeRemovalIdentity]
+    ) -> Bool {
+        guard pendingWorktrees.isEmpty else { return false }
+        pendingWorktrees[worktree.id] = PendingWorktreeRemovalIdentity(
+            worktree
+        )
+        return true
+    }
+
+    @MainActor
+    static func holdsWorktreeRemovalReservation(
+        _ worktree: WorktreeSummary,
+        pendingWorktrees: [UUID: PendingWorktreeRemovalIdentity]
+    ) -> Bool {
+        pendingWorktrees == [
+            worktree.id: PendingWorktreeRemovalIdentity(worktree),
+        ]
+    }
+
+    @MainActor
+    @discardableResult
+    static func clearWorktreeRemovalPreparation(
+        _ worktree: WorktreeSummary,
+        pendingWorktrees: inout [UUID: PendingWorktreeRemovalIdentity]
+    ) -> Bool {
+        guard holdsWorktreeRemovalReservation(
+            worktree,
+            pendingWorktrees: pendingWorktrees
+        ) else { return false }
+        pendingWorktrees.removeAll()
+        return true
+    }
+
+    @MainActor
+    static func presentNonWorktreeWorkspaceAlert(
+        _ alert: WorkspaceAlert,
+        workspaceAlert: inout WorkspaceAlert?,
+        pendingWorktreeRemoval: inout WorktreeRemovalRequest?,
+        pendingWorktrees: inout [UUID: PendingWorktreeRemovalIdentity]
+    ) {
+        if pendingWorktreeRemoval != nil {
+            pendingWorktreeRemoval = nil
+            pendingWorktrees.removeAll()
+        }
+        workspaceAlert = alert
+    }
+
+    @MainActor
+    static func beginWorktreeRemovalResolution(
+        pendingWorktreeRemoval: inout WorktreeRemovalRequest?
+    ) {
+        pendingWorktreeRemoval = nil
+    }
+
+    @MainActor
+    static func transitionWorktreeRemovalConfirmation(
+        to request: WorktreeRemovalRequest,
+        pendingWorktreeRemoval: inout WorktreeRemovalRequest?,
+        pendingWorktrees: inout [UUID: PendingWorktreeRemovalIdentity]
+    ) {
+        pendingWorktreeRemoval = request
+        if pendingWorktrees[request.worktree.id] == nil {
+            pendingWorktrees[request.worktree.id] =
+                PendingWorktreeRemovalIdentity(request.worktree)
+        }
+    }
+
+    @MainActor
+    static func finishFailedWorktreeRemoval(
+        _ current: WorkspaceSelection,
+        in snapshot: WorkspaceSnapshot,
+        currentSnapshot: (() -> WorkspaceSnapshot)? = nil,
+        visibility: WorktreeVisibility,
+        pendingWorktrees: inout [UUID: PendingWorktreeRemovalIdentity]
+    ) -> WorkspaceSelection {
+        let updated = selectionAfterSnapshotChange(
+            current,
+            in: currentSnapshot?() ?? snapshot,
+            visibility: visibility,
+            pendingRemovals: pendingWorktrees
+        )
+        pendingWorktrees.removeAll()
+        return updated
     }
 
     static func selectionForHostTmuxSession(
@@ -1558,6 +1739,40 @@ public struct RootView: View {
         selection = selection.normalizedBySelectingVisibleFallback(
             in: snapshot,
             visibility: worktreeVisibility
+        )
+    }
+
+    static func selectionAfterSnapshotChange(
+        _ current: WorkspaceSelection,
+        in snapshot: WorkspaceSnapshot,
+        visibility: WorktreeVisibility,
+        pendingRemovals: [UUID: PendingWorktreeRemovalIdentity]
+    ) -> WorkspaceSelection {
+        if let selectedWorktreeID = current.selectedWorktreeID,
+           let pending = pendingRemovals[selectedWorktreeID],
+           let projectID = current.selectedProjectID,
+           snapshot.project(id: projectID) != nil {
+            let worktree = snapshot.worktree(id: selectedWorktreeID)
+            let generationChanged = pending.generation.map {
+                worktree?.generation != $0
+            } ?? false
+            guard worktree == nil || generationChanged else {
+                return current.normalizedBySelectingVisibleFallback(
+                    in: snapshot,
+                    visibility: visibility
+                )
+            }
+            var updated = current
+            updated.select(
+                .project(projectID),
+                in: snapshot,
+                visibility: visibility
+            )
+            return updated
+        }
+        return current.normalizedBySelectingVisibleFallback(
+            in: snapshot,
+            visibility: visibility
         )
     }
 

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -773,11 +773,11 @@ public struct RootView: View {
                 )
             },
             onFailure: { error in
-                workspaceAlert = .herdrLifecycleFailure(
+                presentNonWorktreeWorkspaceAlert(.herdrLifecycleFailure(
                     session: session.name,
                     action: "open",
                     message: error.localizedDescription
-                )
+                ))
             }
         )
     }
@@ -839,11 +839,11 @@ public struct RootView: View {
                 }
                 herdrCreationTask = nil
                 guard !(error is CancellationError) else { return }
-                workspaceAlert = .herdrLifecycleFailure(
+                presentNonWorktreeWorkspaceAlert(.herdrLifecycleFailure(
                     session: name,
                     action: "create",
                     message: error.localizedDescription
-                )
+                ))
             }
         }
     }
@@ -885,11 +885,11 @@ public struct RootView: View {
                 ))
             },
             onFailure: { error in
-                workspaceAlert = .herdrLifecycleFailure(
+                presentNonWorktreeWorkspaceAlert(.herdrLifecycleFailure(
                     session: session.name,
                     action: "restart",
                     message: error.localizedDescription
-                )
+                ))
             }
         )
     }
@@ -904,11 +904,11 @@ public struct RootView: View {
         }
         guard let prepare = handlers.prepareHerdrSessionLifecycle else {
             herdrLifecyclePreparation.cancel()
-            workspaceAlert = .herdrLifecycleFailure(
+            presentNonWorktreeWorkspaceAlert(.herdrLifecycleFailure(
                 session: session.name,
                 action: action == .stop ? "stop" : "delete",
                 message: "Herdr session lifecycle actions are unavailable."
-            )
+            ))
             return
         }
         herdrLifecyclePreparation.start(
@@ -919,14 +919,16 @@ public struct RootView: View {
                 handlers.cancelHerdrSessionLifecycle?(request)
             },
             onPrepared: { request in
-                workspaceAlert = .herdrLifecycleConfirmation(request)
+                presentNonWorktreeWorkspaceAlert(
+                    .herdrLifecycleConfirmation(request)
+                )
             },
             onFailure: { error in
-                workspaceAlert = .herdrLifecycleFailure(
+                presentNonWorktreeWorkspaceAlert(.herdrLifecycleFailure(
                     session: session.name,
                     action: action == .stop ? "stop" : "delete",
                     message: error.localizedDescription
-                )
+                ))
             }
         )
     }
@@ -1051,11 +1053,13 @@ public struct RootView: View {
                             else { throw HerdrLifecycleUnavailableError() }
                             try await perform(request)
                         } catch {
-                            workspaceAlert = .herdrLifecycleFailure(
-                                session: request.session.name,
-                                action: request.action == .stop
-                                    ? "stop" : "delete",
-                                message: error.localizedDescription
+                            presentNonWorktreeWorkspaceAlert(
+                                .herdrLifecycleFailure(
+                                    session: request.session.name,
+                                    action: request.action == .stop
+                                        ? "stop" : "delete",
+                                    message: error.localizedDescription
+                                )
                             )
                         }
                     }

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -174,6 +174,11 @@ public struct WorktreeRemovalRequest: Equatable, Sendable {
     }
 }
 
+public enum WorktreeRemovalResult: Equatable, Sendable {
+    case removed
+    case confirmationRequired(WorktreeRemovalRequest)
+}
+
 public enum SSHConnectionRecoveryResult: Equatable, Sendable {
     case hostKey(SSHHostKeyConfirmation)
     case authenticationRequired
@@ -330,6 +335,7 @@ public struct InteractionHandlers {
         ((WorkspaceTmuxSessionSelection) async throws -> Void)?
     public let createTmuxSession:
         ((WorkspaceTmuxSessionCreationRequest) -> Void)?
+    public let currentWorkspaceSnapshot: (() -> WorkspaceSnapshot)?
     public let refreshWorkspaceInventory: (() -> Void)?
     public let reconnectActiveTmuxSessionNow: (() -> Void)?
     public let reconnectActiveHerdrSessionNow: (() -> Void)?
@@ -357,7 +363,7 @@ public struct InteractionHandlers {
     public let prepareWorktreeRemoval:
         ((UUID) async throws -> WorktreeRemovalRequest)?
     public let removeWorktree:
-        ((WorktreeRemovalRequest) async throws -> Void)?
+        ((WorktreeRemovalRequest) async throws -> WorktreeRemovalResult)?
 
     public init(
         closeWindow: (() -> Void)? = nil,
@@ -390,6 +396,7 @@ public struct InteractionHandlers {
         ((WorkspaceTmuxSessionSelection) async throws -> Void)? = nil,
         createTmuxSession:
         ((WorkspaceTmuxSessionCreationRequest) -> Void)? = nil,
+        currentWorkspaceSnapshot: (() -> WorkspaceSnapshot)? = nil,
         refreshWorkspaceInventory: (() -> Void)? = nil,
         reconnectActiveTmuxSessionNow: (() -> Void)? = nil,
         reconnectActiveHerdrSessionNow: (() -> Void)? = nil,
@@ -417,7 +424,7 @@ public struct InteractionHandlers {
         prepareWorktreeRemoval:
         ((UUID) async throws -> WorktreeRemovalRequest)? = nil,
         removeWorktree:
-        ((WorktreeRemovalRequest) async throws -> Void)? = nil
+        ((WorktreeRemovalRequest) async throws -> WorktreeRemovalResult)? = nil
     ) {
         self.closeWindow = closeWindow
         self.dismissLogViewer = dismissLogViewer
@@ -437,6 +444,7 @@ public struct InteractionHandlers {
         self.killTmuxSession = killTmuxSession
         self.applyTmuxSessionTheme = applyTmuxSessionTheme
         self.createTmuxSession = createTmuxSession
+        self.currentWorkspaceSnapshot = currentWorkspaceSnapshot
         self.refreshWorkspaceInventory = refreshWorkspaceInventory
         self.reconnectActiveTmuxSessionNow = reconnectActiveTmuxSessionNow
         self.reconnectActiveHerdrSessionNow = reconnectActiveHerdrSessionNow

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -432,6 +432,381 @@ struct KwtInventoryClientTests {
         )
     }
 
+    @Test("an incomplete refresh retains protected generation evidence")
+    func retainsProtectedGenerationAcrossIncompleteRefresh() {
+        let hostID = UUID()
+        let projectID = UUID()
+        let generation = "0123456789abcdef0123456789abcdef"
+        let socketName = "kwt-pr-0123456789abcdef"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [ProjectSummary(
+                id: projectID,
+                hostID: hostID,
+                scopedKey: "repo",
+                name: "repo",
+                rootPath: "/repo"
+            )],
+            worktrees: [WorktreeSummary(
+                id: UUID(),
+                hostID: hostID,
+                projectID: projectID,
+                name: "feature",
+                path: "/repo-feature",
+                branch: "feature/protected",
+                generation: generation,
+                tmuxSessionName: "kwt-repo-feature",
+                tmuxSocketName: socketName
+            )]
+        )
+        func inventory(generation: String?) -> KwtHostInventory {
+            KwtHostInventory(projects: [KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "repo",
+                    name: "repo",
+                    path: "/repo",
+                    lastTouched: nil
+                ),
+                worktrees: [KwtWorktreeRecord(
+                    path: "/repo-feature",
+                    branch: "feature/protected",
+                    commitHash: "abc",
+                    isMain: false,
+                    createdAt: nil,
+                    generation: generation,
+                    repository: "repo",
+                    sessionName: "kwt-repo-feature",
+                    tmuxSocketName: nil
+                )],
+                warning: nil
+            )])
+        }
+
+        let incomplete = KwtSnapshotMerger.merge(
+            inventory(generation: nil),
+            hostID: hostID,
+            into: snapshot
+        )
+        let restored = KwtSnapshotMerger.merge(
+            inventory(generation: generation),
+            hostID: hostID,
+            into: incomplete
+        )
+
+        #expect(incomplete.worktrees[0].generation == generation)
+        #expect(incomplete.worktrees[0].tmuxSocketName == socketName)
+        #expect(restored.worktrees[0].generation == generation)
+        #expect(restored.worktrees[0].tmuxSocketName == socketName)
+    }
+
+    @Test("generationless replacements do not inherit protected identity")
+    func generationlessReplacementsDoNotInheritProtectedIdentity() {
+        let hostID = UUID()
+        let projectID = UUID()
+        let generation = "0123456789abcdef0123456789abcdef"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [ProjectSummary(
+                id: projectID,
+                hostID: hostID,
+                scopedKey: "repo",
+                name: "repo",
+                rootPath: "/repo"
+            )],
+            worktrees: [WorktreeSummary(
+                id: UUID(),
+                hostID: hostID,
+                projectID: projectID,
+                name: "feature",
+                path: "/repo-feature",
+                branch: "feature/original",
+                generation: generation,
+                tmuxSessionName: "kwt-repo-original",
+                tmuxSocketName: "protected-socket"
+            )]
+        )
+        let replacements = [
+            (
+                branch: "feature/replacement",
+                isMain: false,
+                session: "kwt-repo-original"
+            ),
+            (
+                branch: "feature/original",
+                isMain: true,
+                session: "kwt-repo-original"
+            ),
+            (
+                branch: "feature/original",
+                isMain: false,
+                session: "kwt-repo-replacement"
+            ),
+        ]
+
+        for replacement in replacements {
+            let inventory = KwtHostInventory(projects: [KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "repo",
+                    name: "repo",
+                    path: "/repo",
+                    lastTouched: nil
+                ),
+                worktrees: [KwtWorktreeRecord(
+                    path: "/repo-feature",
+                    branch: replacement.branch,
+                    commitHash: "def",
+                    isMain: replacement.isMain,
+                    createdAt: nil,
+                    generation: nil,
+                    repository: "repo",
+                    sessionName: replacement.session,
+                    tmuxSocketName: nil
+                )],
+                warning: nil
+            )])
+
+            let merged = KwtSnapshotMerger.merge(
+                inventory,
+                hostID: hostID,
+                into: snapshot
+            )
+
+            #expect(merged.worktrees[0].generation == nil)
+            #expect(merged.worktrees[0].tmuxSocketName == nil)
+        }
+    }
+
+    @Test(
+        "canonical generation outranks a reused path for socket identity",
+        arguments: ["same-generation-socket", nil] as [String?]
+    )
+    func generationOutranksReusedPathForSocketIdentity(
+        _ generationSocketName: String?
+    ) {
+        let hostID = UUID()
+        let unrelatedProjectID = UUID()
+        let targetProjectID = UUID()
+        let unrelatedWorktreeID = UUID()
+        let generation = "0123456789abcdef0123456789abcdef"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [
+                ProjectSummary(
+                    id: unrelatedProjectID,
+                    hostID: hostID,
+                    scopedKey: "repo-a",
+                    name: "repo-a",
+                    rootPath: "/repo-a"
+                ),
+                ProjectSummary(
+                    id: targetProjectID,
+                    hostID: hostID,
+                    scopedKey: "repo-b",
+                    name: "repo-b",
+                    rootPath: "/repo-b"
+                ),
+            ],
+            worktrees: [
+                WorktreeSummary(
+                    id: unrelatedWorktreeID,
+                    hostID: hostID,
+                    projectID: unrelatedProjectID,
+                    name: "unrelated",
+                    path: "/reused-path",
+                    branch: "feature/unrelated",
+                    generation: "fedcba9876543210fedcba9876543210",
+                    tmuxSessionName: "kwt-repo-a-unrelated",
+                    tmuxSocketName: "same-path-socket"
+                ),
+                WorktreeSummary(
+                    id: UUID(),
+                    hostID: hostID,
+                    projectID: targetProjectID,
+                    name: "target",
+                    path: "/old-path",
+                    branch: "feature/target",
+                    generation: generation,
+                    tmuxSessionName: "kwt-repo-b-target",
+                    tmuxSocketName: generationSocketName
+                ),
+            ]
+        )
+        let inventory = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "repo-a",
+                    name: "repo-a",
+                    path: "/repo-a",
+                    lastTouched: nil
+                ),
+                worktrees: [KwtWorktreeRecord(
+                    path: "/reused-path",
+                    branch: "feature/unrelated",
+                    commitHash: "def",
+                    isMain: false,
+                    createdAt: nil,
+                    generation: "fedcba9876543210fedcba9876543210",
+                    repository: "repo-a",
+                    sessionName: "kwt-repo-a-unrelated",
+                    tmuxSocketName: "same-path-socket"
+                )],
+                warning: nil
+            ),
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "repo-b",
+                    name: "repo-b",
+                    path: "/repo-b",
+                    lastTouched: nil
+                ),
+                worktrees: [KwtWorktreeRecord(
+                    path: "/reused-path",
+                    branch: "feature/target",
+                    commitHash: "abc",
+                    isMain: false,
+                    createdAt: nil,
+                    generation: generation,
+                    repository: "repo-b",
+                    sessionName: "kwt-repo-b-target",
+                    tmuxSocketName: nil
+                )],
+                warning: nil
+            ),
+        ])
+
+        let merged = KwtSnapshotMerger.merge(
+            inventory,
+            hostID: hostID,
+            into: snapshot
+        )
+
+        #expect(merged.worktrees.count == 2)
+        let unrelated = merged.worktrees.first {
+            $0.projectID == unrelatedProjectID
+        }
+        let target = merged.worktrees.first {
+            $0.projectID == targetProjectID
+        }
+        #expect(unrelated?.id == unrelatedWorktreeID)
+        #expect(target?.id != unrelated?.id)
+        #expect(target?.tmuxSocketName == generationSocketName)
+    }
+
+    @Test("noncanonical generations do not transfer socket identity")
+    func rejectsNoncanonicalGenerationForSocketIdentity() {
+        let hostID = UUID()
+        let projectID = UUID()
+        let generation = "legacy-generation"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [ProjectSummary(
+                id: projectID,
+                hostID: hostID,
+                scopedKey: "repo",
+                name: "repo",
+                rootPath: "/repo"
+            )],
+            worktrees: [WorktreeSummary(
+                id: UUID(),
+                hostID: hostID,
+                projectID: projectID,
+                name: "unrelated",
+                path: "/old-path",
+                branch: "feature/unrelated",
+                generation: generation,
+                tmuxSessionName: "kwt-repo-unrelated",
+                tmuxSocketName: "protected-socket"
+            )]
+        )
+        let inventory = KwtHostInventory(projects: [KwtProjectInventory(
+            project: KwtProjectRecord(
+                repository: "repo",
+                name: "repo",
+                path: "/repo",
+                lastTouched: nil
+            ),
+            worktrees: [KwtWorktreeRecord(
+                path: "/new-path",
+                branch: "feature/target",
+                commitHash: "abc",
+                isMain: false,
+                createdAt: nil,
+                generation: generation,
+                repository: "repo",
+                sessionName: "kwt-repo-target",
+                tmuxSocketName: nil
+            )],
+            warning: nil
+        )])
+
+        let merged = KwtSnapshotMerger.merge(
+            inventory,
+            hostID: hostID,
+            into: snapshot
+        )
+
+        #expect(merged.worktrees.count == 1)
+        #expect(merged.worktrees[0].tmuxSocketName == nil)
+    }
+
+    @Test("a canonical replacement cannot inherit a reused path socket")
+    func canonicalReplacementDoesNotInheritPathSocket() {
+        let hostID = UUID()
+        let projectID = UUID()
+        let replacementGeneration = "fedcba9876543210fedcba9876543210"
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [ProjectSummary(
+                id: projectID,
+                hostID: hostID,
+                scopedKey: "repo",
+                name: "repo",
+                rootPath: "/repo"
+            )],
+            worktrees: [WorktreeSummary(
+                id: UUID(),
+                hostID: hostID,
+                projectID: projectID,
+                name: "old-generation",
+                path: "/reused-path",
+                branch: "feature/old",
+                generation: "0123456789abcdef0123456789abcdef",
+                tmuxSessionName: "kwt-repo-old",
+                tmuxSocketName: "protected-socket"
+            )]
+        )
+        let inventory = KwtHostInventory(projects: [KwtProjectInventory(
+            project: KwtProjectRecord(
+                repository: "repo",
+                name: "repo",
+                path: "/repo",
+                lastTouched: nil
+            ),
+            worktrees: [KwtWorktreeRecord(
+                path: "/reused-path",
+                branch: "feature/replacement",
+                commitHash: "abc",
+                isMain: false,
+                createdAt: nil,
+                generation: replacementGeneration,
+                repository: "repo",
+                sessionName: "kwt-repo-replacement",
+                tmuxSocketName: nil
+            )],
+            warning: nil
+        )])
+
+        let merged = KwtSnapshotMerger.merge(
+            inventory,
+            hostID: hostID,
+            into: snapshot
+        )
+
+        #expect(merged.worktrees.count == 1)
+        #expect(merged.worktrees[0].generation == replacementGeneration)
+        #expect(merged.worktrees[0].tmuxSocketName == nil)
+    }
+
     @Test("a failed project listing preserves its last successful worktrees")
     func preservesProjectWorktreesAcrossTransientFailure() {
         let hostID = UUID()
@@ -707,10 +1082,12 @@ struct KwtInventoryClientTests {
         let retained = failed.retainingFailedProjectWorktrees(
             from: previous,
             excludingWorktrees: [
-                KwtWorktreeIdentity(
-                    path: removed.path,
-                    generation: "removed-generation"
-                ),
+                "repo": [
+                    KwtWorktreeIdentity(
+                        path: removed.path,
+                        generation: "removed-generation"
+                    ),
+                ],
             ]
         )
 
@@ -753,14 +1130,56 @@ struct KwtInventoryClientTests {
         let retained = failed.retainingFailedProjectWorktrees(
             from: previous,
             excludingWorktrees: [
-                KwtWorktreeIdentity(
-                    path: replacement.path,
-                    generation: "removed-generation"
-                ),
+                "repo": [
+                    KwtWorktreeIdentity(
+                        path: replacement.path,
+                        generation: "removed-generation"
+                    ),
+                ],
             ]
         )
 
         #expect(retained.projects[0].worktrees == [replacement])
+    }
+
+    @Test("worktree exclusions apply only to their own repository")
+    func exclusionsApplyOnlyToOwnRepository() {
+        let reassigned = KwtWorktreeRecord(
+            path: "/worktrees/reassigned",
+            branch: "reassigned",
+            commitHash: "abc",
+            isMain: false,
+            createdAt: nil,
+            generation: "shared-generation",
+            repository: "other-repo",
+            sessionName: "kwt-other-reassigned"
+        )
+        let inventory = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "other-repo",
+                    name: "other",
+                    path: "/other",
+                    lastTouched: nil
+                ),
+                worktrees: [reassigned],
+                warning: nil
+            ),
+        ])
+
+        let retained = inventory.retainingFailedProjectWorktrees(
+            from: nil,
+            excludingWorktrees: [
+                "repo": [
+                    KwtWorktreeIdentity(
+                        path: reassigned.path,
+                        generation: "shared-generation"
+                    ),
+                ],
+            ]
+        )
+
+        #expect(retained.projects[0].worktrees == [reassigned])
     }
 
     @Test("warning inventory records merge over a fresh snapshot")

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -154,6 +154,8 @@ struct TmuxSessionKillerTests {
         #expect(
             command.contains("GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH")
         )
+        #expect(command.contains("GHOSTHUB_TMUX_DIAGNOSTIC"))
+        #expect(command.contains(" 2>&1"))
     }
 
     @Test("Windows identity and kill use PowerShell and psmux quoting")
@@ -246,6 +248,7 @@ struct TmuxSessionKillerTests {
         #expect(recorded[2].contains(
             powerShellEncodedArgument("kill-session -t $42")
         ))
+        #expect(recorded[2].contains(" 2>&1"))
         #expect(!recorded.joined().contains("review's session"))
     }
 
@@ -284,12 +287,51 @@ struct TmuxSessionKillerTests {
         }
     }
 
+    @Test("kill reports explicit session absence")
+    func killReportsExplicitAbsence() async {
+        let killer = TmuxSessionKiller(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in
+                (
+                    1,
+                    TmuxSessionKiller.diagnosticMarker
+                        + "can't find session: worker\n"
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "worker"
+        )
+
+        await #expect {
+            try await killer.kill(
+                selection,
+                expectedIdentity: TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1785182057"
+                ),
+                on: .local
+            )
+        } throws: { error in
+            error as? TmuxSessionKillError == .sessionNotRunning(
+                host: "localhost",
+                session: "worker"
+            )
+        }
+    }
+
     @Test("identity mismatch preserves the replacement session")
     func identityMismatch() async {
         let killer = TmuxSessionKiller(
             pathResolver: { _ in .success("/usr/bin/tmux") },
             runner: { _, _ in
-                (0, "GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH\n")
+                (
+                    0,
+                    TmuxSessionKiller.diagnosticMarker
+                        + "GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH\n"
+                )
             }
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -313,6 +355,35 @@ struct TmuxSessionKillerTests {
                 session: "worker"
             )
         }
+    }
+
+    @Test(
+        "unframed identity mismatch output does not override a successful kill",
+        arguments: [
+            "GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH\n",
+            TmuxSessionKiller.diagnosticMarker
+                + "prefix GHOSTHUB_TMUX_SESSION_IDENTITY_MISMATCH suffix\n",
+        ]
+    )
+    func ignoresUnframedIdentityMismatch(_ output: String) async throws {
+        let killer = TmuxSessionKiller(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in (0, output) }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "worker"
+        )
+
+        try await killer.kill(
+            selection,
+            expectedIdentity: TmuxSessionIdentity(
+                serverPID: "31415",
+                sessionID: "$42",
+                createdAt: "1785182057"
+            ),
+            on: .local
+        )
     }
 
     @Test("session identity is read from the selected socket")
@@ -359,7 +430,8 @@ struct TmuxSessionKillerTests {
             "'/usr/bin/tmux' '-L' 'protected' 'has-session'"
                 + " '-t' '=worker:'"
         ))
-        #expect(commands[0].hasSuffix(" 2>&1"))
+        #expect(commands[0].contains("GHOSTHUB_TMUX_DIAGNOSTIC"))
+        #expect(commands[0].contains(" 2>&1"))
         #expect(commands[1].contains(
             "'/usr/bin/tmux' '-L' 'protected' 'display-message'"
                 + " '-p' '-t' '=worker:'"
@@ -383,6 +455,43 @@ struct TmuxSessionKillerTests {
             try await killer.sessionIdentity(selection, on: .local)
         } throws: { error in
             error as? TmuxSessionKillError == .identityCommandFailed(
+                host: "localhost",
+                session: "worker",
+                status: 1
+            )
+        }
+    }
+
+    @Test("kill ignores unframed shell absence diagnostics")
+    func killIgnoresUnframedShellAbsence() async {
+        let killer = TmuxSessionKiller(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in
+                (
+                    1,
+                    "can't find session: shell-helper\n"
+                        + "error connecting to /tmp/tmux-501/kwt "
+                        + "(Permission denied)"
+                )
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "worker"
+        )
+
+        await #expect {
+            try await killer.kill(
+                selection,
+                expectedIdentity: TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1785182057"
+                ),
+                on: .local
+            )
+        } throws: { error in
+            error as? TmuxSessionKillError == .commandFailed(
                 host: "localhost",
                 session: "worker",
                 status: 1
@@ -416,7 +525,11 @@ struct TmuxSessionKillerTests {
         let killer = TmuxSessionKiller(
             pathResolver: { _ in .success("/usr/bin/tmux") },
             runner: { _, _ in
-                (1, "can't find session: worker\n")
+                (
+                    1,
+                    TmuxSessionKiller.diagnosticMarker
+                        + "can't find session: worker\n"
+                )
             }
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -435,11 +548,80 @@ struct TmuxSessionKillerTests {
     }
 
     @Test(
+        "kill treats missing socket diagnostics as session absence",
+        arguments: [
+            "error connecting to /tmp/tmux-501/kwt (No such file or directory)",
+            "failed to connect to server: No such file or directory",
+        ]
+    )
+    func missingSocketDuringKill(output: String) async {
+        let killer = TmuxSessionKiller(
+            pathResolver: { _ in .success("/usr/bin/tmux") },
+            runner: { _, _ in
+                (1, TmuxSessionKiller.diagnosticMarker + output)
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: UUID(),
+            name: "worker",
+            socketName: "kwt"
+        )
+
+        await #expect {
+            try await killer.kill(
+                selection,
+                expectedIdentity: TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$42",
+                    createdAt: "1785182057"
+                ),
+                on: .local
+            )
+        } throws: { error in
+            error as? TmuxSessionKillError == .sessionNotRunning(
+                host: "localhost",
+                session: "worker"
+            )
+        }
+    }
+
+    @Test(
         "only missing session or server diagnostics confirm absence",
         arguments: [
-            ("can't find session: worker", true),
-            ("no server running on /tmp/tmux-501/default", true),
+            (
+                "GHOSTHUB_TMUX_DIAGNOSTIC\tcan't find session: worker",
+                true
+            ),
+            (
+                "GHOSTHUB_TMUX_DIAGNOSTIC\t"
+                    + "no server running on /tmp/tmux-501/default",
+                true
+            ),
+            (
+                "GHOSTHUB_TMUX_DIAGNOSTIC\t"
+                    + "error connecting to /tmp/tmux-501/kwt "
+                    + "(No such file or directory)",
+                true
+            ),
+            (
+                "GHOSTHUB_TMUX_DIAGNOSTIC\t"
+                    + "failed to connect to server: No such file or directory",
+                true
+            ),
             ("error connecting to socket (Permission denied)", false),
+            (
+                "shell: error connecting to startup helper\n"
+                    + "error connecting to /tmp/tmux-501/kwt "
+                    + "(Permission denied)\n"
+                    + "shell: (No such file or directory)",
+                false
+            ),
+            (
+                "can't find session: shell-helper\n"
+                    + "error connecting to /tmp/tmux-501/kwt "
+                    + "(Permission denied)",
+                false
+            ),
             ("", false),
         ]
     )

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -49,7 +49,7 @@ struct WorkspaceTmuxDiscoveryTests {
         let environment = try setupStandardEnvironment()
         let kwtGate = KillGate()
         let kwtCompletions = Counter()
-        let tmuxGate = BlockingGate()
+        let tmuxGate = KillGate()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -59,16 +59,14 @@ struct WorkspaceTmuxDiscoveryTests {
                 return KwtHostInventory(projects: [])
             },
             tmuxSessionDiscovery: { _ in
-                tmuxGate.wait()
+                await tmuxGate.suspend()
                 return .success([])
             },
             startServices: true
         )
 
         await kwtGate.waitUntilStarted()
-        await waitUntilMainActor(timeout: .seconds(15)) {
-            tmuxGate.didStart
-        }
+        await tmuxGate.waitUntilStarted()
         #expect(!model.isWorkspaceInventoryRefreshComplete)
 
         await kwtGate.release()
@@ -77,7 +75,7 @@ struct WorkspaceTmuxDiscoveryTests {
         }
         #expect(!model.isWorkspaceInventoryRefreshComplete)
 
-        tmuxGate.release()
+        await tmuxGate.release()
         await waitUntilMainActor(timeout: .seconds(15)) {
             model.isWorkspaceInventoryRefreshComplete
         }
@@ -1872,9 +1870,10 @@ struct WorkspaceTmuxDiscoveryTests {
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
 
-        await waitUntilMainActor(timeout: .milliseconds(250)) {
-            identityReads.count == 3
+        await waitUntilMainActor {
+            activityController.warmSessionIDs.contains(selection.id)
         }
+        #expect(identityReads.count >= 3)
         let start = Date.now
         for tick in 1 ... 400
             where !model.workingTmuxSessionIDs.contains(selection.id) {
@@ -1948,20 +1947,20 @@ struct WorkspaceTmuxDiscoveryTests {
             name: "build"
         )
         model.openBorrowedTmuxSession(second)
-        await waitUntilMainActor {
+        await waitUntilMainActor(timeout: .seconds(15)) {
             model.prepareActiveBorrowedTmuxSurface()
             return surfaceStore.requestCount == 2
         }
         identityAvailable.store(true)
 
-        let start = Date.now
-        for tick in 1 ... 400
-            where !model.workingTmuxSessionIDs.contains(first.id) {
-            await activityController.sampleWarmSessions(
-                at: start.addingTimeInterval(Double(tick))
-            )
-            try await Task.sleep(for: .milliseconds(2))
+        await waitUntilMainActor(timeout: .seconds(15)) {
+            activityController.warmSessionIDs.contains(first.id)
         }
+        let start = Date.now
+        await activityController.sampleWarmSessions(at: start)
+        await activityController.sampleWarmSessions(
+            at: start.addingTimeInterval(20)
+        )
 
         #expect(model.workingTmuxSessionIDs.contains(first.id))
         await model.shutdown()

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -1129,6 +1129,91 @@ struct WorkspaceWorktreeRemovalTests {
 
     @MainActor
     @Test(
+        "a stale scene restores the endpoint reconciled during recovery"
+    )
+    func staleSceneRestoresRecoveryReconciledEndpoint() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        var renamed = removable
+        renamed.tmuxSessionName = "kwt-ghosthub-renamed"
+        let beforeRemoval = fixture.beforeRemoval
+        let afterRename = inventory(environment, including: renamed)
+        let loads = LockedValue(0)
+        let coordinator = WorktreeMutationCoordinator()
+        let staleSurfaces = RecordingNativeSessionSurfaceStore()
+        let currentModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterRename
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: coordinator,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let staleModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            nativeTmuxSurfaceStore: staleSurfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            worktreeMutationCoordinator: coordinator
+        )
+        let saved = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let renamedSelection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: renamed)
+        )
+        staleModel.openBorrowedTmuxSession(saved)
+        await waitUntilMainActor {
+            staleSurfaces.requestedConfigurations.count == 1
+        }
+
+        let request = try await currentModel.prepareWorktreeRemoval(
+            removable.id
+        )
+        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+            try await currentModel.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            staleSurfaces.requestedConfigurations.count == 2
+        }
+
+        #expect(
+            staleModel.retainedBorrowedTmuxHandle(for: saved) == nil
+        )
+        #expect(
+            staleModel.retainedBorrowedTmuxHandle(for: renamedSelection)
+                != nil
+        )
+        #expect(
+            staleModel.activeBorrowedTmuxSelection?.name
+                == renamedSelection.name
+        )
+        await currentModel.shutdown()
+        await staleModel.shutdown()
+    }
+
+    @MainActor
+    @Test(
         "a same-repository move after a failed remove restores the moved endpoint"
     )
     func sameRepositoryMoveRestoresMovedEndpoint() async throws {

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -419,6 +419,61 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("a successful removal strips scenes with legacy project identity")
+    func successfulRemovalStripsLegacyIdentityScene() async throws {
+        struct InventoryUnavailable: Error {}
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        var legacySnapshot = fixture.snapshot
+        for index in legacySnapshot.projects.indices
+            where legacySnapshot.projects[index].id == removable.projectID {
+            legacySnapshot.projects[index].scopedKey = ""
+        }
+        let beforeRemoval = fixture.beforeRemoval
+        let afterRemoval = inventory(environment)
+        let loads = LockedValue(0)
+        let coordinator = WorktreeMutationCoordinator()
+        let currentModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterRemoval
+            },
+            kwtWorktreeRemover: { _, _, _, _ in },
+            worktreeMutationCoordinator: coordinator,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let legacyModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: legacySnapshot,
+            kwtInventoryLoader: { _ in throw InventoryUnavailable() },
+            worktreeMutationCoordinator: coordinator
+        )
+        #expect(legacyModel.snapshot.worktree(id: removable.id) != nil)
+
+        let request = try await currentModel.prepareWorktreeRemoval(
+            removable.id
+        )
+        try await currentModel.removeWorktree(request)
+
+        #expect(currentModel.snapshot.worktree(id: removable.id) == nil)
+        #expect(legacyModel.snapshot.worktree(id: removable.id) == nil)
+        await currentModel.shutdown()
+        await legacyModel.shutdown()
+    }
+
+    @MainActor
     @Test("failed removal restores the canonical endpoint in a stale scene")
     func failedRemovalRestoresCanonicalEndpointAcrossScenes() async throws {
         let fixture = try removalFixture(sessionName: "kwt-ghosthub-stale")

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -37,6 +37,27 @@ private actor RemovalPreflightHold {
         )
     }
 
+    func verifyStartedSession(
+        selection: WorkspaceTmuxSessionSelection,
+        host: CommandHost,
+        identity: TmuxSessionIdentity
+    ) async throws -> TmuxSessionIdentity {
+        callCount += 1
+        if callCount == 1 {
+            throw TmuxSessionKillError.sessionNotRunning(
+                host: host.displayName,
+                session: selection.name
+            )
+        }
+        if callCount == 2 {
+            started = true
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+        return identity
+    }
+
     func load(_ inventory: KwtHostInventory) async -> KwtHostInventory {
         started = true
         await withCheckedContinuation { continuation in
@@ -126,6 +147,59 @@ private func inventory(
     ])
 }
 
+private struct RemovalFixture {
+    let environment: StandardEnvironment
+    var removable: WorktreeSummary
+    var snapshot: WorkspaceSnapshot
+    var beforeRemoval: KwtHostInventory
+}
+
+/// Builds the standard local environment plus one removable worktree, the
+/// snapshot that contains it, and the inventory that still reports it.
+private func removalFixture(
+    path: String = "/tmp/ghosthub-feature",
+    name: String = "feature/remove",
+    branch: String = "feature/remove",
+    sessionName: String? = "kwt-ghosthub-feature",
+    socketName: String? = nil,
+    sessionBackend: SessionBackendKind = .localPTY,
+    runningSession: Bool = false
+) throws -> RemovalFixture {
+    let environment = try setupStandardEnvironment()
+    var removable = WorktreeSummary.fixture(
+        hostID: environment.host.id,
+        projectID: environment.project.id,
+        scopedKey: path,
+        name: name,
+        path: path,
+        branch: branch,
+        generation: stableWorktreeGeneration
+    )
+    removable.tmuxSessionName = sessionName
+    removable.tmuxSocketName = socketName
+    removable.sessionBackend = sessionBackend
+    var snapshot = environment.snapshot
+    snapshot.worktrees.append(removable)
+    if runningSession, let sessionName {
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: [],
+                serverPID: "31415",
+                sessionID: "$8",
+                createdAt: "1721552400"
+            ),
+        ]
+    }
+    return RemovalFixture(
+        environment: environment,
+        removable: removable,
+        snapshot: snapshot,
+        beforeRemoval: inventory(environment, including: removable)
+    )
+}
+
 @Suite("Workspace worktree removal", .serialized)
 struct WorkspaceWorktreeRemovalTests {
     @MainActor
@@ -136,30 +210,11 @@ struct WorkspaceWorktreeRemovalTests {
     func removalReconcilesOtherScenes(
         checkoutAlreadyAbsent: Bool
     ) async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        snapshot.hosts[0].tmuxSessions = [
-            TmuxSessionSummary(
-                name: "kwt-ghosthub-feature",
-                managed: true,
-                windows: [],
-                serverPID: "31415",
-                sessionID: "$8",
-                createdAt: "1721552400"
-            ),
-        ]
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture(runningSession: true)
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let afterRemoval = inventory(environment)
         let warningAfterRemoval: KwtHostInventory = {
             var inventory = beforeRemoval
@@ -217,7 +272,7 @@ struct WorkspaceWorktreeRemovalTests {
         )
         secondModel.startKwtInventory()
         secondModel.startTmuxSessionDiscovery()
-        await waitUntilMainActor {
+        await waitUntilMainActor(timeout: .seconds(10)) {
             secondLoads.load() >= 1
                 && secondDiscoveries.load() >= 1
         }
@@ -228,7 +283,7 @@ struct WorkspaceWorktreeRemovalTests {
         // Wait on the reconciled snapshot itself: the load and discovery
         // counters increment when the closures are entered, before their
         // results are applied, so counter-based waits race the assertion.
-        await waitUntilMainActor {
+        await waitUntilMainActor(timeout: .seconds(10)) {
             secondModel.snapshot.worktree(id: removable.id) == nil
                 && secondModel.snapshot.host(id: environment.host.id)?
                 .tmuxSessions.isEmpty == true
@@ -240,26 +295,17 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("removal cancels pending presentations in every scene")
     func removalCancelsPendingPresentationsInEveryScene() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         var staleSnapshot = snapshot
         let staleIndex = try #require(
             staleSnapshot.worktrees.firstIndex { $0.id == removable.id }
         )
         staleSnapshot.worktrees[staleIndex].generation = nil
 
-        let beforeRemoval = inventory(environment, including: removable)
+        let beforeRemoval = fixture.beforeRemoval
         let afterRemoval = inventory(environment)
         let coordinator = WorktreeMutationCoordinator()
         let pathGate = DispatchSemaphore(value: 0)
@@ -336,12 +382,7 @@ struct WorkspaceWorktreeRemovalTests {
         let removal = Task { @MainActor in
             try await firstModel.removeWorktree(request)
         }
-        for _ in 0 ..< 1_000 {
-            if await removerHold.started {
-                break
-            }
-            await Task.yield()
-        }
+        await waitUntilMainActor { await removerHold.started }
         #expect(await removerHold.started)
 
         #expect(firstModel.retainedBorrowedTmuxPresentationCount == 0)
@@ -380,23 +421,14 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal restores the canonical endpoint in a stale scene")
     func failedRemovalRestoresCanonicalEndpointAcrossScenes() async throws {
-        let environment = try setupStandardEnvironment()
-        var stale = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        stale.tmuxSessionName = "kwt-ghosthub-stale"
+        let fixture = try removalFixture(sessionName: "kwt-ghosthub-stale")
+        let environment = fixture.environment
+        let stale = fixture.removable
+        let staleSnapshot = fixture.snapshot
         var canonical = stale
         canonical.tmuxSessionName = "kwt-ghosthub-canonical"
         var currentSnapshot = environment.snapshot
         currentSnapshot.worktrees.append(canonical)
-        var staleSnapshot = environment.snapshot
-        staleSnapshot.worktrees.append(stale)
         let currentInventory = inventory(
             environment,
             including: canonical
@@ -464,22 +496,723 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test(
+        "a replacement racing a failed remove suppresses stale restoration"
+    )
+    func replacementAfterFailedRemoveRequiresConfirmation() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var replacement = removable
+        replacement.generation = "fedcba9876543210fedcba9876543210"
+        let beforeRemoval = fixture.beforeRemoval
+        let afterReplacement = inventory(
+            environment,
+            including: replacement,
+            generation: replacement.generation
+        )
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterReplacement
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Replacement should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.generation == replacement.generation)
+        #expect(loads.load() == 2)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaces.requestedConfigurations.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a same-generation metadata change after a failed remove keeps the worktree"
+    )
+    func metadataChangeAfterFailedRemoveKeepsWorktree() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var changed = removable
+        changed.branch = "feature/renamed"
+        let beforeRemoval = fixture.beforeRemoval
+        let afterMetadataChange = inventory(environment, including: changed)
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterMetadataChange
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Metadata change should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.branch == changed.branch)
+        #expect(
+            updatedRequest.worktree.generation == stableWorktreeGeneration
+        )
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+
+        model.startKwtInventory()
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            loads.load() >= 3 && model.isWorkspaceInventoryRefreshComplete
+        }
+        #expect(model.snapshot.worktrees.contains {
+            $0.path == removable.path
+                && $0.generation == stableWorktreeGeneration
+        })
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "failed removal restores the refreshed same-generation endpoint",
+        arguments: [true, false]
+    )
+    func failedRemovalRestoresRefreshedEndpoint(
+        sessionNameChanged: Bool
+    ) async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var changed = removable
+        if sessionNameChanged {
+            changed.tmuxSessionName = "kwt-ghosthub-renamed"
+        } else {
+            changed.tmuxSocketName = "kwt-ghosthub-socket"
+        }
+        let beforeRemoval = fixture.beforeRemoval
+        let afterEndpointChange = inventory(environment, including: changed)
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterEndpointChange
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let changedSelection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: changed)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case .confirmationRequired = result else {
+            Issue.record("Endpoint change should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) == nil)
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: changedSelection) != nil
+        )
+        #expect(
+            model.activeBorrowedTmuxSelection?.name
+                == changedSelection.name
+        )
+        #expect(
+            model.activeBorrowedTmuxSelection?.socketName
+                == changedSelection.socketName
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "an absent target after a failed remove suppresses restoration"
+    )
+    func absentTargetAfterFailedRemoveSuppressesRestoration() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let afterRemoval = inventory(environment)
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterRemoval
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        await #expect(
+            throws: KwtWorktreeError.removalFailed(
+                host: "Local",
+                status: 1
+            )
+        ) {
+            try await model.removeWorktree(request)
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(loads.load() == 2)
+        #expect(model.snapshot.worktree(id: removable.id) == nil)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaces.requestedConfigurations.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a cross-project reassignment after a failed remove suppresses restoration"
+    )
+    func crossProjectReassignmentSuppressesRestoration() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let afterReassignment = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: environment.project.scopedKey,
+                    name: environment.project.name,
+                    path: environment.project.rootPath,
+                    lastTouched: nil
+                ),
+                worktrees: [
+                    KwtWorktreeRecord(
+                        path: environment.worktree.path,
+                        branch: environment.worktree.branch,
+                        commitHash: "",
+                        isMain: true,
+                        createdAt: nil,
+                        generation: nil,
+                        repository: environment.project.scopedKey,
+                        sessionName: "kwt-ghosthub-main",
+                        tmuxSocketName: nil
+                    ),
+                ],
+                warning: nil
+            ),
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "/tmp/ghosthub-other",
+                    name: "other",
+                    path: "/tmp/ghosthub-other",
+                    lastTouched: nil
+                ),
+                worktrees: [
+                    KwtWorktreeRecord(
+                        path: removable.path,
+                        branch: removable.branch,
+                        commitHash: "",
+                        isMain: false,
+                        createdAt: nil,
+                        generation: stableWorktreeGeneration,
+                        repository: "/tmp/ghosthub-other",
+                        sessionName: "kwt-ghosthub-other-feature",
+                        tmuxSocketName: nil
+                    ),
+                ],
+                warning: nil
+            ),
+        ])
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterReassignment
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+            try await model.removeWorktree(request)
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(loads.load() == 2)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaces.requestedConfigurations.count == 1)
+        #expect(model.snapshot.worktrees.contains { worktree in
+            worktree.path == removable.path
+                && worktree.generation == stableWorktreeGeneration
+                && model.snapshot.project(id: worktree.projectID)?.scopedKey
+                == "/tmp/ghosthub-other"
+        })
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a cross-project reassignment closes stale-scene presentations"
+    )
+    func crossProjectReassignmentClosesStaleScenePresentation() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let beforeRemoval = fixture.beforeRemoval
+        let afterReassignment = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: environment.project.scopedKey,
+                    name: environment.project.name,
+                    path: environment.project.rootPath,
+                    lastTouched: nil
+                ),
+                worktrees: [
+                    KwtWorktreeRecord(
+                        path: environment.worktree.path,
+                        branch: environment.worktree.branch,
+                        commitHash: "",
+                        isMain: true,
+                        createdAt: nil,
+                        generation: nil,
+                        repository: environment.project.scopedKey,
+                        sessionName: "kwt-ghosthub-main",
+                        tmuxSocketName: nil
+                    ),
+                ],
+                warning: nil
+            ),
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "/tmp/ghosthub-other",
+                    name: "other",
+                    path: "/tmp/ghosthub-other",
+                    lastTouched: nil
+                ),
+                worktrees: [
+                    KwtWorktreeRecord(
+                        path: removable.path,
+                        branch: removable.branch,
+                        commitHash: "",
+                        isMain: false,
+                        createdAt: nil,
+                        generation: stableWorktreeGeneration,
+                        repository: "/tmp/ghosthub-other",
+                        sessionName: "kwt-ghosthub-other-feature",
+                        tmuxSocketName: nil
+                    ),
+                ],
+                warning: nil
+            ),
+        ])
+        let loads = LockedValue(0)
+        let coordinator = WorktreeMutationCoordinator()
+        let staleSurfaces = RecordingNativeSessionSurfaceStore()
+        let currentModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterReassignment
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: coordinator,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let staleModel = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            nativeTmuxSurfaceStore: staleSurfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            worktreeMutationCoordinator: coordinator
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        staleModel.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            staleSurfaces.requestedConfigurations.count == 1
+        }
+
+        let request = try await currentModel.prepareWorktreeRemoval(
+            removable.id
+        )
+        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+            try await currentModel.removeWorktree(request)
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(staleModel.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(staleSurfaces.requestedConfigurations.count == 1)
+        #expect(staleModel.snapshot.worktree(id: removable.id) == nil)
+        await currentModel.shutdown()
+        await staleModel.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "an incomplete owning repository keeps failed-removal identity"
+    )
+    func incompleteOwningRepositoryKeepsFailedRemovalIdentity() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let movedRootPath = "/tmp/ghosthub-moved-root"
+        let conflictedRefresh = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: environment.project.scopedKey,
+                    name: environment.project.name,
+                    path: movedRootPath,
+                    lastTouched: nil
+                ),
+                worktrees: [],
+                warning: "kwt could not enumerate worktrees"
+            ),
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "/tmp/ghosthub-occupant",
+                    name: "occupant",
+                    path: environment.project.rootPath,
+                    lastTouched: nil
+                ),
+                worktrees: [],
+                warning: nil
+            ),
+        ])
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : conflictedRefresh
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        await #expect(
+            throws: KwtWorktreeError.removalFailed(
+                host: "Local",
+                status: 1
+            )
+        ) {
+            try await model.removeWorktree(request)
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+
+        #expect(loads.load() == 2)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) != nil)
+        #expect(model.snapshot.worktrees.contains {
+            $0.path == removable.path
+                && $0.generation == stableWorktreeGeneration
+        })
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a same-repository move after a failed remove restores the moved endpoint"
+    )
+    func sameRepositoryMoveRestoresMovedEndpoint() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var moved = removable
+        moved.path = "/tmp/ghosthub-feature-moved"
+        moved.scopedKey = moved.path
+        let beforeRemoval = fixture.beforeRemoval
+        let afterMove = inventory(environment, including: moved)
+        let loads = LockedValue(0)
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() == 1
+                    ? beforeRemoval
+                    : afterMove
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            worktreeMutationCoordinator: WorktreeMutationCoordinator(),
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 1
+        }
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("A moved target should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.path == moved.path)
+        #expect(
+            updatedRequest.worktree.generation == stableWorktreeGeneration
+        )
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count == 2
+        }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(
+            model.activeBorrowedTmuxSelection?.workspacePath == moved.path
+        )
+        #expect(model.snapshot.worktrees.contains {
+            $0.path == moved.path
+                && $0.generation == stableWorktreeGeneration
+        })
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("post-removal refresh ignores a generationless stale record")
     func postRemovalRefreshIgnoresGenerationlessRecord() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let staleRefresh = inventory(
             environment,
             including: removable,
@@ -521,20 +1254,11 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal restores an inactive retained presentation")
     func failedRemovalRestoresInactivePresentation() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let removerHold = RemovalPreflightHold()
         let model = try makeModel(
             database: environment.database,
@@ -582,12 +1306,7 @@ struct WorkspaceWorktreeRemovalTests {
         let removal = Task { @MainActor in
             try await model.removeWorktree(request)
         }
-        for _ in 0 ..< 1_000 {
-            if await removerHold.started {
-                break
-            }
-            await Task.yield()
-        }
+        await waitUntilMainActor { await removerHold.started }
         #expect(await removerHold.started)
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(model.suppressesSelectedWorktreeSessionOpen)
@@ -617,20 +1336,11 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal does not replace newer active presentation")
     func failedRemovalPreservesNewerActivePresentation() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let removerHold = RemovalPreflightHold()
         let model = try makeModel(
             database: environment.database,
@@ -686,20 +1396,11 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal re-establishes a terminated worktree session")
     func failedRemovalReestablishesTerminatedSession() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let surfaces = RecordingNativeSessionSurfaceStore()
         let kills = LockedValue(0)
         let model = try makeModel(
@@ -822,20 +1523,11 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal preserves interrupted local establishment")
     func failedRemovalPreservesInterruptedLocalEstablishment() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let surfaces = RecordingNativeSessionSurfaceStore()
         let model = try makeModel(
             database: environment.database,
@@ -893,21 +1585,11 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("failed removal restores a pathless matching endpoint")
     func failedRemovalRestoresPathlessMatchingEndpoint() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        removable.tmuxSocketName = "kwt-pr-0123456789abcdef"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
-        let beforeRemoval = inventory(environment, including: removable)
+        let fixture = try removalFixture(socketName: "kwt-pr-0123456789abcdef")
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
         let surfaces = RecordingNativeSessionSurfaceStore()
         let kills = LockedValue(0)
         let model = try makeModel(
@@ -1058,21 +1740,12 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("removal preflight invalidates a replaced retained endpoint")
     func removalPreflightInvalidatesReplacedPresentation() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         var replacement = removable
         replacement.tmuxSessionName = "kwt-ghosthub-replacement"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
         let replacementInventory = inventory(
             environment,
             including: replacement
@@ -1110,22 +1783,13 @@ struct WorkspaceWorktreeRemovalTests {
         "live session removal leaves a same-path worktree on another host"
     )
     func liveSessionIsKilledFirst() async throws {
-        let environment = try setupStandardEnvironment()
-        let feature = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
+        let fixture = try removalFixture(
+            socketName: "kwt-pr-0123456789abcdef",
+            sessionBackend: .localTmux
         )
-        var removable = feature
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        removable.tmuxSocketName = "kwt-pr-0123456789abcdef"
-        removable.sessionBackend = .localTmux
-
-        var snapshot = environment.snapshot
+        let environment = fixture.environment
+        let removable = fixture.removable
+        var snapshot = fixture.snapshot
         let otherHost = HostSummary.fixture(
             name: "Build Box",
             kind: .remote,
@@ -1147,10 +1811,10 @@ struct WorkspaceWorktreeRemovalTests {
         )
         snapshot.hosts.append(otherHost)
         snapshot.projects.append(otherProject)
-        snapshot.worktrees += [removable, samePath]
+        snapshot.worktrees.append(samePath)
         let events = LockedValue<[String]>([])
         let loads = LockedValue(0)
-        let beforeRemoval = inventory(environment, including: removable)
+        let beforeRemoval = fixture.beforeRemoval
         let afterRemoval = inventory(environment)
         let model = try makeModel(
             database: environment.database,
@@ -1194,10 +1858,8 @@ struct WorkspaceWorktreeRemovalTests {
         ])
         #expect(model.snapshot.worktree(id: removable.id) == nil)
         #expect(model.snapshot.worktree(id: samePath.id) == samePath)
-        #expect(
-            model.selection.selectedWorktreeID
-                == environment.worktree.id
-        )
+        #expect(model.selection.selectedProjectID == environment.project.id)
+        #expect(model.selection.selectedWorktreeID == nil)
         await model.shutdown()
     }
 
@@ -1215,16 +1877,9 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("an already-absent worktree completes cached removal")
     func alreadyAbsentWorktreeCompletesRemoval() async throws {
-        let environment = try setupStandardEnvironment()
-        let removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
-        )
+        let fixture = try removalFixture(sessionName: nil)
+        let environment = fixture.environment
+        let removable = fixture.removable
         let session = TerminalSessionSummary(
             id: UUID(),
             hostID: environment.host.id,
@@ -1232,8 +1887,7 @@ struct WorkspaceWorktreeRemovalTests {
             scopedKey: removable.scopedKey,
             isAlive: false
         )
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        var snapshot = fixture.snapshot
         snapshot.sessions.append(session)
         let removals = LockedValue(0)
         let kills = LockedValue(0)
@@ -1263,21 +1917,13 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("an already-absent worktree still kills its confirmed session")
     func alreadyAbsentWorktreeKillsConfirmedSession() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
+        let fixture = try removalFixture(
+            socketName: "kwt-pr-0123456789abcdef",
+            sessionBackend: .localTmux
         )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        removable.tmuxSocketName = "kwt-pr-0123456789abcdef"
-        removable.sessionBackend = .localTmux
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let events = LockedValue<[String]>([])
         let model = try makeModel(
             database: environment.database,
@@ -1311,21 +1957,13 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("a session starting for an absent worktree requires confirmation again")
     func newlyStartedSessionForAbsentWorktreeAbortsRemoval() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
+        let fixture = try removalFixture(
+            socketName: "kwt-pr-0123456789abcdef",
+            sessionBackend: .localTmux
         )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        removable.tmuxSocketName = "kwt-pr-0123456789abcdef"
-        removable.sessionBackend = .localTmux
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let reads = LockedValue(0)
         let removals = LockedValue(0)
         let kills = LockedValue(0)
@@ -1482,8 +2120,65 @@ struct WorkspaceWorktreeRemovalTests {
         )
         model.snapshot.hosts[0].sshDestination = "replacement.example.com"
 
-        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
             try await model.removeWorktree(request)
+        }
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a changed host endpoint cannot refresh removal confirmation")
+    func changedHostEndpointIsNotRecoverable() async throws {
+        let environment = try setupRemoteEnvironment()
+        var worktree = try #require(environment.snapshot.worktrees.first)
+        worktree.generation = stableWorktreeGeneration
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [worktree]
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(worktree.id)
+        model.snapshot.hosts[0].sshDestination = "replacement.example.com"
+
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a changed target cannot redirect confirmation to a new host")
+    func changedTargetAndHostEndpointAreNotRecoverable() async throws {
+        let environment = try setupRemoteEnvironment()
+        var worktree = try #require(environment.snapshot.worktrees.first)
+        worktree.generation = stableWorktreeGeneration
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [worktree]
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(worktree.id)
+        model.snapshot.worktrees[0].branch = "feature/replacement"
+        model.snapshot.hosts[0].sshDestination = "replacement.example.com"
+
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
+            try await model.resolveWorktreeRemoval(request)
         }
         #expect(removals.load() == 0)
         await model.shutdown()
@@ -1516,19 +2211,14 @@ struct WorkspaceWorktreeRemovalTests {
         )
         let request = try await model.prepareWorktreeRemoval(worktree.id)
         let removal = Task { @MainActor in
-            try await model.removeWorktree(request)
+            try await model.resolveWorktreeRemoval(request)
         }
-        for _ in 0 ..< 1_000 {
-            if await hold.started {
-                break
-            }
-            await Task.yield()
-        }
+        await waitUntilMainActor { await hold.started }
         #expect(await hold.started)
         model.snapshot.hosts[0].sshDestination = "replacement.example.com"
         await hold.release()
 
-        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
             try await removal.value
         }
         #expect(removals.load() == 0)
@@ -1588,7 +2278,7 @@ struct WorkspaceWorktreeRemovalTests {
 
         model.snapshot.hosts[0].sshDestination = "replacement.example.com"
         await killHold.release()
-        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
             try await removal.value
         }
         await waitUntilMainActor {
@@ -1597,6 +2287,118 @@ struct WorkspaceWorktreeRemovalTests {
 
         #expect(removals.load() == 0)
         #expect(surfaces.lastCommand?.contains("'open'") == true)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a session start cannot redirect removal recovery to a new host")
+    func sessionStartRecoveryRejectsChangedHostEndpoint() async throws {
+        let environment = try setupRemoteEnvironment()
+        var worktree = try #require(environment.snapshot.worktrees.first)
+        worktree.generation = stableWorktreeGeneration
+        worktree.scopedKey = worktree.path
+        worktree.tmuxSessionName = "kwt-remote-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [worktree]
+        let hold = RemovalPreflightHold()
+        let preflight = inventory(environment, including: worktree)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                try await hold.verifyStartedSession(
+                    selection: selection,
+                    host: host,
+                    identity: identity
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(worktree.id)
+        let removal = Task { @MainActor in
+            try await model.resolveWorktreeRemoval(request)
+        }
+        await waitUntilMainActor { await hold.started }
+        model.snapshot.hosts[0].sshDestination = "replacement.example.com"
+        await hold.release()
+
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
+            try await removal.value
+        }
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a replaced session cannot redirect removal recovery to a new host")
+    func sessionChangeRecoveryRejectsChangedHostEndpoint() async throws {
+        let environment = try setupRemoteEnvironment()
+        var worktree = try #require(environment.snapshot.worktrees.first)
+        worktree.generation = stableWorktreeGeneration
+        worktree.scopedKey = worktree.path
+        worktree.tmuxSessionName = "kwt-remote-feature"
+        var snapshot = environment.snapshot
+        snapshot.worktrees = [worktree]
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "kwt-remote-feature",
+                managed: true,
+                windows: [],
+                serverPID: "31415",
+                sessionID: "$8",
+                createdAt: "1721552400"
+            ),
+        ]
+        let hold = RemovalPreflightHold()
+        let preflight = inventory(environment, including: worktree)
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { selection, _, host in
+                _ = await hold.load(preflight)
+                throw TmuxSessionKillError.sessionChanged(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                TmuxSessionIdentity(
+                    serverPID: "27182",
+                    sessionID: "$13",
+                    createdAt: "1786136400"
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(worktree.id)
+        let removal = Task { @MainActor in
+            try await model.resolveWorktreeRemoval(request)
+        }
+        await waitUntilMainActor { await hold.started }
+        model.snapshot.hosts[0].sshDestination = "replacement.example.com"
+        await hold.release()
+
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
+            try await removal.value
+        }
+        #expect(removals.load() == 0)
         await model.shutdown()
     }
 
@@ -1630,17 +2432,12 @@ struct WorkspaceWorktreeRemovalTests {
         let removal = Task { @MainActor in
             try await model.removeWorktree(request)
         }
-        for _ in 0 ..< 1_000 {
-            if await hold.started {
-                break
-            }
-            await Task.yield()
-        }
+        await waitUntilMainActor { await hold.started }
         #expect(await hold.started)
         model.snapshot.hosts[0].sshDestination = "replacement.example.com"
         await hold.release()
 
-        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
+        await #expect(throws: KwtWorktreeError.removalHostChanged) {
             try await removal.value
         }
         #expect(removals.load() == 0)
@@ -1651,21 +2448,17 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("a session starting after confirmation requires confirmation again")
     func newlyStartedSessionAbortsRemoval() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature"
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            branch: "main",
+            sessionName: "kwt-project-a-feature"
         )
-        removable.generation = stableWorktreeGeneration
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let reads = LockedValue(0)
         let removals = LockedValue(0)
-        let beforeRemoval = inventory(environment, including: removable)
+        let beforeRemoval = fixture.beforeRemoval
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -1693,18 +2486,138 @@ struct WorkspaceWorktreeRemovalTests {
 
         let request = try await model.prepareWorktreeRemoval(removable.id)
         #expect(request.sessionKillRequest == nil)
-        do {
-            try await model.removeWorktree(request)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
             Issue.record("Removal should require a new confirmation")
-        } catch {
-            #expect(
-                error as? KwtWorktreeError
-                    == .sessionStartedAfterConfirmation(
-                        session: "kwt-ghosthub-feature"
-                    )
-            )
+            await model.shutdown()
+            return
         }
 
+        #expect(
+            updatedRequest.sessionKillRequest?.session.name
+                == "kwt-project-a-feature"
+        )
+        #expect(removals.load() == 0)
+        #expect(model.snapshot.worktree(id: removable.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a replaced session requires a fresh removal confirmation")
+    func replacedSessionRequiresFreshConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            branch: "main",
+            sessionName: "kwt-project-a-feature",
+            runningSession: true
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let reads = LockedValue(0)
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let replacementIdentity = TmuxSessionIdentity(
+            serverPID: "27182",
+            sessionID: "$13",
+            createdAt: "1786136400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { selection, _, _ in
+                kills.withLock { $0 += 1 }
+                throw TmuxSessionKillError.sessionChanged(
+                    host: "localhost",
+                    session: selection.name
+                )
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                reads.withLock { $0 += 1 }
+                return replacementIdentity
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        #expect(request.sessionKillRequest?.serverPID == "31415")
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Replacement should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.sessionKillRequest?.serverPID == "27182")
+        #expect(updatedRequest.sessionKillRequest?.sessionID == "$13")
+        #expect(
+            updatedRequest.sessionKillRequest?.sessionCreatedAt
+                == "1786136400"
+        )
+        #expect(reads.load() == 1)
+        #expect(kills.load() == 1)
+        #expect(removals.load() == 0)
+        #expect(model.snapshot.worktree(id: removable.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a confirmed session ending requires a fresh removal confirmation")
+    func endedSessionRequiresFreshConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            branch: "main",
+            sessionName: "kwt-project-a-feature",
+            runningSession: true
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let reads = LockedValue(0)
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { selection, _, host in
+                kills.withLock { $0 += 1 }
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                reads.withLock { $0 += 1 }
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        #expect(request.sessionKillRequest?.serverPID == "31415")
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Ended session should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.sessionKillRequest == nil)
+        #expect(reads.load() == 1)
+        #expect(kills.load() == 1)
         #expect(removals.load() == 0)
         #expect(model.snapshot.worktree(id: removable.id) != nil)
         await model.shutdown()
@@ -1713,21 +2626,13 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("refresh failure after removal is a reconciliation warning")
     func refreshFailureDoesNotUndoRemoval() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature"
-        )
-        removable.generation = stableWorktreeGeneration
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let fixture = try removalFixture(branch: "main")
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let loads = LockedValue(0)
         let removals = LockedValue(0)
-        let beforeRemoval = inventory(environment, including: removable)
+        let beforeRemoval = fixture.beforeRemoval
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -1771,21 +2676,17 @@ struct WorkspaceWorktreeRemovalTests {
     @MainActor
     @Test("successful removal cancels pending window restoration")
     func removalCancelsPendingRestoration() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-restoration-boundary",
-            name: "feature/restoration-boundary",
+        let fixture = try removalFixture(
             path: "/tmp/ghosthub-restoration-boundary",
+            name: "feature/restoration-boundary",
             branch: "feature/restoration-boundary",
-            generation: stableWorktreeGeneration
+            sessionName: "kwt-ghosthub-restoration-boundary"
         )
-        removable.tmuxSessionName = "kwt-ghosthub-restoration-boundary"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let loads = LockedValue(0)
-        let beforeRemoval = inventory(environment, including: removable)
+        let beforeRemoval = fixture.beforeRemoval
         let afterRemoval = inventory(environment)
         let model = try makeModel(
             database: environment.database,
@@ -1839,23 +2740,17 @@ struct WorkspaceWorktreeRemovalTests {
         replacementBranch: String,
         replacementSession: String
     ) async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
-            generation: stableWorktreeGeneration
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
         )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         var replacement = removable
         replacement.branch = replacementBranch
         replacement.name = replacementBranch
         replacement.tmuxSessionName = replacementSession
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
         let events = LockedValue<[String]>([])
         let replacementInventory = inventory(
             environment,
@@ -1905,21 +2800,467 @@ struct WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
-    @Test("a recreated worktree invalidates removal confirmation")
-    func recreatedWorktreeAbortsRemoval() async throws {
-        let environment = try setupStandardEnvironment()
-        var removable = WorktreeSummary.fixture(
-            hostID: environment.host.id,
-            projectID: environment.project.id,
-            scopedKey: "/tmp/ghosthub-feature",
-            name: "feature/remove",
-            path: "/tmp/ghosthub-feature",
-            branch: "feature/remove",
+    @Test("a moved worktree outranks a replacement reusing its runtime ID")
+    func movedWorktreeRequiresConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var moved = removable
+        moved.path = "/tmp/project-a-moved"
+        moved.scopedKey = moved.path
+        let replacementGeneration = "fedcba9876543210fedcba9876543210"
+        var inventoryAfterMove = inventory(environment, including: moved)
+        inventoryAfterMove.projects[0].worktrees.append(KwtWorktreeRecord(
+            path: removable.path,
+            branch: "feature/replacement",
+            commitHash: "",
+            isMain: false,
+            createdAt: nil,
+            generation: replacementGeneration,
+            repository: environment.project.scopedKey,
+            sessionName: "kwt-project-a-replacement",
+            tmuxSocketName: nil
+        ))
+        let movedInventory = inventoryAfterMove
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in movedInventory },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in identity }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.id != request.worktree.id)
+        #expect(updatedRequest.worktree.path == moved.path)
+        #expect(
+            updatedRequest.worktree.generation
+                == stableWorktreeGeneration
+        )
+        #expect(kills.load() == 0)
+        #expect(removals.load() == 0)
+        #expect(
+            model.snapshot.worktree(id: removable.id)?.generation
+                == replacementGeneration
+        )
+        #expect(model.snapshot.worktree(id: updatedRequest.worktree.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a moved worktree retains its protected socket identity")
+    func movedWorktreeRetainsProtectedSocket() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var moved = removable
+        moved.path = "/tmp/project-a-moved"
+        moved.scopedKey = moved.path
+        var inventoryAfterMove = inventory(environment, including: moved)
+        let recordIndex = try #require(
+            inventoryAfterMove.projects[0].worktrees.firstIndex {
+                $0.path == moved.path
+            }
+        )
+        inventoryAfterMove.projects[0]
+            .worktrees[recordIndex].tmuxSocketName = nil
+        let movedInventory = inventoryAfterMove
+        let probes = LockedValue<[String?]>([])
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in movedInventory },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                probes.withLock { $0.append(selection.socketName) }
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.path == moved.path)
+        #expect(updatedRequest.worktree.tmuxSocketName == "protected")
+        #expect(probes.load() == ["protected", "protected"])
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a replacement claiming the confirmed tmux endpoint requires confirmation",
+        arguments: ["protected", nil] as [String?]
+    )
+    func replacementClaimingTmuxEndpointRequiresConfirmation(
+        replacementSocket: String?
+    ) async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var replacement = WorktreeSummary.fixture(
+            hostID: removable.hostID,
+            projectID: removable.projectID,
+            scopedKey: "/tmp/project-a-replacement",
+            name: removable.name,
+            path: "/tmp/project-a-replacement",
+            branch: removable.branch,
+            generation: "fedcba9876543210fedcba9876543210"
+        )
+        replacement.tmuxSessionName = removable.tmuxSessionName
+        replacement.tmuxSocketName = replacementSocket
+        let replacementInventory = inventory(
+            environment,
+            including: replacement,
+            generation: replacement.generation
+        )
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in replacementInventory },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in identity }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Replacement should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.path == replacement.path)
+        #expect(updatedRequest.worktree.generation == replacement.generation)
+        #expect(updatedRequest.worktree.tmuxSocketName == replacementSocket)
+        #expect(kills.load() == 0)
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a different project claiming removal identity fails closed",
+        arguments: [true, false]
+    )
+    func differentProjectClaimingRemovalIdentityFailsClosed(
+        claimsGeneration: Bool
+    ) async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var conflictingInventory = inventory(environment)
+        conflictingInventory.projects.append(KwtProjectInventory(
+            project: KwtProjectRecord(
+                repository: "/tmp/project-b",
+                name: "project-b",
+                path: "/tmp/project-b",
+                lastTouched: nil
+            ),
+            worktrees: [
+                KwtWorktreeRecord(
+                    path: "/tmp/project-b-feature",
+                    branch: "feature/other",
+                    commitHash: "",
+                    isMain: false,
+                    createdAt: nil,
+                    generation: claimsGeneration
+                        ? stableWorktreeGeneration
+                        : "fedcba9876543210fedcba9876543210",
+                    repository: "/tmp/project-b",
+                    sessionName: claimsGeneration
+                        ? "kwt-project-b-feature"
+                        : removable.tmuxSessionName ?? "",
+                    tmuxSocketName: claimsGeneration
+                        ? nil
+                        : removable.tmuxSocketName
+                ),
+            ],
+            warning: nil
+        ))
+        let preflightInventory = conflictingInventory
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflightInventory },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in identity }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.worktreeUnavailable) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        #expect(kills.load() == 0)
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a snapshot-moved worktree requires a refreshed confirmation")
+    func snapshotMovedWorktreeRequiresConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        var moved = WorktreeSummary.fixture(
+            hostID: removable.hostID,
+            projectID: removable.projectID,
+            scopedKey: "/tmp/project-a-moved",
+            name: removable.name,
+            path: "/tmp/project-a-moved",
+            branch: removable.branch,
             generation: stableWorktreeGeneration
         )
-        removable.tmuxSessionName = "kwt-ghosthub-feature"
-        var snapshot = environment.snapshot
-        snapshot.worktrees.append(removable)
+        moved.tmuxSessionName = removable.tmuxSessionName
+        model.snapshot.worktrees.removeAll { $0.id == removable.id }
+        model.snapshot.worktrees.append(moved)
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.id == moved.id)
+        #expect(updatedRequest.worktree.path == moved.path)
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a snapshot-moved project requires a refreshed confirmation")
+    func snapshotMovedProjectRequiresConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let movedPath = "/tmp/project-a-moved"
+        model.snapshot.projects[0].rootPath = movedPath
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.project.rootPath == movedPath)
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a snapshot-removed worktree remains unavailable")
+    func snapshotRemovedWorktreeRemainsUnavailable() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        model.snapshot.worktrees.removeAll { $0.id == removable.id }
+
+        await #expect(throws: KwtWorktreeError.worktreeUnavailable) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a snapshot-recreated endpoint owner requires confirmation")
+    func snapshotRecreatedEndpointOwnerRequiresConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let index = try #require(
+            model.snapshot.worktrees.firstIndex { $0.id == removable.id }
+        )
+        model.snapshot.worktrees[index].generation =
+            "fedcba9876543210fedcba9876543210"
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Replacement should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.worktree.id == removable.id)
+        #expect(
+            updatedRequest.worktree.generation
+                == "fedcba9876543210fedcba9876543210"
+        )
+        #expect(updatedRequest.worktree.tmuxSocketName == "protected")
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a recreated worktree requires a refreshed confirmation")
+    func recreatedWorktreeRequiresConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
         let removals = LockedValue(0)
         let recreatedInventory = inventory(
             environment,
@@ -1943,12 +3284,457 @@ struct WorkspaceWorktreeRemovalTests {
         )
 
         let request = try await model.prepareWorktreeRemoval(removable.id)
-        await #expect(throws: KwtWorktreeError.removalTargetChanged) {
-            try await model.removeWorktree(request)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
         }
 
+        #expect(
+            updatedRequest.worktree.generation
+                == "fedcba9876543210fedcba9876543210"
+        )
         #expect(removals.load() == 0)
         await model.shutdown()
+    }
+
+    @MainActor
+    @Test("an omitted preflight socket preserves the protected identity")
+    func omittedPreflightSocketUsesProtectedIdentity() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var preflight = fixture.beforeRemoval
+        let recordIndex = try #require(
+            preflight.projects[0].worktrees.firstIndex {
+                $0.path == removable.path
+            }
+        )
+        preflight.projects[0].worktrees[recordIndex].tmuxSocketName = nil
+        let omissionPreflight = preflight
+        let removals = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in omissionPreflight },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+
+        #expect(result == .removed)
+        #expect(removals.load() == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("an unchanged recovery request remains an error")
+    func unchangedRecoveryRequestRemainsAnError() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let beforeRemoval = fixture.beforeRemoval
+        let expected = KwtWorktreeError.removalTargetChanged
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in throw expected },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: expected) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("an unrelated removal failure is not recoverable")
+    func unrelatedFailureRemainsAnError() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let expected = KwtWorktreeError.removalFailed(
+            host: "this Mac",
+            status: 42
+        )
+        let beforeRemoval = fixture.beforeRemoval
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in throw expected },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: expected) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a missing project invalidates cached removal state")
+    func missingProjectInvalidatesCachedState() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.worktreeUnavailable) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        #expect(model.snapshot.worktree(id: removable.id) == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a warning-bearing preflight cannot trigger reconfirmation")
+    func warningPreflightRemainsAnError() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let hostSummary = try #require(snapshot.host(id: environment.host.id))
+        let warning = "Project inventory is temporarily unavailable."
+        var warningInventory = inventory(environment)
+        warningInventory.projects[0].warning = warning
+        let preflight = warningInventory
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let expected = KwtWorktreeError.removalPreflightUnavailable(
+            host: hostSummary.name,
+            message: warning
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: expected) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        #expect(model.snapshot.worktree(id: removable.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("an unrelated project warning prevents absent-target removal")
+    func unrelatedProjectWarningPreventsAbsentTargetRemoval() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let hostSummary = try #require(snapshot.host(id: environment.host.id))
+        let warning = "Another project inventory is temporarily unavailable."
+        var warningInventory = inventory(environment)
+        warningInventory.projects.append(KwtProjectInventory(
+            project: KwtProjectRecord(
+                repository: "example.com/acme/unavailable",
+                name: "unavailable",
+                path: "/tmp/project-b",
+                lastTouched: nil
+            ),
+            worktrees: [],
+            warning: warning
+        ))
+        let preflight = warningInventory
+        let kills = LockedValue(0)
+        let removals = LockedValue(0)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            kwtWorktreeRemover: { _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in identity }
+        )
+        let expected = KwtWorktreeError.removalPreflightUnavailable(
+            host: hostSummary.name,
+            message: warning
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: expected) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        #expect(kills.load() == 0)
+        #expect(removals.load() == 0)
+        #expect(model.snapshot.worktree(id: removable.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a failed project-list preflight cannot trigger reconfirmation")
+    func projectListWarningPreflightRemainsAnError() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let hostSummary = try #require(snapshot.host(id: environment.host.id))
+        let warning = "Project listing is temporarily unavailable."
+        let preflight = KwtHostInventory(
+            projects: [],
+            projectsWarning: warning
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+        let expected = KwtWorktreeError.removalPreflightUnavailable(
+            host: hostSummary.name,
+            message: warning
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: expected) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
+        #expect(model.snapshot.worktree(id: removable.id) != nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a changed project path refreshes removal confirmation")
+    func changedProjectPathRefreshesConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        let movedPath = "/tmp/project-a-moved"
+        var movedInventory = fixture.beforeRemoval
+        movedInventory.projects[0].project.path = movedPath
+        let preflight = movedInventory
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.project.rootPath == movedPath)
+        #expect(model.snapshot.project(id: environment.project.id)?.rootPath == movedPath)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("project path reuse refreshes confirmation for the moved repository")
+    func projectPathReuseRefreshesMovedRepositoryConfirmation() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature"
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+
+        let movedPath = "/tmp/project-a-moved"
+        var movedProject = fixture.beforeRemoval.projects[0]
+        movedProject.project.path = movedPath
+        let replacementRepository = "example.com/acme/replacement"
+        let replacementProject = KwtProjectInventory(
+            project: KwtProjectRecord(
+                repository: replacementRepository,
+                name: "replacement",
+                path: environment.project.rootPath,
+                lastTouched: nil
+            ),
+            worktrees: [
+                KwtWorktreeRecord(
+                    path: environment.project.rootPath,
+                    branch: "main",
+                    commitHash: "",
+                    isMain: true,
+                    createdAt: nil,
+                    generation: nil,
+                    repository: replacementRepository,
+                    sessionName: "kwt-replacement-main",
+                    tmuxSocketName: nil
+                ),
+            ],
+            warning: nil
+        )
+        let preflight = KwtHostInventory(projects: [
+            replacementProject,
+            movedProject,
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in preflight },
+            tmuxSessionIdentityReader: { selection, host in
+                throw TmuxSessionKillError.sessionNotRunning(
+                    host: host.displayName,
+                    session: selection.name
+                )
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require a new confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.project.id == environment.project.id)
+        #expect(updatedRequest.project.scopedKey == environment.project.scopedKey)
+        #expect(updatedRequest.project.rootPath == movedPath)
+        #expect(updatedRequest.worktree.generation == stableWorktreeGeneration)
+        let hostProjects = model.snapshot.projects.filter {
+            $0.hostID == environment.host.id
+        }
+        #expect(Set(hostProjects.map(\.id)).count == hostProjects.count)
+        #expect(
+            hostProjects.first { $0.scopedKey == replacementRepository }?.id
+                != environment.project.id
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("removal completion keeps the owning project selected")
+    func removalKeepsOwningProjectSelected() throws {
+        let environment = try setupStandardEnvironment()
+        let removed = WorktreeSummary.fixture(
+            hostID: environment.host.id,
+            projectID: environment.project.id,
+            name: "feature/remove",
+            path: "/tmp/project-a-feature"
+        )
+        var snapshot = environment.snapshot
+        snapshot.worktrees.append(removed)
+        var current = WorkspaceSelection(
+            selectedHostID: environment.host.id
+        )
+        current.select(
+            WorkspaceNavigationTarget.worktree(removed.id),
+            in: snapshot
+        )
+        snapshot.worktrees.removeAll { $0.id == removed.id }
+
+        let resolved = WorkspaceSceneModel.selectionAfterWorktreeRemoval(
+            current,
+            in: snapshot,
+            visibility: WorktreeVisibility.default
+        )
+
+        #expect(resolved.selectedProjectID == environment.project.id)
+        #expect(resolved.selectedWorktreeID == nil)
     }
 
     @MainActor

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -966,6 +966,36 @@ struct TmuxSessionPresentationLifecycleTests {
         )
     }
 
+    @Test("herdr alert releases a displaced removal confirmation")
+    func herdrAlertReleasesDisplacedRemovalConfirmation() {
+        let model = WorktreeRemovalPresentationModel()
+        var workspaceAlert: WorkspaceAlert? =
+            .worktreeRemovalConfirmation(model.request)
+        var pendingWorktreeRemoval: WorktreeRemovalRequest? = model.request
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+
+        RootView.presentNonWorktreeWorkspaceAlert(
+            .herdrLifecycleFailure(
+                session: "build",
+                action: "stop",
+                message: "stop failed"
+            ),
+            workspaceAlert: &workspaceAlert,
+            pendingWorktreeRemoval: &pendingWorktreeRemoval,
+            pendingWorktrees: &pendingWorktrees
+        )
+
+        #expect(pendingWorktreeRemoval == nil)
+        #expect(pendingWorktrees.isEmpty)
+        #expect(
+            workspaceAlert?.id == "herdr:failure:stop:build:stop failed"
+        )
+        #expect(RootView.reserveWorktreeRemovalPreparation(
+            model.request.worktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+    }
+
     @Test("non-worktree alert preserves non-confirmation removal ownership")
     func nonWorktreeAlertPreservesNonConfirmationRemovalOwnership() {
         let model = WorktreeRemovalPresentationModel()

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -6,6 +6,14 @@ import Synchronization
 import Testing
 @testable import GhosthubUI
 
+private func pendingRemovalIdentities(
+    _ worktrees: WorktreeSummary...
+) -> [UUID: RootView.PendingWorktreeRemovalIdentity] {
+    Dictionary(uniqueKeysWithValues: worktrees.map {
+        ($0.id, RootView.PendingWorktreeRemovalIdentity($0))
+    })
+}
+
 @MainActor
 @Suite("Native tmux presentation lifecycle")
 struct TmuxSessionPresentationLifecycleTests {
@@ -647,6 +655,348 @@ struct TmuxSessionPresentationLifecycleTests {
         withExtendedLifetime(hostingView) {}
     }
 
+    @Test("in-app removal does not open a sibling worktree session")
+    func inAppRemovalDoesNotOpenSiblingSession() {
+        let model = WorktreeRemovalPresentationModel()
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+        let hostingView = hostView(
+            WorktreeRemovalPresentationHarness(
+                model: model,
+                onOpen: { requestedSessions.append($0) }
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        #expect(requestedSessions.isEmpty)
+
+        model.completeRemoval()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(model.selection.selectedProjectID == model.projectID)
+        #expect(model.selection.selectedWorktreeID == nil)
+        #expect(requestedSessions.isEmpty)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("asynchronous removal failure uses the latest display snapshot")
+    func asynchronousRemovalFailureUsesLatestSnapshot() {
+        let model = WorktreeRemovalPresentationModel()
+        var requestedSessions: [WorkspaceTmuxSessionSelection] = []
+        let hostingView = hostView(
+            AsynchronousFailedWorktreeRemovalPresentationHarness(
+                model: model,
+                onOpen: { requestedSessions.append($0) }
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+
+        #expect(model.selection.selectedProjectID == model.projectID)
+        #expect(model.selection.selectedWorktreeID == nil)
+        #expect(requestedSessions.isEmpty)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("reconfirmation does not open a sibling worktree session")
+    func reconfirmationDoesNotOpenSiblingSession() throws {
+        let model = WorktreeRemovalPresentationModel()
+        model.refreshMovedTarget()
+
+        let updated = RootView.selectionAfterSnapshotChange(
+            model.selection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingRemovalIdentities(model.request.worktree)
+        )
+
+        #expect(updated.selectedProjectID == model.projectID)
+        #expect(updated.selectedWorktreeID == nil)
+
+        let primary = try #require(
+            model.display.snapshot.worktrees.first { $0.isPrimary }
+        )
+        var newerSelection = model.selection
+        newerSelection.select(
+            .worktree(primary.id),
+            in: model.display.snapshot
+        )
+        let preserved = RootView.selectionAfterSnapshotChange(
+            newerSelection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingRemovalIdentities(model.request.worktree)
+        )
+        #expect(preserved.selectedWorktreeID == primary.id)
+    }
+
+    @Test("a pending removal treats generation reuse as displacement")
+    func pendingRemovalGenerationReuseSelectsProject() {
+        let model = WorktreeRemovalPresentationModel()
+        model.reuseRemovedWorktreeID()
+
+        let updated = RootView.selectionAfterSnapshotChange(
+            model.selection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingRemovalIdentities(model.request.worktree)
+        )
+
+        #expect(updated.selectedProjectID == model.projectID)
+        #expect(updated.selectedWorktreeID == nil)
+    }
+
+    @Test("failed removal normalizes a displaced target before cleanup")
+    func failedRemovalNormalizesDisplacedTargetBeforeCleanup() {
+        let model = WorktreeRemovalPresentationModel()
+        model.removeTargetDuringPreparation()
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+
+        let updated = RootView.finishFailedWorktreeRemoval(
+            model.selection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingWorktrees: &pendingWorktrees
+        )
+        let afterDelayedSnapshot = RootView.selectionAfterSnapshotChange(
+            updated,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingWorktrees
+        )
+
+        #expect(updated.selectedProjectID == model.projectID)
+        #expect(updated.selectedWorktreeID == nil)
+        #expect(pendingWorktrees.isEmpty)
+        #expect(afterDelayedSnapshot.selectedProjectID == model.projectID)
+        #expect(afterDelayedSnapshot.selectedWorktreeID == nil)
+    }
+
+    @Test("failed removal cleanup preserves newer worktree navigation")
+    func failedRemovalCleanupPreservesNewerNavigation() throws {
+        let model = WorktreeRemovalPresentationModel()
+        model.removeTargetDuringPreparation()
+        let primary = try #require(
+            model.display.snapshot.worktrees.first { $0.isPrimary }
+        )
+        var newerSelection = model.selection
+        newerSelection.select(
+            .worktree(primary.id),
+            in: model.display.snapshot
+        )
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+
+        let updated = RootView.finishFailedWorktreeRemoval(
+            newerSelection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingWorktrees: &pendingWorktrees
+        )
+
+        #expect(updated.selectedWorktreeID == primary.id)
+        #expect(pendingWorktrees.isEmpty)
+    }
+
+    @Test("moved reconfirmation normalizes the original removal selection")
+    func movedReconfirmationNormalizesOriginalRemovalSelection() throws {
+        let model = WorktreeRemovalPresentationModel()
+        var selection = model.selection
+        var pendingRemoval: WorktreeRemovalRequest?
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+        model.refreshMovedTarget()
+        let moved = try #require(
+            model.display.snapshot.worktrees.first {
+                $0.generation == model.request.worktree.generation
+            }
+        )
+        let project = try #require(
+            model.display.snapshot.project(id: model.projectID)
+        )
+        let host = try #require(
+            model.display.snapshot.host(id: moved.hostID)
+        )
+        let updatedRequest = WorktreeRemovalRequest(
+            worktree: moved,
+            project: project,
+            confirmedHost: host
+        )
+
+        RootView.transitionWorktreeRemovalConfirmation(
+            to: updatedRequest,
+            pendingWorktreeRemoval: &pendingRemoval,
+            pendingWorktrees: &pendingWorktrees
+        )
+        selection = RootView.selectionAfterSnapshotChange(
+            selection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingWorktrees
+        )
+
+        #expect(selection.selectedProjectID == model.projectID)
+        #expect(selection.selectedWorktreeID == nil)
+        #expect(pendingRemoval == updatedRequest)
+        #expect(
+            pendingWorktrees
+                == pendingRemovalIdentities(model.request.worktree, moved)
+        )
+    }
+
+    @Test("removal preparation does not open a sibling worktree session")
+    func removalPreparationDoesNotOpenSiblingSession() async throws {
+        let model = WorktreeRemovalPresentationModel()
+        let preparation = WorktreeRemovalPreparationHold()
+        var pendingWorktrees:
+            [UUID: RootView.PendingWorktreeRemovalIdentity] = [:]
+        #expect(RootView.reserveWorktreeRemovalPreparation(
+            model.request.worktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+        let preparationTask = Task { @MainActor in
+            try await RootView.prepareWorktreeRemoval(
+                model.request.worktree,
+                using: { _ in
+                    try await preparation.prepare(model.request)
+                }
+            )
+        }
+        await preparation.waitUntilStarted()
+        #expect(
+            pendingWorktrees == pendingRemovalIdentities(model.request.worktree)
+        )
+
+        model.removeTargetDuringPreparation()
+        let updated = RootView.selectionAfterSnapshotChange(
+            model.selection,
+            in: model.display.snapshot,
+            visibility: .default,
+            pendingRemovals: pendingWorktrees
+        )
+
+        #expect(updated.selectedProjectID == model.projectID)
+        #expect(updated.selectedWorktreeID == nil)
+
+        await preparation.release()
+        await #expect(throws: CancellationError.self) {
+            try await preparationTask.value
+        }
+        RootView.clearWorktreeRemovalPreparation(
+            model.request.worktree,
+            pendingWorktrees: &pendingWorktrees
+        )
+        #expect(pendingWorktrees.isEmpty)
+    }
+
+    @Test("worktree removal preparation is single-flight")
+    func worktreeRemovalPreparationIsSingleFlight() async throws {
+        let model = WorktreeRemovalPresentationModel()
+        let preparation = WorktreeRemovalPreparationHold()
+        let secondWorktree = WorktreeSummary.fixture(
+            hostID: model.request.worktree.hostID,
+            projectID: model.projectID,
+            name: "feature/second",
+            path: "/tmp/project-a-second"
+        )
+        var pendingWorktrees:
+            [UUID: RootView.PendingWorktreeRemovalIdentity] = [:]
+        var preparedWorktreeIDs: [UUID] = []
+        #expect(RootView.reserveWorktreeRemovalPreparation(
+            model.request.worktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+        let firstTask = Task { @MainActor in
+            try await RootView.prepareWorktreeRemoval(
+                model.request.worktree,
+                using: { worktreeID in
+                    preparedWorktreeIDs.append(worktreeID)
+                    return try await preparation.prepare(model.request)
+                }
+            )
+        }
+        await preparation.waitUntilStarted()
+
+        #expect(!RootView.reserveWorktreeRemovalPreparation(
+            secondWorktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+        #expect(!RootView.clearWorktreeRemovalPreparation(
+            secondWorktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+
+        #expect(
+            pendingWorktrees == pendingRemovalIdentities(model.request.worktree)
+        )
+        #expect(preparedWorktreeIDs == [model.removedWorktreeID])
+
+        await preparation.release()
+        await #expect(throws: CancellationError.self) {
+            try await firstTask.value
+        }
+        #expect(RootView.clearWorktreeRemovalPreparation(
+            model.request.worktree,
+            pendingWorktrees: &pendingWorktrees
+        ))
+        #expect(pendingWorktrees.isEmpty)
+    }
+
+    @Test("non-worktree alert releases a displaced removal confirmation")
+    func nonWorktreeAlertReleasesDisplacedRemovalConfirmation() {
+        let model = WorktreeRemovalPresentationModel()
+        var workspaceAlert: WorkspaceAlert? =
+            .worktreeRemovalConfirmation(model.request)
+        var pendingWorktreeRemoval: WorktreeRemovalRequest? = model.request
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+
+        RootView.presentNonWorktreeWorkspaceAlert(
+            .sessionThemeFailure(
+                session: "project-a-feature",
+                message: "theme failed"
+            ),
+            workspaceAlert: &workspaceAlert,
+            pendingWorktreeRemoval: &pendingWorktreeRemoval,
+            pendingWorktrees: &pendingWorktrees
+        )
+
+        #expect(pendingWorktreeRemoval == nil)
+        #expect(pendingWorktrees.isEmpty)
+        #expect(
+            workspaceAlert?.id
+                == "session-theme:failure:project-a-feature:theme failed"
+        )
+    }
+
+    @Test("non-worktree alert preserves non-confirmation removal ownership")
+    func nonWorktreeAlertPreservesNonConfirmationRemovalOwnership() {
+        let model = WorktreeRemovalPresentationModel()
+        var workspaceAlert: WorkspaceAlert?
+        var pendingWorktreeRemoval: WorktreeRemovalRequest? = model.request
+        var pendingWorktrees = pendingRemovalIdentities(model.request.worktree)
+
+        RootView.beginWorktreeRemovalResolution(
+            pendingWorktreeRemoval: &pendingWorktreeRemoval
+        )
+
+        RootView.presentNonWorktreeWorkspaceAlert(
+            .sessionKillFailure(
+                session: "project-a-feature",
+                message: "kill failed"
+            ),
+            workspaceAlert: &workspaceAlert,
+            pendingWorktreeRemoval: &pendingWorktreeRemoval,
+            pendingWorktrees: &pendingWorktrees
+        )
+
+        #expect(pendingWorktreeRemoval == nil)
+        #expect(
+            pendingWorktrees == pendingRemovalIdentities(model.request.worktree)
+        )
+        #expect(
+            workspaceAlert?.id
+                == "session:failure:project-a-feature:kill failed"
+        )
+    }
+
     @Test(
         "non-authoritative generation does not replace active presentation",
         arguments: ["generation-b", nil] as [String?]
@@ -1088,5 +1438,211 @@ private struct WorktreeReplacementPresentationHarness: View {
             handlers: InteractionHandlers(openTmuxSession: onOpen),
             selection: $selection
         )
+    }
+}
+
+@MainActor
+private final class WorktreeRemovalPresentationModel: ObservableObject {
+    @Published var display: WorkspaceDisplayState
+    @Published var selection: WorkspaceSelection
+    let projectID: UUID
+    let request: WorktreeRemovalRequest
+    let removedWorktreeID: UUID
+    var didRunAsynchronousFailure = false
+
+    init() {
+        let host = HostSummary.fixture()
+        let project = ProjectSummary.fixture(hostID: host.id)
+        var primary = WorktreeSummary.fixture(
+            hostID: host.id,
+            projectID: project.id,
+            name: "main",
+            path: "/tmp/project-a"
+        )
+        primary.isPrimary = true
+        primary.tmuxSessionName = "project-a-main"
+        var removed = WorktreeSummary.fixture(
+            hostID: host.id,
+            projectID: project.id,
+            name: "feature/remove",
+            path: "/tmp/project-a-feature",
+            generation: "0123456789abcdef0123456789abcdef"
+        )
+        removed.tmuxSessionName = "project-a-feature"
+        let snapshot = WorkspaceSnapshot.fixture(
+            hosts: [host],
+            projects: [project],
+            worktrees: [primary, removed]
+        )
+        let activeSession = WorkspaceTmuxSessionSelection(
+            hostID: host.id,
+            name: "project-a-feature",
+            worktreeID: removed.id,
+            worktreePath: removed.path,
+            worktreeGeneration: removed.generation
+        )
+
+        projectID = project.id
+        request = WorktreeRemovalRequest(
+            worktree: removed,
+            project: project,
+            confirmedHost: host
+        )
+        removedWorktreeID = removed.id
+        selection = WorkspaceSelection(
+            selectedHostID: host.id,
+            selectedProjectID: project.id,
+            selectedWorktreeID: removed.id
+        )
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            isWorkspaceInventoryRefreshComplete: true,
+            activeTmuxSession: activeSession
+        )
+    }
+
+    func completeRemoval() {
+        var snapshot = display.snapshot
+        snapshot.worktrees.removeAll { $0.id == removedWorktreeID }
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            isWorkspaceInventoryRefreshComplete: true
+        )
+        selection = selection.normalized(
+            in: snapshot,
+            visibility: .default
+        )
+    }
+
+    func refreshMovedTarget() {
+        var snapshot = display.snapshot
+        snapshot.worktrees.removeAll { $0.id == removedWorktreeID }
+        var moved = WorktreeSummary.fixture(
+            hostID: request.worktree.hostID,
+            projectID: request.worktree.projectID,
+            scopedKey: "/tmp/project-a-moved",
+            name: request.worktree.name,
+            path: "/tmp/project-a-moved",
+            branch: request.worktree.branch,
+            generation: request.worktree.generation
+        )
+        moved.tmuxSessionName = request.worktree.tmuxSessionName
+        snapshot.worktrees.append(moved)
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            isWorkspaceInventoryRefreshComplete: true
+        )
+    }
+
+    func removeTargetDuringPreparation() {
+        var snapshot = display.snapshot
+        snapshot.worktrees.removeAll { $0.id == removedWorktreeID }
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            isWorkspaceInventoryRefreshComplete: true
+        )
+    }
+
+    func failRemovalAfterSnapshotUpdate() async throws {
+        removeTargetDuringPreparation()
+        throw WorktreeRemovalPresentationFailure.failed
+    }
+
+    func reuseRemovedWorktreeID() {
+        var snapshot = display.snapshot
+        guard let index = snapshot.worktrees.firstIndex(where: {
+            $0.id == removedWorktreeID
+        }) else {
+            Issue.record("Removal target should exist before ID reuse")
+            return
+        }
+        snapshot.worktrees[index].generation =
+            "fedcba9876543210fedcba9876543210"
+        snapshot.worktrees[index].tmuxSessionName = "project-a-replacement"
+        display = WorkspaceDisplayState(
+            snapshot: snapshot,
+            isWorkspaceInventoryRefreshComplete: true
+        )
+    }
+}
+
+private actor WorktreeRemovalPreparationHold {
+    private var started = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func prepare(
+        _ request: WorktreeRemovalRequest
+    ) async throws -> WorktreeRemovalRequest {
+        started = true
+        startWaiters.forEach { $0.resume() }
+        startWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+        throw CancellationError()
+    }
+
+    func waitUntilStarted() async {
+        guard !started else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+private struct WorktreeRemovalPresentationHarness: View {
+    @ObservedObject var model: WorktreeRemovalPresentationModel
+    let onOpen: (WorkspaceTmuxSessionSelection) -> Void
+
+    var body: some View {
+        RootView(
+            display: model.display,
+            handlers: InteractionHandlers(openTmuxSession: onOpen),
+            selection: $model.selection
+        )
+    }
+}
+
+private enum WorktreeRemovalPresentationFailure: Error {
+    case failed
+}
+
+private struct AsynchronousFailedWorktreeRemovalPresentationHarness: View {
+    @ObservedObject var model: WorktreeRemovalPresentationModel
+    let onOpen: (WorkspaceTmuxSessionSelection) -> Void
+
+    var body: some View {
+        let renderedSnapshot = model.display.snapshot
+        let currentSnapshot = { model.display.snapshot }
+        RootView(
+            display: model.display,
+            handlers: InteractionHandlers(
+                openTmuxSession: onOpen,
+                currentWorkspaceSnapshot: currentSnapshot
+            ),
+            selection: $model.selection
+        )
+        .task {
+            guard !model.didRunAsynchronousFailure else { return }
+            model.didRunAsynchronousFailure = true
+            var pending = pendingRemovalIdentities(model.request.worktree)
+            do {
+                try await model.failRemovalAfterSnapshotUpdate()
+            } catch {
+                model.selection = RootView.finishFailedWorktreeRemoval(
+                    model.selection,
+                    in: renderedSnapshot,
+                    currentSnapshot: currentSnapshot,
+                    visibility: .default,
+                    pendingWorktrees: &pending
+                )
+            }
+        }
     }
 }

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -109,7 +109,12 @@ confirm the exact worktree and host, Ghosthub:
 
 The Git branch is kept. If the checkout is already absent, Ghosthub skips the
 redundant filesystem removal but still reconciles the exact live session
-covered by the confirmation.
+covered by the confirmation. If the worktree or session changes while the
+confirmation is open, Ghosthub stops and presents the current removal details
+for fresh confirmation instead of continuing automatically.
+
+After removal, the owning project remains selected. Ghosthub does not select
+another worktree or open its tmux session on your behalf.
 
 ## Rearrange worktrees
 


### PR DESCRIPTION
Worktree removal can race authoritative kwt inventory, live tmux session changes, and other scenes' presentations. This change makes removal fail closed on any identity doubt, recover cleanly when a removal fails partway, and scope every conclusion to the repository that confirmed the removal.

Confirmation and preflight:
- Removal re-reads kwt inventory before deleting and requires a fresh confirmation whenever the confirmed target changed: replaced generation, changed metadata or tmux endpoint, moved path, changed host endpoint, or a session that started after confirmation.
- Inventory warnings are inconclusive. An incomplete owning repository surfaces as a preflight failure and is never read as proof that a worktree was removed.
- Repository identity outranks path, and canonical generation outranks path. A protected tmux socket survives incomplete refreshes and worktree moves but is never inherited by a new generation at a reused path.
- Removal preparation is single-flight in both the scene model and the UI, and a displaced confirmation releases its reservation.

Failed-removal recovery:
- Presentations invalidated for a failed removal are restored: to the refreshed endpoint when reconciliation renamed the session or socket, and at the new path when the worktree moved within its repository.
- Survival of the removal target is judged only within the confirmed repository. The same path or generation reappearing under another project closes stale presentations in every scene instead of restoring them.
- Removal tombstones are scoped to the owning repository across the inventory cache, snapshot, and refresh exclusions, so a worktree reassigned to another project stays visible there.
- After a successful removal the owning project stays selected, newer user navigation is preserved, and no sibling session is auto-opened.

Also in this diff:
- Kill-session absence classification only reads framed tmux output lines, so shell startup noise cannot be mistaken for a missing session or server.
- The tmux session discovery closure is async; warm-activity enrollment tests now wait on the controller's enrolled-session set (new `warmSessionIDs` accessor) instead of racing enrollment timing.
- Removal tests share a single fixture helper, and the website worktrees guide documents the recovery behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)