### PR TITLE
Make Rust session navigation compact and terminal full-bleed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,14 @@ records, never probe or kill server state.
 Host command capture is bounded and descendant-contained so inherited output
 pipes cannot outlive a cancelled or completed refresh.
 
+The Rust application keeps its host rail and discovered-session rail visible
+around an active terminal. Switching sessions is an explicit workspace action:
+it validates the selected inventory target before detaching the current
+ordinary client, then launches the replacement through the same atomic live-
+identity check as an initial attachment. This presentation navigation never
+destroys server state and does not grant the UI direct host, session, or
+terminal dependencies.
+
 ### Application Updates
 
 Packaged releases embed Sparkle 2 and check a stable HTTPS appcast published as

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -725,9 +725,9 @@ socket-directory = "/run/user/1000/tmux"
 
 [terminal]
 font-family = "Cascadia Mono"
-font-size = 14
-background = "#111318"
-foreground = "#eef0f4"
+font-size = 13
+background = "#0c0f14"
+foreground = "#d8dee9"
 clipboard-write = true
 ~~~
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -679,6 +679,15 @@ destroying the session. The shell contains a synthetic host list, a minimal
 discovered-session view, one terminal presentation, a visible cancellable WSL
 startup state, and host-scoped retryable diagnostics.
 
+The Windows application shell keeps host and session navigation mounted while
+a terminal presentation is active. Selecting a different discovered session
+captures that target from the current inventory, detaches the existing
+ordinary client, and performs the normal fresh-identity attachment check for
+the replacement. Selecting the active session focuses its existing
+presentation. Navigation never sends a mux kill command. The chrome is shaped
+for additional admitted local mux hosts, but Slice 1 exposes only WSL tmux;
+psmux remains rejection evidence until it satisfies the same capability bar.
+
 The flow resolves and verifies the exact mux binary, discovers live identity,
 reserves the presentation, and launches an AttachPlan whose single tmux
 `if-shell -F` command atomically compares server PID, session ID, and creation

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -725,7 +725,7 @@ socket-directory = "/run/user/1000/tmux"
 
 [terminal]
 font-family = "Cascadia Mono"
