### PR TITLE
Make Rust tmux navigation compact and immediate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,10 +167,13 @@ Host command capture is bounded and descendant-contained so inherited output
 pipes cannot outlive a cancelled or completed refresh.
 
 The Rust application keeps its host rail and discovered-session rail visible
-around an active terminal. Switching sessions is an explicit workspace action:
-it validates the selected inventory target before detaching the current
-ordinary client, then launches the replacement through the same atomic live-
-identity check as an initial attachment. This presentation navigation never
+around an active terminal. Each workspace retains every tmux presentation it
+explicitly opens, including its ordinary client, worker, and surface. Switching
+sessions changes only the selected presentation; returning to an open session
+remounts that same surface synchronously without reconnecting. The first visit
+still validates the current inventory target and launches through the atomic
+live-identity check. Explicit close detaches only the selected presentation,
+while application shutdown detaches all retained clients. Navigation never
 destroys server state and does not grant the UI direct host, session, or
 terminal dependencies.
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -676,17 +676,22 @@ The first executable milestone opens a native Windows GPUI shell independently
 of WSL, then discovers and attaches to an existing tmux session in one resolved
 WSL2 distro when the system WSL launcher is present. It detaches without
 destroying the session. The shell contains a synthetic host list, a minimal
-discovered-session view, one terminal presentation, a visible cancellable WSL
-startup state, and host-scoped retryable diagnostics.
+discovered-session view, one visible terminal presentation, a visible
+cancellable WSL startup state, and host-scoped retryable diagnostics.
 
 The Windows application shell keeps host and session navigation mounted while
-a terminal presentation is active. Selecting a different discovered session
-captures that target from the current inventory, detaches the existing
-ordinary client, and performs the normal fresh-identity attachment check for
-the replacement. Selecting the active session focuses its existing
-presentation. Navigation never sends a mux kill command. The chrome is shaped
-for additional admitted local mux hosts, but Slice 1 exposes only WSL tmux;
-psmux remains rejection evidence until it satisfies the same capability bar.
+a terminal presentation is active. A workspace retains the ordinary client,
+worker, and surface for every presentation it explicitly opens. Selecting a
+different discovered session hides the current surface without detaching its
+client. A first visit captures the target from current inventory and performs
+the normal fresh-identity attachment check; returning to an open session
+remounts the retained surface synchronously. Retained entries are keyed by the
+exact host, resolved endpoint, socket directory, session, and live identity.
+Explicit close detaches only the selected presentation, and application
+shutdown detaches every retained client. Navigation never sends a mux kill
+command. The chrome is shaped for additional admitted local mux hosts, but
+Slice 1 exposes only WSL tmux; psmux remains rejection evidence until it
+satisfies the same capability bar.
 
 The flow resolves and verifies the exact mux binary, discovers live identity,
 reserves the presentation, and launches an AttachPlan whose single tmux

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -372,6 +372,11 @@ impl<R: CommandRunner> WslHost<R> {
         &self.runner
     }
 
+    #[must_use]
+    pub fn socket_directory(&self) -> Option<&str> {
+        self.config.socket_directory()
+    }
+
     /// Resolve the exact WSL runtime and discover its tmux inventory.
     ///
     /// # Errors

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -217,8 +217,10 @@ pub struct TerminalWorker {
     coalesced_wake: Sender<()>,
     shutdown: Sender<()>,
     events: Receiver<TerminalEvent>,
+    deferred_events: Mutex<VecDeque<TerminalEvent>>,
     surface: Arc<SurfaceStore>,
     confirmed_live: Arc<AtomicBool>,
+    clipboard_writes_enabled: Arc<AtomicBool>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
@@ -345,6 +347,8 @@ impl TerminalWorker {
         let (write_complete_sender, write_complete_receiver) = bounded(1);
         let confirmed_live = Arc::new(AtomicBool::new(false));
         let worker_confirmed_live = Arc::clone(&confirmed_live);
+        let clipboard_writes_enabled = Arc::new(AtomicBool::new(true));
+        let worker_clipboard_writes_enabled = Arc::clone(&clipboard_writes_enabled);
 
         thread::Builder::new()
             .name("ghosthub-pty-writer".to_owned())
@@ -376,6 +380,7 @@ impl TerminalWorker {
                     &write_complete_receiver,
                     &events_sender,
                     &worker_confirmed_live,
+                    &worker_clipboard_writes_enabled,
                 );
             })
             .map_err(|error| WorkerError::new("spawn terminal worker", error))?;
@@ -387,8 +392,10 @@ impl TerminalWorker {
             coalesced_wake,
             shutdown,
             events,
+            deferred_events: Mutex::new(VecDeque::new()),
             surface,
             confirmed_live,
+            clipboard_writes_enabled,
             thread: Some(worker_thread),
         })
     }
@@ -407,6 +414,23 @@ impl TerminalWorker {
     #[must_use]
     pub fn is_confirmed_live(&self) -> bool {
         self.confirmed_live.load(Ordering::Acquire)
+    }
+
+    /// Enable or suppress clipboard writes emitted by this presentation.
+    ///
+    /// Disabling also discards writes already queued for the UI while retaining
+    /// lifecycle and diagnostic events for normal processing.
+    pub fn set_clipboard_writes_enabled(&self, enabled: bool) {
+        self.clipboard_writes_enabled
+            .store(enabled, Ordering::Release);
+        if enabled {
+            return;
+        }
+        let mut deferred = self
+            .deferred_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        discard_clipboard_events(&self.events, &mut deferred);
     }
 
     /// Queue one neutral key or paste event for mode-aware encoding.
@@ -523,12 +547,32 @@ impl TerminalWorker {
     ///
     /// Returns an error after the terminal event channel has disconnected.
     pub fn try_event(&self) -> Result<Option<TerminalEvent>, WorkerError> {
+        if let Some(event) = self
+            .deferred_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front()
+        {
+            return Ok(Some(event));
+        }
         match self.events.try_recv() {
             Ok(event) => Ok(Some(event)),
             Err(TryRecvError::Empty) => Ok(None),
             Err(error @ TryRecvError::Disconnected) => {
                 Err(WorkerError::new("receive terminal event", error))
             }
+        }
+    }
+}
+
+fn discard_clipboard_events(
+    events: &Receiver<TerminalEvent>,
+    deferred: &mut VecDeque<TerminalEvent>,
+) {
+    deferred.retain(|event| !matches!(event, TerminalEvent::ClipboardWrite(_)));
+    while let Ok(event) = events.try_recv() {
+        if !matches!(event, TerminalEvent::ClipboardWrite(_)) {
+            deferred.push_back(event);
         }
     }
 }
@@ -599,6 +643,7 @@ fn run_worker(
     write_completions: &Receiver<WriterMessage>,
     events: &Sender<TerminalEvent>,
     confirmed_live: &AtomicBool,
+    clipboard_writes_enabled: &AtomicBool,
 ) {
     let mut report_exit = false;
     let mut observed_exit = None;
@@ -772,7 +817,9 @@ fn run_worker(
                         }
                     }
                     for write in output.clipboard_writes {
-                        if !emit_event(events, shutdown, TerminalEvent::ClipboardWrite(write)) {
+                        if clipboard_writes_enabled.load(Ordering::Acquire)
+                            && !emit_event(events, shutdown, TerminalEvent::ClipboardWrite(write))
+                        {
                             break 'worker;
                         }
                     }
@@ -1303,6 +1350,7 @@ mod tests {
     use input::{Modifiers, MouseAction, MouseButton, MouseInput, TerminalModes};
 
     use super::*;
+    use crate::ClipboardTarget;
 
     #[derive(Debug)]
     struct DropProbe(Arc<Mutex<Vec<&'static str>>>);
@@ -1314,6 +1362,30 @@ mod tests {
     }
 
     struct RecordingWriter(Arc<Mutex<Vec<&'static str>>>);
+
+    #[test]
+    fn hiding_a_presentation_discards_queued_clipboard_writes_only() {
+        let (sender, receiver) = bounded(4);
+        sender
+            .send(TerminalEvent::ClipboardWrite(ClipboardWrite {
+                target: ClipboardTarget::Clipboard,
+                text: "hidden".to_owned(),
+            }))
+            .expect("queue clipboard write");
+        sender
+            .send(TerminalEvent::Error("preserved".to_owned()))
+            .expect("queue diagnostic");
+        let mut deferred = VecDeque::new();
+
+        discard_clipboard_events(&receiver, &mut deferred);
+
+        assert!(matches!(
+            deferred.pop_front(),
+            Some(TerminalEvent::Error(error)) if error == "preserved"
+        ));
+        assert!(deferred.is_empty());
+        assert!(receiver.is_empty());
+    }
 
     impl Write for RecordingWriter {
         fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt;
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -30,10 +30,16 @@ const REAP_ATTEMPTS: usize = 20;
 const REAP_POLL_DELAY: Duration = Duration::from_millis(25);
 
 pub enum TerminalEvent {
-    ClipboardWrite(ClipboardWrite),
+    ClipboardWrite {
+        write: ClipboardWrite,
+        visibility: u64,
+    },
     ClipboardRead(ClipboardReadRequest),
     ConfirmPaste(EncodedInput),
-    Exited { code: u32, output_tail: String },
+    Exited {
+        code: u32,
+        output_tail: String,
+    },
     Error(String),
 }
 
@@ -220,7 +226,7 @@ pub struct TerminalWorker {
     deferred_events: Mutex<VecDeque<TerminalEvent>>,
     surface: Arc<SurfaceStore>,
     confirmed_live: Arc<AtomicBool>,
-    clipboard_writes_enabled: Arc<AtomicBool>,
+    clipboard_visibility: Arc<AtomicU64>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
@@ -347,8 +353,8 @@ impl TerminalWorker {
         let (write_complete_sender, write_complete_receiver) = bounded(1);
         let confirmed_live = Arc::new(AtomicBool::new(false));
         let worker_confirmed_live = Arc::clone(&confirmed_live);
-        let clipboard_writes_enabled = Arc::new(AtomicBool::new(true));
-        let worker_clipboard_writes_enabled = Arc::clone(&clipboard_writes_enabled);
+        let clipboard_visibility = Arc::new(AtomicU64::new(1));
+        let worker_clipboard_visibility = Arc::clone(&clipboard_visibility);
 
         thread::Builder::new()
             .name("ghosthub-pty-writer".to_owned())
@@ -380,7 +386,7 @@ impl TerminalWorker {
                     &write_complete_receiver,
                     &events_sender,
                     &worker_confirmed_live,
-                    &worker_clipboard_writes_enabled,
+                    &worker_clipboard_visibility,
                 );
             })
             .map_err(|error| WorkerError::new("spawn terminal worker", error))?;
@@ -395,7 +401,7 @@ impl TerminalWorker {
             deferred_events: Mutex::new(VecDeque::new()),
             surface,
             confirmed_live,
-            clipboard_writes_enabled,
+            clipboard_visibility,
             thread: Some(worker_thread),
         })
     }
@@ -421,8 +427,7 @@ impl TerminalWorker {
     /// Disabling also discards writes already queued for the UI while retaining
     /// lifecycle and diagnostic events for normal processing.
     pub fn set_clipboard_writes_enabled(&self, enabled: bool) {
-        self.clipboard_writes_enabled
-            .store(enabled, Ordering::Release);
+        advance_clipboard_visibility(&self.clipboard_visibility, enabled);
         if enabled {
             return;
         }
@@ -547,21 +552,54 @@ impl TerminalWorker {
     ///
     /// Returns an error after the terminal event channel has disconnected.
     pub fn try_event(&self) -> Result<Option<TerminalEvent>, WorkerError> {
-        if let Some(event) = self
-            .deferred_events
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .pop_front()
-        {
-            return Ok(Some(event));
-        }
-        match self.events.try_recv() {
-            Ok(event) => Ok(Some(event)),
-            Err(TryRecvError::Empty) => Ok(None),
-            Err(error @ TryRecvError::Disconnected) => {
-                Err(WorkerError::new("receive terminal event", error))
+        loop {
+            let deferred = self
+                .deferred_events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .pop_front();
+            let event = match deferred {
+                Some(event) => event,
+                None => match self.events.try_recv() {
+                    Ok(event) => event,
+                    Err(TryRecvError::Empty) => return Ok(None),
+                    Err(error @ TryRecvError::Disconnected) => {
+                        return Err(WorkerError::new("receive terminal event", error));
+                    }
+                },
+            };
+            if clipboard_event_is_visible(&event, self.clipboard_visibility.load(Ordering::Acquire))
+            {
+                return Ok(Some(event));
             }
         }
+    }
+}
+
+const fn clipboard_visibility_is_enabled(visibility: u64) -> bool {
+    visibility & 1 == 1
+}
+
+fn advance_clipboard_visibility(visibility: &AtomicU64, enabled: bool) -> u64 {
+    let mut current = visibility.load(Ordering::Acquire);
+    loop {
+        let next = (current.wrapping_add(2) & !1) | u64::from(enabled);
+        match visibility.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return next,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn clipboard_event_is_visible(event: &TerminalEvent, current_visibility: u64) -> bool {
+    match event {
+        TerminalEvent::ClipboardWrite { visibility, .. } => {
+            clipboard_visibility_is_enabled(current_visibility) && *visibility == current_visibility
+        }
+        TerminalEvent::ClipboardRead(_)
+        | TerminalEvent::ConfirmPaste(_)
+        | TerminalEvent::Exited { .. }
+        | TerminalEvent::Error(_) => true,
     }
 }
 
@@ -569,9 +607,9 @@ fn discard_clipboard_events(
     events: &Receiver<TerminalEvent>,
     deferred: &mut VecDeque<TerminalEvent>,
 ) {
-    deferred.retain(|event| !matches!(event, TerminalEvent::ClipboardWrite(_)));
+    deferred.retain(|event| !matches!(event, TerminalEvent::ClipboardWrite { .. }));
     while let Ok(event) = events.try_recv() {
-        if !matches!(event, TerminalEvent::ClipboardWrite(_)) {
+        if !matches!(event, TerminalEvent::ClipboardWrite { .. }) {
             deferred.push_back(event);
         }
     }
@@ -643,7 +681,7 @@ fn run_worker(
     write_completions: &Receiver<WriterMessage>,
     events: &Sender<TerminalEvent>,
     confirmed_live: &AtomicBool,
-    clipboard_writes_enabled: &AtomicBool,
+    clipboard_visibility: &AtomicU64,
 ) {
     let mut report_exit = false;
     let mut observed_exit = None;
@@ -817,8 +855,13 @@ fn run_worker(
                         }
                     }
                     for write in output.clipboard_writes {
-                        if clipboard_writes_enabled.load(Ordering::Acquire)
-                            && !emit_event(events, shutdown, TerminalEvent::ClipboardWrite(write))
+                        let visibility = clipboard_visibility.load(Ordering::Acquire);
+                        if clipboard_visibility_is_enabled(visibility)
+                            && !emit_event(
+                                events,
+                                shutdown,
+                                TerminalEvent::ClipboardWrite { write, visibility },
+                            )
                         {
                             break 'worker;
                         }
@@ -1367,10 +1410,13 @@ mod tests {
     fn hiding_a_presentation_discards_queued_clipboard_writes_only() {
         let (sender, receiver) = bounded(4);
         sender
-            .send(TerminalEvent::ClipboardWrite(ClipboardWrite {
-                target: ClipboardTarget::Clipboard,
-                text: "hidden".to_owned(),
-            }))
+            .send(TerminalEvent::ClipboardWrite {
+                write: ClipboardWrite {
+                    target: ClipboardTarget::Clipboard,
+                    text: "hidden".to_owned(),
+                },
+                visibility: 1,
+            })
             .expect("queue clipboard write");
         sender
             .send(TerminalEvent::Error("preserved".to_owned()))
@@ -1385,6 +1431,34 @@ mod tests {
         ));
         assert!(deferred.is_empty());
         assert!(receiver.is_empty());
+    }
+
+    #[test]
+    fn clipboard_visibility_rejects_writes_enqueued_after_hiding() {
+        let visibility = AtomicU64::new(1);
+        let stale = TerminalEvent::ClipboardWrite {
+            write: ClipboardWrite {
+                target: ClipboardTarget::Clipboard,
+                text: "stale".to_owned(),
+            },
+            visibility: visibility.load(Ordering::Acquire),
+        };
+
+        let hidden = advance_clipboard_visibility(&visibility, false);
+        assert!(!clipboard_event_is_visible(&stale, hidden));
+
+        let visible_again = advance_clipboard_visibility(&visibility, true);
+        assert!(!clipboard_event_is_visible(&stale, visible_again));
+        assert!(clipboard_event_is_visible(
+            &TerminalEvent::ClipboardWrite {
+                write: ClipboardWrite {
+                    target: ClipboardTarget::Clipboard,
+                    text: "current".to_owned(),
+                },
+                visibility: visible_again,
+            },
+            visible_again,
+        ));
     }
 
     impl Write for RecordingWriter {

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1665,6 +1665,7 @@ impl RootView {
                 session_index,
                 &session.selection,
                 session.active,
+                session.show_endpoint,
                 cx,
             ));
         }
@@ -1716,6 +1717,7 @@ impl RootView {
         index: usize,
         selection: &SessionSelection,
         is_active: bool,
+        show_endpoint: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let selection = selection.clone();
@@ -1753,6 +1755,15 @@ impl RootView {
                     .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
                     .child(name.clone()),
             );
+        if show_endpoint {
+            row = row.child(
+                div()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(0x73_7a87))
+                    .child(format!("· {}", selection.endpoint())),
+            );
+        }
         if is_active {
             row = row.child(
                 div()
@@ -1984,6 +1995,7 @@ fn terminal_presentation_id(content: &WorkspaceContent) -> Option<u64> {
 struct TreeSession {
     selection: SessionSelection,
     active: bool,
+    show_endpoint: bool,
 }
 
 fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelection> {
@@ -2037,6 +2049,7 @@ fn tree_sessions(
         .into_iter()
         .map(|selection| TreeSession {
             active: active.as_ref() == Some(&selection),
+            show_endpoint: selection.endpoint() != host.endpoint(),
             selection,
         })
         .collect()
@@ -2641,8 +2654,30 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].selection.endpoint(), "Debian");
         assert!(!rows[0].active);
+        assert!(!rows[0].show_endpoint);
         assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
         assert!(rows[1].active);
+        assert!(rows[1].show_endpoint);
+    }
+
+    #[test]
+    fn retained_session_from_a_previous_default_distro_is_endpoint_qualified() {
+        let host = HostItem::wsl(
+            "Debian",
+            None,
+            HostConnectionState::Ready,
+            vec![SessionItem::new("demo", 0)],
+            None,
+        );
+        let retained = vec![SessionSelection::new("wsl", "Ubuntu", "demo")];
+
+        let rows = tree_sessions(&host, &WorkspaceContent::Shell, &retained);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].selection.endpoint(), "Debian");
+        assert!(!rows[0].show_endpoint);
+        assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
+        assert!(rows[1].show_endpoint);
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1463,6 +1463,7 @@ impl RootView {
                 host,
                 snapshot.selected_host() == Some(host.id()),
                 snapshot.content(),
+                snapshot.retained_selections(),
                 cx,
             ));
         }
@@ -1499,6 +1500,7 @@ impl RootView {
         host: &HostItem,
         is_selected: bool,
         content: &WorkspaceContent,
+        retained: &[SessionSelection],
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let mut host_tree =
@@ -1538,7 +1540,7 @@ impl RootView {
             HostConnectionState::Ready => {}
         }
 
-        let sessions = tree_sessions(host, content);
+        let sessions = tree_sessions(host, content, retained);
         if host.connection() == HostConnectionState::Ready || !sessions.is_empty() {
             host_tree = host_tree.child(Self::session_tree(host_index, &sessions, cx));
         }
@@ -2004,40 +2006,40 @@ fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelecti
     }
 }
 
-fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession> {
+fn tree_sessions(
+    host: &HostItem,
+    content: &WorkspaceContent,
+    retained: &[SessionSelection],
+) -> Vec<TreeSession> {
     let active = active_session_selection(content);
     let active_for_host = active
         .as_ref()
         .filter(|active| active.host_id() == host.id());
-    if host.connection() != HostConnectionState::Ready {
-        return active_for_host.map_or_else(Vec::new, |active| {
-            vec![TreeSession {
-                selection: active.clone(),
-                active: true,
-            }]
-        });
-    }
 
-    let mut sessions = host
-        .sessions()
+    let mut selections = if host.connection() == HostConnectionState::Ready {
+        host.sessions()
+            .iter()
+            .map(|session| SessionSelection::new(host.id(), host.endpoint(), session.name()))
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    for selection in retained
         .iter()
-        .map(|session| {
-            let selection = SessionSelection::new(host.id(), host.endpoint(), session.name());
-            TreeSession {
-                active: active.as_ref() == Some(&selection),
-                selection,
-            }
-        })
-        .collect::<Vec<_>>();
-    if let Some(active) = active_for_host
-        && !sessions.iter().any(|session| session.active)
+        .filter(|selection| selection.host_id() == host.id())
+        .chain(active_for_host)
     {
-        sessions.push(TreeSession {
-            selection: active.clone(),
-            active: true,
-        });
+        if !selections.contains(selection) {
+            selections.push(selection.clone());
+        }
     }
-    sessions
+    selections
+        .into_iter()
+        .map(|selection| TreeSession {
+            active: active.as_ref() == Some(&selection),
+            selection,
+        })
+        .collect()
 }
 
 fn workspace_window_title(content: &WorkspaceContent) -> String {
@@ -2610,7 +2612,7 @@ mod tests {
                 None,
             );
 
-            let rows = tree_sessions(&host, &terminal);
+            let rows = tree_sessions(&host, &terminal, &[]);
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].selection.session(), "demo");
             assert!(rows[0].active);
@@ -2635,12 +2637,34 @@ mod tests {
             None,
         );
 
-        let rows = tree_sessions(&host, &terminal);
+        let rows = tree_sessions(&host, &terminal, &[]);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].selection.endpoint(), "Debian");
         assert!(!rows[0].active);
         assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
         assert!(rows[1].active);
+    }
+
+    #[test]
+    fn retained_sessions_stay_in_the_tree_while_the_host_is_unavailable() {
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Unavailable,
+            Vec::new(),
+            None,
+        );
+        let retained = vec![
+            SessionSelection::new("wsl", "Ubuntu", "one"),
+            SessionSelection::new("wsl", "Ubuntu", "two"),
+        ];
+
+        let rows = tree_sessions(&host, &WorkspaceContent::Shell, &retained);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].selection.session(), "one");
+        assert_eq!(rows[1].selection.session(), "two");
+        assert!(rows.iter().all(|row| !row.active));
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1662,7 +1662,6 @@ impl RootView {
                 host_index,
                 session_index,
                 &session.selection,
-                session.attached_clients,
                 session.active,
                 cx,
             ));
@@ -1714,13 +1713,11 @@ impl RootView {
         host_index: usize,
         index: usize,
         selection: &SessionSelection,
-        attached_clients: Option<u32>,
         is_active: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let selection = selection.clone();
         let name = selection.session().to_owned();
-        let detail = session_status_label(attached_clients, is_active);
         let mut row = div()
             .id((
                 gpui::ElementId::named_usize("tree-session-host", host_index),
@@ -1752,13 +1749,6 @@ impl RootView {
                     .text_sm()
                     .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
                     .child(name.clone()),
-            )
-            .child(
-                div()
-                    .flex_none()
-                    .text_xs()
-                    .text_color(rgb(if is_active { 0xa9_c9_ea } else { 0x6f_7682 }))
-                    .child(detail),
             );
         if is_active {
             row = row.child(
@@ -1777,6 +1767,14 @@ impl RootView {
                         this.detach(cx);
                         cx.stop_propagation();
                     })),
+            );
+        } else {
+            row = row.child(
+                div()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(0x79_aee3))
+                    .child("Open"),
             );
         }
         row.on_click(cx.listener(move |this, _, window, cx| {
@@ -1969,21 +1967,7 @@ fn terminal_presentation_id(content: &WorkspaceContent) -> Option<u64> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TreeSession {
     selection: SessionSelection,
-    attached_clients: Option<u32>,
     active: bool,
-}
-
-fn session_status_label(attached_clients: Option<u32>, is_active: bool) -> String {
-    if is_active {
-        "open".to_owned()
-    } else {
-        match attached_clients {
-            Some(0) => "detached".to_owned(),
-            Some(1) => "1 client".to_owned(),
-            Some(count) => format!("{count} clients"),
-            None => "unknown".to_owned(),
-        }
-    }
 }
 
 fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelection> {
@@ -2013,16 +1997,8 @@ fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession
         .filter(|active| active.host_id() == host.id());
     if host.connection() != HostConnectionState::Ready {
         return active_for_host.map_or_else(Vec::new, |active| {
-            let attached_clients = host
-                .sessions()
-                .iter()
-                .find(|session| {
-                    host.endpoint() == active.endpoint() && session.name() == active.session()
-                })
-                .map(workspace::SessionItem::attached_clients);
             vec![TreeSession {
                 selection: active.clone(),
-                attached_clients,
                 active: true,
             }]
         });
@@ -2036,7 +2012,6 @@ fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession
             TreeSession {
                 active: active.as_ref() == Some(&selection),
                 selection,
-                attached_clients: Some(session.attached_clients()),
             }
         })
         .collect::<Vec<_>>();
@@ -2045,7 +2020,6 @@ fn tree_sessions(host: &HostItem, content: &WorkspaceContent) -> Vec<TreeSession
     {
         sessions.push(TreeSession {
             selection: active.clone(),
-            attached_clients: None,
             active: true,
         });
     }
@@ -2498,9 +2472,9 @@ mod tests {
         active_session_selection, clear_terminal_input_state, clears_after_input_delivery,
         clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
         input_queue_has_capacity, named_key, normalize_cell_width,
-        queued_input_matches_presentation, session_status_label, terminal_cell_at_with_offset,
-        terminal_key_input, terminal_line_height, terminal_wheel_steps, transitioned_presentation,
-        tree_sessions, workspace_window_title,
+        queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
+        workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -2627,15 +2601,6 @@ mod tests {
             assert_eq!(rows[0].selection.session(), "demo");
             assert!(rows[0].active);
         }
-    }
-
-    #[test]
-    fn session_status_is_compact_and_explicit() {
-        assert_eq!(session_status_label(Some(0), false), "detached");
-        assert_eq!(session_status_label(Some(1), false), "1 client");
-        assert_eq!(session_status_label(Some(3), false), "3 clients");
-        assert_eq!(session_status_label(None, false), "unknown");
-        assert_eq!(session_status_label(Some(3), true), "open");
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -847,17 +847,17 @@ impl RootView {
         }
         if let Some(button) = terminal_mouse_button(event.button) {
             let cell = self.terminal_cell_at(event.position.x.into(), event.position.y.into());
-            if let Some(cell) = self.pointer.release_cell(button, cell)
-                && self.send_mouse_at_cell(
+            if let Some(cell) = self.pointer.release_cell(button, cell) {
+                if self.send_mouse_at_cell(
                     presentation_id,
                     MouseAction::Release(button),
                     cell,
                     event.modifiers,
-                )
-            {
-                self.pointer.finish_release(button);
+                ) {
+                    self.pointer.finish_release(button);
+                }
+                cx.stop_propagation();
             }
-            cx.stop_propagation();
         }
     }
 
@@ -1717,6 +1717,7 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let selection = selection.clone();
+        let open_selection = selection.clone();
         let name = selection.session().to_owned();
         let mut row = div()
             .id((
@@ -1771,10 +1772,23 @@ impl RootView {
         } else {
             row = row.child(
                 div()
+                    .id((
+                        gpui::ElementId::named_usize("open-tree-session-host", host_index),
+                        index.to_string(),
+                    ))
                     .flex_none()
+                    .px_1()
+                    .py_1()
+                    .rounded_sm()
+                    .cursor_pointer()
                     .text_xs()
                     .text_color(rgb(0x79_aee3))
-                    .child("Open"),
+                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xb6_d8_f8)))
+                    .child("Open")
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.select_session(&open_selection, window, cx);
+                        cx.stop_propagation();
+                    })),
             );
         }
         row.on_click(cx.listener(move |this, _, window, cx| {

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -19,7 +19,10 @@ use workspace::{
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
-const APP_NAVIGATION_WIDTH: f32 = 280.0;
+const APP_NAVIGATION_WIDTH: f32 = 260.0;
+const NAVIGATION_HEADER_HEIGHT: f32 = 36.0;
+const HOST_ROW_HEIGHT: f32 = 42.0;
+const SESSION_ROW_HEIGHT: f32 = 30.0;
 const CELL_LINE_GAP: f32 = 4.0;
 const UI_INPUT_CAPACITY: usize = 512;
 const MOUSE_RELEASE_RESERVE: usize = 3;
@@ -1475,15 +1478,15 @@ impl RootView {
             .border_color(rgb(0x25_2932))
             .child(
                 div()
-                    .h(px(44.0))
+                    .h(px(NAVIGATION_HEADER_HEIGHT))
                     .flex_none()
                     .flex()
                     .items_center()
-                    .px_3()
+                    .px_2()
                     .border_b_1()
                     .border_color(rgb(0x1d_2028))
                     .text_xs()
-                    .font_weight(FontWeight::BOLD)
+                    .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(0xa5_ac_b8))
                     .child("WORKSPACES"),
             )
@@ -1556,14 +1559,27 @@ impl RootView {
         };
         let mut host_header = div()
             .id(("host", host_index))
-            .h(px(46.0))
+            .h(px(HOST_ROW_HEIGHT))
             .flex()
             .items_center()
-            .gap_2()
-            .px_3()
+            .gap_1()
+            .px_2()
             .bg(rgb(if is_selected { 0x16_1920 } else { 0x0f_1116 }))
-            .child(div().text_color(rgb(0x6f_7682)).child("▾"))
-            .child(div().text_color(rgb(status_color)).child("●"))
+            .child(
+                div()
+                    .w(px(12.0))
+                    .flex_none()
+                    .text_center()
+                    .text_color(rgb(0x6f_7682))
+                    .child("▾"),
+            )
+            .child(
+                div()
+                    .size(px(7.0))
+                    .flex_none()
+                    .rounded_full()
+                    .bg(rgb(status_color)),
+            )
             .child(
                 div()
                     .min_w_0()
@@ -1574,7 +1590,7 @@ impl RootView {
                         div()
                             .truncate()
                             .text_sm()
-                            .font_weight(FontWeight::BOLD)
+                            .font_weight(FontWeight::SEMIBOLD)
                             .text_color(rgb(0xd2_d7_df))
                             .child(host.name().to_owned()),
                     )
@@ -1591,14 +1607,16 @@ impl RootView {
                 div()
                     .id(("refresh-host", host_index))
                     .flex_none()
-                    .px_2()
-                    .py_1()
+                    .size(px(24.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
                     .rounded_sm()
                     .cursor_pointer()
                     .text_xs()
                     .text_color(rgb(0x8f_96_a3))
                     .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
-                    .child("Refresh")
+                    .child("↻")
                     .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
             );
         }
@@ -1610,23 +1628,30 @@ impl RootView {
         sessions: &[TreeSession],
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let mut tree = div().flex().flex_col().child(
-            div()
-                .h(px(28.0))
-                .flex()
-                .items_center()
-                .pl(px(35.0))
-                .text_xs()
-                .font_weight(FontWeight::BOLD)
-                .text_color(rgb(0x73_7a87))
-                .child("TMUX SESSIONS"),
-        );
+        let mut tree = div()
+            .ml(px(18.0))
+            .border_l_1()
+            .border_color(rgb(0x25_2932))
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .h(px(24.0))
+                    .flex()
+                    .items_center()
+                    .pl(px(17.0))
+                    .text_xs()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(rgb(0x73_7a87))
+                    .child("TMUX SESSIONS"),
+            );
         if sessions.is_empty() {
             tree = tree.child(
                 div()
-                    .px_3()
-                    .pl(px(51.0))
-                    .py_2()
+                    .h(px(SESSION_ROW_HEIGHT))
+                    .flex()
+                    .items_center()
+                    .pl(px(31.0))
                     .text_xs()
                     .text_color(rgb(0x73_7a87))
                     .child("No sessions"),
@@ -1695,51 +1720,45 @@ impl RootView {
     ) -> gpui::AnyElement {
         let selection = selection.clone();
         let name = selection.session().to_owned();
-        let detail = if is_active {
-            "open".to_owned()
-        } else if attached_clients == Some(0) {
-            "detached".to_owned()
-        } else if attached_clients == Some(1) {
-            "1 client".to_owned()
-        } else {
-            format!("{} clients", attached_clients.unwrap_or_default())
-        };
+        let detail = session_status_label(attached_clients, is_active);
         let mut row = div()
             .id((
                 gpui::ElementId::named_usize("tree-session-host", host_index),
                 index.to_string(),
             ))
-            .mx_2()
-            .h(px(40.0))
+            .mr_1()
+            .h(px(SESSION_ROW_HEIGHT))
             .flex()
             .items_center()
-            .gap_2()
-            .pl(px(27.0))
+            .gap_1()
+            .pl(px(14.0))
             .pr_2()
-            .rounded_sm()
             .cursor_pointer()
             .bg(rgb(if is_active { 0x13_3d6a } else { 0x0f_1116 }))
             .hover(|style| style.bg(rgb(if is_active { 0x17_477a } else { 0x1b_1f27 })))
-            .child(div().flex_none().text_color(rgb(0x7f_8794)).child("›_"))
+            .child(
+                div()
+                    .w(px(18.0))
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(if is_active { 0x9d_c7ed } else { 0x7f_8794 }))
+                    .child(">_"),
+            )
             .child(
                 div()
                     .min_w_0()
                     .flex_1()
-                    .flex()
-                    .flex_col()
-                    .child(
-                        div()
-                            .truncate()
-                            .text_sm()
-                            .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
-                            .child(name.clone()),
-                    )
-                    .child(
-                        div()
-                            .text_xs()
-                            .text_color(rgb(if is_active { 0xa9_c9_ea } else { 0x6f_7682 }))
-                            .child(detail),
-                    ),
+                    .truncate()
+                    .text_sm()
+                    .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
+                    .child(name.clone()),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(if is_active { 0xa9_c9_ea } else { 0x6f_7682 }))
+                    .child(detail),
             );
         if is_active {
             row = row.child(
@@ -1952,6 +1971,19 @@ struct TreeSession {
     selection: SessionSelection,
     attached_clients: Option<u32>,
     active: bool,
+}
+
+fn session_status_label(attached_clients: Option<u32>, is_active: bool) -> String {
+    if is_active {
+        "open".to_owned()
+    } else {
+        match attached_clients {
+            Some(0) => "detached".to_owned(),
+            Some(1) => "1 client".to_owned(),
+            Some(count) => format!("{count} clients"),
+            None => "unknown".to_owned(),
+        }
+    }
 }
 
 fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelection> {
@@ -2466,9 +2498,9 @@ mod tests {
         active_session_selection, clear_terminal_input_state, clears_after_input_delivery,
         clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
         input_queue_has_capacity, named_key, normalize_cell_width,
-        queued_input_matches_presentation, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
-        workspace_window_title,
+        queued_input_matches_presentation, session_status_label, terminal_cell_at_with_offset,
+        terminal_key_input, terminal_line_height, terminal_wheel_steps, transitioned_presentation,
+        tree_sessions, workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -2595,6 +2627,15 @@ mod tests {
             assert_eq!(rows[0].selection.session(), "demo");
             assert!(rows[0].active);
         }
+    }
+
+    #[test]
+    fn session_status_is_compact_and_explicit() {
+        assert_eq!(session_status_label(Some(0), false), "detached");
+        assert_eq!(session_status_label(Some(1), false), "1 client");
+        assert_eq!(session_status_label(Some(3), false), "3 clients");
+        assert_eq!(session_status_label(None, false), "unknown");
+        assert_eq!(session_status_label(Some(3), true), "open");
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -598,6 +598,7 @@ impl<T> AttachmentState<T> {
         }
     }
 
+    #[cfg(test)]
     fn reserve(&mut self, request: T, term: AttachTerm) -> Option<u64> {
         self.reserve_with_fallback(request, term, None)
     }
@@ -1338,7 +1339,9 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .contains(&key);
-        let previous = self.retain_active_presentation()?;
+        let in_flight_fallback = self.supersede_inflight_attachment()?;
+        let visible_previous = self.retain_active_presentation()?;
+        let previous = in_flight_fallback.or(visible_previous);
         match self.activate_retained_presentation(&key) {
             Ok(true) => return Ok(()),
             Ok(false) => {}
@@ -1358,6 +1361,33 @@ impl Workspace {
             ));
         }
         self.start_attachment(request, previous)
+    }
+
+    fn supersede_inflight_attachment(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let attaching = matches!(
+            *self
+                .inner
+                .state
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            WorkspaceContent::Attaching { .. }
+        );
+        if !attaching {
+            return Ok(None);
+        }
+        let active = attachment.take_active().ok_or_else(|| {
+            WorkspaceError::new("the in-flight terminal presentation is not available")
+        })?;
+        let fallback = active.fallback;
+        drop(attachment);
+        clear_pending_paste(&self.inner);
+        self.restore_inventory_state();
+        Ok(fallback)
     }
 
     fn retain_active_presentation(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -2074,13 +2104,13 @@ fn activate_retained_presentation(
         .terminal_geometry
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let request = presentation.attachment.request.clone();
     let term = presentation.attachment.term;
     let mut attachment = inner
         .attachment
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let Some(generation) = attachment.reserve(request, term) else {
+    let Some(generation) = reserve_retained_attachment(&mut attachment, &presentation.attachment)
+    else {
         drop(attachment);
         reinsert_retained_presentation(inner, presentation);
         return Err(WorkspaceError::new(
@@ -2135,6 +2165,17 @@ fn activate_retained_presentation(
         },
     );
     Ok(true)
+}
+
+fn reserve_retained_attachment(
+    state: &mut AttachmentState<AttachRequest>,
+    retained: &ActiveAttachment<AttachRequest>,
+) -> Option<u64> {
+    state.reserve_with_fallback(
+        retained.request.clone(),
+        retained.term,
+        retained.fallback.clone(),
+    )
 }
 
 fn reinsert_retained_presentation(
@@ -2408,7 +2449,7 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
         }
         Err(AttachFreshError::SessionChanged { error, snapshot }) => {
             let fallback = take_failed_retained_retry(inner, &retry.key);
-            publish_stale_attachment_failure(inner, &retry.request, snapshot, &error);
+            publish_retained_stale_failure(inner, &retry.request, snapshot, &error);
             restore_retry_fallback_if_idle(inner, fallback);
         }
     }
@@ -2498,6 +2539,18 @@ fn publish_stale_attachment_failure(
 ) {
     clear_pending_paste(inner);
     restore_presentation_inventory(inner);
+    publish_refresh(inner, request.inventory_generation, || {
+        set_local_notice(inner, error.to_string());
+        set_attach_inventory(inner, request, snapshot);
+    });
+}
+
+fn publish_retained_stale_failure(
+    inner: &Inner,
+    request: &AttachRequest,
+    snapshot: HostSnapshot,
+    error: &WorkspaceError,
+) {
     publish_refresh(inner, request.inventory_generation, || {
         set_local_notice(inner, error.to_string());
         set_attach_inventory(inner, request, snapshot);
@@ -3091,6 +3144,93 @@ mod tests {
     }
 
     #[test]
+    fn retained_stale_failure_preserves_the_visible_terminal_and_pending_input() {
+        let executable = WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+            .expect("absolute WSL path");
+        let config = WslConfig::with_distro("Ubuntu").expect("valid config");
+        let workspace = Workspace::application(
+            TerminalAppearance::default(),
+            Some(WslHostSpec::available(config.clone(), executable.clone())),
+        );
+        let host = WslHost::new(
+            config,
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            executable,
+        );
+        let original = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "hidden",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        );
+        *workspace
+            .inner
+            .host
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Published::new(
+            HostContext {
+                host,
+                snapshot: original,
+            },
+            0,
+        ));
+        let request = capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", "hidden"),
+        )
+        .expect("hidden attach request");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "visible".to_owned(),
+                presentation_id: 9,
+                surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(
+                    1,
+                    GridSize::new(80, 24).expect("valid grid"),
+                ))),
+            },
+        );
+        *workspace.inner.pending_paste.lock().expect("pending paste") = Some(PendingPaste {
+            worker_generation: 7,
+            input: input::encode_input(
+                &KeyInput::paste("pending\ninput"),
+                input::TerminalModes::default(),
+            ),
+        });
+        let replacement = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+
+        publish_retained_stale_failure(
+            &workspace.inner,
+            &request,
+            replacement,
+            &WorkspaceError::new("hidden session changed"),
+        );
+
+        let snapshot = workspace.snapshot();
+        assert!(matches!(
+            snapshot.content(),
+            WorkspaceContent::Terminal { session, presentation_id, .. }
+                if session == "visible" && *presentation_id == 9
+        ));
+        assert!(
+            workspace
+                .inner
+                .pending_paste
+                .lock()
+                .expect("pending paste")
+                .is_some()
+        );
+        assert_eq!(snapshot.notice(), Some("hidden session changed"));
+        assert!(snapshot.hosts()[0].sessions().is_empty());
+    }
+
+    #[test]
     fn legacy_attachment_failure_remains_top_level() {
         let workspace = Workspace::preview(WorkspaceSnapshot::ready(
             Appearance::default(),
@@ -3196,6 +3336,26 @@ mod tests {
             retained.restarting[0].attachment.fallback.as_ref(),
             Some(&fallback)
         );
+
+        let mut restored_attachment = AttachmentState::new();
+        let restored_generation = reserve_retained_attachment(
+            &mut restored_attachment,
+            &retained.restarting[0].attachment,
+        )
+        .expect("reactivate retained attachment");
+        let mut restored_worker = WorkerState::new();
+        let worker_generation = restored_worker.publish(());
+        let fallback_after_reactivation =
+            restored_attachment.fallback_if_current(restored_generation);
+
+        assert!(claim_terminal_exit(
+            &mut restored_attachment,
+            &mut restored_worker,
+            restored_generation,
+            worker_generation,
+            false,
+        ));
+        assert_eq!(fallback_after_reactivation.as_ref(), Some(&fallback));
     }
 
     #[test]
@@ -3887,6 +4047,106 @@ mod tests {
                 .is_err(),
             "an equal name on a different endpoint is not the active selection"
         );
+    }
+
+    #[test]
+    fn a_different_selection_supersedes_an_inflight_attachment_and_carries_its_fallback() {
+        let executable = WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+            .expect("absolute WSL path");
+        let config = WslConfig::with_distro("Ubuntu").expect("valid config");
+        let workspace = Workspace::application(
+            TerminalAppearance::default(),
+            Some(WslHostSpec::available(config.clone(), executable.clone())),
+        );
+        let host = WslHost::new(
+            config,
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            executable,
+        );
+        let snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![
+                session::DiscoveredSession::new(
+                    "opening",
+                    session::SessionIdentity::new(100, "$1", 200),
+                    0,
+                ),
+                session::DiscoveredSession::new(
+                    "selected",
+                    session::SessionIdentity::new(100, "$2", 201),
+                    0,
+                ),
+            ],
+        );
+        *workspace
+            .inner
+            .host
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Published::new(
+            HostContext {
+                host,
+                snapshot: snapshot.clone(),
+            },
+            0,
+        ));
+        set_inventory_state(&workspace.inner, ready_content(&snapshot));
+        let opening = capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", "opening"),
+        )
+        .expect("opening request");
+        let selected = capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", "selected"),
+        )
+        .expect("selected request");
+        let fallback = PresentationKey {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            socket_directory: None,
+            session: "previous".to_owned(),
+            identity: session::SessionIdentity::new(100, "$3", 202),
+        };
+        workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve_with_fallback(opening, AttachTerm::Xterm256Color, Some(fallback.clone()))
+            .expect("reserve opening attachment");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "opening".to_owned(),
+            },
+        );
+
+        let carried_fallback = workspace
+            .supersede_inflight_attachment()
+            .expect("supersede opening attachment");
+        let selected_generation = workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve_with_fallback(selected, AttachTerm::Xterm256Color, carried_fallback)
+            .expect("reserve selected attachment");
+
+        let attachment = workspace.inner.attachment.lock().expect("attachment");
+        let active = attachment.active().expect("selected attachment active");
+        assert_eq!(active.request.name, "selected");
+        assert_eq!(
+            attachment.fallback_if_current(selected_generation).as_ref(),
+            Some(&fallback)
+        );
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { .. } | WorkspaceContent::Shell
+        ));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -359,6 +359,8 @@ pub enum WorkspaceEvent {
 }
 
 const MAX_EVENTS_PER_DRAIN: usize = 32;
+const RETAINED_EVENT_RESERVE: usize = 8;
+const ACTIVE_EVENT_BUDGET: usize = MAX_EVENTS_PER_DRAIN - RETAINED_EVENT_RESERVE;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WorkspaceError {
@@ -970,7 +972,9 @@ impl RetainedPresentations<TerminalWorker> {
         while index < self.entries.len() && processed < budget {
             let confirmed = self.entries[index].worker.is_confirmed_live();
             match self.entries[index].worker.try_event() {
-                Ok(Some(TerminalEvent::ClipboardWrite(_) | TerminalEvent::ClipboardRead(_))) => {
+                Ok(Some(
+                    TerminalEvent::ClipboardWrite { .. } | TerminalEvent::ClipboardRead(_),
+                )) => {
                     processed += 1;
                     index += 1;
                 }
@@ -1385,17 +1389,14 @@ impl Workspace {
             ));
         }
         let navigation_generation = self.begin_navigation();
-        if let Some(key) = self.retained_key_for_selection(selection) {
-            if self.activate_retained_presentation(&key, None)? {
-                return Ok(());
-            }
-            return Err(WorkspaceError::new(
+        let (key, request) = self.navigation_target(selection)?;
+        match request {
+            None if self.activate_retained_presentation(&key, None)? => Ok(()),
+            None => Err(WorkspaceError::new(
                 "the retained terminal presentation is no longer available",
-            ));
+            )),
+            Some(request) => self.start_attachment(request, None, navigation_generation),
         }
-
-        let request = capture_attach_request(&self.inner, selection)?;
-        self.start_attachment(request, None, navigation_generation)
     }
 
     /// Select another presentation, retaining the current ordinary tmux client.
@@ -1436,12 +1437,7 @@ impl Workspace {
             return Ok(());
         }
 
-        let (key, request) = if let Some(key) = self.retained_key_for_selection(selection) {
-            (key, None)
-        } else {
-            let request = capture_attach_request(&self.inner, selection)?;
-            (request.presentation_key(), Some(request))
-        };
+        let (key, request) = self.navigation_target(selection)?;
         if self
             .inner
             .attachment
@@ -1509,6 +1505,14 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .key_for_selection(selection)
+    }
+
+    fn navigation_target(
+        &self,
+        selection: &SessionSelection,
+    ) -> Result<(PresentationKey, Option<AttachRequest>), WorkspaceError> {
+        let retained = self.retained_key_for_selection(selection);
+        choose_navigation_target(retained, capture_attach_request(&self.inner, selection))
     }
 
     fn supersede_inflight_attachment(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -1879,14 +1883,14 @@ impl Workspace {
         let mut exit_error = None;
         let mut retry_term = false;
         let mut processed = 0;
-        for _ in 0..MAX_EVENTS_PER_DRAIN {
+        for _ in 0..ACTIVE_EVENT_BUDGET {
             let Some((event, source_worker_generation, client_confirmed_live)) =
                 self.next_terminal_event()
             else {
                 break;
             };
             match event {
-                Ok(Some(TerminalEvent::ClipboardWrite(write))) => {
+                Ok(Some(TerminalEvent::ClipboardWrite { write, .. })) => {
                     processed += 1;
                     emitted.push(WorkspaceEvent::ClipboardWrite {
                         text: write.text,
@@ -1958,9 +1962,13 @@ impl Workspace {
                 &mut emitted,
             );
         }
+        let active_processed = processed;
         let retained_budget = retained_event_budget(processed, exited);
-        processed += self.drain_retained_events(retained_budget, &mut emitted);
-        (emitted, event_drain_may_have_more(processed, exited))
+        let retained_processed = self.drain_retained_events(retained_budget, &mut emitted);
+        let may_have_more =
+            event_source_may_have_more(active_processed, ACTIVE_EVENT_BUDGET, exited)
+                || event_source_may_have_more(retained_processed, retained_budget, false);
+        (emitted, may_have_more)
     }
 
     fn next_terminal_event(
@@ -2392,8 +2400,8 @@ fn reinsert_retained_presentation(
         .insert(presentation);
 }
 
-const fn event_drain_may_have_more(processed: usize, exited: bool) -> bool {
-    !exited && processed == MAX_EVENTS_PER_DRAIN
+const fn event_source_may_have_more(processed: usize, budget: usize, exited: bool) -> bool {
+    budget > 0 && !exited && processed == budget
 }
 
 const fn retained_event_budget(processed: usize, exited: bool) -> usize {
@@ -2444,6 +2452,23 @@ fn capture_attach_request(
             inventory_generation,
         })
     })
+}
+
+fn choose_navigation_target(
+    retained: Option<PresentationKey>,
+    current: Result<AttachRequest, WorkspaceError>,
+) -> Result<(PresentationKey, Option<AttachRequest>), WorkspaceError> {
+    match current {
+        Ok(request) => {
+            let key = request.presentation_key();
+            if retained.as_ref() == Some(&key) {
+                Ok((key, None))
+            } else {
+                Ok((key, Some(request)))
+            }
+        }
+        Err(error) => retained.map_or(Err(error), |key| Ok((key, None))),
+    }
 }
 
 fn begin_refresh(inner: &Inner, cancellation: &CancellationToken) -> u64 {
@@ -3442,10 +3467,27 @@ mod tests {
     }
 
     #[test]
-    fn terminal_event_drain_requests_continuation_only_after_exhausting_its_budget() {
-        assert!(!event_drain_may_have_more(MAX_EVENTS_PER_DRAIN - 1, false));
-        assert!(event_drain_may_have_more(MAX_EVENTS_PER_DRAIN, false));
-        assert!(!event_drain_may_have_more(MAX_EVENTS_PER_DRAIN, true));
+    fn terminal_event_drain_reserves_progress_for_retained_workers() {
+        assert_eq!(ACTIVE_EVENT_BUDGET, MAX_EVENTS_PER_DRAIN - 8);
+        assert_eq!(
+            retained_event_budget(ACTIVE_EVENT_BUDGET, false),
+            RETAINED_EVENT_RESERVE
+        );
+        assert!(!event_source_may_have_more(
+            ACTIVE_EVENT_BUDGET - 1,
+            ACTIVE_EVENT_BUDGET,
+            false
+        ));
+        assert!(event_source_may_have_more(
+            ACTIVE_EVENT_BUDGET,
+            ACTIVE_EVENT_BUDGET,
+            false
+        ));
+        assert!(!event_source_may_have_more(
+            ACTIVE_EVENT_BUDGET,
+            ACTIVE_EVENT_BUDGET,
+            true
+        ));
     }
 
     #[test]
@@ -3885,6 +3927,32 @@ mod tests {
 
         assert_eq!(original, renamed);
         assert_ne!(original, restarted);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn current_inventory_identity_wins_over_a_same_name_retained_session() {
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let stale = attach_request_fixture(
+            &snapshot,
+            session::SessionIdentity::new(100, "$1", 200),
+            "demo",
+        );
+        let current = attach_request_fixture(
+            &snapshot,
+            session::SessionIdentity::new(100, "$2", 201),
+            "demo",
+        );
+
+        let (selected, request) =
+            choose_navigation_target(Some(stale.presentation_key()), Ok(current.clone()))
+                .expect("current session remains selectable");
+
+        assert_eq!(selected, current.presentation_key());
+        assert_eq!(
+            request.map(|request| request.identity),
+            Some(current.identity)
+        );
     }
 
     #[cfg(windows)]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -563,6 +563,7 @@ struct PresentationKey {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct FallbackAuthority {
     presentation: PresentationKey,
+    target: PresentationKey,
     navigation_generation: u64,
 }
 
@@ -1460,6 +1461,7 @@ impl Workspace {
         let previous = in_flight_fallback.or(visible_previous);
         let fallback = previous.clone().map(|presentation| FallbackAuthority {
             presentation,
+            target: key.clone(),
             navigation_generation,
         });
         match self.activate_retained_presentation(&key, fallback.clone()) {
@@ -2071,8 +2073,8 @@ impl Workspace {
         let Some((request, generation, fallback)) = attachment else {
             return;
         };
-        let fallback = fallback
-            .filter(|fallback| fallback_owns_visible_request(&self.inner, fallback, &request));
+        let fallback =
+            fallback.filter(|fallback| fallback_owns_request(&self.inner, fallback, &request));
         {
             let mut attachment = self
                 .inner
@@ -2602,11 +2604,6 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             if let Some(active) = attachment.active_mut() {
                 session.clone_into(&mut active.request.name);
             }
-            let visible_request = attachment
-                .active()
-                .expect("current attachment was checked")
-                .request
-                .clone();
             if let Err(error) = publish_worker_at_latest_geometry(
                 &inner.terminal_geometry,
                 &inner.worker,
@@ -2618,9 +2615,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             ) {
                 let fallback = attachment
                     .fallback_if_current(generation)
-                    .filter(|fallback| {
-                        fallback_owns_visible_request(inner, fallback, &visible_request)
-                    });
+                    .filter(|fallback| fallback_owns_request(inner, fallback, request));
                 attachment.clear_if_current(generation);
                 drop(attachment);
                 publish_attachment_failure(inner, request.inventory_generation, error);
@@ -2737,25 +2732,13 @@ fn remove_failed_retained_retry(inner: &Inner, key: &PresentationKey) {
     }
 }
 
-fn fallback_owns_visible_request(
+fn fallback_owns_request(
     inner: &Inner,
     fallback: &FallbackAuthority,
     request: &AttachRequest,
 ) -> bool {
-    if inner.navigation_generation.load(Ordering::Acquire) != fallback.navigation_generation {
-        return false;
-    }
-    matches!(
-        &*inner
-            .state
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner),
-        WorkspaceContent::Attaching { host_id, endpoint, session }
-            | WorkspaceContent::Terminal { host_id, endpoint, session, .. }
-            if host_id == &request.host_id
-                && endpoint == request.endpoint.distro()
-                && session == &request.name
-    )
+    inner.navigation_generation.load(Ordering::Acquire) == fallback.navigation_generation
+        && fallback.target == request.presentation_key()
 }
 
 fn failed_attachment_context(
@@ -2769,7 +2752,7 @@ fn failed_attachment_context(
     let request = attachment.active()?.request.clone();
     let fallback = attachment
         .fallback_if_current(generation)
-        .filter(|fallback| fallback_owns_visible_request(inner, fallback, &request));
+        .filter(|fallback| fallback_owns_request(inner, fallback, &request));
     Some((request, fallback))
 }
 
@@ -3438,8 +3421,10 @@ mod tests {
         identity: session::SessionIdentity,
         navigation_generation: u64,
     ) -> FallbackAuthority {
+        let presentation = presentation_key_fixture(kernel_boot_id, init_start_ticks, identity);
         FallbackAuthority {
-            presentation: presentation_key_fixture(kernel_boot_id, init_start_ticks, identity),
+            target: presentation.clone(),
+            presentation,
             navigation_generation,
         }
     }
@@ -3815,6 +3800,7 @@ mod tests {
                 identity: session::SessionIdentity::new(100, "$2", 201),
                 ..key.clone()
             },
+            target: key.clone(),
             navigation_generation: 7,
         };
         let mut retained = RetainedPresentations::new();
@@ -3857,6 +3843,7 @@ mod tests {
         let mut restored_attachment = AttachmentState::new();
         let rebound_fallback = FallbackAuthority {
             presentation: fallback.presentation.clone(),
+            target: fallback.target.clone(),
             navigation_generation: 8,
         };
         let restored_generation = reserve_retained_attachment(
@@ -4147,6 +4134,7 @@ mod tests {
                 42,
                 session::SessionIdentity::new(100, "$2", 201),
             ),
+            target: request.presentation_key(),
             navigation_generation,
         };
         set_inner_state(
@@ -4158,13 +4146,9 @@ mod tests {
             },
         );
 
-        assert!(fallback_owns_visible_request(
-            &workspace.inner,
-            &fallback,
-            &request
-        ));
+        assert!(fallback_owns_request(&workspace.inner, &fallback, &request));
         workspace.detach();
-        assert!(!fallback_owns_visible_request(
+        assert!(!fallback_owns_request(
             &workspace.inner,
             &fallback,
             &request
@@ -4173,7 +4157,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn failed_attachment_context_uses_the_reconciled_session_name() {
+    fn failed_attachment_context_uses_stable_identity_after_name_reconciliation() {
         let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
         let request = attach_request_fixture(
             &snapshot,
@@ -4186,12 +4170,13 @@ mod tests {
             Vec::new(),
         ));
         let navigation_generation = workspace.begin_navigation();
-        let fallback = fallback_fixture(
+        let mut fallback = fallback_fixture(
             "boot-id",
             42,
             session::SessionIdentity::new(100, "$2", 201),
             navigation_generation,
         );
+        fallback.target = request.presentation_key();
         let generation = workspace
             .inner
             .attachment
@@ -4212,7 +4197,7 @@ mod tests {
             WorkspaceContent::Attaching {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
-                session: "renamed".to_owned(),
+                session: "original".to_owned(),
             },
         );
 
@@ -4965,12 +4950,13 @@ mod tests {
         )
         .expect("selected request");
         let opening_navigation = workspace.begin_navigation();
-        let fallback = fallback_fixture(
+        let mut fallback = fallback_fixture(
             "boot-id",
             42,
             session::SessionIdentity::new(100, "$3", 202),
             opening_navigation,
         );
+        fallback.target = opening.presentation_key();
         workspace
             .inner
             .attachment
@@ -4993,6 +4979,7 @@ mod tests {
         let selected_navigation = workspace.begin_navigation();
         let carried_fallback = carried_fallback.map(|presentation| FallbackAuthority {
             presentation,
+            target: selected.presentation_key(),
             navigation_generation: selected_navigation,
         });
         let selected_generation = workspace
@@ -5005,11 +4992,11 @@ mod tests {
 
         let attachment = workspace.inner.attachment.lock().expect("attachment");
         let active = attachment.active().expect("selected attachment active");
-        assert_eq!(active.request.name, "selected");
         assert_eq!(
             attachment.fallback_if_current(selected_generation).as_ref(),
             Some(&FallbackAuthority {
                 presentation: fallback.presentation,
+                target: active.request.presentation_key(),
                 navigation_generation: selected_navigation,
             })
         );

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -554,8 +554,14 @@ struct PresentationKey {
     host_id: String,
     endpoint: String,
     socket_directory: Option<String>,
-    session: String,
+    runtime: host::WslRuntimeIdentity,
     identity: session::SessionIdentity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FallbackAuthority {
+    presentation: PresentationKey,
+    navigation_generation: u64,
 }
 
 impl AttachRequest {
@@ -564,7 +570,7 @@ impl AttachRequest {
             host_id: self.host_id.clone(),
             endpoint: self.endpoint.distro().to_owned(),
             socket_directory: self.host.socket_directory().map(str::to_owned),
-            session: self.name.clone(),
+            runtime: self.runtime.clone(),
             identity: self.identity.clone(),
         }
     }
@@ -582,7 +588,7 @@ struct ActiveAttachment<T> {
     request: T,
     term: AttachTerm,
     generation: u64,
-    fallback: Option<PresentationKey>,
+    fallback: Option<FallbackAuthority>,
 }
 
 struct AttachmentState<T> {
@@ -607,7 +613,7 @@ impl<T> AttachmentState<T> {
         &mut self,
         request: T,
         term: AttachTerm,
-        fallback: Option<PresentationKey>,
+        fallback: Option<FallbackAuthority>,
     ) -> Option<u64> {
         if self.active.is_some() {
             return None;
@@ -629,6 +635,10 @@ impl<T> AttachmentState<T> {
         self.active.as_ref()
     }
 
+    fn active_mut(&mut self) -> Option<&mut ActiveAttachment<T>> {
+        self.active.as_mut()
+    }
+
     fn is_current(&self, generation: u64) -> bool {
         self.generation == generation
             && self
@@ -647,7 +657,7 @@ impl<T> AttachmentState<T> {
         true
     }
 
-    fn fallback_if_current(&self, generation: u64) -> Option<PresentationKey> {
+    fn fallback_if_current(&self, generation: u64) -> Option<FallbackAuthority> {
         self.is_current(generation)
             .then(|| {
                 self.active
@@ -804,6 +814,33 @@ impl<T> RetainedPresentations<T> {
             .collect()
     }
 
+    fn reconcile_session_names(&mut self, snapshot: &HostSnapshot, socket_directory: Option<&str>) {
+        for presentation in &mut self.entries {
+            if let Some(name) =
+                refreshed_session_name(&presentation.key, snapshot, socket_directory)
+            {
+                presentation.selection = SessionSelection::new(
+                    &presentation.key.host_id,
+                    presentation.key.endpoint.clone(),
+                    name,
+                );
+                presentation.attachment.request.name = name.to_owned();
+            }
+        }
+        for presentation in &mut self.restarting {
+            if let Some(name) =
+                refreshed_session_name(&presentation.key, snapshot, socket_directory)
+            {
+                presentation.selection = SessionSelection::new(
+                    &presentation.key.host_id,
+                    presentation.key.endpoint.clone(),
+                    name,
+                );
+                presentation.attachment.request.name = name.to_owned();
+            }
+        }
+    }
+
     fn finish_restart(&mut self, key: &PresentationKey, worker: T) -> bool {
         let Some(index) = self.restarting.iter().position(|entry| &entry.key == key) else {
             return false;
@@ -862,6 +899,25 @@ impl<T> RetainedPresentations<T> {
             }
         }
     }
+}
+
+fn refreshed_session_name<'a>(
+    key: &PresentationKey,
+    snapshot: &'a HostSnapshot,
+    socket_directory: Option<&str>,
+) -> Option<&'a str> {
+    (key.host_id == "wsl"
+        && key.endpoint == snapshot.endpoint().distro()
+        && key.socket_directory.as_deref() == socket_directory
+        && key.runtime == *snapshot.runtime())
+    .then(|| {
+        snapshot
+            .sessions()
+            .iter()
+            .find(|session| session.identity() == &key.identity)
+            .map(session::DiscoveredSession::name)
+    })
+    .flatten()
 }
 
 impl RetainedPresentations<TerminalWorker> {
@@ -997,6 +1053,8 @@ struct Inner {
     inventory_state: Mutex<WorkspaceContent>,
     revision: AtomicU64,
     presentation_generation: AtomicU64,
+    navigation_generation: AtomicU64,
+    navigation: Mutex<()>,
     host: Mutex<Option<Published<HostContext>>>,
     discovery_cancel: Mutex<Option<CancellationToken>>,
     event_drain: Mutex<()>,
@@ -1055,6 +1113,8 @@ impl Workspace {
                 inventory_state: Mutex::new(snapshot.content),
                 revision: AtomicU64::new(snapshot.revision),
                 presentation_generation: AtomicU64::new(presentation_generation),
+                navigation_generation: AtomicU64::new(0),
+                navigation: Mutex::new(()),
                 host: Mutex::new(None),
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
@@ -1111,6 +1171,8 @@ impl Workspace {
                 inventory_state: Mutex::new(WorkspaceContent::Shell),
                 revision: AtomicU64::new(0),
                 presentation_generation: AtomicU64::new(0),
+                navigation_generation: AtomicU64::new(0),
+                navigation: Mutex::new(()),
                 host: Mutex::new(None),
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
@@ -1151,6 +1213,8 @@ impl Workspace {
                 inventory_state: Mutex::new(WorkspaceContent::Loading),
                 revision: AtomicU64::new(0),
                 presentation_generation: AtomicU64::new(0),
+                navigation_generation: AtomicU64::new(0),
+                navigation: Mutex::new(()),
                 host: Mutex::new(None),
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
@@ -1267,6 +1331,11 @@ impl Workspace {
     /// Returns an error if another presentation is active or the requested
     /// session is not in the latest resolved inventory.
     pub fn attach(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if self
             .inner
             .worker
@@ -1281,11 +1350,12 @@ impl Workspace {
         }
         let request = capture_attach_request(&self.inner, selection)?;
         let key = request.presentation_key();
-        if self.activate_retained_presentation(&key)? {
+        let navigation_generation = self.begin_navigation();
+        if self.activate_retained_presentation(&key, Some(selection), None)? {
             return Ok(());
         }
 
-        self.start_attachment(request, None)
+        self.start_attachment(request, None, navigation_generation)
     }
 
     /// Select another presentation, retaining the current ordinary tmux client.
@@ -1299,6 +1369,11 @@ impl Workspace {
     /// Returns an error if the requested session is absent from the latest
     /// inventory or the replacement attachment cannot be started.
     pub fn switch_session(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let same_visible_selection = matches!(
             self.inner
                 .state
@@ -1333,6 +1408,7 @@ impl Workspace {
         {
             return Ok(());
         }
+        let navigation_generation = self.begin_navigation();
         let already_open = self
             .inner
             .retained_presentations
@@ -1342,25 +1418,37 @@ impl Workspace {
         let in_flight_fallback = self.supersede_inflight_attachment()?;
         let visible_previous = self.retain_active_presentation()?;
         let previous = in_flight_fallback.or(visible_previous);
-        match self.activate_retained_presentation(&key) {
+        let fallback = previous.clone().map(|presentation| FallbackAuthority {
+            presentation,
+            navigation_generation,
+        });
+        match self.activate_retained_presentation(&key, Some(selection), fallback.clone()) {
             Ok(true) => return Ok(()),
             Ok(false) => {}
             Err(error) => {
                 if let Some(previous) = previous {
-                    let _restored = self.activate_retained_presentation(&previous);
+                    let _restored = self.activate_retained_presentation(&previous, None, None);
                 }
                 return Err(error);
             }
         }
         if already_open {
             if let Some(previous) = previous {
-                let _restored = self.activate_retained_presentation(&previous);
+                let _restored = self.activate_retained_presentation(&previous, None, None);
             }
             return Err(WorkspaceError::new(
                 "the retained terminal presentation is no longer available",
             ));
         }
-        self.start_attachment(request, previous)
+        self.start_attachment(request, fallback, navigation_generation)
+    }
+
+    fn begin_navigation(&self) -> u64 {
+        self.inner
+            .navigation_generation
+            .fetch_add(1, Ordering::AcqRel)
+            .checked_add(1)
+            .expect("navigation generation exhausted")
     }
 
     fn supersede_inflight_attachment(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -1383,7 +1471,7 @@ impl Workspace {
         let active = attachment.take_active().ok_or_else(|| {
             WorkspaceError::new("the in-flight terminal presentation is not available")
         })?;
-        let fallback = active.fallback;
+        let fallback = active.fallback.map(|fallback| fallback.presentation);
         drop(attachment);
         clear_pending_paste(&self.inner);
         self.restore_inventory_state();
@@ -1460,14 +1548,17 @@ impl Workspace {
     fn activate_retained_presentation(
         &self,
         key: &PresentationKey,
+        selection: Option<&SessionSelection>,
+        fallback: Option<FallbackAuthority>,
     ) -> Result<bool, WorkspaceError> {
-        activate_retained_presentation(&self.inner, key)
+        activate_retained_presentation(&self.inner, key, selection, fallback)
     }
 
     fn start_attachment(
         &self,
         request: AttachRequest,
-        fallback: Option<PresentationKey>,
+        fallback: Option<FallbackAuthority>,
+        navigation_generation: u64,
     ) -> Result<(), WorkspaceError> {
         let generation;
         {
@@ -1501,6 +1592,7 @@ impl Workspace {
         }
         self.inner.revision.fetch_add(1, Ordering::Release);
         let inner = Arc::clone(&self.inner);
+        let failure_request = request.clone();
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-terminal-attach".to_owned())
             .spawn(move || {
@@ -1513,9 +1605,13 @@ impl Workspace {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if attachment.clear_if_current(generation) {
+                let fallback = fallback.filter(|fallback| {
+                    fallback_owns_visible_request(&self.inner, fallback, &failure_request)
+                        && fallback.navigation_generation == navigation_generation
+                });
                 drop(attachment);
                 self.restore_inventory_state();
-                restore_attach_fallback(&self.inner, fallback);
+                restore_attach_fallback_locked(&self.inner, fallback);
             }
             return Err(WorkspaceError::new(format!("start attach task: {error}")));
         }
@@ -1691,6 +1787,12 @@ impl Workspace {
     }
 
     pub fn detach(&self) {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.begin_navigation();
         self.inner
             .attachment
             .lock()
@@ -1843,7 +1945,7 @@ impl Workspace {
     fn attachment_for_worker(
         &self,
         worker_generation: u64,
-    ) -> Option<(AttachRequest, AttachTerm, u64, Option<PresentationKey>)> {
+    ) -> Option<(AttachRequest, AttachTerm, u64, Option<FallbackAuthority>)> {
         let attachment = self
             .inner
             .attachment
@@ -1892,7 +1994,7 @@ impl Workspace {
 
     fn handle_terminal_exit(
         &self,
-        attachment: Option<(AttachRequest, u64, Option<PresentationKey>)>,
+        attachment: Option<(AttachRequest, u64, Option<FallbackAuthority>)>,
         worker_generation: u64,
         retry_term: bool,
         exit_error: Option<String>,
@@ -1901,6 +2003,8 @@ impl Workspace {
         let Some((request, generation, fallback)) = attachment else {
             return;
         };
+        let fallback = fallback
+            .filter(|fallback| fallback_owns_visible_request(&self.inner, fallback, &request));
         {
             let mut attachment = self
                 .inner
@@ -1992,6 +2096,11 @@ impl Workspace {
                     match resolved {
                         Ok(context) => {
                             let state = ready_content(&context.snapshot);
+                            reconcile_presentation_session_names(
+                                &task_inner,
+                                &context.snapshot,
+                                context.host.socket_directory(),
+                            );
                             *task_inner
                                 .host
                                 .lock()
@@ -2048,6 +2157,7 @@ impl Workspace {
             }
         }
         let inner = Arc::clone(&self.inner);
+        let failure_request = request.clone();
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-terminal-terminfo-retry".to_owned())
             .spawn(move || run_attach(&inner, &request, AttachTerm::Xterm, generation))
@@ -2057,7 +2167,11 @@ impl Workspace {
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let fallback = attachment.fallback_if_current(generation);
+            let fallback = attachment
+                .fallback_if_current(generation)
+                .filter(|fallback| {
+                    fallback_owns_visible_request(&self.inner, fallback, &failure_request)
+                });
             if attachment.clear_if_current(generation) {
                 drop(attachment);
                 self.restore_inventory_state();
@@ -2091,8 +2205,10 @@ impl Workspace {
 fn activate_retained_presentation(
     inner: &Inner,
     key: &PresentationKey,
+    selection: Option<&SessionSelection>,
+    fallback: Option<FallbackAuthority>,
 ) -> Result<bool, WorkspaceError> {
-    let Some(presentation) = inner
+    let Some(mut presentation) = inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -2100,6 +2216,12 @@ fn activate_retained_presentation(
     else {
         return Ok(false);
     };
+    if let Some(selection) = selection {
+        presentation.selection = selection.clone();
+        selection
+            .session()
+            .clone_into(&mut presentation.attachment.request.name);
+    }
     let geometry = *inner
         .terminal_geometry
         .lock()
@@ -2109,7 +2231,8 @@ fn activate_retained_presentation(
         .attachment
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let Some(generation) = reserve_retained_attachment(&mut attachment, &presentation.attachment)
+    let Some(generation) =
+        reserve_retained_attachment(&mut attachment, &presentation.attachment, fallback)
     else {
         drop(attachment);
         reinsert_retained_presentation(inner, presentation);
@@ -2170,11 +2293,12 @@ fn activate_retained_presentation(
 fn reserve_retained_attachment(
     state: &mut AttachmentState<AttachRequest>,
     retained: &ActiveAttachment<AttachRequest>,
+    fallback: Option<FallbackAuthority>,
 ) -> Option<u64> {
     state.reserve_with_fallback(
         retained.request.clone(),
         retained.term,
-        retained.fallback.clone(),
+        fallback.or_else(|| retained.fallback.clone()),
     )
 }
 
@@ -2374,7 +2498,9 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                     worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
                 },
             ) {
-                let fallback = attachment.fallback_if_current(generation);
+                let fallback = attachment
+                    .fallback_if_current(generation)
+                    .filter(|fallback| fallback_owns_visible_request(inner, fallback, request));
                 attachment.clear_if_current(generation);
                 drop(attachment);
                 publish_attachment_failure(inner, request.inventory_generation, error);
@@ -2399,7 +2525,9 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let fallback = attachment.fallback_if_current(generation);
+            let fallback = attachment
+                .fallback_if_current(generation)
+                .filter(|fallback| fallback_owns_visible_request(inner, fallback, request));
             if !attachment.clear_if_current(generation) {
                 return;
             }
@@ -2448,52 +2576,69 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
             fail_retained_retry(inner, &retry.key, Some(error.to_string()));
         }
         Err(AttachFreshError::SessionChanged { error, snapshot }) => {
-            let fallback = take_failed_retained_retry(inner, &retry.key);
+            remove_failed_retained_retry(inner, &retry.key);
             publish_retained_stale_failure(inner, &retry.request, snapshot, &error);
-            restore_retry_fallback_if_idle(inner, fallback);
         }
     }
 }
 
 fn fail_retained_retry(inner: &Inner, key: &PresentationKey, diagnostic: Option<String>) {
-    let fallback = take_failed_retained_retry(inner, key);
+    remove_failed_retained_retry(inner, key);
     if let Some(diagnostic) = diagnostic {
         publish_local_notice(inner, diagnostic);
     }
-    restore_retry_fallback_if_idle(inner, fallback);
 }
 
-fn take_failed_retained_retry(inner: &Inner, key: &PresentationKey) -> Option<PresentationKey> {
-    inner
+fn remove_failed_retained_retry(inner: &Inner, key: &PresentationKey) {
+    let _removed = inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .fail_restart(key)
-        .and_then(|restart| restart.attachment.fallback)
+        .fail_restart(key);
 }
 
-fn restore_retry_fallback_if_idle(inner: &Inner, fallback: Option<PresentationKey>) {
-    let has_active_worker = inner
-        .worker
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .active()
-        .is_some();
-    if !has_active_worker {
-        restore_attach_fallback(inner, fallback);
+fn fallback_owns_visible_request(
+    inner: &Inner,
+    fallback: &FallbackAuthority,
+    request: &AttachRequest,
+) -> bool {
+    if inner.navigation_generation.load(Ordering::Acquire) != fallback.navigation_generation {
+        return false;
     }
+    matches!(
+        &*inner
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        WorkspaceContent::Attaching { host_id, endpoint, session }
+            | WorkspaceContent::Terminal { host_id, endpoint, session, .. }
+            if host_id == &request.host_id
+                && endpoint == request.endpoint.distro()
+                && session == &request.name
+    )
 }
 
-fn restore_attach_fallback(inner: &Inner, fallback: Option<PresentationKey>) {
+fn restore_attach_fallback(inner: &Inner, fallback: Option<FallbackAuthority>) {
+    let _navigation = inner
+        .navigation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    restore_attach_fallback_locked(inner, fallback);
+}
+
+fn restore_attach_fallback_locked(inner: &Inner, fallback: Option<FallbackAuthority>) {
     let Some(fallback) = fallback else {
         return;
     };
+    if inner.navigation_generation.load(Ordering::Acquire) != fallback.navigation_generation {
+        return;
+    }
     let preserved_notice = inner
         .terminal_notice
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
-    match activate_retained_presentation(inner, &fallback) {
+    match activate_retained_presentation(inner, &fallback.presentation, None, None) {
         Ok(true) => {
             if let Some(notice) = preserved_notice {
                 set_local_notice(inner, notice);
@@ -2518,6 +2663,7 @@ fn publish_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: Ho
 
 fn set_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSnapshot) {
     let inventory_state = ready_content(&snapshot);
+    reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
     *inner
         .host
         .lock()
@@ -2529,6 +2675,77 @@ fn set_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSn
         request.inventory_generation,
     ));
     set_inventory_state(inner, inventory_state);
+}
+
+fn reconcile_presentation_session_names(
+    inner: &Inner,
+    snapshot: &HostSnapshot,
+    socket_directory: Option<&str>,
+) {
+    reconcile_retained_session_names(inner, snapshot, socket_directory);
+    let renamed = {
+        let mut attachment = inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        attachment.active_mut().and_then(|active| {
+            let name = refreshed_session_name(
+                &active.request.presentation_key(),
+                snapshot,
+                socket_directory,
+            )?;
+            if name == active.request.name {
+                return None;
+            }
+            name.clone_into(&mut active.request.name);
+            Some((
+                active.request.host_id.clone(),
+                active.request.endpoint.distro().to_owned(),
+                name.to_owned(),
+            ))
+        })
+    };
+    let Some((renamed_host, renamed_endpoint, renamed_session)) = renamed else {
+        return;
+    };
+    let changed = {
+        let mut state = inner
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match &mut *state {
+            WorkspaceContent::Attaching {
+                host_id,
+                endpoint,
+                session,
+            }
+            | WorkspaceContent::Terminal {
+                host_id,
+                endpoint,
+                session,
+                ..
+            } if host_id == &renamed_host && endpoint == &renamed_endpoint => {
+                session.clone_from(&renamed_session);
+                true
+            }
+            _ => false,
+        }
+    };
+    if changed {
+        inner.revision.fetch_add(1, Ordering::Release);
+    }
+}
+
+fn reconcile_retained_session_names(
+    inner: &Inner,
+    snapshot: &HostSnapshot,
+    socket_directory: Option<&str>,
+) {
+    inner
+        .retained_presentations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .reconcile_session_names(snapshot, socket_directory);
 }
 
 fn publish_stale_attachment_failure(
@@ -2968,6 +3185,34 @@ mod tests {
         }
     }
 
+    fn presentation_key_fixture(
+        kernel_boot_id: &str,
+        init_start_ticks: u64,
+        identity: session::SessionIdentity,
+    ) -> PresentationKey {
+        let snapshot =
+            HostSnapshot::test_fixture("Ubuntu", kernel_boot_id, init_start_ticks, Vec::new());
+        PresentationKey {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            socket_directory: None,
+            runtime: snapshot.runtime().clone(),
+            identity,
+        }
+    }
+
+    fn fallback_fixture(
+        kernel_boot_id: &str,
+        init_start_ticks: u64,
+        identity: session::SessionIdentity,
+        navigation_generation: u64,
+    ) -> FallbackAuthority {
+        FallbackAuthority {
+            presentation: presentation_key_fixture(kernel_boot_id, init_start_ticks, identity),
+            navigation_generation,
+        }
+    }
+
     #[test]
     fn terminal_event_drain_requests_continuation_only_after_exhausting_its_budget() {
         assert!(!event_drain_may_have_more(MAX_EVENTS_PER_DRAIN - 1, false));
@@ -3295,10 +3540,12 @@ mod tests {
             inventory_generation: 1,
         };
         let key = request.presentation_key();
-        let fallback = PresentationKey {
-            session: "previous".to_owned(),
-            identity: session::SessionIdentity::new(100, "$2", 201),
-            ..key.clone()
+        let fallback = FallbackAuthority {
+            presentation: PresentationKey {
+                identity: session::SessionIdentity::new(100, "$2", 201),
+                ..key.clone()
+            },
+            navigation_generation: 7,
         };
         let mut retained = RetainedPresentations::new();
         retained.insert(RetainedPresentation {
@@ -3338,9 +3585,14 @@ mod tests {
         );
 
         let mut restored_attachment = AttachmentState::new();
+        let rebound_fallback = FallbackAuthority {
+            presentation: fallback.presentation.clone(),
+            navigation_generation: 8,
+        };
         let restored_generation = reserve_retained_attachment(
             &mut restored_attachment,
             &retained.restarting[0].attachment,
+            Some(rebound_fallback.clone()),
         )
         .expect("reactivate retained attachment");
         let mut restored_worker = WorkerState::new();
@@ -3355,7 +3607,170 @@ mod tests {
             worker_generation,
             false,
         ));
-        assert_eq!(fallback_after_reactivation.as_ref(), Some(&fallback));
+        assert_eq!(fallback_after_reactivation, Some(rebound_fallback));
+    }
+
+    #[test]
+    fn presentation_identity_survives_rename_but_not_a_wsl_runtime_restart() {
+        let identity = session::SessionIdentity::new(100, "$1", 200);
+        let original = presentation_key_fixture("boot-a", 42, identity.clone());
+        let renamed = presentation_key_fixture("boot-a", 42, identity.clone());
+        let restarted = presentation_key_fixture("boot-b", 7, identity);
+
+        assert_eq!(original, renamed);
+        assert_ne!(original, restarted);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn inventory_rename_updates_the_retained_display_name_without_changing_its_key() {
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let identity = session::SessionIdentity::new(100, "$1", 200);
+        let original_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "original",
+                identity.clone(),
+                0,
+            )],
+        );
+        let request = AttachRequest {
+            host_id: "wsl".to_owned(),
+            host,
+            endpoint: original_snapshot.endpoint().clone(),
+            runtime: original_snapshot.runtime().clone(),
+            identity: identity.clone(),
+            name: "original".to_owned(),
+            inventory_generation: 1,
+        };
+        let key = request.presentation_key();
+        let mut retained = RetainedPresentations::new();
+        retained.insert(RetainedPresentation {
+            key: key.clone(),
+            selection: SessionSelection::new("wsl", "Ubuntu", "original"),
+            attachment: ActiveAttachment {
+                request: request.clone(),
+                term: AttachTerm::Xterm256Color,
+                generation: 1,
+                fallback: None,
+            },
+            worker: (),
+            presentation_id: 7,
+        });
+        let renamed_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new("renamed", identity, 0)],
+        );
+
+        retained.reconcile_session_names(&renamed_snapshot, None);
+
+        assert!(retained.contains(&key));
+        assert_eq!(retained.selections()[0].session(), "renamed");
+        assert_eq!(retained.entries[0].attachment.request.name, "renamed");
+
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve(request, AttachTerm::Xterm256Color)
+            .expect("reserve visible attachment");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "original".to_owned(),
+            },
+        );
+
+        reconcile_presentation_session_names(&workspace.inner, &renamed_snapshot, None);
+
+        assert_eq!(
+            workspace
+                .inner
+                .attachment
+                .lock()
+                .expect("attachment")
+                .active()
+                .expect("visible attachment")
+                .request
+                .name,
+            "renamed"
+        );
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Attaching { session, .. } if session == "renamed"
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn detach_invalidates_fallback_authority_before_an_async_failure() {
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = AttachRequest {
+            host_id: "wsl".to_owned(),
+            host,
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            identity: session::SessionIdentity::new(100, "$1", 200),
+            name: "replacement".to_owned(),
+            inventory_generation: 1,
+        };
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let navigation_generation = workspace.begin_navigation();
+        let fallback = FallbackAuthority {
+            presentation: presentation_key_fixture(
+                "boot-id",
+                42,
+                session::SessionIdentity::new(100, "$2", 201),
+            ),
+            navigation_generation,
+        };
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "replacement".to_owned(),
+            },
+        );
+
+        assert!(fallback_owns_visible_request(
+            &workspace.inner,
+            &fallback,
+            &request
+        ));
+        workspace.detach();
+        assert!(!fallback_owns_visible_request(
+            &workspace.inner,
+            &fallback,
+            &request
+        ));
     }
 
     #[test]
@@ -3783,13 +4198,12 @@ mod tests {
 
     #[test]
     fn replacement_fallback_survives_publication_until_the_client_is_confirmed() {
-        let fallback = PresentationKey {
-            host_id: "wsl".to_owned(),
-            endpoint: "Ubuntu".to_owned(),
-            socket_directory: None,
-            session: "previous".to_owned(),
-            identity: session::SessionIdentity::new(100, "$1", 200),
-        };
+        let fallback = fallback_fixture(
+            "boot-id",
+            42,
+            session::SessionIdentity::new(100, "$1", 200),
+            1,
+        );
         let mut attachment = AttachmentState::new();
         let attachment_generation = attachment
             .reserve_with_fallback(
@@ -3804,7 +4218,7 @@ mod tests {
         let fallback_for_exit = attachment.fallback_if_current(attachment_generation);
         assert_eq!(
             fallback_for_exit,
-            Some(fallback),
+            Some(fallback.clone()),
             "publishing the replacement must not consume its fallback"
         );
 
@@ -3815,21 +4229,17 @@ mod tests {
             worker_generation,
             false,
         ));
-        assert_eq!(
-            fallback_for_exit.as_ref().map(|key| key.session.as_str()),
-            Some("previous")
-        );
+        assert_eq!(fallback_for_exit, Some(fallback));
     }
 
     #[test]
     fn confirmed_replacement_releases_its_fallback() {
-        let fallback = PresentationKey {
-            host_id: "wsl".to_owned(),
-            endpoint: "Ubuntu".to_owned(),
-            socket_directory: None,
-            session: "previous".to_owned(),
-            identity: session::SessionIdentity::new(100, "$1", 200),
-        };
+        let fallback = fallback_fixture(
+            "boot-id",
+            42,
+            session::SessionIdentity::new(100, "$1", 200),
+            1,
+        );
         let mut attachment = AttachmentState::new();
         let generation = attachment
             .reserve_with_fallback("replacement", AttachTerm::Xterm256Color, Some(fallback))
@@ -4102,13 +4512,13 @@ mod tests {
             &SessionSelection::new("wsl", "Ubuntu", "selected"),
         )
         .expect("selected request");
-        let fallback = PresentationKey {
-            host_id: "wsl".to_owned(),
-            endpoint: "Ubuntu".to_owned(),
-            socket_directory: None,
-            session: "previous".to_owned(),
-            identity: session::SessionIdentity::new(100, "$3", 202),
-        };
+        let opening_navigation = workspace.begin_navigation();
+        let fallback = fallback_fixture(
+            "boot-id",
+            42,
+            session::SessionIdentity::new(100, "$3", 202),
+            opening_navigation,
+        );
         workspace
             .inner
             .attachment
@@ -4128,6 +4538,11 @@ mod tests {
         let carried_fallback = workspace
             .supersede_inflight_attachment()
             .expect("supersede opening attachment");
+        let selected_navigation = workspace.begin_navigation();
+        let carried_fallback = carried_fallback.map(|presentation| FallbackAuthority {
+            presentation,
+            navigation_generation: selected_navigation,
+        });
         let selected_generation = workspace
             .inner
             .attachment
@@ -4141,12 +4556,11 @@ mod tests {
         assert_eq!(active.request.name, "selected");
         assert_eq!(
             attachment.fallback_if_current(selected_generation).as_ref(),
-            Some(&fallback)
+            Some(&FallbackAuthority {
+                presentation: fallback.presentation,
+                navigation_generation: selected_navigation,
+            })
         );
-        assert!(matches!(
-            workspace.snapshot().content(),
-            WorkspaceContent::Ready { .. } | WorkspaceContent::Shell
-        ));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -266,6 +266,7 @@ pub struct WorkspaceSnapshot {
     hosts: Vec<HostItem>,
     selected_host: Option<String>,
     notice: Option<String>,
+    retained_selections: Vec<SessionSelection>,
 }
 
 impl WorkspaceSnapshot {
@@ -285,6 +286,7 @@ impl WorkspaceSnapshot {
             hosts: Vec::new(),
             selected_host: None,
             notice: None,
+            retained_selections: Vec::new(),
         }
     }
 
@@ -298,6 +300,7 @@ impl WorkspaceSnapshot {
             hosts,
             selected_host,
             notice: None,
+            retained_selections: Vec::new(),
         }
     }
 
@@ -329,6 +332,11 @@ impl WorkspaceSnapshot {
     #[must_use]
     pub fn notice(&self) -> Option<&str> {
         self.notice.as_deref()
+    }
+
+    #[must_use]
+    pub fn retained_selections(&self) -> &[SessionSelection] {
+        &self.retained_selections
     }
 }
 
@@ -648,6 +656,16 @@ impl<T> AttachmentState<T> {
             .flatten()
     }
 
+    fn confirm_if_current(&mut self, generation: u64) -> bool {
+        if !self.is_current(generation) {
+            return false;
+        }
+        if let Some(active) = &mut self.active {
+            active.fallback = None;
+        }
+        true
+    }
+
     fn clear_if_current(&mut self, generation: u64) -> bool {
         if !self.is_current(generation) {
             return false;
@@ -754,6 +772,13 @@ impl<T> RetainedPresentations<T> {
 
     fn contains(&self, key: &PresentationKey) -> bool {
         self.entries.iter().any(|entry| &entry.key == key)
+    }
+
+    fn selections(&self) -> Vec<SessionSelection> {
+        self.entries
+            .iter()
+            .map(|entry| entry.selection.clone())
+            .collect()
     }
 }
 
@@ -901,6 +926,7 @@ impl Workspace {
             hosts: Vec::new(),
             selected_host: None,
             notice: None,
+            retained_selections: Vec::new(),
         })
     }
 
@@ -1120,6 +1146,12 @@ impl Workspace {
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone(),
+            retained_selections: self
+                .inner
+                .retained_presentations
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .selections(),
         }
     }
 
@@ -1555,16 +1587,10 @@ impl Workspace {
         let mut retry_term = false;
         let mut processed = 0;
         for _ in 0..MAX_EVENTS_PER_DRAIN {
-            let (event, source_worker_generation, client_confirmed_live) = {
-                let worker = self
-                    .inner
-                    .worker
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let Some((worker, generation)) = worker.active_with_generation() else {
-                    break;
-                };
-                (worker.try_event(), generation, worker.is_confirmed_live())
+            let Some((event, source_worker_generation, client_confirmed_live)) =
+                self.next_terminal_event()
+            else {
+                break;
             };
             match event {
                 Ok(Some(TerminalEvent::ClipboardWrite(write))) => {
@@ -1595,7 +1621,7 @@ impl Workspace {
                 }
                 Ok(Some(TerminalEvent::Exited { code, output_tail })) => {
                     processed += 1;
-                    let Some((request, term, generation)) =
+                    let Some((request, term, generation, fallback)) =
                         self.attachment_for_worker(source_worker_generation)
                     else {
                         break;
@@ -1606,7 +1632,7 @@ impl Workspace {
                         term,
                         client_confirmed_live,
                     );
-                    exited_attachment = Some((request, generation));
+                    exited_attachment = Some((request, generation, fallback));
                     exited_worker_generation = Some(source_worker_generation);
                     exited = true;
                     break;
@@ -1617,13 +1643,13 @@ impl Workspace {
                 }
                 Ok(None) => break,
                 Err(error) => {
-                    let Some((request, _, generation)) =
+                    let Some((request, _, generation, fallback)) =
                         self.attachment_for_worker(source_worker_generation)
                     else {
                         break;
                     };
                     exit_error = Some(error.to_string());
-                    exited_attachment = Some((request, generation));
+                    exited_attachment = Some((request, generation, fallback));
                     exited_worker_generation = Some(source_worker_generation);
                     exited = true;
                     break;
@@ -1644,6 +1670,28 @@ impl Workspace {
         (emitted, event_drain_may_have_more(processed, exited))
     }
 
+    fn next_terminal_event(
+        &self,
+    ) -> Option<(
+        Result<Option<TerminalEvent>, terminal::WorkerError>,
+        u64,
+        bool,
+    )> {
+        let (event, worker_generation, confirmed) = {
+            let worker = self
+                .inner
+                .worker
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let (worker, generation) = worker.active_with_generation()?;
+            (worker.try_event(), generation, worker.is_confirmed_live())
+        };
+        if confirmed {
+            self.mark_attachment_confirmed(worker_generation);
+        }
+        Some((event, worker_generation, confirmed))
+    }
+
     fn drain_retained_events(&self, budget: usize, emitted: &mut Vec<WorkspaceEvent>) -> usize {
         let (hidden_events, processed) = self
             .inner
@@ -1658,7 +1706,7 @@ impl Workspace {
     fn attachment_for_worker(
         &self,
         worker_generation: u64,
-    ) -> Option<(AttachRequest, AttachTerm, u64)> {
+    ) -> Option<(AttachRequest, AttachTerm, u64, Option<PresentationKey>)> {
         let attachment = self
             .inner
             .attachment
@@ -1674,20 +1722,46 @@ impl Workspace {
         {
             return None;
         }
-        attachment
-            .active()
-            .map(|active| (active.request.clone(), active.term, active.generation))
+        attachment.active().map(|active| {
+            (
+                active.request.clone(),
+                active.term,
+                active.generation,
+                active.fallback.clone(),
+            )
+        })
+    }
+
+    fn mark_attachment_confirmed(&self, worker_generation: u64) {
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self
+            .inner
+            .worker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .generation()
+            != worker_generation
+        {
+            return;
+        }
+        if let Some(generation) = attachment.active().map(|active| active.generation) {
+            attachment.confirm_if_current(generation);
+        }
     }
 
     fn handle_terminal_exit(
         &self,
-        attachment: Option<(AttachRequest, u64)>,
+        attachment: Option<(AttachRequest, u64, Option<PresentationKey>)>,
         worker_generation: u64,
         retry_term: bool,
         exit_error: Option<String>,
         emitted: &mut Vec<WorkspaceEvent>,
     ) {
-        let Some((request, generation)) = attachment else {
+        let Some((request, generation, fallback)) = attachment else {
             return;
         };
         {
@@ -1728,6 +1802,8 @@ impl Workspace {
         }
         if retry_term {
             self.retry_with_xterm(request, generation, emitted);
+        } else {
+            restore_attach_fallback(&self.inner, fallback);
         }
     }
 
@@ -2872,6 +2948,7 @@ mod tests {
             hosts: Vec::new(),
             selected_host: None,
             notice: None,
+            retained_selections: Vec::new(),
         });
         *workspace.inner.pending_paste.lock().expect("pending paste") = Some(PendingPaste {
             worker_generation: 1,
@@ -3276,6 +3353,64 @@ mod tests {
 
         assert!(geometry_was_locked, "geometry lock was released too early");
         assert!(worker_was_locked, "worker lock was released too early");
+    }
+
+    #[test]
+    fn replacement_fallback_survives_publication_until_the_client_is_confirmed() {
+        let fallback = PresentationKey {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            socket_directory: None,
+            session: "previous".to_owned(),
+            identity: session::SessionIdentity::new(100, "$1", 200),
+        };
+        let mut attachment = AttachmentState::new();
+        let attachment_generation = attachment
+            .reserve_with_fallback(
+                "replacement",
+                AttachTerm::Xterm256Color,
+                Some(fallback.clone()),
+            )
+            .expect("reserve replacement attachment");
+        let mut worker = WorkerState::new();
+        let worker_generation = worker.publish("replacement client");
+
+        let fallback_for_exit = attachment.fallback_if_current(attachment_generation);
+        assert_eq!(
+            fallback_for_exit,
+            Some(fallback),
+            "publishing the replacement must not consume its fallback"
+        );
+
+        assert!(claim_terminal_exit(
+            &mut attachment,
+            &mut worker,
+            attachment_generation,
+            worker_generation,
+            false,
+        ));
+        assert_eq!(
+            fallback_for_exit.as_ref().map(|key| key.session.as_str()),
+            Some("previous")
+        );
+    }
+
+    #[test]
+    fn confirmed_replacement_releases_its_fallback() {
+        let fallback = PresentationKey {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            socket_directory: None,
+            session: "previous".to_owned(),
+            identity: session::SessionIdentity::new(100, "$1", 200),
+        };
+        let mut attachment = AttachmentState::new();
+        let generation = attachment
+            .reserve_with_fallback("replacement", AttachTerm::Xterm256Color, Some(fallback))
+            .expect("reserve replacement attachment");
+
+        assert!(attachment.confirm_if_current(generation));
+        assert_eq!(attachment.fallback_if_current(generation), None);
     }
 
     #[test]
@@ -3707,6 +3842,7 @@ mod tests {
             )],
             selected_host: Some("wsl".to_owned()),
             notice: None,
+            retained_selections: Vec::new(),
         });
 
         set_inventory_state(

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -806,6 +806,19 @@ impl<T> RetainedPresentations<T> {
             || self.restarting.iter().any(|entry| &entry.key == key)
     }
 
+    fn key_for_selection(&self, selection: &SessionSelection) -> Option<PresentationKey> {
+        self.entries
+            .iter()
+            .find(|entry| &entry.selection == selection)
+            .map(|entry| entry.key.clone())
+            .or_else(|| {
+                self.restarting
+                    .iter()
+                    .find(|entry| &entry.selection == selection)
+                    .map(|entry| entry.key.clone())
+            })
+    }
+
     fn selections(&self) -> Vec<SessionSelection> {
         self.entries
             .iter()
@@ -929,21 +942,13 @@ impl RetainedPresentations<TerminalWorker> {
         while index < self.entries.len() && processed < budget {
             let confirmed = self.entries[index].worker.is_confirmed_live();
             match self.entries[index].worker.try_event() {
-                Ok(Some(TerminalEvent::ClipboardWrite(write))) => {
+                Ok(Some(TerminalEvent::ClipboardWrite(_) | TerminalEvent::ClipboardRead(_))) => {
                     processed += 1;
-                    emitted.push(WorkspaceEvent::ClipboardWrite {
-                        text: write.text,
-                        primary: write.target == ClipboardTarget::Selection,
-                    });
                     index += 1;
                 }
                 Ok(Some(TerminalEvent::ConfirmPaste(_))) => {
                     processed += 1;
                     let _cancelled = self.entries[index].worker.cancel_paste();
-                    index += 1;
-                }
-                Ok(Some(TerminalEvent::ClipboardRead(_))) => {
-                    processed += 1;
                     index += 1;
                 }
                 Ok(Some(TerminalEvent::Error(error))) => {
@@ -1348,13 +1353,17 @@ impl Workspace {
                 "a terminal presentation is already open",
             ));
         }
-        let request = capture_attach_request(&self.inner, selection)?;
-        let key = request.presentation_key();
         let navigation_generation = self.begin_navigation();
-        if self.activate_retained_presentation(&key, Some(selection), None)? {
-            return Ok(());
+        if let Some(key) = self.retained_key_for_selection(selection) {
+            if self.activate_retained_presentation(&key, Some(selection), None)? {
+                return Ok(());
+            }
+            return Err(WorkspaceError::new(
+                "the retained terminal presentation is no longer available",
+            ));
         }
 
+        let request = capture_attach_request(&self.inner, selection)?;
         self.start_attachment(request, None, navigation_generation)
     }
 
@@ -1396,8 +1405,12 @@ impl Workspace {
             return Ok(());
         }
 
-        let request = capture_attach_request(&self.inner, selection)?;
-        let key = request.presentation_key();
+        let (key, request) = if let Some(key) = self.retained_key_for_selection(selection) {
+            (key, None)
+        } else {
+            let request = capture_attach_request(&self.inner, selection)?;
+            (request.presentation_key(), Some(request))
+        };
         if self
             .inner
             .attachment
@@ -1440,6 +1453,11 @@ impl Workspace {
                 "the retained terminal presentation is no longer available",
             ));
         }
+        let Some(request) = request else {
+            return Err(WorkspaceError::new(
+                "the retained terminal presentation is no longer available",
+            ));
+        };
         self.start_attachment(request, fallback, navigation_generation)
     }
 
@@ -1449,6 +1467,14 @@ impl Workspace {
             .fetch_add(1, Ordering::AcqRel)
             .checked_add(1)
             .expect("navigation generation exhausted")
+    }
+
+    fn retained_key_for_selection(&self, selection: &SessionSelection) -> Option<PresentationKey> {
+        self.inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .key_for_selection(selection)
     }
 
     fn supersede_inflight_attachment(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -1519,6 +1545,7 @@ impl Workspace {
             ));
         }
         if let Some(active) = worker.active() {
+            active.set_clipboard_writes_enabled(false);
             let _cancelled = active.cancel_paste();
         }
         let active_attachment = attachment
@@ -2089,18 +2116,19 @@ impl Workspace {
                 if task_cancellation.is_cancelled() {
                     return;
                 }
-                publish_refresh(&task_inner, generation, || {
+                let reconciliation = resolved.as_ref().ok().map(|context| {
+                    (
+                        context.snapshot.clone(),
+                        context.host.socket_directory().map(str::to_owned),
+                    )
+                });
+                let published = publish_refresh(&task_inner, generation, || {
                     if task_cancellation.is_cancelled() {
                         return;
                     }
                     match resolved {
                         Ok(context) => {
                             let state = ready_content(&context.snapshot);
-                            reconcile_presentation_session_names(
-                                &task_inner,
-                                &context.snapshot,
-                                context.host.socket_directory(),
-                            );
                             *task_inner
                                 .host
                                 .lock()
@@ -2116,6 +2144,14 @@ impl Workspace {
                         .refresh_finished
                         .store(generation, Ordering::Release);
                 });
+                if published && let Some((snapshot, socket_directory)) = reconciliation {
+                    reconcile_presentation_session_names(
+                        &task_inner,
+                        generation,
+                        &snapshot,
+                        socket_directory.as_deref(),
+                    );
+                }
                 task_cancellation.cancel();
             }),
         );
@@ -2270,8 +2306,9 @@ fn activate_retained_presentation(
         worker,
         presentation_id,
     } = presentation;
+    worker.set_clipboard_writes_enabled(false);
     let surface = worker.surface_handle();
-    workers.publish(worker);
+    let worker_generation = workers.publish(worker);
     drop(workers);
     drop(attachment);
 
@@ -2287,6 +2324,15 @@ fn activate_retained_presentation(
             surface,
         },
     );
+    let workers = inner
+        .worker
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if workers.generation() == worker_generation
+        && let Some(worker) = workers.active()
+    {
+        worker.set_clipboard_writes_enabled(true);
+    }
     Ok(true)
 }
 
@@ -2477,7 +2523,7 @@ fn fail_refresh_start(
 
 fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generation: u64) {
     match attach_fresh(inner, request, term) {
-        Ok((worker, snapshot, session, initial_geometry)) => {
+        Ok((worker, snapshot, attached_session, initial_geometry)) => {
             let mut attachment = inner
                 .attachment
                 .lock()
@@ -2489,6 +2535,20 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             let surface = worker.surface_handle();
             let endpoint = snapshot.endpoint().distro().to_owned();
             publish_attach_inventory(inner, request, snapshot);
+            let key = attachment
+                .active()
+                .expect("current attachment was checked")
+                .request
+                .presentation_key();
+            let session = current_inventory_session_name(inner, &key).unwrap_or(attached_session);
+            if let Some(active) = attachment.active_mut() {
+                session.clone_into(&mut active.request.name);
+            }
+            let visible_request = attachment
+                .active()
+                .expect("current attachment was checked")
+                .request
+                .clone();
             if let Err(error) = publish_worker_at_latest_geometry(
                 &inner.terminal_geometry,
                 &inner.worker,
@@ -2500,7 +2560,9 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             ) {
                 let fallback = attachment
                     .fallback_if_current(generation)
-                    .filter(|fallback| fallback_owns_visible_request(inner, fallback, request));
+                    .filter(|fallback| {
+                        fallback_owns_visible_request(inner, fallback, &visible_request)
+                    });
                 attachment.clear_if_current(generation);
                 drop(attachment);
                 publish_attachment_failure(inner, request.inventory_generation, error);
@@ -2545,6 +2607,22 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
     }
 }
 
+fn current_inventory_session_name(inner: &Inner, key: &PresentationKey) -> Option<String> {
+    inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .and_then(|published| {
+            refreshed_session_name(
+                key,
+                &published.value.snapshot,
+                published.value.host.socket_directory(),
+            )
+        })
+        .map(str::to_owned)
+}
+
 fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
     match attach_fresh(inner, &retry.request, AttachTerm::Xterm) {
         Ok((worker, snapshot, _, initial_geometry)) => {
@@ -2562,6 +2640,7 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
                 fail_retained_retry(inner, &retry.key, Some(error.to_string()));
                 return;
             }
+            worker.set_clipboard_writes_enabled(false);
             let published = inner
                 .retained_presentations
                 .lock()
@@ -2679,32 +2758,38 @@ fn set_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSn
 
 fn reconcile_presentation_session_names(
     inner: &Inner,
+    refresh_generation: u64,
     snapshot: &HostSnapshot,
     socket_directory: Option<&str>,
 ) {
+    let mut attachment = inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _publication = inner
+        .refresh_publication
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.refresh_generation.load(Ordering::Acquire) != refresh_generation {
+        return;
+    }
     reconcile_retained_session_names(inner, snapshot, socket_directory);
-    let renamed = {
-        let mut attachment = inner
-            .attachment
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        attachment.active_mut().and_then(|active| {
-            let name = refreshed_session_name(
-                &active.request.presentation_key(),
-                snapshot,
-                socket_directory,
-            )?;
-            if name == active.request.name {
-                return None;
-            }
-            name.clone_into(&mut active.request.name);
-            Some((
-                active.request.host_id.clone(),
-                active.request.endpoint.distro().to_owned(),
-                name.to_owned(),
-            ))
-        })
-    };
+    let renamed = attachment.active_mut().and_then(|active| {
+        let name = refreshed_session_name(
+            &active.request.presentation_key(),
+            snapshot,
+            socket_directory,
+        )?;
+        if name == active.request.name {
+            return None;
+        }
+        name.clone_into(&mut active.request.name);
+        Some((
+            active.request.host_id.clone(),
+            active.request.endpoint.distro().to_owned(),
+            name.to_owned(),
+        ))
+    });
     let Some((renamed_host, renamed_endpoint, renamed_session)) = renamed else {
         return;
     };
@@ -3213,6 +3298,28 @@ mod tests {
         }
     }
 
+    #[cfg(windows)]
+    fn attach_request_fixture(
+        snapshot: &HostSnapshot,
+        identity: session::SessionIdentity,
+        name: &str,
+    ) -> AttachRequest {
+        AttachRequest {
+            host_id: "wsl".to_owned(),
+            host: WslHost::new(
+                WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+                Arc::new(StdCommandRunner) as SharedCommandRunner,
+                WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                    .expect("absolute WSL path"),
+            ),
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            identity,
+            name: name.to_owned(),
+            inventory_generation: 1,
+        }
+    }
+
     #[test]
     fn terminal_event_drain_requests_continuation_only_after_exhausting_its_budget() {
         assert!(!event_drain_may_have_more(MAX_EVENTS_PER_DRAIN - 1, false));
@@ -3624,12 +3731,6 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn inventory_rename_updates_the_retained_display_name_without_changing_its_key() {
-        let host = WslHost::new(
-            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
-            Arc::new(StdCommandRunner) as SharedCommandRunner,
-            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
-                .expect("absolute WSL path"),
-        );
         let identity = session::SessionIdentity::new(100, "$1", 200);
         let original_snapshot = HostSnapshot::test_fixture(
             "Ubuntu",
@@ -3641,15 +3742,7 @@ mod tests {
                 0,
             )],
         );
-        let request = AttachRequest {
-            host_id: "wsl".to_owned(),
-            host,
-            endpoint: original_snapshot.endpoint().clone(),
-            runtime: original_snapshot.runtime().clone(),
-            identity: identity.clone(),
-            name: "original".to_owned(),
-            inventory_generation: 1,
-        };
+        let request = attach_request_fixture(&original_snapshot, identity.clone(), "original");
         let key = request.presentation_key();
         let mut retained = RetainedPresentations::new();
         retained.insert(RetainedPresentation {
@@ -3676,12 +3769,27 @@ mod tests {
         assert!(retained.contains(&key));
         assert_eq!(retained.selections()[0].session(), "renamed");
         assert_eq!(retained.entries[0].attachment.request.name, "renamed");
+        assert_eq!(
+            retained.key_for_selection(&SessionSelection::new("wsl", "Ubuntu", "renamed")),
+            Some(key.clone())
+        );
 
         let workspace = Workspace::preview(WorkspaceSnapshot::ready(
             Appearance::default(),
             "Ubuntu",
             Vec::new(),
         ));
+        *workspace.inner.host.lock().expect("host") = Some(Published::new(
+            HostContext {
+                host: request.host.clone(),
+                snapshot: renamed_snapshot.clone(),
+            },
+            2,
+        ));
+        assert_eq!(
+            current_inventory_session_name(&workspace.inner, &key).as_deref(),
+            Some("renamed")
+        );
         workspace
             .inner
             .attachment
@@ -3698,7 +3806,7 @@ mod tests {
             },
         );
 
-        reconcile_presentation_session_names(&workspace.inner, &renamed_snapshot, None);
+        reconcile_presentation_session_names(&workspace.inner, 0, &renamed_snapshot, None);
 
         assert_eq!(
             workspace

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -574,6 +574,7 @@ struct ActiveAttachment<T> {
     request: T,
     term: AttachTerm,
     generation: u64,
+    fallback: Option<PresentationKey>,
 }
 
 struct AttachmentState<T> {
@@ -590,6 +591,15 @@ impl<T> AttachmentState<T> {
     }
 
     fn reserve(&mut self, request: T, term: AttachTerm) -> Option<u64> {
+        self.reserve_with_fallback(request, term, None)
+    }
+
+    fn reserve_with_fallback(
+        &mut self,
+        request: T,
+        term: AttachTerm,
+        fallback: Option<PresentationKey>,
+    ) -> Option<u64> {
         if self.active.is_some() {
             return None;
         }
@@ -601,6 +611,7 @@ impl<T> AttachmentState<T> {
             request,
             term,
             generation: self.generation,
+            fallback,
         });
         Some(self.generation)
     }
@@ -625,6 +636,16 @@ impl<T> AttachmentState<T> {
             active.term = term;
         }
         true
+    }
+
+    fn fallback_if_current(&self, generation: u64) -> Option<PresentationKey> {
+        self.is_current(generation)
+            .then(|| {
+                self.active
+                    .as_ref()
+                    .and_then(|active| active.fallback.clone())
+            })
+            .flatten()
     }
 
     fn clear_if_current(&mut self, generation: u64) -> bool {
@@ -1127,7 +1148,7 @@ impl Workspace {
             return Ok(());
         }
 
-        self.start_attachment(request)
+        self.start_attachment(request, None)
     }
 
     /// Select another presentation, retaining the current ordinary tmux client.
@@ -1182,8 +1203,15 @@ impl Workspace {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .contains(&key);
         let previous = self.retain_active_presentation()?;
-        if self.activate_retained_presentation(&key)? {
-            return Ok(());
+        match self.activate_retained_presentation(&key) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => {
+                if let Some(previous) = previous {
+                    let _restored = self.activate_retained_presentation(&previous);
+                }
+                return Err(error);
+            }
         }
         if already_open {
             if let Some(previous) = previous {
@@ -1193,13 +1221,7 @@ impl Workspace {
                 "the retained terminal presentation is no longer available",
             ));
         }
-        if let Err(error) = self.start_attachment(request) {
-            if let Some(previous) = previous {
-                let _restored = self.activate_retained_presentation(&previous);
-            }
-            return Err(error);
-        }
-        Ok(())
+        self.start_attachment(request, previous)
     }
 
     fn retain_active_presentation(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -1273,73 +1295,14 @@ impl Workspace {
         &self,
         key: &PresentationKey,
     ) -> Result<bool, WorkspaceError> {
-        let Some(presentation) = self
-            .inner
-            .retained_presentations
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take(key)
-        else {
-            return Ok(false);
-        };
-        let RetainedPresentation {
-            key: _,
-            selection,
-            attachment: retained_attachment,
-            worker,
-            presentation_id,
-        } = presentation;
-        let request = retained_attachment.request;
-        let term = retained_attachment.term;
-        let surface = worker.surface_handle();
-        let geometry = *self
-            .inner
-            .terminal_geometry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-        let mut attachment = self
-            .inner
-            .attachment
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let generation = attachment
-            .reserve(request, term)
-            .ok_or_else(|| WorkspaceError::new("a terminal presentation is already opening"))?;
-        if let Err(error) =
-            worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
-        {
-            attachment.clear_if_current(generation);
-            return Err(WorkspaceError::from_worker(&error));
-        }
-        let mut workers = self
-            .inner
-            .worker
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if workers.active().is_some() {
-            attachment.clear_if_current(generation);
-            return Err(WorkspaceError::new(
-                "a terminal presentation is already open",
-            ));
-        }
-        workers.publish(worker);
-        drop(workers);
-        drop(attachment);
-
-        clear_pending_paste(&self.inner);
-        set_terminal_notice(&self.inner, term);
-        self.set_state(WorkspaceContent::Terminal {
-            host_id: selection.host_id().to_owned(),
-            endpoint: selection.endpoint().to_owned(),
-            session: selection.session().to_owned(),
-            presentation_id,
-            surface,
-        });
-        Ok(true)
+        activate_retained_presentation(&self.inner, key)
     }
 
-    fn start_attachment(&self, request: AttachRequest) -> Result<(), WorkspaceError> {
+    fn start_attachment(
+        &self,
+        request: AttachRequest,
+        fallback: Option<PresentationKey>,
+    ) -> Result<(), WorkspaceError> {
         let generation;
         {
             let mut attachment = self
@@ -1361,7 +1324,7 @@ impl Workspace {
                 ));
             }
             generation = attachment
-                .reserve(request.clone(), AttachTerm::Xterm256Color)
+                .reserve_with_fallback(request.clone(), AttachTerm::Xterm256Color, fallback.clone())
                 .ok_or_else(|| WorkspaceError::new("a terminal presentation is already opening"))?;
             clear_terminal_notice(&self.inner);
             *state = WorkspaceContent::Attaching {
@@ -1384,7 +1347,9 @@ impl Workspace {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if attachment.clear_if_current(generation) {
+                drop(attachment);
                 self.restore_inventory_state();
+                restore_attach_fallback(&self.inner, fallback);
             }
             return Err(WorkspaceError::new(format!("start attach task: {error}")));
         }
@@ -1879,8 +1844,11 @@ impl Workspace {
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let fallback = attachment.fallback_if_current(generation);
             if attachment.clear_if_current(generation) {
+                drop(attachment);
                 self.restore_inventory_state();
+                restore_attach_fallback(&self.inner, fallback);
                 emitted.push(WorkspaceEvent::Error(format!(
                     "start TERM=xterm retry: {error}"
                 )));
@@ -1891,6 +1859,96 @@ impl Workspace {
     fn set_state(&self, state: WorkspaceContent) {
         set_inner_state(&self.inner, state);
     }
+}
+
+fn activate_retained_presentation(
+    inner: &Inner,
+    key: &PresentationKey,
+) -> Result<bool, WorkspaceError> {
+    let Some(presentation) = inner
+        .retained_presentations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take(key)
+    else {
+        return Ok(false);
+    };
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let request = presentation.attachment.request.clone();
+    let term = presentation.attachment.term;
+    let mut attachment = inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(generation) = attachment.reserve(request, term) else {
+        drop(attachment);
+        reinsert_retained_presentation(inner, presentation);
+        return Err(WorkspaceError::new(
+            "a terminal presentation is already opening",
+        ));
+    };
+    if let Err(error) =
+        presentation
+            .worker
+            .resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
+    {
+        attachment.clear_if_current(generation);
+        drop(attachment);
+        reinsert_retained_presentation(inner, presentation);
+        return Err(WorkspaceError::from_worker(&error));
+    }
+    let mut workers = inner
+        .worker
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if workers.active().is_some() {
+        attachment.clear_if_current(generation);
+        drop(workers);
+        drop(attachment);
+        reinsert_retained_presentation(inner, presentation);
+        return Err(WorkspaceError::new(
+            "a terminal presentation is already open",
+        ));
+    }
+    let RetainedPresentation {
+        key: _,
+        selection,
+        attachment: _,
+        worker,
+        presentation_id,
+    } = presentation;
+    let surface = worker.surface_handle();
+    workers.publish(worker);
+    drop(workers);
+    drop(attachment);
+
+    clear_pending_paste(inner);
+    set_terminal_notice(inner, term);
+    set_inner_state(
+        inner,
+        WorkspaceContent::Terminal {
+            host_id: selection.host_id().to_owned(),
+            endpoint: selection.endpoint().to_owned(),
+            session: selection.session().to_owned(),
+            presentation_id,
+            surface,
+        },
+    );
+    Ok(true)
+}
+
+fn reinsert_retained_presentation(
+    inner: &Inner,
+    presentation: RetainedPresentation<TerminalWorker>,
+) {
+    inner
+        .retained_presentations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(presentation);
 }
 
 const fn event_drain_may_have_more(processed: usize, exited: bool) -> bool {
@@ -2078,8 +2136,11 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                     worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
                 },
             ) {
+                let fallback = attachment.fallback_if_current(generation);
                 attachment.clear_if_current(generation);
+                drop(attachment);
                 publish_attachment_failure(inner, request.inventory_generation, error);
+                restore_attach_fallback(inner, fallback);
                 return;
             }
             set_terminal_notice(inner, term);
@@ -2100,9 +2161,11 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let fallback = attachment.fallback_if_current(generation);
             if !attachment.clear_if_current(generation) {
                 return;
             }
+            drop(attachment);
             match error {
                 AttachFreshError::Host(error) => {
                     publish_attachment_failure(inner, request.inventory_generation, error);
@@ -2111,7 +2174,25 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                     publish_stale_attachment_failure(inner, request, snapshot, &error);
                 }
             }
+            restore_attach_fallback(inner, fallback);
         }
+    }
+}
+
+fn restore_attach_fallback(inner: &Inner, fallback: Option<PresentationKey>) {
+    let Some(fallback) = fallback else {
+        return;
+    };
+    match activate_retained_presentation(inner, &fallback) {
+        Ok(true) => {}
+        Ok(false) => set_local_notice(
+            inner,
+            "the previous terminal presentation is no longer available".to_owned(),
+        ),
+        Err(error) => set_local_notice(
+            inner,
+            format!("could not restore the previous terminal presentation: {error}"),
+        ),
     }
 }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -865,11 +865,27 @@ impl<T> RetainedPresentations<T> {
         changed
     }
 
-    fn finish_restart(&mut self, key: &PresentationKey, worker: T) -> bool {
+    fn finish_restart(
+        &mut self,
+        key: &PresentationKey,
+        worker: T,
+        original_name: &str,
+        resolved_request: &AttachRequest,
+    ) -> bool {
         let Some(index) = self.restarting.iter().position(|entry| &entry.key == key) else {
             return false;
         };
-        let restart = self.restarting.remove(index);
+        let mut restart = self.restarting.remove(index);
+        if restart.attachment.request.name == original_name {
+            restart.selection = SessionSelection::new(
+                &restart.key.host_id,
+                restart.key.endpoint.clone(),
+                &resolved_request.name,
+            );
+            resolved_request
+                .name
+                .clone_into(&mut restart.attachment.request.name);
+        }
         self.insert(RetainedPresentation {
             key: restart.key,
             selection: restart.selection,
@@ -1469,6 +1485,9 @@ impl Workspace {
             ));
         }
         let Some(request) = request else {
+            if let Some(previous) = previous {
+                let _restored = self.activate_retained_presentation(&previous, None);
+            }
             return Err(WorkspaceError::new(
                 "the retained terminal presentation is no longer available",
             ));
@@ -2638,8 +2657,8 @@ fn current_inventory_session_name(inner: &Inner, key: &PresentationKey) -> Optio
 }
 
 fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
-    match attach_fresh(inner, &retry.request, AttachTerm::Xterm) {
-        Ok((worker, snapshot, _, initial_geometry)) => {
+    match attach_fresh_retained(inner, retry) {
+        Ok((worker, snapshot, resolved_request, initial_geometry)) => {
             let latest_geometry = *inner
                 .terminal_geometry
                 .lock()
@@ -2659,9 +2678,9 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
                 .retained_presentations
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .finish_restart(&retry.key, worker);
+                .finish_restart(&retry.key, worker, &retry.request.name, &resolved_request);
             if published {
-                publish_attach_inventory(inner, &retry.request, snapshot);
+                publish_attach_inventory(inner, &resolved_request, snapshot);
                 inner.revision.fetch_add(1, Ordering::Release);
             }
         }
@@ -2921,18 +2940,7 @@ fn attach_fresh(
     request: &AttachRequest,
     term: AttachTerm,
 ) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
-    let fresh = request
-        .host
-        .discover(&ConptyAdmissionAttacher::new())
-        .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
-    if fresh.endpoint() != &request.endpoint || fresh.runtime() != &request.runtime {
-        return Err(AttachFreshError::SessionChanged {
-            error: WorkspaceError::new(
-                "WSL runtime changed since session discovery; refresh and try again",
-            ),
-            snapshot: fresh,
-        });
-    }
+    let fresh = discover_fresh_runtime(request)?;
     let session = fresh
         .sessions()
         .iter()
@@ -2954,9 +2962,82 @@ fn attach_fresh(
             snapshot: fresh,
         });
     }
+    launch_fresh_session(inner, request, term, &fresh, &session)
+}
+
+fn attach_fresh_retained(
+    inner: &Inner,
+    retry: &RetainedRetry,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        AttachRequest,
+        TerminalGeometry,
+    ),
+    AttachFreshError,
+> {
+    let fresh = discover_fresh_runtime(&retry.request)?;
+    let Some(resolved_request) = resolve_retained_retry_request(retry, &fresh) else {
+        return Err(AttachFreshError::SessionChanged {
+            error: WorkspaceError::new(
+                "session identity changed since discovery; refusing stale attachment",
+            ),
+            snapshot: fresh,
+        });
+    };
+    let session = fresh
+        .sessions()
+        .iter()
+        .find(|session| session.identity() == &retry.key.identity)
+        .cloned()
+        .expect("resolved retained request has a matching session");
+    let (worker, snapshot, _, geometry) = launch_fresh_session(
+        inner,
+        &resolved_request,
+        AttachTerm::Xterm,
+        &fresh,
+        &session,
+    )?;
+    Ok((worker, snapshot, resolved_request, geometry))
+}
+
+fn discover_fresh_runtime(request: &AttachRequest) -> Result<HostSnapshot, AttachFreshError> {
+    let fresh = request
+        .host
+        .discover(&ConptyAdmissionAttacher::new())
+        .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+    if fresh.endpoint() != &request.endpoint || fresh.runtime() != &request.runtime {
+        return Err(AttachFreshError::SessionChanged {
+            error: WorkspaceError::new(
+                "WSL runtime changed since session discovery; refresh and try again",
+            ),
+            snapshot: fresh,
+        });
+    }
+    Ok(fresh)
+}
+
+fn resolve_retained_retry_request(
+    retry: &RetainedRetry,
+    fresh: &HostSnapshot,
+) -> Option<AttachRequest> {
+    let name = refreshed_session_name(&retry.key, fresh, retry.request.host.socket_directory())?;
+    let mut request = retry.request.clone();
+    name.clone_into(&mut request.name);
+    Some(request)
+}
+
+fn launch_fresh_session(
+    inner: &Inner,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    session: &session::DiscoveredSession,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
     let plan = request
         .host
-        .attach_plan_with_term(fresh.endpoint(), &session, term);
+        .attach_plan_with_term(fresh.endpoint(), session, term);
     let geometry = *inner
         .terminal_geometry
         .lock()
@@ -2970,7 +3051,12 @@ fn attach_fresh(
         default_colors(&inner.appearance),
     )
     .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
-    Ok((worker, fresh, plan.target_name().to_owned(), geometry))
+    Ok((
+        worker,
+        fresh.clone(),
+        plan.target_name().to_owned(),
+        geometry,
+    ))
 }
 
 fn set_terminal_notice(inner: &Inner, term: AttachTerm) {
@@ -3750,6 +3836,44 @@ mod tests {
             false,
         ));
         assert_eq!(fallback_after_reactivation, Some(rebound_fallback));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn retained_terminfo_retry_resolves_a_renamed_session_by_identity() {
+        let identity = session::SessionIdentity::new(100, "$1", 200);
+        let original_snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = attach_request_fixture(&original_snapshot, identity.clone(), "original");
+        let key = request.presentation_key();
+        let retry = RetainedRetry {
+            key: key.clone(),
+            request: request.clone(),
+        };
+        let renamed_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new("renamed", identity, 0)],
+        );
+        let resolved_request = resolve_retained_retry_request(&retry, &renamed_snapshot)
+            .expect("stable retained identity survives a rename");
+        let mut retained = RetainedPresentations::new();
+        retained.restarting.push(RetainedRestart {
+            key: key.clone(),
+            selection: SessionSelection::new("wsl", "Ubuntu", "original"),
+            attachment: ActiveAttachment {
+                request,
+                term: AttachTerm::Xterm,
+                generation: 1,
+                fallback: None,
+            },
+            presentation_id: 7,
+        });
+
+        assert_eq!(resolved_request.name, "renamed");
+        assert!(retained.finish_restart(&key, (), &retry.request.name, &resolved_request));
+        assert_eq!(retained.entries[0].selection.session(), "renamed");
+        assert_eq!(retained.entries[0].attachment.request.name, "renamed");
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -743,14 +743,34 @@ struct RetainedPresentation<T> {
     presentation_id: u64,
 }
 
+struct RetainedRestart {
+    key: PresentationKey,
+    selection: SessionSelection,
+    attachment: ActiveAttachment<AttachRequest>,
+    presentation_id: u64,
+}
+
+struct RetainedRetry {
+    key: PresentationKey,
+    request: AttachRequest,
+}
+
+struct RetainedDrain {
+    emitted: Vec<WorkspaceEvent>,
+    retries: Vec<RetainedRetry>,
+    processed: usize,
+}
+
 struct RetainedPresentations<T> {
     entries: Vec<RetainedPresentation<T>>,
+    restarting: Vec<RetainedRestart>,
 }
 
 impl<T> RetainedPresentations<T> {
     const fn new() -> Self {
         Self {
             entries: Vec::new(),
+            restarting: Vec::new(),
         }
     }
 
@@ -772,22 +792,85 @@ impl<T> RetainedPresentations<T> {
 
     fn contains(&self, key: &PresentationKey) -> bool {
         self.entries.iter().any(|entry| &entry.key == key)
+            || self.restarting.iter().any(|entry| &entry.key == key)
     }
 
     fn selections(&self) -> Vec<SessionSelection> {
         self.entries
             .iter()
             .map(|entry| entry.selection.clone())
+            .chain(self.restarting.iter().map(|entry| entry.selection.clone()))
             .collect()
+    }
+
+    fn finish_restart(&mut self, key: &PresentationKey, worker: T) -> bool {
+        let Some(index) = self.restarting.iter().position(|entry| &entry.key == key) else {
+            return false;
+        };
+        let restart = self.restarting.remove(index);
+        self.insert(RetainedPresentation {
+            key: restart.key,
+            selection: restart.selection,
+            attachment: restart.attachment,
+            worker,
+            presentation_id: restart.presentation_id,
+        });
+        true
+    }
+
+    fn fail_restart(&mut self, key: &PresentationKey) -> Option<RetainedRestart> {
+        let index = self.restarting.iter().position(|entry| &entry.key == key)?;
+        Some(self.restarting.remove(index))
+    }
+
+    fn handle_exit(
+        &mut self,
+        index: usize,
+        code: u32,
+        output_tail: &str,
+        confirmed: bool,
+        emitted: &mut Vec<WorkspaceEvent>,
+        retries: &mut Vec<RetainedRetry>,
+    ) {
+        let term = self.entries[index].attachment.term;
+        let (retry, diagnostic) = classify_terminal_exit_event(code, output_tail, term, confirmed);
+        if retry {
+            let presentation = self.entries.remove(index);
+            let RetainedPresentation {
+                key,
+                selection,
+                mut attachment,
+                worker: _,
+                presentation_id,
+            } = presentation;
+            attachment.term = AttachTerm::Xterm;
+            retries.push(RetainedRetry {
+                key: key.clone(),
+                request: attachment.request.clone(),
+            });
+            self.restarting.push(RetainedRestart {
+                key,
+                selection,
+                attachment,
+                presentation_id,
+            });
+        } else {
+            self.entries.remove(index);
+            if let Some(diagnostic) = diagnostic {
+                emitted.push(WorkspaceEvent::Error(diagnostic));
+            }
+        }
     }
 }
 
 impl RetainedPresentations<TerminalWorker> {
-    fn drain_events(&mut self, budget: usize) -> (Vec<WorkspaceEvent>, usize) {
+    fn drain_events(&mut self, budget: usize) -> RetainedDrain {
         let mut emitted = Vec::new();
+        let mut retries = Vec::new();
         let mut processed = 0;
         let mut index = 0;
         while index < self.entries.len() && processed < budget {
+            let confirmed = self.entries[index].worker.is_confirmed_live();
             match self.entries[index].worker.try_event() {
                 Ok(Some(TerminalEvent::ClipboardWrite(write))) => {
                     processed += 1;
@@ -802,18 +885,39 @@ impl RetainedPresentations<TerminalWorker> {
                     let _cancelled = self.entries[index].worker.cancel_paste();
                     index += 1;
                 }
-                Ok(Some(TerminalEvent::ClipboardRead(_) | TerminalEvent::Error(_))) => {
+                Ok(Some(TerminalEvent::ClipboardRead(_))) => {
                     processed += 1;
                     index += 1;
                 }
-                Ok(Some(TerminalEvent::Exited { .. })) | Err(_) => {
+                Ok(Some(TerminalEvent::Error(error))) => {
+                    processed += 1;
+                    emitted.push(WorkspaceEvent::Error(error));
+                    index += 1;
+                }
+                Ok(Some(TerminalEvent::Exited { code, output_tail })) => {
+                    processed += 1;
+                    self.handle_exit(
+                        index,
+                        code,
+                        &output_tail,
+                        confirmed,
+                        &mut emitted,
+                        &mut retries,
+                    );
+                }
+                Err(error) => {
                     processed += 1;
                     self.entries.remove(index);
+                    emitted.push(WorkspaceEvent::Error(error.to_string()));
                 }
                 Ok(None) => index += 1,
             }
         }
-        (emitted, processed)
+        RetainedDrain {
+            emitted,
+            retries,
+            processed,
+        }
     }
 }
 
@@ -1693,14 +1797,17 @@ impl Workspace {
     }
 
     fn drain_retained_events(&self, budget: usize, emitted: &mut Vec<WorkspaceEvent>) -> usize {
-        let (hidden_events, processed) = self
+        let drain = self
             .inner
             .retained_presentations
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .drain_events(budget);
-        emitted.extend(hidden_events);
-        processed
+        emitted.extend(drain.emitted);
+        for retry in drain.retries {
+            self.retry_retained_with_xterm(retry, emitted);
+        }
+        drain.processed
     }
 
     fn attachment_for_worker(
@@ -1929,6 +2036,20 @@ impl Workspace {
                     "start TERM=xterm retry: {error}"
                 )));
             }
+        }
+    }
+
+    fn retry_retained_with_xterm(&self, retry: RetainedRetry, emitted: &mut Vec<WorkspaceEvent>) {
+        let inner = Arc::clone(&self.inner);
+        let key = retry.key.clone();
+        if let Err(error) = thread::Builder::new()
+            .name("ghosthub-retained-terminal-terminfo-retry".to_owned())
+            .spawn(move || run_retained_retry(&inner, &retry))
+        {
+            fail_retained_retry(&self.inner, &key, None);
+            emitted.push(WorkspaceEvent::Error(format!(
+                "start retained TERM=xterm retry: {error}"
+            )));
         }
     }
 
@@ -2255,12 +2376,88 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
     }
 }
 
+fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
+    match attach_fresh(inner, &retry.request, AttachTerm::Xterm) {
+        Ok((worker, snapshot, _, initial_geometry)) => {
+            let latest_geometry = *inner
+                .terminal_geometry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if latest_geometry != initial_geometry
+                && let Err(error) = worker.resize_with_metadata(
+                    latest_geometry.grid,
+                    latest_geometry.sequence,
+                    latest_geometry.pixels,
+                )
+            {
+                fail_retained_retry(inner, &retry.key, Some(error.to_string()));
+                return;
+            }
+            let published = inner
+                .retained_presentations
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .finish_restart(&retry.key, worker);
+            if published {
+                publish_attach_inventory(inner, &retry.request, snapshot);
+                inner.revision.fetch_add(1, Ordering::Release);
+            }
+        }
+        Err(AttachFreshError::Host(error)) => {
+            fail_retained_retry(inner, &retry.key, Some(error.to_string()));
+        }
+        Err(AttachFreshError::SessionChanged { error, snapshot }) => {
+            let fallback = take_failed_retained_retry(inner, &retry.key);
+            publish_stale_attachment_failure(inner, &retry.request, snapshot, &error);
+            restore_retry_fallback_if_idle(inner, fallback);
+        }
+    }
+}
+
+fn fail_retained_retry(inner: &Inner, key: &PresentationKey, diagnostic: Option<String>) {
+    let fallback = take_failed_retained_retry(inner, key);
+    if let Some(diagnostic) = diagnostic {
+        publish_local_notice(inner, diagnostic);
+    }
+    restore_retry_fallback_if_idle(inner, fallback);
+}
+
+fn take_failed_retained_retry(inner: &Inner, key: &PresentationKey) -> Option<PresentationKey> {
+    inner
+        .retained_presentations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .fail_restart(key)
+        .and_then(|restart| restart.attachment.fallback)
+}
+
+fn restore_retry_fallback_if_idle(inner: &Inner, fallback: Option<PresentationKey>) {
+    let has_active_worker = inner
+        .worker
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .active()
+        .is_some();
+    if !has_active_worker {
+        restore_attach_fallback(inner, fallback);
+    }
+}
+
 fn restore_attach_fallback(inner: &Inner, fallback: Option<PresentationKey>) {
     let Some(fallback) = fallback else {
         return;
     };
+    let preserved_notice = inner
+        .terminal_notice
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
     match activate_retained_presentation(inner, &fallback) {
-        Ok(true) => {}
+        Ok(true) => {
+            if let Some(notice) = preserved_notice {
+                set_local_notice(inner, notice);
+            }
+        }
         Ok(false) => set_local_notice(
             inner,
             "the previous terminal presentation is no longer available".to_owned(),
@@ -2399,6 +2596,11 @@ fn set_local_notice(inner: &Inner, message: String) {
         .terminal_notice
         .write()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(message);
+}
+
+fn publish_local_notice(inner: &Inner, message: String) {
+    set_local_notice(inner, message);
+    inner.revision.fetch_add(1, Ordering::Release);
 }
 
 fn clear_terminal_notice(inner: &Inner) {
@@ -2930,6 +3132,70 @@ mod tests {
 
         assert!(retry_term);
         assert_eq!(diagnostic, None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn hidden_unconfirmed_client_keeps_its_identity_and_fallback_during_terminfo_retry() {
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let identity = session::SessionIdentity::new(100, "$1", 200);
+        let request = AttachRequest {
+            host_id: "wsl".to_owned(),
+            host,
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            identity: identity.clone(),
+            name: "replacement".to_owned(),
+            inventory_generation: 1,
+        };
+        let key = request.presentation_key();
+        let fallback = PresentationKey {
+            session: "previous".to_owned(),
+            identity: session::SessionIdentity::new(100, "$2", 201),
+            ..key.clone()
+        };
+        let mut retained = RetainedPresentations::new();
+        retained.insert(RetainedPresentation {
+            key: key.clone(),
+            selection: SessionSelection::new("wsl", "Ubuntu", "replacement"),
+            attachment: ActiveAttachment {
+                request,
+                term: AttachTerm::Xterm256Color,
+                generation: 1,
+                fallback: Some(fallback.clone()),
+            },
+            worker: (),
+            presentation_id: 7,
+        });
+        let mut emitted = Vec::new();
+        let mut retries = Vec::new();
+
+        retained.handle_exit(
+            0,
+            1,
+            "missing or unsuitable terminal: xterm-256color\r\n",
+            false,
+            &mut emitted,
+            &mut retries,
+        );
+
+        let retry = retries.pop().expect("retained xterm retry");
+
+        assert!(emitted.is_empty());
+        assert_eq!(retry.key, key);
+        assert!(retained.contains(&key));
+        assert_eq!(retained.selections()[0].session(), "replacement");
+        assert_eq!(retained.restarting[0].attachment.term, AttachTerm::Xterm);
+        assert_eq!(
+            retained.restarting[0].attachment.fallback.as_ref(),
+            Some(&fallback)
+        );
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -770,6 +770,7 @@ struct RetainedDrain {
     emitted: Vec<WorkspaceEvent>,
     retries: Vec<RetainedRetry>,
     processed: usize,
+    changed: bool,
 }
 
 struct RetainedPresentations<T> {
@@ -827,10 +828,16 @@ impl<T> RetainedPresentations<T> {
             .collect()
     }
 
-    fn reconcile_session_names(&mut self, snapshot: &HostSnapshot, socket_directory: Option<&str>) {
+    fn reconcile_session_names(
+        &mut self,
+        snapshot: &HostSnapshot,
+        socket_directory: Option<&str>,
+    ) -> bool {
+        let mut changed = false;
         for presentation in &mut self.entries {
             if let Some(name) =
                 refreshed_session_name(&presentation.key, snapshot, socket_directory)
+                && name != presentation.attachment.request.name
             {
                 presentation.selection = SessionSelection::new(
                     &presentation.key.host_id,
@@ -838,11 +845,13 @@ impl<T> RetainedPresentations<T> {
                     name,
                 );
                 presentation.attachment.request.name = name.to_owned();
+                changed = true;
             }
         }
         for presentation in &mut self.restarting {
             if let Some(name) =
                 refreshed_session_name(&presentation.key, snapshot, socket_directory)
+                && name != presentation.attachment.request.name
             {
                 presentation.selection = SessionSelection::new(
                     &presentation.key.host_id,
@@ -850,8 +859,10 @@ impl<T> RetainedPresentations<T> {
                     name,
                 );
                 presentation.attachment.request.name = name.to_owned();
+                changed = true;
             }
         }
+        changed
     }
 
     fn finish_restart(&mut self, key: &PresentationKey, worker: T) -> bool {
@@ -938,6 +949,7 @@ impl RetainedPresentations<TerminalWorker> {
         let mut emitted = Vec::new();
         let mut retries = Vec::new();
         let mut processed = 0;
+        let mut changed = false;
         let mut index = 0;
         while index < self.entries.len() && processed < budget {
             let confirmed = self.entries[index].worker.is_confirmed_live();
@@ -958,6 +970,7 @@ impl RetainedPresentations<TerminalWorker> {
                 }
                 Ok(Some(TerminalEvent::Exited { code, output_tail })) => {
                     processed += 1;
+                    changed = true;
                     self.handle_exit(
                         index,
                         code,
@@ -970,6 +983,7 @@ impl RetainedPresentations<TerminalWorker> {
                 Err(error) => {
                     processed += 1;
                     self.entries.remove(index);
+                    changed = true;
                     emitted.push(WorkspaceEvent::Error(error.to_string()));
                 }
                 Ok(None) => index += 1,
@@ -979,6 +993,7 @@ impl RetainedPresentations<TerminalWorker> {
             emitted,
             retries,
             processed,
+            changed,
         }
     }
 }
@@ -1505,7 +1520,20 @@ impl Workspace {
     }
 
     fn retain_active_presentation(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
-        let presentation = {
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(active_attachment) = attachment.active() else {
+            return Ok(None);
+        };
+        let selection = SessionSelection::new(
+            &active_attachment.request.host_id,
+            active_attachment.request.endpoint.distro(),
+            &active_attachment.request.name,
+        );
+        let presentation_id = {
             let state = self
                 .inner
                 .state
@@ -1513,33 +1541,17 @@ impl Workspace {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             match &*state {
                 WorkspaceContent::Terminal {
-                    host_id,
-                    endpoint,
-                    session,
-                    presentation_id,
-                    ..
-                } => Some((
-                    SessionSelection::new(host_id, endpoint, session),
-                    *presentation_id,
-                )),
-                _ => None,
+                    presentation_id, ..
+                } => *presentation_id,
+                _ => return Ok(None),
             }
         };
-        let Some((selection, presentation_id)) = presentation else {
-            return Ok(None);
-        };
-
-        let mut attachment = self
-            .inner
-            .attachment
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut worker = self
             .inner
             .worker
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if attachment.active().is_none() || worker.active().is_none() {
+        if worker.active().is_none() {
             return Err(WorkspaceError::new(
                 "the active terminal presentation is not available",
             ));
@@ -1554,7 +1566,6 @@ impl Workspace {
         let key = active_attachment.request.presentation_key();
         let active_worker = worker.invalidate().expect("active worker was checked");
         drop(worker);
-        drop(attachment);
         clear_pending_paste(&self.inner);
         clear_terminal_notice(&self.inner);
         self.inner
@@ -1569,6 +1580,7 @@ impl Workspace {
                 presentation_id,
             });
         self.restore_inventory_state();
+        drop(attachment);
         Ok(Some(key))
     }
 
@@ -1961,6 +1973,9 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .drain_events(budget);
+        if drain.changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
         emitted.extend(drain.emitted);
         for retry in drain.retries {
             self.retry_retained_with_xterm(retry, emitted);
@@ -2239,6 +2254,10 @@ fn activate_retained_presentation(
     key: &PresentationKey,
     fallback: Option<FallbackAuthority>,
 ) -> Result<bool, WorkspaceError> {
+    let mut attachment = inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some(presentation) = inner
         .retained_presentations
         .lock()
@@ -2252,10 +2271,6 @@ fn activate_retained_presentation(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let term = presentation.attachment.term;
-    let mut attachment = inner
-        .attachment
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some(generation) =
         reserve_retained_attachment(&mut attachment, &presentation.attachment, fallback)
     else {
@@ -2288,9 +2303,19 @@ fn activate_retained_presentation(
             "a terminal presentation is already open",
         ));
     }
+    let selection = attachment
+        .active()
+        .map(|active| {
+            SessionSelection::new(
+                &active.request.host_id,
+                active.request.endpoint.distro(),
+                &active.request.name,
+            )
+        })
+        .expect("retained attachment was just reserved");
     let RetainedPresentation {
         key: _,
-        selection,
+        selection: _,
         attachment: _,
         worker,
         presentation_id,
@@ -2299,7 +2324,6 @@ fn activate_retained_presentation(
     let surface = worker.surface_handle();
     let worker_generation = workers.publish(worker);
     drop(workers);
-    drop(attachment);
 
     clear_pending_paste(inner);
     set_terminal_notice(inner, term);
@@ -2313,6 +2337,7 @@ fn activate_retained_presentation(
             surface,
         },
     );
+    drop(attachment);
     let workers = inner
         .worker
         .lock()
@@ -2658,11 +2683,14 @@ fn fail_retained_retry(inner: &Inner, key: &PresentationKey, diagnostic: Option<
 }
 
 fn remove_failed_retained_retry(inner: &Inner, key: &PresentationKey) {
-    let _removed = inner
+    let removed = inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .fail_restart(key);
+    if removed.is_some() {
+        inner.revision.fetch_add(1, Ordering::Release);
+    }
 }
 
 fn fallback_owns_visible_request(
@@ -2830,11 +2858,14 @@ fn reconcile_retained_session_names(
     snapshot: &HostSnapshot,
     socket_directory: Option<&str>,
 ) {
-    inner
+    let changed = inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .reconcile_session_names(snapshot, socket_directory);
+    if changed {
+        inner.revision.fetch_add(1, Ordering::Release);
+    }
 }
 
 fn publish_stale_attachment_failure(
@@ -3771,7 +3802,7 @@ mod tests {
             vec![session::DiscoveredSession::new("renamed", identity, 0)],
         );
 
-        retained.reconcile_session_names(&renamed_snapshot, None);
+        assert!(retained.reconcile_session_names(&renamed_snapshot, None));
 
         assert!(retained.contains(&key));
         assert_eq!(retained.selections()[0].session(), "renamed");
@@ -3836,6 +3867,61 @@ mod tests {
             workspace.snapshot().content(),
             WorkspaceContent::Attaching { session, .. } if session == "renamed"
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn retained_rename_advances_the_workspace_revision_once() {
+        let identity = session::SessionIdentity::new(100, "$1", 200);
+        let original_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "original",
+                identity.clone(),
+                0,
+            )],
+        );
+        let request = attach_request_fixture(&original_snapshot, identity.clone(), "original");
+        let renamed_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new("renamed", identity, 0)],
+        );
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        workspace
+            .inner
+            .retained_presentations
+            .lock()
+            .expect("retained presentations")
+            .restarting
+            .push(RetainedRestart {
+                key: request.presentation_key(),
+                selection: SessionSelection::new("wsl", "Ubuntu", "original"),
+                attachment: ActiveAttachment {
+                    request,
+                    term: AttachTerm::Xterm256Color,
+                    generation: 1,
+                    fallback: None,
+                },
+                presentation_id: 7,
+            });
+        let revision = workspace.snapshot().revision();
+
+        reconcile_retained_session_names(&workspace.inner, &renamed_snapshot, None);
+        let renamed = workspace.snapshot();
+
+        assert_eq!(renamed.revision(), revision + 1);
+        assert_eq!(renamed.retained_selections()[0].session(), "renamed");
+
+        reconcile_retained_session_names(&workspace.inner, &renamed_snapshot, None);
+        assert_eq!(workspace.snapshot().revision(), renamed.revision());
     }
 
     #[cfg(windows)]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -541,6 +541,27 @@ struct AttachRequest {
     inventory_generation: u64,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PresentationKey {
+    host_id: String,
+    endpoint: String,
+    socket_directory: Option<String>,
+    session: String,
+    identity: session::SessionIdentity,
+}
+
+impl AttachRequest {
+    fn presentation_key(&self) -> PresentationKey {
+        PresentationKey {
+            host_id: self.host_id.clone(),
+            endpoint: self.endpoint.distro().to_owned(),
+            socket_directory: self.host.socket_directory().map(str::to_owned),
+            session: self.name.clone(),
+            identity: self.identity.clone(),
+        }
+    }
+}
+
 enum AttachFreshError {
     Host(WorkspaceError),
     SessionChanged {
@@ -621,6 +642,14 @@ impl<T> AttachmentState<T> {
             .expect("attachment generation exhausted");
         self.active = None;
     }
+
+    fn take_active(&mut self) -> Option<ActiveAttachment<T>> {
+        self.generation = self
+            .generation
+            .checked_add(1)
+            .expect("attachment generation exhausted");
+        self.active.take()
+    }
 }
 
 struct WorkerState<T> {
@@ -664,6 +693,81 @@ impl<T> WorkerState<T> {
             .generation
             .checked_add(1)
             .expect("worker generation exhausted");
+    }
+}
+
+struct RetainedPresentation<T> {
+    key: PresentationKey,
+    selection: SessionSelection,
+    attachment: ActiveAttachment<AttachRequest>,
+    worker: T,
+    presentation_id: u64,
+}
+
+struct RetainedPresentations<T> {
+    entries: Vec<RetainedPresentation<T>>,
+}
+
+impl<T> RetainedPresentations<T> {
+    const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, presentation: RetainedPresentation<T>) {
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.key == presentation.key)
+        {
+            self.entries.remove(index);
+        }
+        self.entries.push(presentation);
+    }
+
+    fn take(&mut self, key: &PresentationKey) -> Option<RetainedPresentation<T>> {
+        let index = self.entries.iter().position(|entry| &entry.key == key)?;
+        Some(self.entries.remove(index))
+    }
+
+    fn contains(&self, key: &PresentationKey) -> bool {
+        self.entries.iter().any(|entry| &entry.key == key)
+    }
+}
+
+impl RetainedPresentations<TerminalWorker> {
+    fn drain_events(&mut self, budget: usize) -> (Vec<WorkspaceEvent>, usize) {
+        let mut emitted = Vec::new();
+        let mut processed = 0;
+        let mut index = 0;
+        while index < self.entries.len() && processed < budget {
+            match self.entries[index].worker.try_event() {
+                Ok(Some(TerminalEvent::ClipboardWrite(write))) => {
+                    processed += 1;
+                    emitted.push(WorkspaceEvent::ClipboardWrite {
+                        text: write.text,
+                        primary: write.target == ClipboardTarget::Selection,
+                    });
+                    index += 1;
+                }
+                Ok(Some(TerminalEvent::ConfirmPaste(_))) => {
+                    processed += 1;
+                    let _cancelled = self.entries[index].worker.cancel_paste();
+                    index += 1;
+                }
+                Ok(Some(TerminalEvent::ClipboardRead(_) | TerminalEvent::Error(_))) => {
+                    processed += 1;
+                    index += 1;
+                }
+                Ok(Some(TerminalEvent::Exited { .. })) | Err(_) => {
+                    processed += 1;
+                    self.entries.remove(index);
+                }
+                Ok(None) => index += 1,
+            }
+        }
+        (emitted, processed)
     }
 }
 
@@ -746,6 +850,7 @@ struct Inner {
     discovery_cancel: Mutex<Option<CancellationToken>>,
     event_drain: Mutex<()>,
     worker: Mutex<WorkerState<TerminalWorker>>,
+    retained_presentations: Mutex<RetainedPresentations<TerminalWorker>>,
     pending_paste: Mutex<Option<PendingPaste>>,
     terminal_geometry: Mutex<TerminalGeometry>,
     allow_remote_clipboard_write: bool,
@@ -802,6 +907,7 @@ impl Workspace {
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
                 worker: Mutex::new(WorkerState::new()),
+                retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write: true,
@@ -857,6 +963,7 @@ impl Workspace {
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
                 worker: Mutex::new(WorkerState::new()),
+                retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -896,6 +1003,7 @@ impl Workspace {
                 discovery_cancel: Mutex::new(None),
                 event_drain: Mutex::new(()),
                 worker: Mutex::new(WorkerState::new()),
+                retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -1014,22 +1122,26 @@ impl Workspace {
             ));
         }
         let request = capture_attach_request(&self.inner, selection)?;
+        let key = request.presentation_key();
+        if self.activate_retained_presentation(&key)? {
+            return Ok(());
+        }
 
         self.start_attachment(request)
     }
 
-    /// Detach the active ordinary client and attach to another discovered session.
+    /// Select another presentation, retaining the current ordinary tmux client.
     ///
-    /// The target is captured before the current presentation is detached, so an
-    /// invalid selection cannot close the working terminal. The fresh identity
-    /// check still runs immediately before the replacement client launches.
+    /// A presentation that has already been opened is restored synchronously.
+    /// The first visit still performs a fresh identity check immediately before
+    /// launching its ordinary client.
     ///
     /// # Errors
     ///
     /// Returns an error if the requested session is absent from the latest
     /// inventory or the replacement attachment cannot be started.
     pub fn switch_session(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
-        if matches!(
+        let same_visible_selection = matches!(
             self.inner
                 .state
                 .read()
@@ -1039,13 +1151,192 @@ impl Workspace {
                 if host_id == selection.host_id()
                     && endpoint == selection.endpoint()
                     && session == selection.session()
-        ) {
+        );
+        let has_active_attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some();
+        if same_visible_selection && !has_active_attachment {
             return Ok(());
         }
 
         let request = capture_attach_request(&self.inner, selection)?;
-        self.detach();
-        self.start_attachment(request)
+        let key = request.presentation_key();
+        if self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some_and(|active| active.request.presentation_key() == key)
+        {
+            return Ok(());
+        }
+        let already_open = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&key);
+        let previous = self.retain_active_presentation()?;
+        if self.activate_retained_presentation(&key)? {
+            return Ok(());
+        }
+        if already_open {
+            if let Some(previous) = previous {
+                let _restored = self.activate_retained_presentation(&previous);
+            }
+            return Err(WorkspaceError::new(
+                "the retained terminal presentation is no longer available",
+            ));
+        }
+        if let Err(error) = self.start_attachment(request) {
+            if let Some(previous) = previous {
+                let _restored = self.activate_retained_presentation(&previous);
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn retain_active_presentation(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
+        let presentation = {
+            let state = self
+                .inner
+                .state
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match &*state {
+                WorkspaceContent::Terminal {
+                    host_id,
+                    endpoint,
+                    session,
+                    presentation_id,
+                    ..
+                } => Some((
+                    SessionSelection::new(host_id, endpoint, session),
+                    *presentation_id,
+                )),
+                _ => None,
+            }
+        };
+        let Some((selection, presentation_id)) = presentation else {
+            return Ok(None);
+        };
+
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut worker = self
+            .inner
+            .worker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if attachment.active().is_none() || worker.active().is_none() {
+            return Err(WorkspaceError::new(
+                "the active terminal presentation is not available",
+            ));
+        }
+        if let Some(active) = worker.active() {
+            let _cancelled = active.cancel_paste();
+        }
+        let active_attachment = attachment
+            .take_active()
+            .expect("active attachment was checked");
+        let key = active_attachment.request.presentation_key();
+        let active_worker = worker.invalidate().expect("active worker was checked");
+        drop(worker);
+        drop(attachment);
+        clear_pending_paste(&self.inner);
+        clear_terminal_notice(&self.inner);
+        self.inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(RetainedPresentation {
+                key: key.clone(),
+                selection: selection.clone(),
+                attachment: active_attachment,
+                worker: active_worker,
+                presentation_id,
+            });
+        self.restore_inventory_state();
+        Ok(Some(key))
+    }
+
+    fn activate_retained_presentation(
+        &self,
+        key: &PresentationKey,
+    ) -> Result<bool, WorkspaceError> {
+        let Some(presentation) = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take(key)
+        else {
+            return Ok(false);
+        };
+        let RetainedPresentation {
+            key: _,
+            selection,
+            attachment: retained_attachment,
+            worker,
+            presentation_id,
+        } = presentation;
+        let request = retained_attachment.request;
+        let term = retained_attachment.term;
+        let surface = worker.surface_handle();
+        let geometry = *self
+            .inner
+            .terminal_geometry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let generation = attachment
+            .reserve(request, term)
+            .ok_or_else(|| WorkspaceError::new("a terminal presentation is already opening"))?;
+        if let Err(error) =
+            worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
+        {
+            attachment.clear_if_current(generation);
+            return Err(WorkspaceError::from_worker(&error));
+        }
+        let mut workers = self
+            .inner
+            .worker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if workers.active().is_some() {
+            attachment.clear_if_current(generation);
+            return Err(WorkspaceError::new(
+                "a terminal presentation is already open",
+            ));
+        }
+        workers.publish(worker);
+        drop(workers);
+        drop(attachment);
+
+        clear_pending_paste(&self.inner);
+        set_terminal_notice(&self.inner, term);
+        self.set_state(WorkspaceContent::Terminal {
+            host_id: selection.host_id().to_owned(),
+            endpoint: selection.endpoint().to_owned(),
+            session: selection.session().to_owned(),
+            presentation_id,
+            surface,
+        });
+        Ok(true)
     }
 
     fn start_attachment(&self, request: AttachRequest) -> Result<(), WorkspaceError> {
@@ -1383,7 +1674,20 @@ impl Workspace {
                 &mut emitted,
             );
         }
+        let retained_budget = retained_event_budget(processed, exited);
+        processed += self.drain_retained_events(retained_budget, &mut emitted);
         (emitted, event_drain_may_have_more(processed, exited))
+    }
+
+    fn drain_retained_events(&self, budget: usize, emitted: &mut Vec<WorkspaceEvent>) -> usize {
+        let (hidden_events, processed) = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain_events(budget);
+        emitted.extend(hidden_events);
+        processed
     }
 
     fn attachment_for_worker(
@@ -1591,6 +1895,14 @@ impl Workspace {
 
 const fn event_drain_may_have_more(processed: usize, exited: bool) -> bool {
     !exited && processed == MAX_EVENTS_PER_DRAIN
+}
+
+const fn retained_event_budget(processed: usize, exited: bool) -> usize {
+    if exited {
+        0
+    } else {
+        MAX_EVENTS_PER_DRAIN.saturating_sub(processed)
+    }
 }
 
 fn capture_attach_request(

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1355,7 +1355,7 @@ impl Workspace {
         }
         let navigation_generation = self.begin_navigation();
         if let Some(key) = self.retained_key_for_selection(selection) {
-            if self.activate_retained_presentation(&key, Some(selection), None)? {
+            if self.activate_retained_presentation(&key, None)? {
                 return Ok(());
             }
             return Err(WorkspaceError::new(
@@ -1435,19 +1435,19 @@ impl Workspace {
             presentation,
             navigation_generation,
         });
-        match self.activate_retained_presentation(&key, Some(selection), fallback.clone()) {
+        match self.activate_retained_presentation(&key, fallback.clone()) {
             Ok(true) => return Ok(()),
             Ok(false) => {}
             Err(error) => {
                 if let Some(previous) = previous {
-                    let _restored = self.activate_retained_presentation(&previous, None, None);
+                    let _restored = self.activate_retained_presentation(&previous, None);
                 }
                 return Err(error);
             }
         }
         if already_open {
             if let Some(previous) = previous {
-                let _restored = self.activate_retained_presentation(&previous, None, None);
+                let _restored = self.activate_retained_presentation(&previous, None);
             }
             return Err(WorkspaceError::new(
                 "the retained terminal presentation is no longer available",
@@ -1575,10 +1575,9 @@ impl Workspace {
     fn activate_retained_presentation(
         &self,
         key: &PresentationKey,
-        selection: Option<&SessionSelection>,
         fallback: Option<FallbackAuthority>,
     ) -> Result<bool, WorkspaceError> {
-        activate_retained_presentation(&self.inner, key, selection, fallback)
+        activate_retained_presentation(&self.inner, key, fallback)
     }
 
     fn start_attachment(
@@ -1608,7 +1607,7 @@ impl Workspace {
                 ));
             }
             generation = attachment
-                .reserve_with_fallback(request.clone(), AttachTerm::Xterm256Color, fallback.clone())
+                .reserve_with_fallback(request.clone(), AttachTerm::Xterm256Color, fallback)
                 .ok_or_else(|| WorkspaceError::new("a terminal presentation is already opening"))?;
             clear_terminal_notice(&self.inner);
             *state = WorkspaceContent::Attaching {
@@ -1619,7 +1618,6 @@ impl Workspace {
         }
         self.inner.revision.fetch_add(1, Ordering::Release);
         let inner = Arc::clone(&self.inner);
-        let failure_request = request.clone();
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-terminal-attach".to_owned())
             .spawn(move || {
@@ -1631,11 +1629,12 @@ impl Workspace {
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if attachment.clear_if_current(generation) {
-                let fallback = fallback.filter(|fallback| {
-                    fallback_owns_visible_request(&self.inner, fallback, &failure_request)
-                        && fallback.navigation_generation == navigation_generation
-                });
+            if let Some((_, fallback)) =
+                failed_attachment_context(&self.inner, &attachment, generation)
+            {
+                let fallback = fallback
+                    .filter(|fallback| fallback.navigation_generation == navigation_generation);
+                attachment.clear_if_current(generation);
                 drop(attachment);
                 self.restore_inventory_state();
                 restore_attach_fallback_locked(&self.inner, fallback);
@@ -2193,7 +2192,6 @@ impl Workspace {
             }
         }
         let inner = Arc::clone(&self.inner);
-        let failure_request = request.clone();
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-terminal-terminfo-retry".to_owned())
             .spawn(move || run_attach(&inner, &request, AttachTerm::Xterm, generation))
@@ -2203,12 +2201,10 @@ impl Workspace {
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let fallback = attachment
-                .fallback_if_current(generation)
-                .filter(|fallback| {
-                    fallback_owns_visible_request(&self.inner, fallback, &failure_request)
-                });
-            if attachment.clear_if_current(generation) {
+            if let Some((_, fallback)) =
+                failed_attachment_context(&self.inner, &attachment, generation)
+            {
+                attachment.clear_if_current(generation);
                 drop(attachment);
                 self.restore_inventory_state();
                 restore_attach_fallback(&self.inner, fallback);
@@ -2241,10 +2237,9 @@ impl Workspace {
 fn activate_retained_presentation(
     inner: &Inner,
     key: &PresentationKey,
-    selection: Option<&SessionSelection>,
     fallback: Option<FallbackAuthority>,
 ) -> Result<bool, WorkspaceError> {
-    let Some(mut presentation) = inner
+    let Some(presentation) = inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -2252,12 +2247,6 @@ fn activate_retained_presentation(
     else {
         return Ok(false);
     };
-    if let Some(selection) = selection {
-        presentation.selection = selection.clone();
-        selection
-            .session()
-            .clone_into(&mut presentation.attachment.request.name);
-    }
     let geometry = *inner
         .terminal_geometry
         .lock()
@@ -2587,19 +2576,19 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                 .attachment
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let fallback = attachment
-                .fallback_if_current(generation)
-                .filter(|fallback| fallback_owns_visible_request(inner, fallback, request));
-            if !attachment.clear_if_current(generation) {
+            let Some((current_request, fallback)) =
+                failed_attachment_context(inner, &attachment, generation)
+            else {
                 return;
-            }
+            };
+            attachment.clear_if_current(generation);
             drop(attachment);
             match error {
                 AttachFreshError::Host(error) => {
-                    publish_attachment_failure(inner, request.inventory_generation, error);
+                    publish_attachment_failure(inner, current_request.inventory_generation, error);
                 }
                 AttachFreshError::SessionChanged { error, snapshot } => {
-                    publish_stale_attachment_failure(inner, request, snapshot, &error);
+                    publish_stale_attachment_failure(inner, &current_request, snapshot, &error);
                 }
             }
             restore_attach_fallback(inner, fallback);
@@ -2697,6 +2686,21 @@ fn fallback_owns_visible_request(
     )
 }
 
+fn failed_attachment_context(
+    inner: &Inner,
+    attachment: &AttachmentState<AttachRequest>,
+    generation: u64,
+) -> Option<(AttachRequest, Option<FallbackAuthority>)> {
+    if !attachment.is_current(generation) {
+        return None;
+    }
+    let request = attachment.active()?.request.clone();
+    let fallback = attachment
+        .fallback_if_current(generation)
+        .filter(|fallback| fallback_owns_visible_request(inner, fallback, &request));
+    Some((request, fallback))
+}
+
 fn restore_attach_fallback(inner: &Inner, fallback: Option<FallbackAuthority>) {
     let _navigation = inner
         .navigation
@@ -2717,7 +2721,7 @@ fn restore_attach_fallback_locked(inner: &Inner, fallback: Option<FallbackAuthor
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
-    match activate_retained_presentation(inner, &fallback.presentation, None, None) {
+    match activate_retained_presentation(inner, &fallback.presentation, None) {
         Ok(true) => {
             if let Some(notice) = preserved_notice {
                 set_local_notice(inner, notice);
@@ -3757,6 +3761,9 @@ mod tests {
             worker: (),
             presentation_id: 7,
         });
+        let stale_activation_key = retained
+            .key_for_selection(&SessionSelection::new("wsl", "Ubuntu", "original"))
+            .expect("stale caller captured retained identity");
         let renamed_snapshot = HostSnapshot::test_fixture(
             "Ubuntu",
             "boot-id",
@@ -3773,6 +3780,11 @@ mod tests {
             retained.key_for_selection(&SessionSelection::new("wsl", "Ubuntu", "renamed")),
             Some(key.clone())
         );
+        let activated = retained
+            .take(&stale_activation_key)
+            .expect("identity remains activatable after rename");
+        assert_eq!(activated.selection.session(), "renamed");
+        assert_eq!(activated.attachment.request.name, "renamed");
 
         let workspace = Workspace::preview(WorkspaceSnapshot::ready(
             Appearance::default(),
@@ -3879,6 +3891,60 @@ mod tests {
             &fallback,
             &request
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn failed_attachment_context_uses_the_reconciled_session_name() {
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = attach_request_fixture(
+            &snapshot,
+            session::SessionIdentity::new(100, "$1", 200),
+            "original",
+        );
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let navigation_generation = workspace.begin_navigation();
+        let fallback = fallback_fixture(
+            "boot-id",
+            42,
+            session::SessionIdentity::new(100, "$2", 201),
+            navigation_generation,
+        );
+        let generation = workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve_with_fallback(request, AttachTerm::Xterm256Color, Some(fallback.clone()))
+            .expect("reserve attachment");
+        {
+            let mut attachment = workspace.inner.attachment.lock().expect("attachment");
+            attachment
+                .active_mut()
+                .expect("active attachment")
+                .request
+                .name = "renamed".to_owned();
+        }
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "renamed".to_owned(),
+            },
+        );
+
+        let attachment = workspace.inner.attachment.lock().expect("attachment");
+        let (failed_request, restored_fallback) =
+            failed_attachment_context(&workspace.inner, &attachment, generation)
+                .expect("current failure context");
+
+        assert_eq!(failed_request.name, "renamed");
+        assert_eq!(restored_fallback, Some(fallback));
     }
 
     #[test]

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -282,6 +282,69 @@ fn switches_between_discovered_sessions_without_destroying_either() {
     });
 }
 
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn rename_during_switch_keeps_retained_navigation_consistent() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("rename-switch");
+    server.run_tmux(["new-session", "-d", "-s", "switch-live"]);
+    let workspace = start_workspace(&server);
+    wait_for_sessions(&workspace, &["workspace-live", "switch-live"]);
+
+    workspace
+        .attach(&session_selection(&workspace, "workspace-live"))
+        .expect("attach first session");
+    wait_for_terminal(&workspace, "workspace-live");
+    let switch_target = session_selection(&workspace, "switch-live");
+
+    server.run_tmux(["rename-session", "-t", "=workspace-live", "renamed-live"]);
+    workspace.refresh().expect("start rename refresh");
+    workspace
+        .switch_session(&switch_target)
+        .expect("switch while rename refresh is active");
+    wait_for_terminal(&workspace, "switch-live");
+    wait_until(|| {
+        let snapshot = workspace.snapshot();
+        snapshot
+            .hosts()
+            .iter()
+            .flat_map(workspace::HostItem::sessions)
+            .any(|session| session.name() == "renamed-live")
+            && snapshot
+                .retained_selections()
+                .iter()
+                .any(|selection| selection.session() == "renamed-live")
+            && !snapshot
+                .retained_selections()
+                .iter()
+                .any(|selection| selection.session() == "workspace-live")
+    });
+
+    workspace
+        .switch_session(&session_selection(&workspace, "renamed-live"))
+        .expect("reactivate renamed retained presentation");
+    wait_for_terminal(&workspace, "renamed-live");
+    workspace
+        .switch_session(&switch_target)
+        .expect("retain renamed presentation again");
+    wait_for_terminal(&workspace, "switch-live");
+
+    let revision_before_exit = workspace.snapshot().revision();
+    server.run_tmux(["kill-session", "-t", "=renamed-live"]);
+    wait_until(|| {
+        let _events = workspace.drain_events();
+        let snapshot = workspace.snapshot();
+        snapshot.revision() > revision_before_exit
+            && !snapshot
+                .retained_selections()
+                .iter()
+                .any(|selection| selection.session() == "renamed-live")
+    });
+    workspace.detach();
+}
+
 fn assert_retained(workspace: &Workspace, expected_session: &str) {
     assert!(
         workspace

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -209,6 +209,7 @@ fn switches_between_discovered_sessions_without_destroying_either() {
             WorkspaceContent::Terminal { session, .. } if session == "workspace-live"
         )
     });
+    let first_presentation = active_presentation_id(&workspace);
 
     workspace
         .switch_session(&session_selection(&workspace, "switch-live"))
@@ -222,13 +223,53 @@ fn switches_between_discovered_sessions_without_destroying_either() {
         },
         || workspace_diagnostic(&workspace),
     );
+    let second_presentation = active_presentation_id(&workspace);
 
     let sessions = server.run_tmux(["list-sessions", "-F", "#{session_name}:#{session_attached}"]);
     let sessions = String::from_utf8(sessions.stdout).expect("UTF-8 session inventory");
-    assert!(sessions.lines().any(|line| line == "workspace-live:0"));
+    assert!(sessions.lines().any(|line| line == "workspace-live:1"));
     assert!(sessions.lines().any(|line| line == "switch-live:1"));
 
+    workspace
+        .switch_session(&session_selection(&workspace, "workspace-live"))
+        .expect("restore retained first presentation");
+    assert!(matches!(
+        workspace.snapshot().content(),
+        WorkspaceContent::Terminal {
+            session,
+            presentation_id,
+            ..
+        } if session == "workspace-live" && *presentation_id == first_presentation
+    ));
+
     workspace.detach();
+    wait_until(|| {
+        let sessions =
+            server.run_tmux(["list-sessions", "-F", "#{session_name}:#{session_attached}"]);
+        let sessions = String::from_utf8(sessions.stdout).expect("UTF-8 session inventory");
+        sessions.lines().any(|line| line == "workspace-live:0")
+            && sessions.lines().any(|line| line == "switch-live:1")
+    });
+
+    workspace
+        .attach(&session_selection(&workspace, "switch-live"))
+        .expect("restore retained second presentation");
+    assert!(matches!(
+        workspace.snapshot().content(),
+        WorkspaceContent::Terminal {
+            session,
+            presentation_id,
+            ..
+        } if session == "switch-live" && *presentation_id == second_presentation
+    ));
+    workspace.detach();
+    wait_until(|| {
+        let sessions =
+            server.run_tmux(["list-sessions", "-F", "#{session_name}:#{session_attached}"]);
+        let sessions = String::from_utf8(sessions.stdout).expect("UTF-8 session inventory");
+        sessions.lines().any(|line| line == "workspace-live:0")
+            && sessions.lines().any(|line| line == "switch-live:0")
+    });
     wait_until(|| {
         matches!(
             workspace.snapshot().content(),
@@ -387,4 +428,13 @@ fn session_selection(workspace: &Workspace, session: &str) -> SessionSelection {
     let snapshot = workspace.snapshot();
     let host = &snapshot.hosts()[0];
     SessionSelection::new(host.id(), host.endpoint(), session)
+}
+
+fn active_presentation_id(workspace: &Workspace) -> u64 {
+    match workspace.snapshot().content() {
+        WorkspaceContent::Terminal {
+            presentation_id, ..
+        } => *presentation_id,
+        _ => panic!("terminal presentation should be active"),
+    }
 }

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -282,6 +282,71 @@ fn switches_between_discovered_sessions_without_destroying_either() {
 
 #[test]
 #[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn failed_first_switch_restores_the_previous_presentation() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("switch-failure");
+    server.run_tmux(["new-session", "-d", "-s", "switch-live"]);
+    let workspace = start_workspace(&server);
+    wait_for_sessions(&workspace, &["workspace-live", "switch-live"]);
+
+    workspace
+        .attach(&session_selection(&workspace, "workspace-live"))
+        .expect("attach first session");
+    wait_for_terminal(&workspace, "workspace-live");
+    let presentation_id = active_presentation_id(&workspace);
+    let missing = session_selection(&workspace, "switch-live");
+    server.run_tmux(["kill-session", "-t", "=switch-live"]);
+
+    workspace
+        .switch_session(&missing)
+        .expect("start guarded switch to stale inventory target");
+    wait_for_terminal(&workspace, "workspace-live");
+    assert_eq!(active_presentation_id(&workspace), presentation_id);
+    assert_session_attached(&server, "workspace-live", 1);
+    workspace.detach();
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn failed_retained_activation_restores_the_previous_presentation() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("retained-failure");
+    server.run_tmux(["new-session", "-d", "-s", "switch-live"]);
+    let workspace = start_workspace(&server);
+    wait_for_sessions(&workspace, &["workspace-live", "switch-live"]);
+
+    workspace
+        .attach(&session_selection(&workspace, "workspace-live"))
+        .expect("attach first session");
+    wait_for_terminal(&workspace, "workspace-live");
+    workspace
+        .switch_session(&session_selection(&workspace, "switch-live"))
+        .expect("attach second session");
+    wait_for_terminal(&workspace, "switch-live");
+    let dead_target = session_selection(&workspace, "switch-live");
+    workspace
+        .switch_session(&session_selection(&workspace, "workspace-live"))
+        .expect("restore first session");
+    let presentation_id = active_presentation_id(&workspace);
+
+    server.run_tmux(["kill-session", "-t", "=switch-live"]);
+    thread::sleep(Duration::from_secs(2));
+    assert!(workspace.switch_session(&dead_target).is_err());
+    assert!(matches!(
+        workspace.snapshot().content(),
+        WorkspaceContent::Terminal { session, .. } if session == "workspace-live"
+    ));
+    assert_eq!(active_presentation_id(&workspace), presentation_id);
+    assert_session_attached(&server, "workspace-live", 1);
+    workspace.detach();
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
 fn refuses_to_attach_when_the_discovered_session_was_replaced() {
     let _serial = WSL_LIVE
         .lock()
@@ -437,4 +502,52 @@ fn active_presentation_id(workspace: &Workspace) -> u64 {
         } => *presentation_id,
         _ => panic!("terminal presentation should be active"),
     }
+}
+
+fn start_workspace(server: &IsolatedServer) -> Workspace {
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    Workspace::start_wsl(config, TerminalAppearance::default())
+}
+
+fn wait_for_sessions(workspace: &Workspace, expected: &[&str]) {
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Ready { sessions, .. }
+                    if expected.iter().all(|expected| {
+                        sessions.iter().any(|session| session.name() == *expected)
+                    })
+            )
+        },
+        || workspace_diagnostic(workspace),
+    );
+}
+
+fn wait_for_terminal(workspace: &Workspace, expected: &str) {
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal { session, .. } if session == expected
+            )
+        },
+        || workspace_diagnostic(workspace),
+    );
+}
+
+fn assert_session_attached(server: &IsolatedServer, name: &str, expected: u32) {
+    let output = server.run_tmux([
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}",
+    ]);
+    let sessions = String::from_utf8(output.stdout).expect("UTF-8 attached-client count");
+    assert!(
+        sessions
+            .lines()
+            .any(|line| line == format!("{name}\t{expected}")),
+        "expected {name} to have {expected} attached client(s): {sessions:?}"
+    );
 }

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -178,6 +178,69 @@ fn discovers_attaches_renders_and_detaches_through_workspace() {
 
 #[test]
 #[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn switches_between_discovered_sessions_without_destroying_either() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("switch");
+    server.run_tmux(["new-session", "-d", "-s", "switch-live"]);
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Ready { sessions, .. }
+                    if sessions.iter().any(|session| session.name() == "workspace-live")
+                        && sessions.iter().any(|session| session.name() == "switch-live")
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+
+    workspace
+        .attach(&session_selection(&workspace, "workspace-live"))
+        .expect("attach first session");
+    wait_until(|| {
+        matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Terminal { session, .. } if session == "workspace-live"
+        )
+    });
+
+    workspace
+        .switch_session(&session_selection(&workspace, "switch-live"))
+        .expect("begin session switch");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal { session, .. } if session == "switch-live"
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+
+    let sessions = server.run_tmux(["list-sessions", "-F", "#{session_name}:#{session_attached}"]);
+    let sessions = String::from_utf8(sessions.stdout).expect("UTF-8 session inventory");
+    assert!(sessions.lines().any(|line| line == "workspace-live:0"));
+    assert!(sessions.lines().any(|line| line == "switch-live:1"));
+
+    workspace.detach();
+    wait_until(|| {
+        matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { sessions, .. }
+                if sessions.iter().any(|session| session.name() == "workspace-live")
+                    && sessions.iter().any(|session| session.name() == "switch-live")
+        )
+    });
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
 fn refuses_to_attach_when_the_discovered_session_was_replaced() {
     let _serial = WSL_LIVE
         .lock()

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -316,6 +316,13 @@ fn failed_first_switch_restores_the_previous_presentation() {
         .expect("start guarded switch to stale inventory target");
     wait_for_terminal(&workspace, "workspace-live");
     assert_eq!(active_presentation_id(&workspace), presentation_id);
+    assert!(
+        workspace
+            .snapshot()
+            .notice()
+            .is_some_and(|notice| notice.contains("no longer exists")),
+        "restoring the prior terminal must preserve the switch failure diagnostic"
+    );
     assert_session_attached(&server, "workspace-live", 1);
     workspace.detach();
 }

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -224,6 +224,7 @@ fn switches_between_discovered_sessions_without_destroying_either() {
         || workspace_diagnostic(&workspace),
     );
     let second_presentation = active_presentation_id(&workspace);
+    assert_retained(&workspace, "workspace-live");
 
     let sessions = server.run_tmux(["list-sessions", "-F", "#{session_name}:#{session_attached}"]);
     let sessions = String::from_utf8(sessions.stdout).expect("UTF-8 session inventory");
@@ -241,6 +242,7 @@ fn switches_between_discovered_sessions_without_destroying_either() {
             ..
         } if session == "workspace-live" && *presentation_id == first_presentation
     ));
+    assert_retained(&workspace, "switch-live");
 
     workspace.detach();
     wait_until(|| {
@@ -278,6 +280,16 @@ fn switches_between_discovered_sessions_without_destroying_either() {
                     && sessions.iter().any(|session| session.name() == "switch-live")
         )
     });
+}
+
+fn assert_retained(workspace: &Workspace, expected_session: &str) {
+    assert!(
+        workspace
+            .snapshot()
+            .retained_selections()
+            .iter()
+            .any(|selection| selection.session() == expected_session)
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Makes the Windows workspace tree compact and terminal-first, with full-bleed terminal rendering and clear Open/detach actions.
- Keeps sidebar clicks reliable even when terminal mouse tracking is active.
- Retains every opened tmux client, worker, and surface so returning to a session is immediate instead of reconnecting.
- Keeps explicit close detach-only and preserves every server-side tmux session.
- Verifies exact endpoint, socket, and live session identity before a first attachment.
- Passes the full Rust workspace, architecture, Clippy, contract, and isolated WSL lifecycle suites.