-font-size = 13
+font-size = 14
 background = "#0c0f14"
 foreground = "#d8dee9"
 clipboard-write = true

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -319,9 +319,9 @@ impl Default for TerminalAppearance {
     fn default() -> Self {
         Self {
             font_family: "Cascadia Mono".to_owned(),
-            font_size: 14,
-            background: 0x11_13_18,
-            foreground: 0xee_f0_f4,
+            font_size: 13,
+            background: 0x0c_0f_14,
+            foreground: 0xd8_de_e9,
             allow_remote_clipboard_write: true,
         }
     }

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -319,7 +319,7 @@ impl Default for TerminalAppearance {
     fn default() -> Self {
         Self {
             font_family: "Cascadia Mono".to_owned(),
-            font_size: 13,
+            font_size: 14,
             background: 0x0c_0f_14,
             foreground: 0xd8_de_e9,
             allow_remote_clipboard_write: true,

--- a/rust/config/tests/appearance.rs
+++ b/rust/config/tests/appearance.rs
@@ -5,7 +5,7 @@ fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
     let appearance = TerminalAppearance::default();
 
     assert_eq!(appearance.font_family(), "Cascadia Mono");
-    assert_eq!(appearance.font_size(), 14);
-    assert_eq!(appearance.background(), 0x11_13_18);
-    assert_eq!(appearance.foreground(), 0xee_f0_f4);
+    assert_eq!(appearance.font_size(), 13);
+    assert_eq!(appearance.background(), 0x0c_0f_14);
+    assert_eq!(appearance.foreground(), 0xd8_de_e9);
 }

--- a/rust/config/tests/appearance.rs
+++ b/rust/config/tests/appearance.rs
@@ -5,7 +5,7 @@ fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
     let appearance = TerminalAppearance::default();
 
     assert_eq!(appearance.font_family(), "Cascadia Mono");
-    assert_eq!(appearance.font_size(), 13);
+    assert_eq!(appearance.font_size(), 14);
     assert_eq!(appearance.background(), 0x0c_0f_14);
     assert_eq!(appearance.foreground(), 0xd8_de_e9);
 }

--- a/rust/config/tests/application.rs
+++ b/rust/config/tests/application.rs
@@ -19,9 +19,9 @@ fn missing_application_config_uses_documented_defaults() {
     assert_eq!(loaded.wsl().tmux_binary(), "/usr/bin/tmux");
     assert_eq!(loaded.wsl().socket_directory(), None);
     assert_eq!(loaded.terminal().font_family(), "Cascadia Mono");
-    assert_eq!(loaded.terminal().font_size(), 14);
-    assert_eq!(loaded.terminal().background(), 0x11_13_18);
-    assert_eq!(loaded.terminal().foreground(), 0xee_f0_f4);
+    assert_eq!(loaded.terminal().font_size(), 13);
+    assert_eq!(loaded.terminal().background(), 0x0c_0f_14);
+    assert_eq!(loaded.terminal().foreground(), 0xd8_de_e9);
     assert!(loaded.terminal().allow_remote_clipboard_write());
 }
 

--- a/rust/config/tests/application.rs
+++ b/rust/config/tests/application.rs
@@ -19,7 +19,7 @@ fn missing_application_config_uses_documented_defaults() {
     assert_eq!(loaded.wsl().tmux_binary(), "/usr/bin/tmux");
     assert_eq!(loaded.wsl().socket_directory(), None);
     assert_eq!(loaded.terminal().font_family(), "Cascadia Mono");
-    assert_eq!(loaded.terminal().font_size(), 13);
+    assert_eq!(loaded.terminal().font_size(), 14);
     assert_eq!(loaded.terminal().background(), 0x0c_0f_14);
     assert_eq!(loaded.terminal().foreground(), 0xd8_de_e9);
     assert!(loaded.terminal().allow_remote_clipboard_write());

--- a/rust/surface/src/lib.rs
+++ b/rust/surface/src/lib.rs
@@ -60,8 +60,8 @@ pub struct Rgb {
 }
 
 impl Rgb {
-    pub const WHITE: Self = Self::new(0xee, 0xf0, 0xf4);
-    pub const BLACK: Self = Self::new(0x11, 0x13, 0x18);
+    pub const WHITE: Self = Self::new(0xd8, 0xde, 0xe9);
+    pub const BLACK: Self = Self::new(0x0c, 0x0f, 0x14);
 
     #[must_use]
     pub const fn new(red: u8, green: u8, blue: u8) -> Self {

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -23,10 +23,8 @@ const TERMINAL_HEADER_HEIGHT: f32 = 40.0;
 const TERMINAL_PADDING: f32 = 12.0;
 const TERMINAL_STAGE_INSET: f32 = 8.0;
 const TERMINAL_STAGE_BORDER: f32 = 1.0;
-const HOST_SIDEBAR_WIDTH: f32 = 196.0;
-const SESSION_SIDEBAR_WIDTH: f32 = 252.0;
-const APP_NAVIGATION_WIDTH: f32 = HOST_SIDEBAR_WIDTH + SESSION_SIDEBAR_WIDTH;
-const CELL_LINE_GAP: f32 = 2.0;
+const APP_NAVIGATION_WIDTH: f32 = 280.0;
+const CELL_LINE_GAP: f32 = 4.0;
 const UI_INPUT_CAPACITY: usize = 512;
 const MOUSE_RELEASE_RESERVE: usize = 3;
 const MAX_WHEEL_EVENTS_PER_CALLBACK: usize = 64;
@@ -1468,71 +1466,10 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let hosts = snapshot.hosts();
-        let sidebar = div()
-            .w(px(HOST_SIDEBAR_WIDTH))
-            .h_full()
-            .flex_none()
-            .flex()
-            .flex_col()
-            .p_3()
-            .bg(rgb(0x10_12_17))
-            .border_r_1()
-            .border_color(rgb(0x25_2932))
-            .child(
-                div()
-                    .h(px(38.0))
-                    .flex()
-                    .items_center()
-                    .px_2()
-                    .text_sm()
-                    .text_color(rgb(0x8f_96_a3))
-                    .child("HOSTS"),
-            )
-            .children(hosts.iter().enumerate().map(|(index, host)| {
-                let status_color = match host.connection() {
-                    HostConnectionState::Ready => 0x62_c0_7a,
-                    HostConnectionState::Connecting => 0xd3_a4_4a,
-                    HostConnectionState::Disconnected => 0x8f_96_a3,
-                    HostConnectionState::Unavailable => 0xd0_65_65,
-                };
-                div()
-                    .id(("host", index))
-                    .px_3()
-                    .py_2()
-                    .rounded_md()
-                    .bg(rgb(if snapshot.selected_host() == Some(host.id()) {
-                        0x24_2832
-                    } else {
-                        0x10_12_17
-                    }))
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap_2()
-                            .child(div().text_color(rgb(status_color)).child("●"))
-                            .child(host.name().to_owned()),
-                    )
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(rgb(0x8f_96_a3))
-                            .child(host.endpoint().to_owned()),
-                    )
-            }));
-
         let selected = snapshot
             .selected_host()
             .and_then(|id| hosts.iter().find(|host| host.id() == id));
-        let session_sidebar = selected.map_or_else(
-            || {
-                div()
-                    .w(px(SESSION_SIDEBAR_WIDTH))
-                    .h_full()
-                    .into_any_element()
-            },
-            |host| Self::session_sidebar(host, snapshot.content(), cx),
-        );
+        let navigator = Self::workspace_tree(snapshot, cx);
         let main = match snapshot.content() {
             WorkspaceContent::Terminal {
                 endpoint,
@@ -1555,131 +1492,200 @@ impl RootView {
         div()
             .size_full()
             .flex()
-            .child(sidebar)
-            .child(session_sidebar)
+            .child(navigator)
             .child(div().flex_1().h_full().child(main))
             .into_any_element()
     }
 
-    fn session_sidebar(
-        host: &HostItem,
-        content: &WorkspaceContent,
+    fn workspace_tree(
+        snapshot: &workspace::WorkspaceSnapshot,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let active = active_session_name(content);
-        let mut sidebar = div()
-            .w(px(SESSION_SIDEBAR_WIDTH))
+        let mut tree = div()
+            .w(px(APP_NAVIGATION_WIDTH))
             .h_full()
             .flex_none()
             .flex()
             .flex_col()
-            .bg(rgb(0x15_17_1d))
+            .bg(rgb(0x0f_1116))
             .border_r_1()
             .border_color(rgb(0x25_2932))
             .child(
                 div()
-                    .h(px(62.0))
+                    .h(px(44.0))
+                    .flex_none()
                     .flex()
                     .items_center()
-                    .justify_between()
-                    .px_4()
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(rgb(0x8f_96_a3))
-                                    .child("SESSIONS"),
-                            )
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(rgb(0xc9_cd_d6))
-                                    .child(host.endpoint().to_owned()),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .id("refresh-session-sidebar")
-                            .px_2()
-                            .py_1()
-                            .rounded_md()
-                            .cursor_pointer()
-                            .text_color(rgb(0xb7_bc_c6))
-                            .hover(|style| style.bg(rgb(0x2a_2f_3a)))
-                            .child("Refresh")
-                            .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
-                    ),
+                    .px_3()
+                    .border_b_1()
+                    .border_color(rgb(0x1d_2028))
+                    .text_xs()
+                    .font_weight(FontWeight::BOLD)
+                    .text_color(rgb(0xa5_ac_b8))
+                    .child("WORKSPACES"),
             );
 
-        match host.connection() {
-            HostConnectionState::Ready if host.sessions().is_empty() => {
-                sidebar = sidebar.child(
-                    div()
-                        .p_4()
-                        .text_sm()
-                        .text_color(rgb(0x8f_96_a3))
-                        .child(empty_inventory_text(host)),
-                );
-            }
-            HostConnectionState::Ready => {
-                for (index, session) in host.sessions().iter().enumerate() {
-                    let is_active = active == Some(session.name());
-                    sidebar = sidebar.child(Self::session_row(index, session, is_active, cx));
-                }
-            }
-            HostConnectionState::Connecting => {
-                sidebar = sidebar.child(
-                    div()
-                        .p_4()
-                        .text_sm()
-                        .text_color(rgb(0x8f_96_a3))
-                        .child("Discovering sessions…"),
-                );
-            }
-            HostConnectionState::Disconnected | HostConnectionState::Unavailable => {}
+        for (host_index, host) in snapshot.hosts().iter().enumerate() {
+            tree = tree.child(Self::host_tree(
+                host_index,
+                host,
+                snapshot.selected_host() == Some(host.id()),
+                snapshot.content(),
+                cx,
+            ));
         }
-        sidebar.into_any_element()
+        tree.into_any_element()
     }
 
-    fn session_row(
+    fn host_tree(
+        host_index: usize,
+        host: &HostItem,
+        is_selected: bool,
+        content: &WorkspaceContent,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let status_color = match host.connection() {
+            HostConnectionState::Ready => 0x62_c0_7a,
+            HostConnectionState::Connecting => 0xd3_a4_4a,
+            HostConnectionState::Disconnected => 0x8f_96_a3,
+            HostConnectionState::Unavailable => 0xd0_65_65,
+        };
+        let mut host_tree = div().flex().flex_col().child(
+            div()
+                .id(("host", host_index))
+                .h(px(46.0))
+                .flex()
+                .items_center()
+                .gap_2()
+                .px_3()
+                .bg(rgb(if is_selected { 0x16_1920 } else { 0x0f_1116 }))
+                .child(div().text_color(rgb(0x6f_7682)).child("▾"))
+                .child(div().text_color(rgb(status_color)).child("●"))
+                .child(
+                    div()
+                        .min_w_0()
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .child(
+                            div()
+                                .truncate()
+                                .text_sm()
+                                .font_weight(FontWeight::BOLD)
+                                .text_color(rgb(0xd2_d7_df))
+                                .child(host.name().to_owned()),
+                        )
+                        .child(
+                            div()
+                                .truncate()
+                                .text_xs()
+                                .text_color(rgb(0x71_7885))
+                                .child(host.endpoint().to_owned()),
+                        ),
+                )
+                .child(
+                    div()
+                        .id(("refresh-host", host_index))
+                        .flex_none()
+                        .px_2()
+                        .py_1()
+                        .rounded_sm()
+                        .cursor_pointer()
+                        .text_xs()
+                        .text_color(rgb(0x8f_96_a3))
+                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                        .child("Refresh")
+                        .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+                ),
+        );
+
+        if host.connection() == HostConnectionState::Ready {
+            host_tree = host_tree.child(
+                div()
+                    .h(px(28.0))
+                    .flex()
+                    .items_center()
+                    .pl(px(35.0))
+                    .text_xs()
+                    .font_weight(FontWeight::BOLD)
+                    .text_color(rgb(0x73_7a87))
+                    .child("TMUX SESSIONS"),
+            );
+            if host.sessions().is_empty() {
+                host_tree = host_tree.child(
+                    div()
+                        .px_3()
+                        .pl(px(51.0))
+                        .py_2()
+                        .text_xs()
+                        .text_color(rgb(0x73_7a87))
+                        .child("No sessions"),
+                );
+            } else {
+                let active = active_session_name(content);
+                for (session_index, session) in host.sessions().iter().enumerate() {
+                    host_tree = host_tree.child(Self::tree_session_row(
+                        host_index,
+                        session_index,
+                        session,
+                        active == Some(session.name()),
+                        cx,
+                    ));
+                }
+            }
+        }
+        host_tree.into_any_element()
+    }
+
+    fn tree_session_row(
+        host_index: usize,
         index: usize,
         session: &workspace::SessionItem,
         is_active: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let name = session.name().to_owned();
-        let detail = if is_active {
-            "OPEN".to_owned()
-        } else if session.attached_clients() == 0 {
+        let detail = if session.attached_clients() == 0 {
             "detached".to_owned()
+        } else if session.attached_clients() == 1 {
+            "1 client".to_owned()
         } else {
-            format!("{} client(s)", session.attached_clients())
+            format!("{} clients", session.attached_clients())
         };
         div()
-            .id(("sidebar-session", index))
+            .id((
+                gpui::ElementId::named_usize("tree-session-host", host_index),
+                index.to_string(),
+            ))
             .mx_2()
-            .mb_1()
-            .px_3()
-            .py_2()
-            .rounded_md()
+            .h(px(40.0))
+            .flex()
+            .items_center()
+            .gap_2()
+            .pl(px(27.0))
+            .pr_2()
+            .rounded_sm()
             .cursor_pointer()
-            .bg(rgb(if is_active { 0x2a_3442 } else { 0x15_17_1d }))
-            .hover(|style| style.bg(rgb(0x25_2a34)))
+            .bg(rgb(if is_active { 0x13_3d6a } else { 0x0f_1116 }))
+            .hover(|style| style.bg(rgb(if is_active { 0x17_477a } else { 0x1b_1f27 })))
+            .child(div().flex_none().text_color(rgb(0x7f_8794)).child("›_"))
             .child(
                 div()
+                    .min_w_0()
+                    .flex_1()
                     .flex()
-                    .items_center()
-                    .justify_between()
-                    .gap_2()
-                    .child(div().flex_1().min_w_0().truncate().child(name.clone()))
+                    .flex_col()
                     .child(
                         div()
-                            .flex_none()
+                            .truncate()
+                            .text_sm()
+                            .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
+                            .child(name.clone()),
+                    )
+                    .child(
+                        div()
                             .text_xs()
-                            .text_color(rgb(if is_active { 0x72_c9_a5 } else { 0x8f_96_a3 }))
+                            .text_color(rgb(if is_active { 0xa9_c9_ea } else { 0x6f_7682 }))
                             .child(detail),
                     ),
             )
@@ -2224,11 +2230,11 @@ fn measure_terminal_metrics(
             |_| f32::from(text_system.bounding_box(font_id, font_size).size.width),
             |advance| f32::from(advance.width),
         ));
-    let line_height = (f32::from(text_system.ascent(font_id, font_size))
-        + f32::from(text_system.descent(font_id, font_size))
-        + CELL_LINE_GAP)
-        .ceil()
-        .max(1.0);
+    let line_height = terminal_line_height(
+        f32::from(font_size),
+        f32::from(text_system.ascent(font_id, font_size)),
+        f32::from(text_system.descent(font_id, font_size)),
+    );
     TerminalMetrics {
         cell_width,
         line_height,
@@ -2237,6 +2243,13 @@ fn measure_terminal_metrics(
 
 fn normalize_cell_width(measured: f32) -> f32 {
     measured.max(1.0)
+}
+
+fn terminal_line_height(font_size: f32, ascent: f32, descent: f32) -> f32 {
+    (ascent + descent + CELL_LINE_GAP)
+        .max(font_size * 1.3)
+        .ceil()
+        .max(1.0)
 }
 
 #[must_use]
@@ -2303,7 +2316,7 @@ mod tests {
         clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
         coalesce_last_wheel, input_queue_has_capacity, named_key, normalize_cell_width,
         queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_wheel_steps, transitioned_presentation,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -2713,6 +2726,12 @@ mod tests {
     fn measured_fractional_cell_width_is_not_rounded() {
         assert!((normalize_cell_width(8.25) - 8.25).abs() < f32::EPSILON);
         assert!((normalize_cell_width(0.5) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn terminal_line_height_keeps_readable_leading() {
+        assert!((terminal_line_height(14.0, 10.0, 3.0) - 19.0).abs() < f32::EPSILON);
+        assert!((terminal_line_height(14.0, 12.0, 4.0) - 20.0).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -19,10 +19,6 @@ use workspace::{
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
-const TERMINAL_HEADER_HEIGHT: f32 = 40.0;
-const TERMINAL_PADDING: f32 = 12.0;
-const TERMINAL_STAGE_INSET: f32 = 8.0;
-const TERMINAL_STAGE_BORDER: f32 = 1.0;
 const APP_NAVIGATION_WIDTH: f32 = 280.0;
 const CELL_LINE_GAP: f32 = 4.0;
 const UI_INPUT_CAPACITY: usize = 512;
@@ -928,11 +924,11 @@ impl RootView {
             x,
             y,
             if snapshot.hosts().is_empty() {
-                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER
+                0.0
             } else {
-                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER
+                APP_NAVIGATION_WIDTH
             },
-            TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
+            0.0,
             self.terminal_metrics.cell_width,
             self.terminal_metrics.line_height,
             size,
@@ -1170,18 +1166,16 @@ impl RootView {
                 0.0
             } else {
                 APP_NAVIGATION_WIDTH
-            }
-            - (TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER) * 2.0;
-        let height =
-            f32::from(bounds.size.height) - (TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER) * 2.0;
+            };
+        let height = f32::from(bounds.size.height);
         let (columns, rows) = terminal_grid_size(
             width,
             height,
             self.terminal_metrics.cell_width,
             self.terminal_metrics.line_height,
         );
-        let content_width = (width - TERMINAL_PADDING * 2.0).max(1.0);
-        let content_height = (height - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING * 2.0).max(1.0);
+        let content_width = width.max(1.0);
+        let content_height = height.max(1.0);
         let pixel_width = content_width.min(f32::from(u16::MAX)) as u16;
         let pixel_height = content_height.min(f32::from(u16::MAX)) as u16;
         let resize = TerminalResize {
@@ -1226,8 +1220,6 @@ impl RootView {
 
     fn terminal_element(
         &mut self,
-        endpoint: &str,
-        session: &str,
         presentation_id: u64,
         surface: &Arc<SurfaceStore>,
         snapshot: &workspace::WorkspaceSnapshot,
@@ -1242,71 +1234,15 @@ impl RootView {
         self.observed_surface_identity = Some(identity);
         self.observed_surface_generation = frame.generation();
         let appearance = snapshot.appearance();
-        let header = div()
-            .h(px(TERMINAL_HEADER_HEIGHT))
-            .flex_none()
-            .flex()
-            .items_center()
-            .justify_between()
-            .px_3()
-            .bg(rgb(0x15_18_1f))
-            .border_b_1()
-            .border_color(rgb(0x2a_2e_38))
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap_2()
-                    .child(div().size(px(7.0)).rounded_full().bg(rgb(0x62_c0_7a)))
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(rgb(0x8f_96_a3))
-                            .child(endpoint.to_owned()),
-                    )
-                    .child(div().text_color(rgb(0x55_5c_69)).child("/"))
-                    .child(
-                        div()
-                            .text_sm()
-                            .text_color(rgb(0xe4_e8_ef))
-                            .child(session.to_owned()),
-                    ),
-            )
-            .child(
-                div()
-                    .id("detach-terminal")
-                    .px_3()
-                    .py_1()
-                    .rounded_md()
-                    .cursor_pointer()
-                    .border_1()
-                    .border_color(rgb(0x35_3a_46))
-                    .text_sm()
-                    .text_color(rgb(0xa8_af_bb))
-                    .hover(|style| style.bg(rgb(0x26_2b_35)).text_color(rgb(0xee_f0_f4)))
-                    .child("Detach")
-                    .on_click(cx.listener(|this, _, _, cx| this.detach(cx))),
-            );
-
         let terminal = self.terminal_surface_element(presentation_id, appearance, rows, cx);
 
         div()
             .size_full()
-            .p(px(TERMINAL_STAGE_INSET))
-            .bg(rgb(0x0d_0f_13))
-            .child(
-                div()
-                    .size_full()
-                    .flex()
-                    .flex_col()
-                    .overflow_hidden()
-                    .rounded_lg()
-                    .border_1()
-                    .border_color(rgb(0x2a_2e_38))
-                    .bg(rgb(appearance.background()))
-                    .child(header)
-                    .child(terminal),
-            )
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .bg(rgb(appearance.background()))
+            .child(terminal)
     }
 
     fn terminal_surface_element(
@@ -1323,7 +1259,6 @@ impl RootView {
             .flex_col()
             .flex_1()
             .overflow_hidden()
-            .p_3()
             .bg(rgb(appearance.background()))
             .text_color(rgb(appearance.foreground()))
             .font_family(appearance.font_family().to_owned())
@@ -1450,12 +1385,12 @@ impl RootView {
                 Self::ready_element(endpoint, sessions, None, cx)
             }
             WorkspaceContent::Terminal {
-                endpoint,
-                session,
+                endpoint: _,
+                session: _,
                 presentation_id,
                 surface,
             } => self
-                .terminal_element(endpoint, session, *presentation_id, surface, snapshot, cx)
+                .terminal_element(*presentation_id, surface, snapshot, cx)
                 .into_any_element(),
         }
     }
@@ -1472,12 +1407,12 @@ impl RootView {
         let navigator = Self::workspace_tree(snapshot, cx);
         let main = match snapshot.content() {
             WorkspaceContent::Terminal {
-                endpoint,
-                session,
+                endpoint: _,
+                session: _,
                 presentation_id,
                 surface,
             } => self
-                .terminal_element(endpoint, session, *presentation_id, surface, snapshot, cx)
+                .terminal_element(*presentation_id, surface, snapshot, cx)
                 .into_any_element(),
             WorkspaceContent::Attaching { endpoint, session } => {
                 centered(format!("Attaching to {endpoint} · {session}…"))
@@ -1645,14 +1580,16 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let name = session.name().to_owned();
-        let detail = if session.attached_clients() == 0 {
+        let detail = if is_active {
+            "open".to_owned()
+        } else if session.attached_clients() == 0 {
             "detached".to_owned()
         } else if session.attached_clients() == 1 {
             "1 client".to_owned()
         } else {
             format!("{} clients", session.attached_clients())
         };
-        div()
+        let mut row = div()
             .id((
                 gpui::ElementId::named_usize("tree-session-host", host_index),
                 index.to_string(),
@@ -1688,11 +1625,30 @@ impl RootView {
                             .text_color(rgb(if is_active { 0xa9_c9_ea } else { 0x6f_7682 }))
                             .child(detail),
                     ),
-            )
-            .on_click(cx.listener(move |this, _, window, cx| {
-                this.select_session(&name, window, cx);
-            }))
-            .into_any_element()
+            );
+        if is_active {
+            row = row.child(
+                div()
+                    .id("detach-terminal")
+                    .flex_none()
+                    .size(px(24.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .text_color(rgb(0xa9_c9_ea))
+                    .hover(|style| style.bg(rgb(0x25_527f)).text_color(rgb(0xff_ff_ff)))
+                    .child("×")
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.detach(cx);
+                        cx.stop_propagation();
+                    })),
+            );
+        }
+        row.on_click(cx.listener(move |this, _, window, cx| {
+            this.select_session(&name, window, cx);
+        }))
+        .into_any_element()
     }
 
     fn host_landing_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
@@ -1885,6 +1841,19 @@ fn active_session_name(content: &WorkspaceContent) -> Option<&str> {
     }
 }
 
+fn workspace_window_title(content: &WorkspaceContent) -> String {
+    match content {
+        WorkspaceContent::Attaching { endpoint, session }
+        | WorkspaceContent::Terminal {
+            endpoint, session, ..
+        } => format!("{session} — {endpoint} — {WINDOW_TITLE}"),
+        WorkspaceContent::Ready { endpoint, .. } => format!("{endpoint} — {WINDOW_TITLE}"),
+        WorkspaceContent::Shell | WorkspaceContent::Loading | WorkspaceContent::Error { .. } => {
+            WINDOW_TITLE.to_owned()
+        }
+    }
+}
+
 fn transitioned_presentation(observed: &mut Option<u64>, current: Option<u64>) -> bool {
     if *observed == current {
         false
@@ -1955,10 +1924,11 @@ impl Focusable for RootView {
 }
 
 impl Render for RootView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let _scope_changed = self.sync_terminal_scope();
         let _handled = self.handle_events(cx);
         let snapshot = self.workspace.snapshot();
+        window.set_window_title(&workspace_window_title(snapshot.content()));
         self.observed_revision = snapshot.revision();
         if !matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
             self.observed_surface_identity = None;
@@ -2190,8 +2160,8 @@ fn terminal_cell_at_with_offset(
     line_height: f32,
     size: surface::GridSize,
 ) -> Option<(usize, usize)> {
-    let content_x = x - x_offset - TERMINAL_PADDING;
-    let content_y = y - y_offset - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING;
+    let content_x = x - x_offset;
+    let content_y = y - y_offset;
     if content_x < 0.0 || content_y < 0.0 {
         return None;
     }
@@ -2210,8 +2180,8 @@ pub fn terminal_grid_size(
     cell_width: f32,
     line_height: f32,
 ) -> (usize, usize) {
-    let content_width = (width - TERMINAL_PADDING * 2.0).max(1.0);
-    let content_height = (height - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING * 2.0).max(1.0);
+    let content_width = width.max(1.0);
+    let content_height = height.max(1.0);
     (
         (content_width / cell_width).floor().max(1.0) as usize,
         (content_height / line_height).floor().max(1.0) as usize,
@@ -2310,13 +2280,13 @@ mod tests {
 
     use super::{
         APP_NAVIGATION_WIDTH, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC,
-        InputRefusal, PendingUiInput, QueuedUiInput, TERMINAL_STAGE_BORDER, TERMINAL_STAGE_INSET,
-        TerminalKeyboard, TerminalPointer, TerminalResize, UI_INPUT_BYTE_CAPACITY,
-        UI_INPUT_CAPACITY, WheelBatch, active_session_name, clear_terminal_input_state,
-        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, input_queue_has_capacity, named_key, normalize_cell_width,
-        queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation,
+        InputRefusal, PendingUiInput, QueuedUiInput, TerminalKeyboard, TerminalPointer,
+        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_name,
+        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
+        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity, named_key,
+        normalize_cell_width, queued_input_matches_presentation, terminal_cell_at_with_offset,
+        terminal_key_input, terminal_line_height, terminal_wheel_steps, transitioned_presentation,
+        workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -2382,15 +2352,40 @@ mod tests {
     }
 
     #[test]
+    fn active_terminal_context_moves_into_the_native_window_title() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let terminal = WorkspaceContent::Terminal {
+            endpoint: "Ubuntu".to_owned(),
+            session: "demo".to_owned(),
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        let attaching = WorkspaceContent::Attaching {
+            endpoint: "Ubuntu".to_owned(),
+            session: "demo".to_owned(),
+        };
+
+        assert_eq!(
+            workspace_window_title(&terminal),
+            "demo — Ubuntu — Ghosthub"
+        );
+        assert_eq!(
+            workspace_window_title(&attaching),
+            "demo — Ubuntu — Ghosthub"
+        );
+        assert_eq!(workspace_window_title(&WorkspaceContent::Shell), "Ghosthub");
+    }
+
+    #[test]
     fn terminal_hit_testing_accounts_for_persistent_navigation() {
         let size = GridSize::new(80, 24).expect("valid grid");
 
         assert_eq!(
             terminal_cell_at_with_offset(
-                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER + 20.0,
-                66.0,
-                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
-                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
+                APP_NAVIGATION_WIDTH + 12.0,
+                8.0,
+                APP_NAVIGATION_WIDTH,
+                0.0,
                 8.0,
                 16.0,
                 size
@@ -2399,10 +2394,10 @@ mod tests {
         );
         assert_eq!(
             terminal_cell_at_with_offset(
+                APP_NAVIGATION_WIDTH - 1.0,
+                8.0,
                 APP_NAVIGATION_WIDTH,
-                66.0,
-                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
-                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
+                0.0,
                 8.0,
                 16.0,
                 size

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -19,8 +19,10 @@ use workspace::{
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
-const TERMINAL_HEADER_HEIGHT: f32 = 42.0;
+const TERMINAL_HEADER_HEIGHT: f32 = 40.0;
 const TERMINAL_PADDING: f32 = 12.0;
+const TERMINAL_STAGE_INSET: f32 = 8.0;
+const TERMINAL_STAGE_BORDER: f32 = 1.0;
 const HOST_SIDEBAR_WIDTH: f32 = 196.0;
 const SESSION_SIDEBAR_WIDTH: f32 = 252.0;
 const APP_NAVIGATION_WIDTH: f32 = HOST_SIDEBAR_WIDTH + SESSION_SIDEBAR_WIDTH;
@@ -928,10 +930,11 @@ impl RootView {
             x,
             y,
             if snapshot.hosts().is_empty() {
-                0.0
+                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER
             } else {
-                APP_NAVIGATION_WIDTH
+                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER
             },
+            TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
             self.terminal_metrics.cell_width,
             self.terminal_metrics.line_height,
             size,
@@ -1169,8 +1172,10 @@ impl RootView {
                 0.0
             } else {
                 APP_NAVIGATION_WIDTH
-            };
-        let height = f32::from(bounds.size.height);
+            }
+            - (TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER) * 2.0;
+        let height =
+            f32::from(bounds.size.height) - (TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER) * 2.0;
         let (columns, rows) = terminal_grid_size(
             width,
             height,
@@ -1239,35 +1244,71 @@ impl RootView {
         self.observed_surface_identity = Some(identity);
         self.observed_surface_generation = frame.generation();
         let appearance = snapshot.appearance();
-        let mut header = div()
-            .h(px(42.0))
+        let header = div()
+            .h(px(TERMINAL_HEADER_HEIGHT))
+            .flex_none()
             .flex()
             .items_center()
             .justify_between()
-            .px_4()
-            .bg(rgb(0x1a_1d24))
-            .text_color(rgb(0xc9_cd_d6))
-            .child(format!("{endpoint}  ·  {session}"));
-        header = header.child(
-            div()
-                .id("detach-terminal")
-                .px_3()
-                .py_1()
-                .rounded_md()
-                .cursor_pointer()
-                .bg(rgb(0x2a_2f_3a))
-                .child("Detach")
-                .on_click(cx.listener(|this, _, _, cx| this.detach(cx))),
-        );
+            .px_3()
+            .bg(rgb(0x15_18_1f))
+            .border_b_1()
+            .border_color(rgb(0x2a_2e_38))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(div().size(px(7.0)).rounded_full().bg(rgb(0x62_c0_7a)))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(0x8f_96_a3))
+                            .child(endpoint.to_owned()),
+                    )
+                    .child(div().text_color(rgb(0x55_5c_69)).child("/"))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(0xe4_e8_ef))
+                            .child(session.to_owned()),
+                    ),
+            )
+            .child(
+                div()
+                    .id("detach-terminal")
+                    .px_3()
+                    .py_1()
+                    .rounded_md()
+                    .cursor_pointer()
+                    .border_1()
+                    .border_color(rgb(0x35_3a_46))
+                    .text_sm()
+                    .text_color(rgb(0xa8_af_bb))
+                    .hover(|style| style.bg(rgb(0x26_2b_35)).text_color(rgb(0xee_f0_f4)))
+                    .child("Detach")
+                    .on_click(cx.listener(|this, _, _, cx| this.detach(cx))),
+            );
 
         let terminal = self.terminal_surface_element(presentation_id, appearance, rows, cx);
 
         div()
             .size_full()
-            .flex()
-            .flex_col()
-            .child(header)
-            .child(terminal)
+            .p(px(TERMINAL_STAGE_INSET))
+            .bg(rgb(0x0d_0f_13))
+            .child(
+                div()
+                    .size_full()
+                    .flex()
+                    .flex_col()
+                    .overflow_hidden()
+                    .rounded_lg()
+                    .border_1()
+                    .border_color(rgb(0x2a_2e_38))
+                    .bg(rgb(appearance.background()))
+                    .child(header)
+                    .child(terminal),
+            )
     }
 
     fn terminal_surface_element(
@@ -1290,6 +1331,7 @@ impl RootView {
             .font_family(appearance.font_family().to_owned())
             .text_size(px(f32::from(appearance.font_size())))
             .line_height(px(self.terminal_metrics.line_height))
+            .font_weight(FontWeight::NORMAL)
             .on_key_down(cx.listener(move |this, event, window, cx| {
                 this.on_key_down(presentation_id, event, window, cx);
             }))
@@ -1631,9 +1673,11 @@ impl RootView {
                     .flex()
                     .items_center()
                     .justify_between()
-                    .child(name.clone())
+                    .gap_2()
+                    .child(div().flex_1().min_w_0().truncate().child(name.clone()))
                     .child(
                         div()
+                            .flex_none()
                             .text_xs()
                             .text_color(rgb(if is_active { 0x72_c9_a5 } else { 0x8f_96_a3 }))
                             .child(detail),
@@ -2128,19 +2172,20 @@ pub fn terminal_cell_at(
     line_height: f32,
     size: surface::GridSize,
 ) -> Option<(usize, usize)> {
-    terminal_cell_at_with_offset(x, y, 0.0, cell_width, line_height, size)
+    terminal_cell_at_with_offset(x, y, 0.0, 0.0, cell_width, line_height, size)
 }
 
 fn terminal_cell_at_with_offset(
     x: f32,
     y: f32,
     x_offset: f32,
+    y_offset: f32,
     cell_width: f32,
     line_height: f32,
     size: surface::GridSize,
 ) -> Option<(usize, usize)> {
     let content_x = x - x_offset - TERMINAL_PADDING;
-    let content_y = y - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING;
+    let content_y = y - y_offset - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING;
     if content_x < 0.0 || content_y < 0.0 {
         return None;
     }
@@ -2252,12 +2297,13 @@ mod tests {
 
     use super::{
         APP_NAVIGATION_WIDTH, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC,
-        InputRefusal, PendingUiInput, QueuedUiInput, TerminalKeyboard, TerminalPointer,
-        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_name,
-        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity, named_key,
-        normalize_cell_width, queued_input_matches_presentation, terminal_cell_at_with_offset,
-        terminal_key_input, terminal_wheel_steps, transitioned_presentation,
+        InputRefusal, PendingUiInput, QueuedUiInput, TERMINAL_STAGE_BORDER, TERMINAL_STAGE_INSET,
+        TerminalKeyboard, TerminalPointer, TerminalResize, UI_INPUT_BYTE_CAPACITY,
+        UI_INPUT_CAPACITY, WheelBatch, active_session_name, clear_terminal_input_state,
+        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
+        coalesce_last_wheel, input_queue_has_capacity, named_key, normalize_cell_width,
+        queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_wheel_steps, transitioned_presentation,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -2328,9 +2374,10 @@ mod tests {
 
         assert_eq!(
             terminal_cell_at_with_offset(
-                APP_NAVIGATION_WIDTH + 20.0,
+                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER + 20.0,
                 66.0,
-                APP_NAVIGATION_WIDTH,
+                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
+                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
                 8.0,
                 16.0,
                 size
@@ -2339,9 +2386,10 @@ mod tests {
         );
         assert_eq!(
             terminal_cell_at_with_offset(
-                APP_NAVIGATION_WIDTH - 8.0,
-                66.0,
                 APP_NAVIGATION_WIDTH,
+                66.0,
+                APP_NAVIGATION_WIDTH + TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
+                TERMINAL_STAGE_INSET + TERMINAL_STAGE_BORDER,
                 8.0,
                 16.0,
                 size

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -21,6 +21,9 @@ use workspace::{
 pub const WINDOW_TITLE: &str = "Ghosthub";
 const TERMINAL_HEADER_HEIGHT: f32 = 42.0;
 const TERMINAL_PADDING: f32 = 12.0;
+const HOST_SIDEBAR_WIDTH: f32 = 196.0;
+const SESSION_SIDEBAR_WIDTH: f32 = 252.0;
+const APP_NAVIGATION_WIDTH: f32 = HOST_SIDEBAR_WIDTH + SESSION_SIDEBAR_WIDTH;
 const CELL_LINE_GAP: f32 = 2.0;
 const UI_INPUT_CAPACITY: usize = 512;
 const MOUSE_RELEASE_RESERVE: usize = 3;
@@ -597,6 +600,37 @@ impl RootView {
         cx.notify();
     }
 
+    fn select_session(&mut self, session: &str, window: &mut Window, cx: &mut Context<Self>) {
+        let snapshot = self.workspace.snapshot();
+        if active_session_name(snapshot.content()) == Some(session) {
+            if matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
+                window.focus(&self.focus);
+            }
+            return;
+        }
+
+        let switching = matches!(
+            snapshot.content(),
+            WorkspaceContent::Attaching { .. } | WorkspaceContent::Terminal { .. }
+        );
+        let result = if switching {
+            self.workspace.switch_session(session)
+        } else {
+            self.workspace.attach(session)
+        };
+        if let Err(error) = result {
+            self.diagnostic = Some(error.to_string());
+        } else {
+            self.diagnostic = None;
+            self.observed_presentation_id = None;
+            self.clear_terminal_input();
+            self.paint_cache.clear();
+            self.resize_for_window(window);
+            window.focus(&self.focus);
+        }
+        cx.notify();
+    }
+
     fn refresh(&mut self, cx: &mut Context<Self>) {
         if let Err(error) = self.workspace.refresh() {
             self.diagnostic = Some(error.to_string());
@@ -890,9 +924,14 @@ impl RootView {
             return None;
         };
         let size = surface.load().size();
-        terminal_cell_at(
+        terminal_cell_at_with_offset(
             x,
             y,
+            if snapshot.hosts().is_empty() {
+                0.0
+            } else {
+                APP_NAVIGATION_WIDTH
+            },
             self.terminal_metrics.cell_width,
             self.terminal_metrics.line_height,
             size,
@@ -1124,7 +1163,13 @@ impl RootView {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn resize_for_window(&mut self, window: &Window) {
         let bounds = window.bounds();
-        let width = f32::from(bounds.size.width);
+        let snapshot = self.workspace.snapshot();
+        let width = f32::from(bounds.size.width)
+            - if snapshot.hosts().is_empty() {
+                0.0
+            } else {
+                APP_NAVIGATION_WIDTH
+            };
         let height = f32::from(bounds.size.height);
         let (columns, rows) = terminal_grid_size(
             width,
@@ -1142,8 +1187,7 @@ impl RootView {
             pixel_width,
             pixel_height,
         };
-        if let Some(presentation_id) = terminal_presentation_id(self.workspace.snapshot().content())
-        {
+        if let Some(presentation_id) = terminal_presentation_id(snapshot.content()) {
             let _accepted = self.enqueue_input(presentation_id, PendingUiInput::Resize(resize));
         } else if let Err(error) = self.workspace.resize_with_pixels(
             resize.columns,
@@ -1332,8 +1376,11 @@ impl RootView {
         snapshot: &workspace::WorkspaceSnapshot,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
+        if !snapshot.hosts().is_empty() {
+            return self.application_shell(snapshot, cx);
+        }
         match snapshot.content() {
-            WorkspaceContent::Shell => Self::shell_element(snapshot, cx),
+            WorkspaceContent::Shell => centered("No terminal hosts are available."),
             WorkspaceContent::Loading => centered("Starting WSL and discovering tmux sessions…"),
             WorkspaceContent::Error { message } => div()
                 .size_full()
@@ -1373,21 +1420,32 @@ impl RootView {
         }
     }
 
-    fn shell_element(
+    fn application_shell(
+        &mut self,
         snapshot: &workspace::WorkspaceSnapshot,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let hosts = snapshot.hosts();
         let sidebar = div()
-            .w(px(230.0))
+            .w(px(HOST_SIDEBAR_WIDTH))
             .h_full()
             .flex_none()
             .flex()
             .flex_col()
-            .gap_2()
-            .p_4()
-            .bg(rgb(0x12_14_19))
-            .child(div().text_sm().text_color(rgb(0x8f_96_a3)).child("HOSTS"))
+            .p_3()
+            .bg(rgb(0x10_12_17))
+            .border_r_1()
+            .border_color(rgb(0x25_2932))
+            .child(
+                div()
+                    .h(px(38.0))
+                    .flex()
+                    .items_center()
+                    .px_2()
+                    .text_sm()
+                    .text_color(rgb(0x8f_96_a3))
+                    .child("HOSTS"),
+            )
             .children(hosts.iter().enumerate().map(|(index, host)| {
                 let status_color = match host.connection() {
                     HostConnectionState::Ready => 0x62_c0_7a,
@@ -1397,9 +1455,14 @@ impl RootView {
                 };
                 div()
                     .id(("host", index))
-                    .p_3()
+                    .px_3()
+                    .py_2()
                     .rounded_md()
-                    .bg(rgb(0x1a_1d24))
+                    .bg(rgb(if snapshot.selected_host() == Some(host.id()) {
+                        0x24_2832
+                    } else {
+                        0x10_12_17
+                    }))
                     .child(
                         div()
                             .flex()
@@ -1419,16 +1482,178 @@ impl RootView {
         let selected = snapshot
             .selected_host()
             .and_then(|id| hosts.iter().find(|host| host.id() == id));
-        let main = selected.map_or_else(
-            || centered("No terminal hosts are available."),
-            |host| Self::host_element(host, cx),
+        let session_sidebar = selected.map_or_else(
+            || {
+                div()
+                    .w(px(SESSION_SIDEBAR_WIDTH))
+                    .h_full()
+                    .into_any_element()
+            },
+            |host| Self::session_sidebar(host, snapshot.content(), cx),
         );
+        let main = match snapshot.content() {
+            WorkspaceContent::Terminal {
+                endpoint,
+                session,
+                presentation_id,
+                surface,
+            } => self
+                .terminal_element(endpoint, session, *presentation_id, surface, snapshot, cx)
+                .into_any_element(),
+            WorkspaceContent::Attaching { endpoint, session } => {
+                centered(format!("Attaching to {endpoint} · {session}…"))
+            }
+            WorkspaceContent::Loading => centered("Starting WSL and discovering tmux sessions…"),
+            WorkspaceContent::Error { message } => centered(message.clone()),
+            WorkspaceContent::Shell | WorkspaceContent::Ready { .. } => selected.map_or_else(
+                || centered("No terminal hosts are available."),
+                |host| Self::host_landing_element(host, cx),
+            ),
+        };
         div()
             .size_full()
             .flex()
             .child(sidebar)
+            .child(session_sidebar)
             .child(div().flex_1().h_full().child(main))
             .into_any_element()
+    }
+
+    fn session_sidebar(
+        host: &HostItem,
+        content: &WorkspaceContent,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let active = active_session_name(content);
+        let mut sidebar = div()
+            .w(px(SESSION_SIDEBAR_WIDTH))
+            .h_full()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .bg(rgb(0x15_17_1d))
+            .border_r_1()
+            .border_color(rgb(0x25_2932))
+            .child(
+                div()
+                    .h(px(62.0))
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .px_4()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(0x8f_96_a3))
+                                    .child("SESSIONS"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(0xc9_cd_d6))
+                                    .child(host.endpoint().to_owned()),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .id("refresh-session-sidebar")
+                            .px_2()
+                            .py_1()
+                            .rounded_md()
+                            .cursor_pointer()
+                            .text_color(rgb(0xb7_bc_c6))
+                            .hover(|style| style.bg(rgb(0x2a_2f_3a)))
+                            .child("Refresh")
+                            .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+                    ),
+            );
+
+        match host.connection() {
+            HostConnectionState::Ready if host.sessions().is_empty() => {
+                sidebar = sidebar.child(
+                    div()
+                        .p_4()
+                        .text_sm()
+                        .text_color(rgb(0x8f_96_a3))
+                        .child(empty_inventory_text(host)),
+                );
+            }
+            HostConnectionState::Ready => {
+                for (index, session) in host.sessions().iter().enumerate() {
+                    let is_active = active == Some(session.name());
+                    sidebar = sidebar.child(Self::session_row(index, session, is_active, cx));
+                }
+            }
+            HostConnectionState::Connecting => {
+                sidebar = sidebar.child(
+                    div()
+                        .p_4()
+                        .text_sm()
+                        .text_color(rgb(0x8f_96_a3))
+                        .child("Discovering sessions…"),
+                );
+            }
+            HostConnectionState::Disconnected | HostConnectionState::Unavailable => {}
+        }
+        sidebar.into_any_element()
+    }
+
+    fn session_row(
+        index: usize,
+        session: &workspace::SessionItem,
+        is_active: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let name = session.name().to_owned();
+        let detail = if is_active {
+            "OPEN".to_owned()
+        } else if session.attached_clients() == 0 {
+            "detached".to_owned()
+        } else {
+            format!("{} client(s)", session.attached_clients())
+        };
+        div()
+            .id(("sidebar-session", index))
+            .mx_2()
+            .mb_1()
+            .px_3()
+            .py_2()
+            .rounded_md()
+            .cursor_pointer()
+            .bg(rgb(if is_active { 0x2a_3442 } else { 0x15_17_1d }))
+            .hover(|style| style.bg(rgb(0x25_2a34)))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child(name.clone())
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(rgb(if is_active { 0x72_c9_a5 } else { 0x8f_96_a3 }))
+                            .child(detail),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.select_session(&name, window, cx);
+            }))
+            .into_any_element()
+    }
+
+    fn host_landing_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
+        if host.connection() == HostConnectionState::Ready {
+            return centered(if host.sessions().is_empty() {
+                "Start a tmux session in WSL, then refresh."
+            } else {
+                "Choose a session to open its terminal."
+            });
+        }
+        Self::host_element(host, cx)
     }
 
     fn host_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
@@ -1596,6 +1821,17 @@ fn terminal_presentation_id(content: &WorkspaceContent) -> Option<u64> {
             presentation_id, ..
         } => Some(*presentation_id),
         _ => None,
+    }
+}
+
+fn active_session_name(content: &WorkspaceContent) -> Option<&str> {
+    match content {
+        WorkspaceContent::Attaching { session, .. }
+        | WorkspaceContent::Terminal { session, .. } => Some(session),
+        WorkspaceContent::Shell
+        | WorkspaceContent::Loading
+        | WorkspaceContent::Ready { .. }
+        | WorkspaceContent::Error { .. } => None,
     }
 }
 
@@ -1892,7 +2128,18 @@ pub fn terminal_cell_at(
     line_height: f32,
     size: surface::GridSize,
 ) -> Option<(usize, usize)> {
-    let content_x = x - TERMINAL_PADDING;
+    terminal_cell_at_with_offset(x, y, 0.0, cell_width, line_height, size)
+}
+
+fn terminal_cell_at_with_offset(
+    x: f32,
+    y: f32,
+    x_offset: f32,
+    cell_width: f32,
+    line_height: f32,
+    size: surface::GridSize,
+) -> Option<(usize, usize)> {
+    let content_x = x - x_offset - TERMINAL_PADDING;
     let content_y = y - TERMINAL_HEADER_HEIGHT - TERMINAL_PADDING;
     if content_x < 0.0 || content_y < 0.0 {
         return None;
@@ -2004,16 +2251,19 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::{
-        INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, PendingUiInput,
-        QueuedUiInput, TerminalKeyboard, TerminalPointer, TerminalResize, UI_INPUT_BYTE_CAPACITY,
-        UI_INPUT_CAPACITY, WheelBatch, clear_terminal_input_state, clears_after_input_delivery,
-        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
-        input_queue_has_capacity, named_key, normalize_cell_width,
-        queued_input_matches_presentation, terminal_key_input, terminal_wheel_steps,
-        transitioned_presentation,
+        APP_NAVIGATION_WIDTH, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC,
+        InputRefusal, PendingUiInput, QueuedUiInput, TerminalKeyboard, TerminalPointer,
+        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_name,
+        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
+        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity, named_key,
+        normalize_cell_width, queued_input_matches_presentation, terminal_cell_at_with_offset,
+        terminal_key_input, terminal_wheel_steps, transitioned_presentation,
     };
+    use std::sync::Arc;
+    use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
         KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey,
+        WorkspaceContent,
     };
 
     #[test]
@@ -2051,6 +2301,53 @@ mod tests {
         assert_eq!(named_key("numpad7"), Some(NamedKey::KeypadDigit(7)));
         assert_eq!(named_key("kpenter"), Some(NamedKey::KeypadEnter));
         assert_eq!(named_key("numpadadd"), Some(NamedKey::KeypadAdd));
+    }
+
+    #[test]
+    fn terminal_and_attaching_states_expose_the_active_session() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let terminal = WorkspaceContent::Terminal {
+            endpoint: "Ubuntu".to_owned(),
+            session: "work".to_owned(),
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        let attaching = WorkspaceContent::Attaching {
+            endpoint: "Ubuntu".to_owned(),
+            session: "other".to_owned(),
+        };
+
+        assert_eq!(active_session_name(&terminal), Some("work"));
+        assert_eq!(active_session_name(&attaching), Some("other"));
+        assert_eq!(active_session_name(&WorkspaceContent::Shell), None);
+    }
+
+    #[test]
+    fn terminal_hit_testing_accounts_for_persistent_navigation() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+
+        assert_eq!(
+            terminal_cell_at_with_offset(
+                APP_NAVIGATION_WIDTH + 20.0,
+                66.0,
+                APP_NAVIGATION_WIDTH,
+                8.0,
+                16.0,
+                size
+            ),
+            Some((1, 0))
+        );
+        assert_eq!(
+            terminal_cell_at_with_offset(
+                APP_NAVIGATION_WIDTH - 8.0,
+                66.0,
+                APP_NAVIGATION_WIDTH,
+                8.0,
+                16.0,
+                size
+            ),
+            None
+        );
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1436,7 +1436,23 @@ impl RootView {
         snapshot: &workspace::WorkspaceSnapshot,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let mut tree = div()
+        let mut body = div()
+            .id("workspace-tree-scroll")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scroll()
+            .overflow_x_hidden();
+        for (host_index, host) in snapshot.hosts().iter().enumerate() {
+            body = body.child(Self::host_tree(
+                host_index,
+                host,
+                snapshot.selected_host() == Some(host.id()),
+                snapshot.content(),
+                cx,
+            ));
+        }
+
+        div()
             .w(px(APP_NAVIGATION_WIDTH))
             .h_full()
             .flex_none()
@@ -1458,18 +1474,9 @@ impl RootView {
                     .font_weight(FontWeight::BOLD)
                     .text_color(rgb(0xa5_ac_b8))
                     .child("WORKSPACES"),
-            );
-
-        for (host_index, host) in snapshot.hosts().iter().enumerate() {
-            tree = tree.child(Self::host_tree(
-                host_index,
-                host,
-                snapshot.selected_host() == Some(host.id()),
-                snapshot.content(),
-                cx,
-            ));
-        }
-        tree.into_any_element()
+            )
+            .child(body)
+            .into_any_element()
     }
 
     fn host_tree(
@@ -1479,115 +1486,210 @@ impl RootView {
         content: &WorkspaceContent,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
+        let mut host_tree =
+            div()
+                .flex()
+                .flex_col()
+                .child(Self::host_header(host_index, host, is_selected, cx));
+
+        match host.connection() {
+            HostConnectionState::Connecting => {
+                host_tree = host_tree.child(Self::host_status_row(
+                    host_index,
+                    "Refreshing sessions…".to_owned(),
+                    "Cancel",
+                    true,
+                    cx,
+                ));
+            }
+            HostConnectionState::Unavailable => {
+                let message = host.diagnostic().map_or_else(
+                    || "Host unavailable".to_owned(),
+                    |diagnostic| diagnostic.message().to_owned(),
+                );
+                host_tree = host_tree.child(Self::host_status_row(
+                    host_index, message, "Retry", false, cx,
+                ));
+            }
+            HostConnectionState::Disconnected => {
+                host_tree = host_tree.child(Self::host_status_row(
+                    host_index,
+                    "Host disconnected".to_owned(),
+                    "Connect",
+                    false,
+                    cx,
+                ));
+            }
+            HostConnectionState::Ready => {}
+        }
+
+        let sessions = tree_sessions(host, content);
+        if host.connection() == HostConnectionState::Ready || !sessions.is_empty() {
+            host_tree = host_tree.child(Self::session_tree(host_index, &sessions, cx));
+        }
+        host_tree.into_any_element()
+    }
+
+    fn host_header(
+        host_index: usize,
+        host: &HostItem,
+        is_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
         let status_color = match host.connection() {
             HostConnectionState::Ready => 0x62_c0_7a,
             HostConnectionState::Connecting => 0xd3_a4_4a,
             HostConnectionState::Disconnected => 0x8f_96_a3,
             HostConnectionState::Unavailable => 0xd0_65_65,
         };
-        let mut host_tree = div().flex().flex_col().child(
+        let mut host_header = div()
+            .id(("host", host_index))
+            .h(px(46.0))
+            .flex()
+            .items_center()
+            .gap_2()
+            .px_3()
+            .bg(rgb(if is_selected { 0x16_1920 } else { 0x0f_1116 }))
+            .child(div().text_color(rgb(0x6f_7682)).child("▾"))
+            .child(div().text_color(rgb(status_color)).child("●"))
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .child(
+                        div()
+                            .truncate()
+                            .text_sm()
+                            .font_weight(FontWeight::BOLD)
+                            .text_color(rgb(0xd2_d7_df))
+                            .child(host.name().to_owned()),
+                    )
+                    .child(
+                        div()
+                            .truncate()
+                            .text_xs()
+                            .text_color(rgb(0x71_7885))
+                            .child(host.endpoint().to_owned()),
+                    ),
+            );
+        if host.connection() == HostConnectionState::Ready {
+            host_header = host_header.child(
+                div()
+                    .id(("refresh-host", host_index))
+                    .flex_none()
+                    .px_2()
+                    .py_1()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .text_xs()
+                    .text_color(rgb(0x8f_96_a3))
+                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                    .child("Refresh")
+                    .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+            );
+        }
+        host_header.into_any_element()
+    }
+
+    fn session_tree(
+        host_index: usize,
+        sessions: &[TreeSession],
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let mut tree = div().flex().flex_col().child(
             div()
-                .id(("host", host_index))
-                .h(px(46.0))
+                .h(px(28.0))
                 .flex()
                 .items_center()
-                .gap_2()
-                .px_3()
-                .bg(rgb(if is_selected { 0x16_1920 } else { 0x0f_1116 }))
-                .child(div().text_color(rgb(0x6f_7682)).child("▾"))
-                .child(div().text_color(rgb(status_color)).child("●"))
-                .child(
-                    div()
-                        .min_w_0()
-                        .flex_1()
-                        .flex()
-                        .flex_col()
-                        .child(
-                            div()
-                                .truncate()
-                                .text_sm()
-                                .font_weight(FontWeight::BOLD)
-                                .text_color(rgb(0xd2_d7_df))
-                                .child(host.name().to_owned()),
-                        )
-                        .child(
-                            div()
-                                .truncate()
-                                .text_xs()
-                                .text_color(rgb(0x71_7885))
-                                .child(host.endpoint().to_owned()),
-                        ),
-                )
-                .child(
-                    div()
-                        .id(("refresh-host", host_index))
-                        .flex_none()
-                        .px_2()
-                        .py_1()
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .text_xs()
-                        .text_color(rgb(0x8f_96_a3))
-                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
-                        .child("Refresh")
-                        .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
-                ),
+                .pl(px(35.0))
+                .text_xs()
+                .font_weight(FontWeight::BOLD)
+                .text_color(rgb(0x73_7a87))
+                .child("TMUX SESSIONS"),
         );
-
-        if host.connection() == HostConnectionState::Ready {
-            host_tree = host_tree.child(
+        if sessions.is_empty() {
+            tree = tree.child(
                 div()
-                    .h(px(28.0))
-                    .flex()
-                    .items_center()
-                    .pl(px(35.0))
+                    .px_3()
+                    .pl(px(51.0))
+                    .py_2()
                     .text_xs()
-                    .font_weight(FontWeight::BOLD)
                     .text_color(rgb(0x73_7a87))
-                    .child("TMUX SESSIONS"),
+                    .child("No sessions"),
             );
-            if host.sessions().is_empty() {
-                host_tree = host_tree.child(
-                    div()
-                        .px_3()
-                        .pl(px(51.0))
-                        .py_2()
-                        .text_xs()
-                        .text_color(rgb(0x73_7a87))
-                        .child("No sessions"),
-                );
-            } else {
-                let active = active_session_name(content);
-                for (session_index, session) in host.sessions().iter().enumerate() {
-                    host_tree = host_tree.child(Self::tree_session_row(
-                        host_index,
-                        session_index,
-                        session,
-                        active == Some(session.name()),
-                        cx,
-                    ));
-                }
-            }
         }
-        host_tree.into_any_element()
+        for (session_index, session) in sessions.iter().enumerate() {
+            tree = tree.child(Self::tree_session_row(
+                host_index,
+                session_index,
+                &session.name,
+                session.attached_clients,
+                session.active,
+                cx,
+            ));
+        }
+        tree.into_any_element()
+    }
+
+    fn host_status_row(
+        host_index: usize,
+        message: String,
+        action: &'static str,
+        cancel: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let action_id = if cancel {
+            "cancel-host-refresh"
+        } else {
+            "retry-host-refresh"
+        };
+        div()
+            .mx_2()
+            .mb_1()
+            .px_2()
+            .py_2()
+            .rounded_sm()
+            .bg(rgb(0x16_1920))
+            .child(div().text_xs().text_color(rgb(0x9b_a2ae)).child(message))
+            .child(
+                div()
+                    .id((action_id, host_index))
+                    .mt_1()
+                    .cursor_pointer()
+                    .text_xs()
+                    .text_color(rgb(0x79_aee3))
+                    .hover(|style| style.text_color(rgb(0xb6_d8_f8)))
+                    .child(action)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        if cancel {
+                            this.cancel_refresh(cx);
+                        } else {
+                            this.refresh(cx);
+                        }
+                    })),
+            )
+            .into_any_element()
     }
 
     fn tree_session_row(
         host_index: usize,
         index: usize,
-        session: &workspace::SessionItem,
+        session_name: &str,
+        attached_clients: Option<u32>,
         is_active: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let name = session.name().to_owned();
+        let name = session_name.to_owned();
         let detail = if is_active {
             "open".to_owned()
-        } else if session.attached_clients() == 0 {
+        } else if attached_clients == Some(0) {
             "detached".to_owned()
-        } else if session.attached_clients() == 1 {
+        } else if attached_clients == Some(1) {
             "1 client".to_owned()
         } else {
-            format!("{} clients", session.attached_clients())
+            format!("{} clients", attached_clients.unwrap_or_default())
         };
         let mut row = div()
             .id((
@@ -1839,6 +1941,74 @@ fn active_session_name(content: &WorkspaceContent) -> Option<&str> {
         | WorkspaceContent::Ready { .. }
         | WorkspaceContent::Error { .. } => None,
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreeSession {
+    name: String,
+    attached_clients: Option<u32>,
+    active: bool,
+}
+
+fn active_session_for_endpoint<'a>(
+    content: &'a WorkspaceContent,
+    endpoint: &str,
+) -> Option<&'a str> {
+    match content {
+        WorkspaceContent::Attaching {
+            endpoint: active_endpoint,
+            session,
+        }
+        | WorkspaceContent::Terminal {
+            endpoint: active_endpoint,
+            session,
+            ..
+        } if active_endpoint == endpoint => Some(session),
+        WorkspaceContent::Shell
+        | WorkspaceContent::Loading
+        | WorkspaceContent::Ready { .. }
+        | WorkspaceContent::Attaching { .. }
+        | WorkspaceContent::Terminal { .. }
+        | WorkspaceContent::Error { .. } => None,
+    }
+}
+
+fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession> {
+    let active = active_session_for_endpoint(content, host.endpoint());
+    if host.connection() != HostConnectionState::Ready {
+        return active.map_or_else(Vec::new, |name| {
+            let attached_clients = host
+                .sessions()
+                .iter()
+                .find(|session| session.name() == name)
+                .map(workspace::SessionItem::attached_clients);
+            vec![TreeSession {
+                name: name.to_owned(),
+                attached_clients,
+                active: true,
+            }]
+        });
+    }
+
+    let mut sessions = host
+        .sessions()
+        .iter()
+        .map(|session| TreeSession {
+            name: session.name().to_owned(),
+            attached_clients: Some(session.attached_clients()),
+            active: active == Some(session.name()),
+        })
+        .collect::<Vec<_>>();
+    if let Some(name) = active
+        && !sessions.iter().any(|session| session.active)
+    {
+        sessions.push(TreeSession {
+            name: name.to_owned(),
+            attached_clients: None,
+            active: true,
+        });
+    }
+    sessions
 }
 
 fn workspace_window_title(content: &WorkspaceContent) -> String {
@@ -2286,13 +2456,13 @@ mod tests {
         coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity, named_key,
         normalize_cell_width, queued_input_matches_presentation, terminal_cell_at_with_offset,
         terminal_key_input, terminal_line_height, terminal_wheel_steps, transitioned_presentation,
-        workspace_window_title,
+        tree_sessions, workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
-        KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey,
-        WorkspaceContent,
+        HostConnectionState, HostItem, KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton,
+        MouseInput, NamedKey, SessionItem, WorkspaceContent,
     };
 
     #[test]
@@ -2374,6 +2544,34 @@ mod tests {
             "demo — Ubuntu — Ghosthub"
         );
         assert_eq!(workspace_window_title(&WorkspaceContent::Shell), "Ghosthub");
+    }
+
+    #[test]
+    fn active_session_stays_in_the_tree_while_its_host_refreshes_or_fails() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let terminal = WorkspaceContent::Terminal {
+            endpoint: "Ubuntu".to_owned(),
+            session: "demo".to_owned(),
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        for state in [
+            HostConnectionState::Connecting,
+            HostConnectionState::Unavailable,
+        ] {
+            let host = HostItem::wsl(
+                "Ubuntu",
+                None,
+                state,
+                vec![SessionItem::new("other", 0)],
+                None,
+            );
+
+            let rows = tree_sessions(&host, &terminal);
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].name, "demo");
+            assert!(rows[0].active);
+        }
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -14,8 +14,8 @@ use model::PortStatus;
 use surface::{CellStyle, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
 use workspace::{
     HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput,
-    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, Workspace,
-    WorkspaceContent, WorkspaceEvent,
+    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionSelection,
+    Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -586,8 +586,13 @@ impl RootView {
         headline_text(&self.status)
     }
 
-    fn attach(&mut self, session: &str, window: &mut Window, cx: &mut Context<Self>) {
-        if let Err(error) = self.workspace.attach(session) {
+    fn attach(
+        &mut self,
+        selection: &SessionSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Err(error) = self.workspace.attach(selection) {
             self.diagnostic = Some(error.to_string());
         } else {
             self.diagnostic = None;
@@ -596,9 +601,14 @@ impl RootView {
         cx.notify();
     }
 
-    fn select_session(&mut self, session: &str, window: &mut Window, cx: &mut Context<Self>) {
+    fn select_session(
+        &mut self,
+        selection: &SessionSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let snapshot = self.workspace.snapshot();
-        if active_session_name(snapshot.content()) == Some(session) {
+        if active_session_selection(snapshot.content()).as_ref() == Some(selection) {
             if matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
                 window.focus(&self.focus);
             }
@@ -610,9 +620,9 @@ impl RootView {
             WorkspaceContent::Attaching { .. } | WorkspaceContent::Terminal { .. }
         );
         let result = if switching {
-            self.workspace.switch_session(session)
+            self.workspace.switch_session(selection)
         } else {
-            self.workspace.attach(session)
+            self.workspace.attach(selection)
         };
         if let Err(error) = result {
             self.diagnostic = Some(error.to_string());
@@ -1378,9 +1388,9 @@ impl RootView {
                         .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
                 )
                 .into_any_element(),
-            WorkspaceContent::Attaching { endpoint, session } => {
-                centered(format!("Attaching to {endpoint} · {session}…"))
-            }
+            WorkspaceContent::Attaching {
+                endpoint, session, ..
+            } => centered(format!("Attaching to {endpoint} · {session}…")),
             WorkspaceContent::Ready { endpoint, sessions } => {
                 Self::ready_element(endpoint, sessions, None, cx)
             }
@@ -1389,6 +1399,7 @@ impl RootView {
                 session: _,
                 presentation_id,
                 surface,
+                ..
             } => self
                 .terminal_element(*presentation_id, surface, snapshot, cx)
                 .into_any_element(),
@@ -1411,12 +1422,13 @@ impl RootView {
                 session: _,
                 presentation_id,
                 surface,
+                ..
             } => self
                 .terminal_element(*presentation_id, surface, snapshot, cx)
                 .into_any_element(),
-            WorkspaceContent::Attaching { endpoint, session } => {
-                centered(format!("Attaching to {endpoint} · {session}…"))
-            }
+            WorkspaceContent::Attaching {
+                endpoint, session, ..
+            } => centered(format!("Attaching to {endpoint} · {session}…")),
             WorkspaceContent::Loading => centered("Starting WSL and discovering tmux sessions…"),
             WorkspaceContent::Error { message } => centered(message.clone()),
             WorkspaceContent::Shell | WorkspaceContent::Ready { .. } => selected.map_or_else(
@@ -1624,7 +1636,7 @@ impl RootView {
             tree = tree.child(Self::tree_session_row(
                 host_index,
                 session_index,
-                &session.name,
+                &session.selection,
                 session.attached_clients,
                 session.active,
                 cx,
@@ -1676,12 +1688,13 @@ impl RootView {
     fn tree_session_row(
         host_index: usize,
         index: usize,
-        session_name: &str,
+        selection: &SessionSelection,
         attached_clients: Option<u32>,
         is_active: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let name = session_name.to_owned();
+        let selection = selection.clone();
+        let name = selection.session().to_owned();
         let detail = if is_active {
             "open".to_owned()
         } else if attached_clients == Some(0) {
@@ -1748,7 +1761,7 @@ impl RootView {
             );
         }
         row.on_click(cx.listener(move |this, _, window, cx| {
-            this.select_session(&name, window, cx);
+            this.select_session(&selection, window, cx);
         }))
         .into_any_element()
     }
@@ -1878,6 +1891,8 @@ impl RootView {
         }
         for (index, session) in sessions.iter().enumerate() {
             let name = session.name().to_owned();
+            let selection =
+                SessionSelection::new(host.map_or("wsl", HostItem::id), endpoint, session.name());
             let detail = if session.attached_clients() == 0 {
                 "detached".to_owned()
             } else {
@@ -1897,7 +1912,7 @@ impl RootView {
                     .child(name.clone())
                     .child(div().text_sm().text_color(rgb(0x8f_96_a3)).child(detail))
                     .on_click(cx.listener(move |this, _, window, cx| {
-                        this.attach(&name, window, cx);
+                        this.attach(&selection, window, cx);
                     })),
             );
         }
@@ -1932,58 +1947,49 @@ fn terminal_presentation_id(content: &WorkspaceContent) -> Option<u64> {
     }
 }
 
-fn active_session_name(content: &WorkspaceContent) -> Option<&str> {
-    match content {
-        WorkspaceContent::Attaching { session, .. }
-        | WorkspaceContent::Terminal { session, .. } => Some(session),
-        WorkspaceContent::Shell
-        | WorkspaceContent::Loading
-        | WorkspaceContent::Ready { .. }
-        | WorkspaceContent::Error { .. } => None,
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TreeSession {
-    name: String,
+    selection: SessionSelection,
     attached_clients: Option<u32>,
     active: bool,
 }
 
-fn active_session_for_endpoint<'a>(
-    content: &'a WorkspaceContent,
-    endpoint: &str,
-) -> Option<&'a str> {
+fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelection> {
     match content {
         WorkspaceContent::Attaching {
-            endpoint: active_endpoint,
+            host_id,
+            endpoint,
             session,
         }
         | WorkspaceContent::Terminal {
-            endpoint: active_endpoint,
+            host_id,
+            endpoint,
             session,
             ..
-        } if active_endpoint == endpoint => Some(session),
+        } => Some(SessionSelection::new(host_id, endpoint, session)),
         WorkspaceContent::Shell
         | WorkspaceContent::Loading
         | WorkspaceContent::Ready { .. }
-        | WorkspaceContent::Attaching { .. }
-        | WorkspaceContent::Terminal { .. }
         | WorkspaceContent::Error { .. } => None,
     }
 }
 
 fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession> {
-    let active = active_session_for_endpoint(content, host.endpoint());
+    let active = active_session_selection(content);
+    let active_for_host = active
+        .as_ref()
+        .filter(|active| active.host_id() == host.id());
     if host.connection() != HostConnectionState::Ready {
-        return active.map_or_else(Vec::new, |name| {
+        return active_for_host.map_or_else(Vec::new, |active| {
             let attached_clients = host
                 .sessions()
                 .iter()
-                .find(|session| session.name() == name)
+                .find(|session| {
+                    host.endpoint() == active.endpoint() && session.name() == active.session()
+                })
                 .map(workspace::SessionItem::attached_clients);
             vec![TreeSession {
-                name: name.to_owned(),
+                selection: active.clone(),
                 attached_clients,
                 active: true,
             }]
@@ -1993,17 +1999,20 @@ fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession
     let mut sessions = host
         .sessions()
         .iter()
-        .map(|session| TreeSession {
-            name: session.name().to_owned(),
-            attached_clients: Some(session.attached_clients()),
-            active: active == Some(session.name()),
+        .map(|session| {
+            let selection = SessionSelection::new(host.id(), host.endpoint(), session.name());
+            TreeSession {
+                active: active.as_ref() == Some(&selection),
+                selection,
+                attached_clients: Some(session.attached_clients()),
+            }
         })
         .collect::<Vec<_>>();
-    if let Some(name) = active
+    if let Some(active) = active_for_host
         && !sessions.iter().any(|session| session.active)
     {
         sessions.push(TreeSession {
-            name: name.to_owned(),
+            selection: active.clone(),
             attached_clients: None,
             active: true,
         });
@@ -2013,7 +2022,9 @@ fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession
 
 fn workspace_window_title(content: &WorkspaceContent) -> String {
     match content {
-        WorkspaceContent::Attaching { endpoint, session }
+        WorkspaceContent::Attaching {
+            endpoint, session, ..
+        }
         | WorkspaceContent::Terminal {
             endpoint, session, ..
         } => format!("{session} — {endpoint} — {WINDOW_TITLE}"),
@@ -2451,18 +2462,19 @@ mod tests {
     use super::{
         APP_NAVIGATION_WIDTH, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC,
         InputRefusal, PendingUiInput, QueuedUiInput, TerminalKeyboard, TerminalPointer,
-        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_name,
-        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity, named_key,
-        normalize_cell_width, queued_input_matches_presentation, terminal_cell_at_with_offset,
-        terminal_key_input, terminal_line_height, terminal_wheel_steps, transitioned_presentation,
-        tree_sessions, workspace_window_title,
+        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch,
+        active_session_selection, clear_terminal_input_state, clears_after_input_delivery,
+        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
+        input_queue_has_capacity, named_key, normalize_cell_width,
+        queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
+        workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
         HostConnectionState, HostItem, KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton,
-        MouseInput, NamedKey, SessionItem, WorkspaceContent,
+        MouseInput, NamedKey, SessionItem, SessionSelection, WorkspaceContent,
     };
 
     #[test]
@@ -2503,34 +2515,44 @@ mod tests {
     }
 
     #[test]
-    fn terminal_and_attaching_states_expose_the_active_session() {
+    fn terminal_and_attaching_states_expose_the_active_selection() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let terminal = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "work".to_owned(),
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };
         let attaching = WorkspaceContent::Attaching {
+            host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "other".to_owned(),
         };
 
-        assert_eq!(active_session_name(&terminal), Some("work"));
-        assert_eq!(active_session_name(&attaching), Some("other"));
-        assert_eq!(active_session_name(&WorkspaceContent::Shell), None);
+        assert_eq!(
+            active_session_selection(&terminal),
+            Some(SessionSelection::new("wsl", "Ubuntu", "work"))
+        );
+        assert_eq!(
+            active_session_selection(&attaching),
+            Some(SessionSelection::new("wsl", "Ubuntu", "other"))
+        );
+        assert_eq!(active_session_selection(&WorkspaceContent::Shell), None);
     }
 
     #[test]
     fn active_terminal_context_moves_into_the_native_window_title() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let terminal = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };
         let attaching = WorkspaceContent::Attaching {
+            host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
         };
@@ -2550,6 +2572,7 @@ mod tests {
     fn active_session_stays_in_the_tree_while_its_host_refreshes_or_fails() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let terminal = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
             presentation_id: 1,
@@ -2569,9 +2592,35 @@ mod tests {
 
             let rows = tree_sessions(&host, &terminal);
             assert_eq!(rows.len(), 1);
-            assert_eq!(rows[0].name, "demo");
+            assert_eq!(rows[0].selection.session(), "demo");
             assert!(rows[0].active);
         }
+    }
+
+    #[test]
+    fn refreshed_endpoint_does_not_alias_an_active_session_with_the_same_name() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let terminal = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            session: "demo".to_owned(),
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        let host = HostItem::wsl(
+            "Debian",
+            None,
+            HostConnectionState::Ready,
+            vec![SessionItem::new("demo", 0)],
+            None,
+        );
+
+        let rows = tree_sessions(&host, &terminal);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].selection.endpoint(), "Debian");
+        assert!(!rows[0].active);
+        assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
+        assert!(rows[1].active);
     }
 
     #[test]

--- a/rust/ui/tests/root_view.rs
+++ b/rust/ui/tests/root_view.rs
@@ -184,8 +184,8 @@ fn paint_cache_does_not_scroll_cursor_highlighting_with_cells() {
     ));
 
     let rows = cache.update(&store.load());
-    assert_eq!(rows[0][0].foreground(), 0xee_f0_f4);
-    assert_eq!(rows[1][0].foreground(), 0x11_13_18);
+    assert_eq!(rows[0][0].foreground(), 0xd8_de_e9);
+    assert_eq!(rows[1][0].foreground(), 0x0c_0f_14);
 }
 
 #[test]

--- a/rust/ui/tests/root_view.rs
+++ b/rust/ui/tests/root_view.rs
@@ -203,17 +203,17 @@ fn terminal_rows_preserve_fixed_grid_columns() {
 fn mouse_coordinates_map_to_the_rendered_grid() {
     let size = GridSize::new(120, 40).expect("valid grid");
 
-    assert_eq!(terminal_cell_at(12.0, 54.0, 10.0, 18.0, size), Some((0, 0)));
+    assert_eq!(terminal_cell_at(5.0, 9.0, 10.0, 18.0, size), Some((0, 0)));
     assert_eq!(
-        terminal_cell_at(1_011.0, 678.0, 10.0, 18.0, size),
+        terminal_cell_at(999.0, 621.0, 10.0, 18.0, size),
         Some((99, 34))
     );
-    assert_eq!(terminal_cell_at(8.0, 50.0, 10.0, 18.0, size), None);
+    assert_eq!(terminal_cell_at(-1.0, 9.0, 10.0, 18.0, size), None);
 }
 
 #[test]
 fn grid_size_uses_the_same_measured_metrics_as_hit_testing() {
-    assert_eq!(terminal_grid_size(1_100.0, 720.0, 10.0, 18.0), (107, 36));
+    assert_eq!(terminal_grid_size(1_100.0, 720.0, 10.0, 18.0), (110, 40));
 }
 
 #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -95,6 +95,43 @@ impl SessionItem {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionSelection {
+    host_id: String,
+    endpoint: String,
+    session: String,
+}
+
+impl SessionSelection {
+    #[must_use]
+    pub fn new(
+        host_id: impl Into<String>,
+        endpoint: impl Into<String>,
+        session: impl Into<String>,
+    ) -> Self {
+        Self {
+            host_id: host_id.into(),
+            endpoint: endpoint.into(),
+            session: session.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn host_id(&self) -> &str {
+        &self.host_id
+    }
+
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    #[must_use]
+    pub fn session(&self) -> &str {
+        &self.session
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HostConnectionState {
     Disconnected,
@@ -205,10 +242,12 @@ pub enum WorkspaceContent {
         sessions: Vec<SessionItem>,
     },
     Attaching {
+        host_id: String,
         endpoint: String,
         session: String,
     },
     Terminal {
+        host_id: String,
         endpoint: String,
         session: String,
         presentation_id: u64,
@@ -493,6 +532,7 @@ struct PendingPaste {
 
 #[derive(Clone)]
 struct AttachRequest {
+    host_id: String,
     host: RuntimeHost,
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
@@ -960,7 +1000,7 @@ impl Workspace {
     ///
     /// Returns an error if another presentation is active or the requested
     /// session is not in the latest resolved inventory.
-    pub fn attach(&self, session_name: &str) -> Result<(), WorkspaceError> {
+    pub fn attach(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
         if self
             .inner
             .worker
@@ -973,7 +1013,7 @@ impl Workspace {
                 "a terminal presentation is already open",
             ));
         }
-        let request = capture_attach_request(&self.inner, session_name)?;
+        let request = capture_attach_request(&self.inner, selection)?;
 
         self.start_attachment(request)
     }
@@ -988,19 +1028,22 @@ impl Workspace {
     ///
     /// Returns an error if the requested session is absent from the latest
     /// inventory or the replacement attachment cannot be started.
-    pub fn switch_session(&self, session_name: &str) -> Result<(), WorkspaceError> {
+    pub fn switch_session(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
         if matches!(
             self.inner
                 .state
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone(),
-            WorkspaceContent::Terminal { session, .. } if session == session_name
+            WorkspaceContent::Terminal { host_id, endpoint, session, .. }
+                if host_id == selection.host_id()
+                    && endpoint == selection.endpoint()
+                    && session == selection.session()
         ) {
             return Ok(());
         }
 
-        let request = capture_attach_request(&self.inner, session_name)?;
+        let request = capture_attach_request(&self.inner, selection)?;
         self.detach();
         self.start_attachment(request)
     }
@@ -1031,6 +1074,7 @@ impl Workspace {
                 .ok_or_else(|| WorkspaceError::new("a terminal presentation is already opening"))?;
             clear_terminal_notice(&self.inner);
             *state = WorkspaceContent::Attaching {
+                host_id: request.host_id.clone(),
                 endpoint: request.endpoint.distro().to_owned(),
                 session: request.name.clone(),
             };
@@ -1403,6 +1447,7 @@ impl Workspace {
             if retry_term {
                 publish_terminfo_retry_boundary(
                     &self.inner,
+                    &request.host_id,
                     request.endpoint.distro(),
                     &request.name,
                 );
@@ -1550,8 +1595,15 @@ const fn event_drain_may_have_more(processed: usize, exited: bool) -> bool {
 
 fn capture_attach_request(
     inner: &Inner,
-    session_name: &str,
+    selection: &SessionSelection,
 ) -> Result<AttachRequest, WorkspaceError> {
+    let selected_host = inner
+        .selected_host
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if selected_host.as_deref() != Some(selection.host_id()) {
+        return Err(WorkspaceError::new("host is not selected"));
+    }
     let host = inner
         .host
         .lock()
@@ -1560,13 +1612,19 @@ fn capture_attach_request(
         .as_ref()
         .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
     context.map(|context, inventory_generation| {
+        if context.snapshot.endpoint().distro() != selection.endpoint() {
+            return Err(WorkspaceError::new(
+                "host endpoint changed; refresh the session selection",
+            ));
+        }
         let session = context
             .snapshot
             .sessions()
             .iter()
-            .find(|session| session.name() == session_name)
+            .find(|session| session.name() == selection.session())
             .ok_or_else(|| WorkspaceError::new("session is not in the current inventory"))?;
         Ok(AttachRequest {
+            host_id: selection.host_id().to_owned(),
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
@@ -1717,6 +1775,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             set_inner_state(
                 inner,
                 WorkspaceContent::Terminal {
+                    host_id: request.host_id.clone(),
                     endpoint,
                     session,
                     presentation_id,
@@ -2020,11 +2079,12 @@ fn clear_pending_paste(inner: &Inner) {
         .take();
 }
 
-fn publish_terminfo_retry_boundary(inner: &Inner, endpoint: &str, session: &str) {
+fn publish_terminfo_retry_boundary(inner: &Inner, host_id: &str, endpoint: &str, session: &str) {
     clear_pending_paste(inner);
     set_inner_state(
         inner,
         WorkspaceContent::Attaching {
+            host_id: host_id.to_owned(),
             endpoint: endpoint.to_owned(),
             session: session.to_owned(),
         },
@@ -2233,6 +2293,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
             },
@@ -2266,6 +2327,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "stale".to_owned(),
             },
@@ -2326,7 +2388,11 @@ mod tests {
                 sessions: vec![SessionItem::new("work", 0)],
             },
         );
-        let request = capture_attach_request(&workspace.inner, "work").expect("attach request");
+        let request = capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", "work"),
+        )
+        .expect("attach request");
         let replacement = HostSnapshot::test_fixture(
             "Ubuntu",
             "boot-id",
@@ -2404,6 +2470,7 @@ mod tests {
             revision: 1,
             appearance: Appearance::default(),
             content: WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 7,
@@ -2421,7 +2488,7 @@ mod tests {
             ),
         });
 
-        publish_terminfo_retry_boundary(&workspace.inner, "Ubuntu", "work");
+        publish_terminfo_retry_boundary(&workspace.inner, "wsl", "Ubuntu", "work");
 
         assert!(
             workspace
@@ -2433,8 +2500,8 @@ mod tests {
         );
         assert!(matches!(
             workspace.snapshot().content(),
-            WorkspaceContent::Attaching { endpoint, session }
-                if endpoint == "Ubuntu" && session == "work"
+            WorkspaceContent::Attaching { host_id, endpoint, session }
+                if host_id == "wsl" && endpoint == "Ubuntu" && session == "work"
         ));
         assert_eq!(next_presentation_id(&workspace.inner), 8);
     }
@@ -2519,9 +2586,15 @@ mod tests {
             HostContext { host, snapshot },
             context_generation,
         ));
+        *workspace
+            .inner
+            .selected_host
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some("wsl".to_owned());
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 1,
@@ -2533,7 +2606,11 @@ mod tests {
         );
 
         let refresh_generation = begin_refresh(&workspace.inner, &CancellationToken::new());
-        let request = capture_attach_request(&workspace.inner, "work").expect("capture request");
+        let request = capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", "work"),
+        )
+        .expect("capture request");
         assert_eq!(request.inventory_generation, context_generation);
         assert!(refresh_generation > request.inventory_generation);
         assert!(publish_refresh(
@@ -2950,6 +3027,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 1,
@@ -2992,6 +3070,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 1,
@@ -3000,13 +3079,20 @@ mod tests {
         );
 
         workspace
-            .switch_session("work")
+            .switch_session(&SessionSelection::new("wsl", "Ubuntu", "work"))
             .expect("active session remains selected");
 
         assert!(matches!(
             workspace.snapshot().content(),
             WorkspaceContent::Terminal { session, .. } if session == "work"
         ));
+
+        assert!(
+            workspace
+                .switch_session(&SessionSelection::new("wsl", "Debian", "work"))
+                .is_err(),
+            "an equal name on a different endpoint is not the active selection"
+        );
     }
 
     #[test]
@@ -3020,6 +3106,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 1,
@@ -3027,7 +3114,11 @@ mod tests {
             },
         );
 
-        assert!(workspace.switch_session("missing").is_err());
+        assert!(
+            workspace
+                .switch_session(&SessionSelection::new("wsl", "Ubuntu", "missing"))
+                .is_err()
+        );
         assert!(matches!(
             workspace.snapshot().content(),
             WorkspaceContent::Terminal { session, .. } if session == "work"
@@ -3045,6 +3136,7 @@ mod tests {
         set_inner_state(
             &workspace.inner,
             WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
                 presentation_id: 1,

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -975,6 +975,37 @@ impl Workspace {
         }
         let request = capture_attach_request(&self.inner, session_name)?;
 
+        self.start_attachment(request)
+    }
+
+    /// Detach the active ordinary client and attach to another discovered session.
+    ///
+    /// The target is captured before the current presentation is detached, so an
+    /// invalid selection cannot close the working terminal. The fresh identity
+    /// check still runs immediately before the replacement client launches.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requested session is absent from the latest
+    /// inventory or the replacement attachment cannot be started.
+    pub fn switch_session(&self, session_name: &str) -> Result<(), WorkspaceError> {
+        if matches!(
+            self.inner
+                .state
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+            WorkspaceContent::Terminal { session, .. } if session == session_name
+        ) {
+            return Ok(());
+        }
+
+        let request = capture_attach_request(&self.inner, session_name)?;
+        self.detach();
+        self.start_attachment(request)
+    }
+
+    fn start_attachment(&self, request: AttachRequest) -> Result<(), WorkspaceError> {
         let generation;
         {
             let mut attachment = self
@@ -2947,6 +2978,59 @@ mod tests {
             workspace.snapshot().content(),
             WorkspaceContent::Ready { sessions, .. }
                 if sessions.len() == 1 && sessions[0].name() == "other"
+        ));
+    }
+
+    #[test]
+    fn switching_to_the_active_session_is_a_no_op() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let size = GridSize::new(80, 24).expect("valid grid");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Terminal {
+                endpoint: "Ubuntu".to_owned(),
+                session: "work".to_owned(),
+                presentation_id: 1,
+                surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
+            },
+        );
+
+        workspace
+            .switch_session("work")
+            .expect("active session remains selected");
+
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Terminal { session, .. } if session == "work"
+        ));
+    }
+
+    #[test]
+    fn invalid_switch_target_does_not_detach_the_active_session() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let size = GridSize::new(80, 24).expect("valid grid");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Terminal {
+                endpoint: "Ubuntu".to_owned(),
+                session: "work".to_owned(),
+                presentation_id: 1,
+                surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
+            },
+        );
+
+        assert!(workspace.switch_session("missing").is_err());
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Terminal { session, .. } if session == "work"
         ));
     }
 

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -8,7 +8,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use config::TerminalAppearance;
 use host::WslConfig;
-use workspace::{KeyInput, Modifiers, NamedKey, Workspace, WorkspaceContent, WorkspaceEvent};
+use workspace::{
+    KeyInput, Modifiers, NamedKey, SessionSelection, Workspace, WorkspaceContent, WorkspaceEvent,
+};
 
 struct IsolatedServer {
     tmpdir: String,
@@ -134,9 +136,10 @@ fn discovers_attaches_renders_and_detaches_through_workspace() {
         },
         || workspace_diagnostic(&workspace),
     );
-    workspace.attach("workspace-live").expect("attach session");
+    let selection = session_selection(&workspace, "workspace-live");
+    workspace.attach(&selection).expect("attach session");
     assert!(
-        workspace.attach("workspace-live").is_err(),
+        workspace.attach(&selection).is_err(),
         "a second presentation must lose the single-window reservation"
     );
     wait_until(|| {
@@ -198,7 +201,7 @@ fn refuses_to_attach_when_the_discovered_session_was_replaced() {
     server.run_tmux(["new-session", "-d", "-s", "workspace-live"]);
 
     workspace
-        .attach("workspace-live")
+        .attach(&session_selection(&workspace, "workspace-live"))
         .expect("begin guarded attach");
 
     wait_until(|| {
@@ -241,7 +244,7 @@ fn detach_restores_the_inventory_revalidated_during_attachment() {
     server.run_tmux(["new-session", "-d", "-s", "appeared-before-attach"]);
 
     workspace
-        .attach("workspace-live")
+        .attach(&session_selection(&workspace, "workspace-live"))
         .expect("attach session after inventory changed");
     wait_until(|| {
         matches!(
@@ -305,7 +308,9 @@ fn workspace_diagnostic(workspace: &Workspace) -> String {
         WorkspaceContent::Ready { endpoint, sessions } => {
             format!("ready in {endpoint} with {} sessions", sessions.len())
         }
-        WorkspaceContent::Attaching { endpoint, session } => {
+        WorkspaceContent::Attaching {
+            endpoint, session, ..
+        } => {
             format!("attaching {session} in {endpoint}")
         }
         WorkspaceContent::Terminal {
@@ -313,4 +318,10 @@ fn workspace_diagnostic(workspace: &Workspace) -> String {
         } => format!("attached to {session} in {endpoint}"),
         WorkspaceContent::Error { message } => format!("error: {message}"),
     }
+}
+
+fn session_selection(workspace: &Workspace, session: &str) -> SessionSelection {
+    let snapshot = workspace.snapshot();
+    let host = &snapshot.hosts()[0];
+    SessionSelection::new(host.id(), host.endpoint(), session)
 }


### PR DESCRIPTION
- Makes the Windows Rust port feel like a compact terminal application instead of a debug shell.
- Replaces separate host and session columns with one lean workspace tree that keeps the terminal dominant.
- Keeps local tmux sessions visible while attaching, using the terminal, and switching sessions.
- Makes the terminal full-bleed and uses measured line spacing consistently for painting, PTY sizing, and mouse input.
- Shows the active session and WSL machine in the native window title instead of adding a second title bar inside the app.
- Keeps switching detach-only, validates the target before leaving the current session, and rechecks exact tmux identity before attachment.
- Passes the full Rust workspace, architecture, Clippy, dependency-policy, and isolated live WSL lifecycle suites.