### PR TITLE
Create and refresh local WSL tmux sessions

### DIFF
--- a/.github/workflows/rust-wsl-live.yml
+++ b/.github/workflows/rust-wsl-live.yml
@@ -1,0 +1,61 @@
+name: Rust WSL Live Acceptance
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wsl-live:
+    name: WSL2 terminal lifecycle
+    runs-on: [self-hosted, Windows, X64, ghosthub-wsl2]
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: rust
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Verify the WSL2 acceptance environment
+        shell: pwsh
+        run: |
+          $wsl = Join-Path ([Environment]::GetFolderPath('System')) 'wsl.exe'
+          if (-not (Test-Path -LiteralPath $wsl -PathType Leaf)) {
+            throw "The acceptance runner does not provide System32\\wsl.exe."
+          }
+
+          $kernel = (& $wsl --exec /usr/bin/uname -r | Out-String).Trim()
+          if ($LASTEXITCODE -ne 0 -or $kernel -notmatch 'WSL2') {
+            throw "The default WSL distro is not running under WSL2: $kernel"
+          }
+
+          & $wsl --exec /usr/bin/tmux -V
+          if ($LASTEXITCODE -ne 0) {
+            throw "The default WSL2 distro does not provide /usr/bin/tmux."
+          }
+
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install 1.96.1 --profile minimal
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: rust
+
+      - name: Run live WSL terminal and workspace tests
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -property installationPath`) do set "VSINSTALL=%%i" || exit /b 1
+          if not defined VSINSTALL exit /b 1
+          call "%VSINSTALL%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=x64 -host_arch=x64 || exit /b 1
+          cargo test-wsl-terminal-live || exit /b 1
+          cargo test-wsl-workspace-live || exit /b 1

--- a/.github/workflows/rust-wsl-live.yml
+++ b/.github/workflows/rust-wsl-live.yml
@@ -1,7 +1,6 @@
 name: Rust WSL Live Acceptance
 
 on:
-  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -14,7 +13,10 @@ concurrency:
 jobs:
   wsl-live:
     name: WSL2 terminal lifecycle
-    runs-on: [self-hosted, Windows, X64, ghosthub-wsl2]
+    if: github.repository == 'kenn-io/ghosthub' && github.ref == 'refs/heads/rust-port'
+    runs-on:
+      group: ghosthub-wsl-acceptance
+      labels: [self-hosted, Windows, X64]
     timeout-minutes: 45
     defaults:
       run:
@@ -23,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Verify the WSL2 acceptance environment

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ KWT_SOURCE_REVISION ?= unpinned
 endif
 SWIFT_TEST_FILTER ?=
 
-.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows test-ssh-authentication-live build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach purge-test-tmux python-test test rust-format-check rust-test rust-lint rust-deny rust-check smoke-test docs-build docs-serve site-docs-serve site-deploy reset-app-state install-hooks format format-check
+.PHONY: help bootstrap-kwt bootstrap-kwt-variants ensure-kwt ensure-kwt-variants bootstrap-libghostty bootstrap-libghostty-release check-libghostty check-libghostty-release test-libghostty-bootstrap test-terminal-fallback test-stage-release-app-bundles test-assemble-app-bundle test-essential-workflows test-ssh-authentication-live build swift-warning-check build-release debug-app release-app release-dmg release-appcast run-release-app run-app swift-test test-tmux-attach purge-test-tmux python-test test rust-format-check rust-test rust-test-wsl-live rust-lint rust-deny rust-check smoke-test docs-build docs-serve site-docs-serve site-deploy reset-app-state install-hooks format format-check
 
 help:
 	@printf '%s\n' \
@@ -109,6 +109,8 @@ help:
 		'      Run both the Swift and Python test suites.' \
 		'  make rust-check' \
 		'      Run Rust formatting, tests, checks, and clippy for the current platform.' \
+		'  make rust-test-wsl-live' \
+		'      Run the isolated WSL2 terminal and workspace acceptance suites.' \
 		'  make rust-deny' \
 		'      Check the complete Windows/Linux Rust dependency graph with cargo-deny.' \
 		'  make format' \
@@ -431,6 +433,10 @@ rust-format-check:
 
 rust-test:
 	@cd "$(RUST_DIR)" && $(CARGO) test --workspace --locked
+
+rust-test-wsl-live:
+	@cd "$(RUST_DIR)" && $(CARGO) test-wsl-terminal-live
+	@cd "$(RUST_DIR)" && $(CARGO) test-wsl-workspace-live
 
 rust-lint:
 	@cd "$(RUST_DIR)" && $(CARGO) check --workspace --all-targets --locked

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -492,6 +492,10 @@ endpoint and tmux server PID, `session_id`, and `session_created` identity. A
 single tmux conditional checks all three live values and kills only the
 matching instance, rejecting a same-named replacement even within the same
 timestamp second or after a rapid tmux server restart.
+The Rust WSL implementation obtains that authority from a fresh host query
+before presenting confirmation and targets the captured stable session ID
+inside the conditional, keeping cached inventory and mutable display names out
+of the destructive command.
 Ghosthub detaches an active client after a successful kill, never before the
 operation can fail. After success, Ghosthub closes the matching current active
 selection and navigates away only when the killed target is active at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,10 @@ frame. Missing WSL omits that host. A slow, failed, or unsupported WSL runtime
 changes only the host entry to an unavailable state with Retry and never
 replaces the application shell. The first refresh has a 45-second total budget
 for cold start; later attempts have 30 seconds, in addition to per-command
-timeouts.
+timeouts. Returning focus to a window refreshes a ready WSL inventory, matching
+the Swift app's activation-driven discovery without retrying disconnected or
+failed hosts in a loop. Later refreshes reuse the admitted host capability so
+they perform ordinary inventory reads instead of repeating tmux admission.
 
 Rust keeps backend and authority boundaries structural: the UI package has
 direct dependencies only on workspace, model, and surface, while persistence

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,9 @@ The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity
 and retains only attach authority. Creation failure never authorizes a rerun or
-server cleanup.
+server cleanup. The creation interaction pins its selected endpoint and may use
+the existing admitted host while an activation-driven inventory refresh is in
+flight; it never follows a changed default distro implicitly.
 
 Rust keeps backend and authority boundaries structural: the UI package has
 direct dependencies only on workspace, model, and surface, while persistence

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,6 +138,11 @@ timeouts. Returning focus to a window refreshes a ready WSL inventory, matching
 the Swift app's activation-driven discovery without retrying disconnected or
 failed hosts in a loop. Later refreshes reuse the admitted host capability so
 they perform ordinary inventory reads instead of repeating tmux admission.
+The ready host also exposes explicit bare-session creation. Rust consumes one
+non-cloneable CreateOnce as an ordinary ConPTY client running atomic
+`new-session -A`; it then captures the fresh WSL runtime and tmux live identity
+and retains only attach authority. Creation failure never authorizes a rerun or
+server cleanup.
 
 Rust keeps backend and authority boundaries structural: the UI package has
 direct dependencies only on workspace, model, and surface, while persistence

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -755,7 +755,10 @@ never retries after consuming its authority. From that point the presentation
 holds only attach authority. A race that creates the same name
 after validation attaches to that exact existing session without changing its
 layout. A failure after launch may detach and report the result but never
-reruns creation or kills the session.
+reruns creation or kills the session. Until promotion to attach authority,
+workspace navigation owns a cancellable pending-creation reservation; choosing
+another session restores navigation immediately and invalidates the background
+task without gaining authority to destroy any session it may have created.
 
 Slice 1 reads font family, font size, and theme through:
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -719,10 +719,12 @@ without attaching and becomes a classified refresh diagnostic.
 
 The same local WSL slice exposes explicit bare-session creation from the host
 tree. The dialog applies the shipped 1-100 character tmux-name rules and
-rejects names already present in current inventory. It pins the displayed WSL
-endpoint and remains usable while that already-admitted host performs a
-background inventory refresh; a disconnected, unavailable, or changed endpoint
-must be selected again. Workspace performs one
+rejects names already present in current inventory. Its title, validation copy,
+terminal-marked input, and subdued detach footer follow the Swift creation
+sheet; distro identity is not presented as the logical host name. The dialog
+pins its selected WSL endpoint and remains usable while that already-admitted
+host performs a background inventory refresh; a disconnected, unavailable, or
+changed endpoint must be selected again. Workspace performs one
 fresh admitted-host read, terminal consumes a non-cloneable CreateOnce whose
 ordinary client executes `new-session -A -s <name>`, and host captures the
 resulting runtime, server, session ID, and creation time. From that point the

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -151,6 +151,14 @@ Expiry cancels the active generation and discards late publication. Retry
 supersedes the earlier generation without changing the configured distro,
 binary, socket directory, or identity rules.
 
+When a Ghosthub window becomes active, workspace refreshes a ready WSL host so
+sessions created or removed in another terminal appear without an explicit
+Refresh click. Connecting, disconnected, and unavailable hosts do not start an
+activation retry; their existing Cancel, Connect, and Retry actions remain
+authoritative. Refresh retains the last published session rows while work is in
+flight and reuses the admitted WSL host capability, including its runtime-bound
+tmux verification cache.
+
 Each host command runs in a disposable descendant container: a kill-on-close
 Job Object on Windows and a dedicated process group on Unix. Stdout and stderr
 travel through a bounded fixed-chunk channel into capped capture buffers. On

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -757,8 +757,9 @@ after validation attaches to that exact existing session without changing its
 layout. A failure after launch may detach and report the result but never
 reruns creation or kills the session. Until promotion to attach authority,
 workspace navigation owns a cancellable pending-creation reservation; choosing
-another session restores navigation immediately and invalidates the background
-task without gaining authority to destroy any session it may have created.
+another session or detaching restores navigation immediately and invalidates
+the background task without gaining authority to destroy any session it may
+have created.
 
 Slice 1 reads font family, font size, and theme through:
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -746,9 +746,13 @@ pins its selected WSL endpoint and remains usable while that already-admitted
 host performs a background inventory refresh; a disconnected, unavailable, or
 changed endpoint must be selected again. Workspace performs one
 fresh admitted-host read, terminal consumes a non-cloneable CreateOnce whose
-ordinary client executes `new-session -A -s <name>`, and host captures the
-resulting runtime, server, session ID, and creation time. From that point the
-presentation holds only attach authority. A race that creates the same name
+ordinary client executes `new-session -A -E -s <name>`, and host captures the
+resulting runtime, server, session ID, and creation time. Admission proves
+`xterm-256color` on that same atomic client shape before caching it for
+creation; if the distro lacks that terminfo entry, admission proves `xterm`
+instead and creation immediately displays the reduced-color notice. Creation
+never retries after consuming its authority. From that point the presentation
+holds only attach authority. A race that creates the same name
 after validation attaches to that exact existing session without changing its
 layout. A failure after launch may detach and report the result but never
 reruns creation or kills the session.

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -863,14 +863,23 @@ scaffolding. Windows tests use a unique WSL tmux socket namespace and assert
 before and after each run that the user's default server is untouched.
 
 The live gate runs separately from ordinary pull-request CI on a Windows x64
-acceptance runner labeled `ghosthub-wsl2`. That runner must have a usable WSL2
-default distro, `/usr/bin/tmux`, and the Windows Rust build toolchain. The
-manually dispatched `rust-wsl-live.yml` workflow runs the same terminal and
-workspace suites as `make rust-test-wsl-live`; a successful live run is
-required acceptance evidence for changes to WSL attachment, creation, guarded
-kill, or client-lifetime behavior. GitHub-hosted Windows runners remain the
-fast compile, unit, contract, and lint gate because their installed WSL tooling
-does not guarantee a usable WSL2 distro or nested virtualization.
+runner in the dedicated `ghosthub-wsl-acceptance` group. That runner must have
+a usable WSL2 default distro, `/usr/bin/tmux`, and the Windows Rust build
+toolchain. The group's GitHub settings permit only the canonical repository
+and the exact `rust-wsl-live.yml` workflow.
+
+The workflow is manual-only. It rejects every repository and ref except
+`kenn-io/ghosthub`'s `rust-port` integration branch, then explicitly checks out
+the immutable dispatch SHA. It never executes feature-branch or fork code on
+the persistent runner. Feature changes run `make rust-test-wsl-live` on an
+isolated developer machine before merge; after merge, the trusted integration
+SHA receives the GitHub acceptance run. A successful live run is required
+acceptance evidence for changes to WSL attachment, creation, guarded kill, or
+client-lifetime behavior.
+
+GitHub-hosted Windows runners remain the fast compile, unit, contract, and lint
+gate because their installed WSL tooling does not guarantee a usable WSL2
+distro or nested virtualization.
 
 The Rust port adds no Swift or macOS live-attach work. Linux compilation is not
 used as evidence for the Windows ConPTY-to-WSL relay path.

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -393,10 +393,12 @@ VerifiedKwtHelper requires the exact revision, verified SHA-256, and
 revision-scoped managed path.
 
 Cached inventory identity is display-only. LiveIdentity has private fields and
-can be produced only by a fresh query immediately before a destructive
-operation. Conditional kill compares server PID, session ID, and creation
-timestamp. Store cannot depend on the session crate and cannot serialize
-runtime authority.
+can be produced only from a fresh, length-framed all-session query immediately
+before a destructive operation. Host matches the decoded display name in Rust;
+the name never crosses back into a tmux target expression. Conditional kill
+then targets the captured session ID while comparing server PID, session ID,
+and creation timestamp. Store cannot depend on the session crate and cannot
+serialize runtime authority.
 
 ### Presentation registry
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -720,8 +720,9 @@ without attaching and becomes a classified refresh diagnostic.
 The same local WSL slice exposes explicit bare-session creation from the host
 tree. The dialog applies the shipped 1-100 character tmux-name rules and
 rejects names already present in current inventory. Its title, validation copy,
-terminal-marked input, and subdued detach footer follow the Swift creation
-sheet; distro identity is not presented as the logical host name. The dialog
+terminal-marked input, and compact actions present only task-relevant content;
+distro and lifecycle explanations are not shown in routine workflow chrome.
+The dialog
 pins its selected WSL endpoint and remains usable while that already-admitted
 host performs a background inventory refresh; a disconnected, unavailable, or
 changed endpoint must be selected again. Workspace performs one

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -717,7 +717,10 @@ without attaching and becomes a classified refresh diagnostic.
 
 The same local WSL slice exposes explicit bare-session creation from the host
 tree. The dialog applies the shipped 1-100 character tmux-name rules and
-rejects names already present in current inventory. Workspace performs one
+rejects names already present in current inventory. It pins the displayed WSL
+endpoint and remains usable while that already-admitted host performs a
+background inventory refresh; a disconnected, unavailable, or changed endpoint
+must be selected again. Workspace performs one
 fresh admitted-host read, terminal consumes a non-cloneable CreateOnce whose
 ordinary client executes `new-session -A -s <name>`, and host captures the
 resulting runtime, server, session ID, and creation time. From that point the

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -701,6 +701,16 @@ command. The chrome is shaped for additional admitted local mux hosts, but
 Slice 1 exposes only WSL tmux; psmux remains rejection evidence until it
 satisfies the same capability bar.
 
+The selected session row also exposes a separate destructive close action.
+It performs a fresh WSL runtime and tmux identity query before showing
+confirmation. Approval carries that non-persistable authority into one tmux
+conditional that compares server PID, session ID, and creation time, then
+kills by the captured stable session ID only on a match. Cancellation changes
+nothing; lookup, runtime, identity, and command failures leave the presentation
+open. A successful kill removes only the matching active or retained
+presentation and refreshes inventory. This action never shares the ordinary
+detach path.
+
 The Windows shell draws one compact title bar in the same visual plane as the
 application chrome. It retains the native window controls and dynamic
 session/endpoint title, and exposes a sidebar button there. `Ctrl+Shift+B`
@@ -801,7 +811,7 @@ Cross-window focus arbitration is deferred until multi-window delivery.
 
 Slice 1 includes policy-controlled OSC 52 writes to the Windows clipboard,
 empty responses for remote OSC 52 reads, and explicit clipboard paste with
-bracketed framing. It excludes IME composition, dead keys, kill,
+bracketed framing. It excludes IME composition, dead keys,
 kwt inventory, worktree mutation, remote SSH, managed-helper
 installation, native Linux product UI, persistence/restoration, multiple
 windows, Console Panel, telemetry, updates, packaging, and acceptance
@@ -845,7 +855,8 @@ After Slice 1:
 2. Worktree selection adds ordinary/protected RepairOrOpen authority; plain
    local session creation already ships through CreateOnce in the WSL slice.
 3. Local lifecycle adds project registration, worktree creation, branch/PR
-   import, deletion, and fresh-identity conditional Kill Session.
+   import, and deletion; the WSL slice already ships fresh-identity conditional
+   Kill Session for bare sessions.
 4. Remote hosts add OpenSSH diagnostics, managed-helper installation,
    attach-only transport reconnect, repair/open reconnect, and remote Windows.
 5. Persistence and restoration add the coalescing writer, host settings,

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -854,13 +854,23 @@ Rust keeps the same separation:
 
 - cargo test-contracts is the fast manifest, parsing, capability, plan,
   sidebar, registry, and architecture gate
-- test-rust-live-attach launches a real isolated tmux server inside a WSL2
+- `make rust-test-wsl-live` launches real isolated tmux servers inside a WSL2
   distro plus PTYs and supervisor children for detach and app-death survival
 
 Cargo test binaries own cross-platform orchestration. Make targets are thin
 wrappers; Windows CI invokes the same Cargo tests without POSIX shell
 scaffolding. Windows tests use a unique WSL tmux socket namespace and assert
 before and after each run that the user's default server is untouched.
+
+The live gate runs separately from ordinary pull-request CI on a Windows x64
+acceptance runner labeled `ghosthub-wsl2`. That runner must have a usable WSL2
+default distro, `/usr/bin/tmux`, and the Windows Rust build toolchain. The
+manually dispatched `rust-wsl-live.yml` workflow runs the same terminal and
+workspace suites as `make rust-test-wsl-live`; a successful live run is
+required acceptance evidence for changes to WSL attachment, creation, guarded
+kill, or client-lifetime behavior. GitHub-hosted Windows runners remain the
+fast compile, unit, contract, and lint gate because their installed WSL tooling
+does not guarantee a usable WSL2 distro or nested virtualization.
 
 The Rust port adds no Swift or macOS live-attach work. Linux compilation is not
 used as evidence for the Windows ConPTY-to-WSL relay path.

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -156,8 +156,10 @@ sessions created or removed in another terminal appear without an explicit
 Refresh click. Connecting, disconnected, and unavailable hosts do not start an
 activation retry; their existing Cancel, Connect, and Retry actions remain
 authoritative. Refresh retains the last published session rows while work is in
-flight and reuses the admitted WSL host capability, including its runtime-bound
-tmux verification cache.
+flight and reuses the admitted WSL host capability, including its endpoint- and
+runtime-bound tmux verification cache. A resolved default-distro change always
+requires fresh admission even when two WSL distributions report the same
+kernel boot ID and PID 1 start time.
 
 Each host command runs in a disposable descendant container: a kill-on-close
 Job Object on Windows and a dedicated process group on Unix. Stdout and stderr

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -701,15 +701,20 @@ command. The chrome is shaped for additional admitted local mux hosts, but
 Slice 1 exposes only WSL tmux; psmux remains rejection evidence until it
 satisfies the same capability bar.
 
-The selected session row also exposes a separate destructive close action.
-It performs a fresh WSL runtime and tmux identity query before showing
-confirmation. Approval carries that non-persistable authority into one tmux
+The active presentation keeps a detach action that only closes its ordinary
+client. Every session in the current live inventory separately exposes Kill
+Session, including sessions that are not open. Kill performs a fresh WSL
+runtime and tmux identity query before showing confirmation for the exact
+endpoint. Approval carries that non-persistable authority into one tmux
 conditional that compares server PID, session ID, and creation time, then
 kills by the captured stable session ID only on a match. Cancellation changes
 nothing; lookup, runtime, identity, and command failures leave the presentation
 open. A successful kill removes only the matching active or retained
-presentation and refreshes inventory. This action never shares the ordinary
-detach path.
+presentation and refreshes inventory. Kill completion rechecks the active
+identity under the navigation lock before detaching, so a concurrent switch
+cannot close an unrelated presentation. This action never shares the ordinary
+detach path. Cached rows remain visible while a host is unavailable, but only
+retained presentations can be reopened until the host reconnects.
 
 The Windows shell draws one compact title bar in the same visual plane as the
 application chrome. It retains the native window controls and dynamic
@@ -728,8 +733,10 @@ to the surviving identity from a fresh process. An identity mismatch exits
 without attaching and becomes a classified refresh diagnostic.
 
 The same local WSL slice exposes explicit bare-session creation from the host
-tree. The dialog applies the shipped 1-100 character tmux-name rules and
-rejects names already present in current inventory. Its title, validation copy,
+tree. The dialog applies the shipped 1-100 character tmux-name rules,
+additionally rejects `#` before it can reach tmux format evaluation, and
+rejects names already present in current inventory. Discovered sessions are
+unaffected and remain attachable by live identity. Its title, validation copy,
 terminal-marked input, and compact actions present only task-relevant content;
 distro and lifecycle explanations are not shown in routine workflow chrome.
 The dialog

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -705,7 +705,9 @@ The Windows shell draws one compact title bar in the same visual plane as the
 application chrome. It retains the native window controls and dynamic
 session/endpoint title, and exposes a sidebar button there. `Ctrl+Shift+B`
 toggles the sidebar without consuming tmux's `Ctrl+B` prefix; terminal geometry
-and pointer mapping update with the visible content area.
+and pointer mapping update with the visible content area. Sidebar host entries
+use one compact line for the logical host name; distro configuration is not
+duplicated beneath it and remains visible only in endpoint-relevant contexts.
 
 The flow resolves and verifies the exact mux binary, discovers live identity,
 reserves the presentation, and launches an AttachPlan whose single tmux

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -715,6 +715,17 @@ the reservation, renders through surface, disconnects on close, and reattaches
 to the surviving identity from a fresh process. An identity mismatch exits
 without attaching and becomes a classified refresh diagnostic.
 
+The same local WSL slice exposes explicit bare-session creation from the host
+tree. The dialog applies the shipped 1-100 character tmux-name rules and
+rejects names already present in current inventory. Workspace performs one
+fresh admitted-host read, terminal consumes a non-cloneable CreateOnce whose
+ordinary client executes `new-session -A -s <name>`, and host captures the
+resulting runtime, server, session ID, and creation time. From that point the
+presentation holds only attach authority. A race that creates the same name
+after validation attaches to that exact existing session without changing its
+layout. A failure after launch may detach and report the result but never
+reruns creation or kills the session.
+
 Slice 1 reads font family, font size, and theme through:
 
 ~~~text
@@ -753,9 +764,10 @@ clipboard-write = true
 Every field is optional. `clipboard-write` governs remote OSC 52 writes;
 remote OSC 52 reads remain denied regardless of configuration.
 
-Windows manual acceptance requires WSL2, tmux, and an existing session started
-outside Ghosthub. Setup is documented as deterministic commands rather than an
-implicit prerequisite. A missing server is an empty inventory, not an error.
+Windows manual acceptance requires WSL2 and tmux. Ghosthub can create the first
+session itself; setup remains documented as deterministic commands for tests
+that exercise discovery of an externally created session. A missing server is
+an empty inventory, not an error.
 
 The milestone proves:
 
@@ -765,6 +777,9 @@ The milestone proves:
 - buffers remain bounded and UI never blocks on PTY or store work
 - reselecting the same session in one window refuses a second client and
   focuses the existing terminal as Ghosthub policy rather than a tmux limit
+- explicit local creation consumes one atomic `new-session -A` authority,
+  publishes the fresh live identity, and survives detach without rerunning
+  creation
 - client close, graceful app exit, and forced app death preserve the server
   and permit fresh-process reattachment to the exact same live identity
 - failed relay-job membership fully unwinds the spawned attachment before the
@@ -778,7 +793,7 @@ Cross-window focus arbitration is deferred until multi-window delivery.
 
 Slice 1 includes policy-controlled OSC 52 writes to the Windows clipboard,
 empty responses for remote OSC 52 reads, and explicit clipboard paste with
-bracketed framing. It excludes IME composition, dead keys, creation, kill,
+bracketed framing. It excludes IME composition, dead keys, kill,
 kwt inventory, worktree mutation, remote SSH, managed-helper
 installation, native Linux product UI, persistence/restoration, multiple
 windows, Console Panel, telemetry, updates, packaging, and acceptance
@@ -819,8 +834,8 @@ After Slice 1:
 
 1. Local Ghosthub inventory adds pinned bundled kwt, project/worktree
    inventory, unbound reconciliation, and the full sidebar hierarchy.
-2. Launch authorities deliver user-visible plain session creation through
-   CreateOnce and worktree selection through ordinary/protected RepairOrOpen.
+2. Worktree selection adds ordinary/protected RepairOrOpen authority; plain
+   local session creation already ships through CreateOnce in the WSL slice.
 3. Local lifecycle adds project registration, worktree creation, branch/PR
    import, deletion, and fresh-identity conditional Kill Session.
 4. Remote hosts add OpenSSH diagnostics, managed-helper installation,

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -59,8 +59,11 @@ attachment establishes that the session is running. Before displaying
 confirmation, Ghosthub captures tmux's server PID, `session_id`, and
 `session_created` values together with the exact local or SSH endpoint, socket,
 and session name. Termination uses one tmux conditional command that compares
-all three live identity values and invokes `kill-session -t =<name>:` only on
-a match. The server PID distinguishes tmux server generations, while the
+all three live identity values and invokes `kill-session` against that exact
+session only on a match. Swift targets the exact name; the Windows WSL client
+targets the captured stable session ID so control characters and a concurrent
+rename never enter tmux's nested command parser. The server PID distinguishes
+tmux server generations, while the
 monotonically assigned session ID distinguishes same-named replacements within
 one server even when their second-resolution creation timestamps match. A
 replacement session is therefore never killed under stale cached inventory or

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -121,6 +121,16 @@ status 255 enters transport reconnect. Bare remote creation becomes
 attach-only before that loop; ordinary and protected kwt paths retain only
 their explicitly documented repair/open behavior.
 
+Rust local WSL creation follows the same one-shot rule as shipped local
+creation. After validating the normalized name, Ghosthub performs a fresh
+admitted-host read and consumes one CreateOnce by launching the ordinary
+ConPTY client with `tmux new-session -A -s <name>`. It captures the resulting
+runtime, server PID, session ID, and creation time before publishing the
+presentation; every later activation is attach-only. If creation and identity
+capture race another creator, `-A` attaches to the exact same-named session.
+If any step after launch fails, Ghosthub detaches the client and reports the
+failure but neither reruns creation nor destroys the possibly created session.
+
 Psmux 3.3.7 failed the required exact-kill proof and never established genuine
 ConPTY `attach-session -E` behavior. Its probe remains rejection evidence, but
 it is not the Rust Windows substrate. The Windows MVP uses real POSIX tmux in

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -60,10 +60,11 @@ confirmation, Ghosthub captures tmux's server PID, `session_id`, and
 `session_created` values together with the exact local or SSH endpoint, socket,
 and session name. Termination uses one tmux conditional command that compares
 all three live identity values and invokes `kill-session` against that exact
-session only on a match. Swift targets the exact name; the Windows WSL client
-targets the captured stable session ID so control characters and a concurrent
-rename never enter tmux's nested command parser. The server PID distinguishes
-tmux server generations, while the
+session only on a match. Swift targets the exact name. The Windows WSL client
+captures authority from a fresh length-framed all-session listing, matches the
+decoded name in Rust, and targets only the captured stable session ID; the name
+never re-enters a tmux target or nested command parser. The server PID
+distinguishes tmux server generations, while the
 monotonically assigned session ID distinguishes same-named replacements within
 one server even when their second-resolution creation timestamps match. A
 replacement session is therefore never killed under stale cached inventory or

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -2,5 +2,5 @@
 test-contracts = "test -p ghosthub-contracts -p ghosthub-config -p ghosthub-host -p ghosthub-session -p ghosthub-architecture"
 test-psmux-live = "test -p ghosthub-session --test psmux_live -- --ignored --nocapture"
 test-wsl-host-live = "test -p ghosthub-host --test wsl_live -- --ignored --nocapture"
-test-wsl-terminal-live = "test -p ghosthub-terminal --test wsl_live -- --ignored --nocapture --test-threads=1"
-test-wsl-workspace-live = "test -p ghosthub-workspace --test wsl_live -- --ignored --nocapture --test-threads=1"
+test-wsl-terminal-live = "test --locked -p ghosthub-terminal --test wsl_live -- --ignored --nocapture --test-threads=1"
+test-wsl-workspace-live = "test --locked -p ghosthub-workspace --test wsl_live -- --ignored --nocapture --test-threads=1"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2119,6 +2119,8 @@ dependencies = [
  "ghosthub-contracts",
  "serde",
  "serde_json",
+ "static_assertions",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,7 +42,9 @@ libc = "=0.2.189"
 portable-pty = "=0.9.0"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
+static_assertions = "=1.1.0"
 toml = "=1.1.4"
+unicode-segmentation = "=1.13.3"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/rust/host/src/lib.rs
+++ b/rust/host/src/lib.rs
@@ -17,8 +17,8 @@ mod windows_system;
 mod wsl;
 
 pub use wsl::{
-    AdmissionAttacher, AttachTerm, HostError, HostSnapshot, SystemWslPresence, WslConfig,
-    WslEndpoint, WslExecutable, WslHost, WslPresence, WslRuntimeIdentity,
+    AdmissionAttacher, AttachTerm, HostError, HostSnapshot, LiveSessionTarget, SystemWslPresence,
+    WslConfig, WslEndpoint, WslExecutable, WslHost, WslPresence, WslRuntimeIdentity,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -187,6 +187,22 @@ pub struct LiveSessionTarget {
 }
 
 impl LiveSessionTarget {
+    #[cfg(feature = "test-support")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_fixture(
+        snapshot: &HostSnapshot,
+        name: impl Into<String>,
+        identity: SessionIdentity,
+    ) -> Self {
+        Self {
+            endpoint: snapshot.endpoint.clone(),
+            runtime: snapshot.runtime.clone(),
+            name: name.into(),
+            identity,
+        }
+    }
+
     #[must_use]
     pub fn endpoint(&self) -> &WslEndpoint {
         &self.endpoint

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -390,6 +390,7 @@ pub struct WslHost<R> {
 
 #[derive(Debug)]
 struct VerifiedAdmission {
+    endpoint: WslEndpoint,
     runtime: WslRuntimeIdentity,
     _binary: VerifiedTmuxBinary,
 }
@@ -839,7 +840,9 @@ impl<R: CommandRunner> WslHost<R> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
-            .is_some_and(|verified| verified.runtime == *runtime)
+            .is_some_and(|verified| {
+                admission_matches(&verified.endpoint, &verified.runtime, endpoint, runtime)
+            })
         {
             return Ok(());
         }
@@ -1399,6 +1402,7 @@ impl<R: CommandRunner> WslHost<R> {
             .verified_tmux
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(VerifiedAdmission {
+            endpoint: endpoint.clone(),
             runtime: runtime.clone(),
             _binary: verified,
         });
@@ -1820,6 +1824,15 @@ impl<R: CommandRunner> WslHost<R> {
                 )
             })
     }
+}
+
+fn admission_matches(
+    verified_endpoint: &WslEndpoint,
+    verified_runtime: &WslRuntimeIdentity,
+    endpoint: &WslEndpoint,
+    runtime: &WslRuntimeIdentity,
+) -> bool {
+    verified_endpoint == endpoint && verified_runtime == runtime
 }
 
 struct AdmissionCleanup<'a, R: CommandRunner> {
@@ -2402,6 +2415,28 @@ mod tests {
         .expect_err("presence failure is visible");
 
         assert_eq!(error.kind(), DiagnosticKind::PermissionDenied);
+    }
+
+    #[test]
+    fn cached_admission_requires_the_same_endpoint_and_runtime() {
+        let ubuntu = WslEndpoint {
+            distro: "Ubuntu".to_owned(),
+        };
+        let debian = WslEndpoint {
+            distro: "Debian".to_owned(),
+        };
+        let runtime = WslRuntimeIdentity {
+            kernel_boot_id: "shared-wsl-kernel".to_owned(),
+            init_start_ticks: 42,
+        };
+        let restarted = WslRuntimeIdentity {
+            kernel_boot_id: "shared-wsl-kernel".to_owned(),
+            init_start_ticks: 43,
+        };
+
+        assert!(admission_matches(&ubuntu, &runtime, &ubuntu, &runtime));
+        assert!(!admission_matches(&ubuntu, &runtime, &debian, &runtime));
+        assert!(!admission_matches(&ubuntu, &runtime, &ubuntu, &restarted));
     }
 
     #[test]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -700,6 +700,16 @@ impl<R: CommandRunner> WslHost<R> {
             ],
         )?;
         if output.status != 0 {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if is_no_server(&stderr) || is_missing_session(&stderr) {
+                let sessions = self.discover_sessions(&target.endpoint, cancellation)?;
+                self.require_runtime(&target.endpoint, &target.runtime, cancellation)?;
+                if sessions.iter().any(|session| {
+                    session.name() == target.name && session.identity() != &target.identity
+                }) {
+                    return Err(session_replaced_after_confirmation(&target.name));
+                }
+            }
             return Err(classify_session_command_failure(
                 output.status,
                 &output.stderr,
@@ -708,13 +718,7 @@ impl<R: CommandRunner> WslHost<R> {
             ));
         }
         if String::from_utf8_lossy(&output.stdout).contains(KILL_IDENTITY_MISMATCH_MARKER) {
-            return Err(HostError::new(
-                DiagnosticKind::Transport,
-                format!(
-                    "Session ‘{}’ was replaced after confirmation. Review the new session before trying again.",
-                    target.name
-                ),
-            ));
+            return Err(session_replaced_after_confirmation(&target.name));
         }
         Ok(())
     }
@@ -2389,6 +2393,15 @@ fn classify_session_command_failure(
         status,
         stderr,
         &format!("{operation} tmux session ‘{session}’"),
+    )
+}
+
+fn session_replaced_after_confirmation(session: &str) -> HostError {
+    HostError::new(
+        DiagnosticKind::Transport,
+        format!(
+            "Session ‘{session}’ was replaced after confirmation. Review the new session before trying again."
+        ),
     )
 }
 

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -8,8 +8,9 @@ use std::time::{Duration, Instant};
 
 use model::DiagnosticKind;
 use session::{
-    AdmissionPlan, AttachPlan, DiscoveredSession, ExecutablePlatform, IDENTITY_MISMATCH_MARKER,
-    ProbeObservation, SessionIdentity, VerifiedTmuxBinary, resolve_tmux_binary,
+    AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform,
+    IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary,
+    resolve_tmux_binary,
 };
 
 use crate::{CancellationToken, CommandOutput, CommandRunner};
@@ -470,6 +471,57 @@ impl<R: CommandRunner> WslHost<R> {
             session.name(),
             session.identity().clone(),
         )
+    }
+
+    /// Build one atomic local create-or-attach client for an already verified
+    /// WSL endpoint. The returned authority cannot be cloned and must be
+    /// consumed by the terminal launcher.
+    #[must_use]
+    pub fn create_once_with_term(
+        &self,
+        endpoint: &WslEndpoint,
+        name: SessionName,
+        term: AttachTerm,
+    ) -> CreateOnce {
+        let mut args = pinned_prefix(endpoint);
+        append_tmux_environment(
+            &mut args,
+            Some(term.environment()),
+            self.config.tmux_tmpdir.as_deref(),
+            &[],
+        );
+        args.push(OsString::from(&self.config.tmux_binary));
+        args.extend(["new-session", "-A", "-s"].into_iter().map(OsString::from));
+        args.push(OsString::from(name.as_str()));
+        CreateOnce::local_atomic(self.wsl_executable.as_os_str(), args, name)
+    }
+
+    /// Capture the exact inventory after a one-shot create client has started,
+    /// without rerunning admission or creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified error when inventory cannot be read or the WSL
+    /// runtime changed across the creation boundary.
+    pub fn discover_after_create(
+        &self,
+        endpoint: &WslEndpoint,
+        runtime: &WslRuntimeIdentity,
+        cancellation: &CancellationToken,
+    ) -> Result<HostSnapshot, HostError> {
+        let sessions = self.discover_sessions(endpoint, cancellation)?;
+        let observed_runtime = self.resolve_runtime(endpoint, cancellation)?;
+        if &observed_runtime != runtime {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "WSL distro restarted while creating the tmux session",
+            ));
+        }
+        Ok(HostSnapshot {
+            endpoint: endpoint.clone(),
+            runtime: observed_runtime,
+            sessions,
+        })
     }
 
     fn resolve_endpoint(&self, cancellation: &CancellationToken) -> Result<WslEndpoint, HostError> {
@@ -2075,5 +2127,57 @@ mod tests {
         assert!(late_creation_ran.get());
         assert!(elapsed.get() >= UNCERTAIN_CLEANUP_SETTLE);
         assert!(!exists.get(), "the final removal must follow late creation");
+    }
+
+    #[test]
+    fn local_creation_is_one_atomic_scrubbed_client_command() {
+        let host = WslHost::new(
+            WslConfig::configured(
+                Some("Ubuntu Work".to_owned()),
+                "/opt/tmux/bin/tmux",
+                Some("/run/user/1000/ghosthub".to_owned()),
+            )
+            .expect("valid config"),
+            crate::StdCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let endpoint = WslEndpoint {
+            distro: "Ubuntu Work".to_owned(),
+        };
+        let plan = host.create_once_with_term(
+            &endpoint,
+            SessionName::parse("release work").expect("valid name"),
+            AttachTerm::Xterm256Color,
+        );
+        let (program, args, target) = plan.into_parts();
+
+        assert_eq!(program, r"C:\Windows\System32\wsl.exe");
+        assert_eq!(target.as_str(), "release work");
+        assert_eq!(
+            args,
+            [
+                "--distribution",
+                "Ubuntu Work",
+                "--exec",
+                "/usr/bin/env",
+                "-u",
+                "TMUX",
+                "-u",
+                "TMUX_PANE",
+                "-u",
+                "TMUX_TMPDIR",
+                "TERM=xterm-256color",
+                "TMUX_TMPDIR=/run/user/1000/ghosthub",
+                "/opt/tmux/bin/tmux",
+                "new-session",
+                "-A",
+                "-s",
+                "release work",
+            ]
+            .into_iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>()
+        );
     }
 }

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -513,13 +513,18 @@ impl<R: CommandRunner> WslHost<R> {
     /// Build one atomic local create-or-attach client for an already verified
     /// WSL endpoint. The returned authority cannot be cloned and must be
     /// consumed by the terminal launcher.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a collision-resistant identity marker cannot be
+    /// generated for the ordinary client's tmux-side identity report.
     pub fn create_once_with_term(
         &self,
         endpoint: &WslEndpoint,
         name: SessionName,
         term: AttachTerm,
-    ) -> CreateOnce {
+    ) -> Result<CreateOnce, HostError> {
+        let identity_marker = creation_identity_marker()?;
         let mut args = pinned_prefix(endpoint);
         append_tmux_environment(
             &mut args,
@@ -528,9 +533,26 @@ impl<R: CommandRunner> WslHost<R> {
             &[],
         );
         args.push(OsString::from(&self.config.tmux_binary));
-        args.extend(["new-session", "-A", "-s"].into_iter().map(OsString::from));
+        args.extend(
+            ["new-session", "-A", "-E", "-s"]
+                .into_iter()
+                .map(OsString::from),
+        );
         args.push(OsString::from(name.as_str()));
-        CreateOnce::local_atomic(self.wsl_executable.as_os_str(), args, name)
+        args.extend(
+            [";", "display-message", "-p", "-F"]
+                .into_iter()
+                .map(OsString::from),
+        );
+        args.push(OsString::from(format!(
+            "{identity_marker}#{{pid}}|#{{session_id}}|#{{session_created}}|!"
+        )));
+        Ok(CreateOnce::local_atomic(
+            self.wsl_executable.as_os_str(),
+            args,
+            name,
+            identity_marker,
+        ))
     }
 
     /// Capture the exact inventory after a one-shot create client has started,
@@ -891,6 +913,55 @@ impl<R: CommandRunner> WslHost<R> {
             ],
             "find primary isolated session",
         )?;
+        let new_session_environment = self.run_tmux_required(
+            endpoint,
+            cancellation,
+            &admission_tmpdir,
+            &[
+                "-f",
+                "/dev/null",
+                "-L",
+                &namespace,
+                "show-environment",
+                "-t",
+                &target,
+                "GHOSTHUB_PROBE",
+            ],
+            "read new-session environment",
+        )?;
+        self.run_tmux_required(
+            endpoint,
+            cancellation,
+            &admission_tmpdir,
+            &[
+                "-f",
+                "/dev/null",
+                "-L",
+                &namespace,
+                "set-option",
+                "-g",
+                "update-environment",
+                "GHOSTHUB_PROBE",
+            ],
+            "configure client environment updates",
+        )?;
+        self.run_tmux_required(
+            endpoint,
+            cancellation,
+            &admission_tmpdir,
+            &[
+                "-f",
+                "/dev/null",
+                "-L",
+                &namespace,
+                "set-environment",
+                "-t",
+                &target,
+                "GHOSTHUB_PROBE",
+                "session",
+            ],
+            "set session environment control value",
+        )?;
         let repeat_create_plan =
             self.admission_new_session_plan(endpoint, &admission_tmpdir, &namespace, &session);
         let repeat_create_client = attacher.attach(&repeat_create_plan).map_err(|error| {
@@ -915,6 +986,22 @@ impl<R: CommandRunner> WslHost<R> {
             &namespace,
             &target,
             false,
+        )?;
+        let create_preserved_value = self.run_tmux_required(
+            endpoint,
+            cancellation,
+            &admission_tmpdir,
+            &[
+                "-f",
+                "/dev/null",
+                "-L",
+                &namespace,
+                "show-environment",
+                "-t",
+                &target,
+                "GHOSTHUB_PROBE",
+            ],
+            "read atomic create-or-attach environment",
         )?;
         self.require_admission_session_absent(
             endpoint,
@@ -943,22 +1030,6 @@ impl<R: CommandRunner> WslHost<R> {
         );
         cleanup.finish_server_creation(&namespace, &collision, &creation);
         creation?;
-        let environment = self.run_tmux_required(
-            endpoint,
-            cancellation,
-            &admission_tmpdir,
-            &[
-                "-f",
-                "/dev/null",
-                "-L",
-                &namespace,
-                "show-environment",
-                "-t",
-                &target,
-                "GHOSTHUB_PROBE",
-            ],
-            "read new-session environment",
-        )?;
         let initial_identity = self.read_admission_identity(
             endpoint,
             cancellation,
@@ -1061,39 +1132,6 @@ impl<R: CommandRunner> WslHost<R> {
             ));
         }
         cleanup.mark_isolated([&namespace, &peer_namespace]);
-        self.run_tmux_required(
-            endpoint,
-            cancellation,
-            &admission_tmpdir,
-            &[
-                "-f",
-                "/dev/null",
-                "-L",
-                &namespace,
-                "set-option",
-                "-g",
-                "update-environment",
-                "GHOSTHUB_PROBE",
-            ],
-            "configure client environment updates",
-        )?;
-        self.run_tmux_required(
-            endpoint,
-            cancellation,
-            &admission_tmpdir,
-            &[
-                "-f",
-                "/dev/null",
-                "-L",
-                &namespace,
-                "set-environment",
-                "-t",
-                &target,
-                "GHOSTHUB_PROBE",
-                "session",
-            ],
-            "set session environment control value",
-        )?;
         let control_plan = self.admission_attach_plan(
             endpoint,
             &admission_tmpdir,
@@ -1321,12 +1359,18 @@ impl<R: CommandRunner> WslHost<R> {
             decode(&positive_value.stdout, "updated session environment")?.trim()
                 == "GHOSTHUB_PROBE=client"
                 && decode(&preserved_value.stdout, "preserved session environment")?.trim()
+                    == "GHOSTHUB_PROBE=session"
+                && decode(
+                    &create_preserved_value.stdout,
+                    "atomic create-or-attach environment",
+                )?
+                .trim()
                     == "GHOSTHUB_PROBE=session";
         let observations = [
             observation("atomic-create-or-attach", true),
             observation(
                 "new-session-environment",
-                String::from_utf8_lossy(&environment.stdout)
+                String::from_utf8_lossy(&new_session_environment.stdout)
                     .lines()
                     .any(|line| line == "GHOSTHUB_PROBE=present"),
             ),
@@ -1532,7 +1576,12 @@ impl<R: CommandRunner> WslHost<R> {
         session_name: &str,
     ) -> AdmissionPlan {
         let mut args = pinned_prefix(endpoint);
-        append_tmux_environment(&mut args, Some("TERM=xterm"), Some(tmux_tmpdir), &[]);
+        append_tmux_environment(
+            &mut args,
+            Some("TERM=xterm"),
+            Some(tmux_tmpdir),
+            &["GHOSTHUB_PROBE=ignored"],
+        );
         args.push(OsString::from(&self.config.tmux_binary));
         args.extend(
             [
@@ -1542,6 +1591,7 @@ impl<R: CommandRunner> WslHost<R> {
                 namespace,
                 "new-session",
                 "-A",
+                "-E",
                 "-s",
                 session_name,
                 "exec /usr/bin/sleep 60",
@@ -2006,6 +2056,17 @@ struct AdmissionScope {
     name_nonce: String,
 }
 
+fn creation_identity_marker() -> Result<String, HostError> {
+    let mut nonce = [0_u8; 16];
+    getrandom::fill(&mut nonce).map_err(|error| {
+        HostError::new(
+            DiagnosticKind::Transport,
+            format!("generate tmux creation identity marker: {error}"),
+        )
+    })?;
+    Ok(format!("__ghc_{:032x}__", u128::from_ne_bytes(nonce)))
+}
+
 fn admission_scope(sequence: u64) -> Result<AdmissionScope, HostError> {
     let mut nonce = [0_u8; 16];
     getrandom::fill(&mut nonce).map_err(|error| {
@@ -2384,12 +2445,14 @@ mod tests {
         let endpoint = WslEndpoint {
             distro: "Ubuntu Work".to_owned(),
         };
-        let plan = host.create_once_with_term(
-            &endpoint,
-            SessionName::parse("release work").expect("valid name"),
-            AttachTerm::Xterm256Color,
-        );
-        let (program, args, target) = plan.into_parts();
+        let plan = host
+            .create_once_with_term(
+                &endpoint,
+                SessionName::parse("release work").expect("valid name"),
+                AttachTerm::Xterm256Color,
+            )
+            .expect("creation plan");
+        let (program, args, target, marker) = plan.into_parts();
 
         assert_eq!(program, r"C:\Windows\System32\wsl.exe");
         assert_eq!(target.as_str(), "release work");
@@ -2411,12 +2474,21 @@ mod tests {
                 "/opt/tmux/bin/tmux",
                 "new-session",
                 "-A",
+                "-E",
                 "-s",
                 "release work",
+                ";",
+                "display-message",
+                "-p",
+                "-F",
             ]
             .into_iter()
             .map(OsString::from)
+            .chain([OsString::from(format!(
+                "{marker}#{{pid}}|#{{session_id}}|#{{session_created}}|!"
+            ))])
             .collect::<Vec<_>>()
         );
+        assert!(marker.starts_with("__ghc_") && marker.ends_with("__"));
     }
 }

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -27,6 +27,8 @@ const UNCERTAIN_CLEANUP_SETTLE: Duration = Duration::from_secs(2);
 // without adding another process crossing.
 const INVENTORY_FORMAT: &str = "#{pid}\t#{session_id}\t#{session_created}\t#{session_attached}\t#{n:session_name}\t#{session_name}";
 const ADMISSION_IDENTITY_FORMAT: &str = "#{pid}\t#{session_id}\t#{n:session_name}\t#{session_name}";
+const LIVE_IDENTITY_FORMAT: &str = "#{pid}\t#{session_id}\t#{session_created}";
+const KILL_IDENTITY_MISMATCH_MARKER: &str = "__ghosthub_kill_identity_mismatch_v1__";
 static ADMISSION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 pub trait AdmissionAttacher {
@@ -169,6 +171,41 @@ pub struct HostSnapshot {
     endpoint: WslEndpoint,
     runtime: WslRuntimeIdentity,
     sessions: Vec<DiscoveredSession>,
+}
+
+/// Fresh, non-persistable authority to kill one exact live tmux session.
+///
+/// The constructor is private so cached inventory cannot be promoted into
+/// destructive authority. Callers can obtain this value only from a live
+/// tmux query immediately before presenting confirmation.
+#[derive(Debug)]
+pub struct LiveSessionTarget {
+    endpoint: WslEndpoint,
+    runtime: WslRuntimeIdentity,
+    name: String,
+    identity: SessionIdentity,
+}
+
+impl LiveSessionTarget {
+    #[must_use]
+    pub fn endpoint(&self) -> &WslEndpoint {
+        &self.endpoint
+    }
+
+    #[must_use]
+    pub const fn runtime(&self) -> &WslRuntimeIdentity {
+        &self.runtime
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub const fn identity(&self) -> &SessionIdentity {
+        &self.identity
+    }
 }
 
 impl HostSnapshot {
@@ -524,6 +561,128 @@ impl<R: CommandRunner> WslHost<R> {
         })
     }
 
+    /// Capture fresh destructive authority for one exact session.
+    ///
+    /// This deliberately does not accept a cached `SessionIdentity`. The WSL
+    /// runtime is checked on both sides of the tmux query so a distro restart
+    /// cannot launder an old inventory row into a confirmation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified error when the runtime changed, the session is no
+    /// longer running, or tmux returned an invalid identity.
+    pub fn capture_live_session(
+        &self,
+        endpoint: &WslEndpoint,
+        expected_runtime: &WslRuntimeIdentity,
+        name: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<LiveSessionTarget, HostError> {
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
+        let target = format!("={name}:");
+        let output = self.run_tmux_command(
+            endpoint,
+            cancellation,
+            &[
+                "-f",
+                "/dev/null",
+                "display-message",
+                "-p",
+                "-t",
+                &target,
+                LIVE_IDENTITY_FORMAT,
+            ],
+        )?;
+        if output.status != 0 {
+            return Err(classify_session_command_failure(
+                output.status,
+                &output.stderr,
+                name,
+                "verify",
+            ));
+        }
+        let identity = parse_live_identity(&output.stdout)?;
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
+        Ok(LiveSessionTarget {
+            endpoint: endpoint.clone(),
+            runtime: expected_runtime.clone(),
+            name: name.to_owned(),
+            identity,
+        })
+    }
+
+    /// Kill the exact session identity captured immediately before user
+    /// confirmation.
+    ///
+    /// Tmux evaluates all three identity fields and performs the kill in one
+    /// server-side command. A replaced session is never destroyed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the WSL runtime changed, the session disappeared,
+    /// its identity no longer matches, or tmux could not execute the command.
+    pub fn kill_live_session(
+        &self,
+        target: &LiveSessionTarget,
+        cancellation: &CancellationToken,
+    ) -> Result<(), HostError> {
+        self.require_runtime(&target.endpoint, &target.runtime, cancellation)?;
+        let identity = &target.identity;
+        let tmux_target = format!("={}:", identity.session_id());
+        let condition = tmux_identity_condition(identity);
+        let kill = format!("kill-session -t ={}", identity.session_id());
+        let mismatch = format!("display-message -p {KILL_IDENTITY_MISMATCH_MARKER}");
+        let output = self.run_tmux_command(
+            &target.endpoint,
+            cancellation,
+            &[
+                "-f",
+                "/dev/null",
+                "if-shell",
+                "-F",
+                "-t",
+                &tmux_target,
+                &condition,
+                &kill,
+                &mismatch,
+            ],
+        )?;
+        if output.status != 0 {
+            return Err(classify_session_command_failure(
+                output.status,
+                &output.stderr,
+                &target.name,
+                "kill",
+            ));
+        }
+        if String::from_utf8_lossy(&output.stdout).contains(KILL_IDENTITY_MISMATCH_MARKER) {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                format!(
+                    "Session ‘{}’ was replaced after confirmation. Review the new session before trying again.",
+                    target.name
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn require_runtime(
+        &self,
+        endpoint: &WslEndpoint,
+        expected: &WslRuntimeIdentity,
+        cancellation: &CancellationToken,
+    ) -> Result<(), HostError> {
+        if self.resolve_runtime(endpoint, cancellation)? == *expected {
+            Ok(())
+        } else {
+            Err(HostError::new(
+                DiagnosticKind::Transport,
+                "WSL restarted; refresh the host before changing the session",
+            ))
+        }
+    }
+
     fn resolve_endpoint(&self, cancellation: &CancellationToken) -> Result<WslEndpoint, HostError> {
         if let Some(distro) = &self.config.distro {
             return Ok(WslEndpoint {
@@ -622,6 +781,24 @@ impl<R: CommandRunner> WslHost<R> {
             ));
         }
         parse_inventory(&output.stdout)
+    }
+
+    fn run_tmux_command(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+        tmux_args: &[&str],
+    ) -> Result<CommandOutput, HostError> {
+        let mut args = pinned_prefix(endpoint);
+        append_tmux_environment(
+            &mut args,
+            Some("TERM=xterm"),
+            self.config.tmux_tmpdir.as_deref(),
+            &[],
+        );
+        args.push(OsString::from(&self.config.tmux_binary));
+        args.extend(tmux_args.iter().map(OsString::from));
+        self.run(&args, cancellation)
     }
 
     #[allow(
@@ -1937,6 +2114,39 @@ fn parse_inventory(bytes: &[u8]) -> Result<Vec<DiscoveredSession>, HostError> {
         .collect()
 }
 
+fn parse_live_identity(bytes: &[u8]) -> Result<SessionIdentity, HostError> {
+    let output = decode(bytes, "live tmux session identity")?;
+    let fields = output
+        .trim_end_matches(['\r', '\n'])
+        .split('\t')
+        .collect::<Vec<_>>();
+    if fields.len() != 3 {
+        return Err(HostError::new(
+            DiagnosticKind::MalformedOutput,
+            "tmux returned an invalid live session identity",
+        ));
+    }
+    let server_pid = fields[0].parse::<u32>().map_err(|_| {
+        HostError::new(
+            DiagnosticKind::MalformedOutput,
+            "tmux returned an invalid live server PID",
+        )
+    })?;
+    let created_at = fields[2].parse::<u64>().map_err(|_| {
+        HostError::new(
+            DiagnosticKind::MalformedOutput,
+            "tmux returned an invalid live session creation time",
+        )
+    })?;
+    if server_pid == 0 || !is_tmux_session_id(fields[1]) {
+        return Err(HostError::new(
+            DiagnosticKind::MalformedOutput,
+            "tmux returned an invalid live session identity",
+        ));
+    }
+    Ok(SessionIdentity::new(server_pid, fields[1], created_at))
+}
+
 struct TmuxNameRecord<'a> {
     fields: Vec<&'a str>,
     name: &'a str,
@@ -2021,6 +2231,26 @@ fn classify_command_failure(status: i32, stderr: &[u8], subject: &str) -> HostEr
     HostError::new(kind, format!("{subject}: {}", stderr.trim()))
 }
 
+fn classify_session_command_failure(
+    status: i32,
+    stderr: &[u8],
+    session: &str,
+    operation: &str,
+) -> HostError {
+    let text = String::from_utf8_lossy(stderr);
+    if is_no_server(&text) || is_missing_session(&text) {
+        return HostError::new(
+            DiagnosticKind::Transport,
+            format!("Session ‘{session}’ is no longer running."),
+        );
+    }
+    classify_command_failure(
+        status,
+        stderr,
+        &format!("{operation} tmux session ‘{session}’"),
+    )
+}
+
 fn classify_admission_failure(status: i32, stderr: &[u8], subject: &str) -> HostError {
     let error = classify_command_failure(status, stderr, subject);
     if error.kind() == DiagnosticKind::Transport {
@@ -2073,6 +2303,15 @@ fn tmux_identity_equals(field: &str, value: &str) -> String {
     condition.push_str(value);
     condition.push('}');
     condition
+}
+
+fn tmux_identity_condition(identity: &SessionIdentity) -> String {
+    format!(
+        "#{{&&:{},#{{&&:{},{}}}}}",
+        tmux_identity_equals("pid", &identity.server_pid().to_string()),
+        tmux_identity_equals("session_id", identity.session_id()),
+        tmux_identity_equals("session_created", &identity.created_at().to_string()),
+    )
 }
 
 #[cfg(test)]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -392,6 +392,7 @@ pub struct WslHost<R> {
 struct VerifiedAdmission {
     endpoint: WslEndpoint,
     runtime: WslRuntimeIdentity,
+    creation_term: AttachTerm,
     _binary: VerifiedTmuxBinary,
 }
 
@@ -517,9 +518,35 @@ impl<R: CommandRunner> WslHost<R> {
     ///
     /// # Errors
     ///
-    /// Returns an error when a collision-resistant identity marker cannot be
-    /// generated for the ordinary client's tmux-side identity report.
-    pub fn create_once_with_term(
+    /// Returns an error when this endpoint and runtime lack fresh admission,
+    /// or when a collision-resistant identity marker cannot be generated for
+    /// the ordinary client's tmux-side identity report.
+    pub fn create_once(
+        &self,
+        endpoint: &WslEndpoint,
+        runtime: &WslRuntimeIdentity,
+        name: SessionName,
+    ) -> Result<(CreateOnce, AttachTerm), HostError> {
+        let term = self
+            .verified_tmux
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|verified| {
+                admission_matches(&verified.endpoint, &verified.runtime, endpoint, runtime)
+            })
+            .map(|verified| verified.creation_term)
+            .ok_or_else(|| {
+                HostError::new(
+                    DiagnosticKind::UnsupportedEnvironment,
+                    "tmux creation requires fresh admission for this WSL runtime",
+                )
+            })?;
+        let authority = self.create_once_with_term(endpoint, name, term)?;
+        Ok((authority, term))
+    }
+
+    fn create_once_with_term(
         &self,
         endpoint: &WslEndpoint,
         name: SessionName,
@@ -965,21 +992,14 @@ impl<R: CommandRunner> WslHost<R> {
             ],
             "set session environment control value",
         )?;
-        let repeat_create_plan =
-            self.admission_new_session_plan(endpoint, &admission_tmpdir, &namespace, &session);
-        let repeat_create_client = attacher.attach(&repeat_create_plan).map_err(|error| {
-            HostError::new(
-                DiagnosticKind::Transport,
-                format!("start atomic create-or-attach admission client: {error}"),
-            )
-        })?;
-        self.wait_for_admission_attachment(
+        let (repeat_create_client, creation_term) = self.start_admission_create_client(
             endpoint,
-            cancellation,
             &admission_tmpdir,
             &namespace,
+            &session,
             &target,
-            true,
+            attacher,
+            cancellation,
         )?;
         drop(repeat_create_client);
         self.wait_for_admission_attachment(
@@ -1404,6 +1424,7 @@ impl<R: CommandRunner> WslHost<R> {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(VerifiedAdmission {
             endpoint: endpoint.clone(),
             runtime: runtime.clone(),
+            creation_term,
             _binary: verified,
         });
         Ok(())
@@ -1578,11 +1599,12 @@ impl<R: CommandRunner> WslHost<R> {
         tmux_tmpdir: &str,
         namespace: &str,
         session_name: &str,
+        term: AttachTerm,
     ) -> AdmissionPlan {
         let mut args = pinned_prefix(endpoint);
         append_tmux_environment(
             &mut args,
-            Some("TERM=xterm"),
+            Some(term.environment()),
             Some(tmux_tmpdir),
             &["GHOSTHUB_PROBE=ignored"],
         );
@@ -1604,6 +1626,82 @@ impl<R: CommandRunner> WslHost<R> {
             .map(OsString::from),
         );
         AdmissionPlan::isolated(self.wsl_executable.as_os_str(), args)
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the admission client is bound to one private tmux target"
+    )]
+    fn start_admission_create_client<A: AdmissionAttacher>(
+        &self,
+        endpoint: &WslEndpoint,
+        tmux_tmpdir: &str,
+        namespace: &str,
+        session_name: &str,
+        target: &str,
+        attacher: &A,
+        cancellation: &CancellationToken,
+    ) -> Result<(A::Client, AttachTerm), HostError> {
+        let preferred_plan = self.admission_new_session_plan(
+            endpoint,
+            tmux_tmpdir,
+            namespace,
+            session_name,
+            AttachTerm::Xterm256Color,
+        );
+        let preferred_failure = match attacher.attach(&preferred_plan) {
+            Ok(client) => match self.wait_for_admission_attachment(
+                endpoint,
+                cancellation,
+                tmux_tmpdir,
+                namespace,
+                target,
+                true,
+            ) {
+                Ok(()) => return Ok((client, AttachTerm::Xterm256Color)),
+                Err(error) => {
+                    drop(client);
+                    if cancellation.is_cancelled() {
+                        return Err(error);
+                    }
+                    self.wait_for_admission_attachment(
+                        endpoint,
+                        cancellation,
+                        tmux_tmpdir,
+                        namespace,
+                        target,
+                        false,
+                    )?;
+                    error.to_string()
+                }
+            },
+            Err(error) => error,
+        };
+
+        let baseline_plan = self.admission_new_session_plan(
+            endpoint,
+            tmux_tmpdir,
+            namespace,
+            session_name,
+            AttachTerm::Xterm,
+        );
+        let client = attacher.attach(&baseline_plan).map_err(|error| {
+            HostError::new(
+                DiagnosticKind::Transport,
+                format!(
+                    "start atomic create-or-attach admission client: {error}; xterm-256color probe failed: {preferred_failure}"
+                ),
+            )
+        })?;
+        self.wait_for_admission_attachment(
+            endpoint,
+            cancellation,
+            tmux_tmpdir,
+            namespace,
+            target,
+            true,
+        )?;
+        Ok((client, AttachTerm::Xterm))
     }
 
     fn admission_attach_plan(

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -27,7 +27,6 @@ const UNCERTAIN_CLEANUP_SETTLE: Duration = Duration::from_secs(2);
 // without adding another process crossing.
 const INVENTORY_FORMAT: &str = "#{pid}\t#{session_id}\t#{session_created}\t#{session_attached}\t#{n:session_name}\t#{session_name}";
 const ADMISSION_IDENTITY_FORMAT: &str = "#{pid}\t#{session_id}\t#{n:session_name}\t#{session_name}";
-const LIVE_IDENTITY_FORMAT: &str = "#{pid}\t#{session_id}\t#{session_created}";
 const KILL_IDENTITY_MISMATCH_MARKER: &str = "__ghosthub_kill_identity_mismatch_v1__";
 static ADMISSION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -645,35 +644,22 @@ impl<R: CommandRunner> WslHost<R> {
         cancellation: &CancellationToken,
     ) -> Result<LiveSessionTarget, HostError> {
         self.require_runtime(endpoint, expected_runtime, cancellation)?;
-        let target = format!("={name}:");
-        let output = self.run_tmux_command(
-            endpoint,
-            cancellation,
-            &[
-                "-f",
-                "/dev/null",
-                "display-message",
-                "-p",
-                "-t",
-                &target,
-                LIVE_IDENTITY_FORMAT,
-            ],
-        )?;
-        if output.status != 0 {
-            return Err(classify_session_command_failure(
-                output.status,
-                &output.stderr,
-                name,
-                "verify",
-            ));
-        }
-        let identity = parse_live_identity(&output.stdout)?;
+        let sessions = self.discover_sessions(endpoint, cancellation)?;
+        let session = sessions
+            .into_iter()
+            .find(|session| session.name() == name)
+            .ok_or_else(|| {
+                HostError::new(
+                    DiagnosticKind::Transport,
+                    format!("Session ‘{name}’ is no longer running. Refresh before trying again."),
+                )
+            })?;
         self.require_runtime(endpoint, expected_runtime, cancellation)?;
         Ok(LiveSessionTarget {
             endpoint: endpoint.clone(),
             runtime: expected_runtime.clone(),
-            name: name.to_owned(),
-            identity,
+            name: session.name().to_owned(),
+            identity: session.identity().clone(),
         })
     }
 
@@ -2300,39 +2286,6 @@ fn parse_inventory(bytes: &[u8]) -> Result<Vec<DiscoveredSession>, HostError> {
             ))
         })
         .collect()
-}
-
-fn parse_live_identity(bytes: &[u8]) -> Result<SessionIdentity, HostError> {
-    let output = decode(bytes, "live tmux session identity")?;
-    let fields = output
-        .trim_end_matches(['\r', '\n'])
-        .split('\t')
-        .collect::<Vec<_>>();
-    if fields.len() != 3 {
-        return Err(HostError::new(
-            DiagnosticKind::MalformedOutput,
-            "tmux returned an invalid live session identity",
-        ));
-    }
-    let server_pid = fields[0].parse::<u32>().map_err(|_| {
-        HostError::new(
-            DiagnosticKind::MalformedOutput,
-            "tmux returned an invalid live server PID",
-        )
-    })?;
-    let created_at = fields[2].parse::<u64>().map_err(|_| {
-        HostError::new(
-            DiagnosticKind::MalformedOutput,
-            "tmux returned an invalid live session creation time",
-        )
-    })?;
-    if server_pid == 0 || !is_tmux_session_id(fields[1]) {
-        return Err(HostError::new(
-            DiagnosticKind::MalformedOutput,
-            "tmux returned an invalid live session identity",
-        ));
-    }
-    Ok(SessionIdentity::new(server_pid, fields[1], created_at))
 }
 
 struct TmuxNameRecord<'a> {

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -881,6 +881,10 @@ fn discovers_identity_in_one_tmux_crossing() {
 }
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the admission transcript assertions stay together for safety auditing"
+)]
 fn admission_uses_inert_sessions_and_always_cleans_its_namespaces() {
     let runner = RecordingRunner::new(vec![
         instance_output(),
@@ -963,12 +967,20 @@ fn admission_uses_inert_sessions_and_always_cleans_its_namespaces() {
             .count(),
         1
     );
+    assert!(attachment_plans.iter().any(|(_, args)| {
+        args.iter().any(|argument| argument == "new-session")
+            && args.iter().any(|argument| argument == "-A")
+            && args.iter().any(|argument| argument == "-E")
+            && args
+                .iter()
+                .any(|argument| argument == "GHOSTHUB_PROBE=ignored")
+    }));
     assert_eq!(
         attachment_plans
             .iter()
             .filter(|(_, args)| args.iter().any(|argument| argument == "-E"))
             .count(),
-        1
+        2
     );
     assert!(
         admission_calls
@@ -1075,7 +1087,7 @@ fn admission_failure_before_isolation_cleans_only_created_sessions() {
             .iter()
             .filter(|(_, args)| args.iter().any(|argument| argument == "kill-session"))
             .count(),
-        2
+        1
     );
 }
 

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1403,6 +1403,41 @@ fn discovery_decodes_length_prefixed_session_names_without_splitting_records() {
 }
 
 #[test]
+fn kill_capture_matches_format_shaped_names_without_targeting_them() {
+    let name = "work#(touch /tmp/ghosthub-owned)\nand-more";
+    let inventory = format!("4242\t$3\t1700000000\t0\t{}\t{name}\n", name.len());
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, &inventory, ""),
+        instance_output(),
+        instance_output(),
+        output(0, &inventory, ""),
+        instance_output(),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("discover format-shaped session name");
+
+    let target = host
+        .capture_live_session(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            name,
+            &CancellationToken::new(),
+        )
+        .expect("capture identity from decoded inventory");
+
+    assert_eq!(target.name(), name);
+    assert_eq!(target.identity().session_id(), "$3");
+    assert!(host.runner().all_calls().iter().all(|(_, args)| {
+        args.iter()
+            .all(|argument| !argument.to_string_lossy().contains("#("))
+    }));
+}
+
+#[test]
 fn attach_plan_targets_the_fresh_stable_session_id() {
     let runner = RecordingRunner::new(vec![
         instance_output(),
@@ -1460,7 +1495,7 @@ fn kill_authority_comes_from_a_fresh_query_and_targets_stable_identity() {
         output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
         instance_output(),
         instance_output(),
-        output(0, "4242\t$3\t1700000000\n", ""),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
         instance_output(),
         instance_output(),
         output(0, "", ""),
@@ -1488,9 +1523,10 @@ fn kill_authority_comes_from_a_fresh_query_and_targets_stable_identity() {
     let calls = host.runner().calls();
     let identity_call = calls
         .iter()
-        .find(|(_, args)| args.iter().any(|argument| argument == "display-message"))
-        .expect("fresh identity query");
-    assert_eq!(argument_after(&identity_call.1, "-t"), Some("=work:"));
+        .filter(|(_, args)| args.iter().any(|argument| argument == "list-sessions"))
+        .nth(1)
+        .expect("fresh all-session identity query");
+    assert_eq!(argument_after(&identity_call.1, "-t"), None);
     let kill_call = calls
         .iter()
         .find(|(_, args)| args.iter().any(|argument| argument == "if-shell"))
@@ -1515,7 +1551,7 @@ fn replaced_session_is_not_killed_after_confirmation() {
         output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
         instance_output(),
         instance_output(),
-        output(0, "4242\t$3\t1700000000\n", ""),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
         instance_output(),
         instance_output(),
         output(0, "__ghosthub_kill_identity_mismatch_v1__\n", ""),

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -8,12 +8,12 @@ use std::sync::{Arc, Mutex};
 
 use contracts::{Manifest, PlatformTag};
 use host::{
-    AdmissionAttacher, CancellationToken, CommandOutput, CommandRunner, HostErrorKind, WslConfig,
-    WslExecutable, WslHost,
+    AdmissionAttacher, AttachTerm, CancellationToken, CommandOutput, CommandRunner, HostErrorKind,
+    WslConfig, WslExecutable, WslHost,
 };
 use serde::Deserialize;
-use session::AdmissionPlan;
 use session::ExecutablePlatform;
+use session::{AdmissionPlan, SessionName};
 
 #[derive(Clone, Copy, Debug)]
 struct AdmissionStatusFailure {
@@ -1007,7 +1007,8 @@ fn admission_does_not_require_xterm_256color_terminfo() {
         runner: host.runner(),
     };
 
-    host.discover(&attacher)
+    let snapshot = host
+        .discover(&attacher)
         .expect("baseline xterm admission succeeds without xterm-256color");
 
     let plans = host.runner().attachment_plans();
@@ -1018,6 +1019,50 @@ fn admission_does_not_require_xterm_256color_terminfo() {
                 .iter()
                 .any(|argument| argument == "TERM=xterm-256color")
     }));
+    let (creation, term) = host
+        .create_once(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            SessionName::parse("baseline").expect("valid session name"),
+        )
+        .expect("baseline creation authority");
+    let (_, args, _, _) = creation.into_parts();
+    assert_eq!(term, AttachTerm::Xterm);
+    assert!(args.iter().any(|argument| argument == "TERM=xterm"));
+    assert!(
+        !args
+            .iter()
+            .any(|argument| argument == "TERM=xterm-256color")
+    );
+}
+
+#[test]
+fn admission_uses_xterm_256color_for_creation_when_the_client_proves_it() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
+        instance_output(),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("admit full-color tmux client");
+
+    let (creation, term) = host
+        .create_once(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            SessionName::parse("full-color").expect("valid session name"),
+        )
+        .expect("full-color creation authority");
+    let (_, args, _, _) = creation.into_parts();
+
+    assert_eq!(term, AttachTerm::Xterm256Color);
+    assert!(
+        args.iter()
+            .any(|argument| argument == "TERM=xterm-256color")
+    );
 }
 
 #[test]

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1397,6 +1397,94 @@ fn attach_plan_targets_the_fresh_stable_session_id() {
 }
 
 #[test]
+fn kill_authority_comes_from_a_fresh_query_and_targets_stable_identity() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
+        instance_output(),
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\n", ""),
+        instance_output(),
+        instance_output(),
+        output(0, "", ""),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("discover sessions");
+
+    let target = host
+        .capture_live_session(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            "work",
+            &CancellationToken::new(),
+        )
+        .expect("capture fresh kill authority");
+    host.kill_live_session(&target, &CancellationToken::new())
+        .expect("kill confirmed identity");
+
+    assert_eq!(target.identity().server_pid(), 4242);
+    assert_eq!(target.identity().session_id(), "$3");
+    assert_eq!(target.identity().created_at(), 1_700_000_000);
+    let calls = host.runner().calls();
+    let identity_call = calls
+        .iter()
+        .find(|(_, args)| args.iter().any(|argument| argument == "display-message"))
+        .expect("fresh identity query");
+    assert_eq!(argument_after(&identity_call.1, "-t"), Some("=work:"));
+    let kill_call = calls
+        .iter()
+        .find(|(_, args)| args.iter().any(|argument| argument == "if-shell"))
+        .expect("conditional kill command");
+    assert_eq!(argument_after(&kill_call.1, "-t"), Some("=$3:"));
+    assert!(kill_call.1.iter().any(|argument| {
+        argument
+            == "#{&&:#{==:#{pid},4242},#{&&:#{==:#{session_id},$3},#{==:#{session_created},1700000000}}}"
+    }));
+    assert!(
+        kill_call
+            .1
+            .iter()
+            .any(|argument| argument == "kill-session -t =$3")
+    );
+}
+
+#[test]
+fn replaced_session_is_not_killed_after_confirmation() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
+        instance_output(),
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\n", ""),
+        instance_output(),
+        instance_output(),
+        output(0, "__ghosthub_kill_identity_mismatch_v1__\n", ""),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("discover sessions");
+    let target = host
+        .capture_live_session(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            "work",
+            &CancellationToken::new(),
+        )
+        .expect("capture fresh kill authority");
+
+    let error = host
+        .kill_live_session(&target, &CancellationToken::new())
+        .expect_err("identity mismatch must refuse the kill");
+
+    assert!(error.to_string().contains("replaced after confirmation"));
+}
+
+#[test]
 fn configured_socket_directory_is_explicit_environment() {
     let config = WslConfig::configured(
         Some("Ubuntu".to_owned()),

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1578,6 +1578,54 @@ fn replaced_session_is_not_killed_after_confirmation() {
 }
 
 #[test]
+fn missing_stable_target_detects_a_same_named_replacement_from_inventory() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
+        instance_output(),
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t0\t4\twork\n", ""),
+        instance_output(),
+        instance_output(),
+        output(1, "", "can't find session: $3"),
+        output(0, "4242\t$4\t1700000001\t0\t4\twork\n", ""),
+        instance_output(),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("discover sessions");
+    let target = host
+        .capture_live_session(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            "work",
+            &CancellationToken::new(),
+        )
+        .expect("capture fresh kill authority");
+
+    let error = host
+        .kill_live_session(&target, &CancellationToken::new())
+        .expect_err("same-named replacement must be reported");
+
+    assert!(error.to_string().contains("replaced after confirmation"));
+    let calls = host.runner().calls();
+    let replacement_query = calls
+        .iter()
+        .filter(|(_, args)| args.iter().any(|argument| argument == "list-sessions"))
+        .nth(2)
+        .expect("replacement inventory query");
+    assert_eq!(argument_after(&replacement_query.1, "-t"), None);
+    assert!(
+        replacement_query
+            .1
+            .iter()
+            .all(|argument| argument != "work")
+    );
+}
+
+#[test]
 fn configured_socket_directory_is_explicit_environment() {
     let config = WslConfig::configured(
         Some("Ubuntu".to_owned()),

--- a/rust/session/Cargo.toml
+++ b/rust/session/Cargo.toml
@@ -12,10 +12,12 @@ path = "src/lib.rs"
 
 [dependencies]
 serde.workspace = true
+unicode-segmentation.workspace = true
 
 [dev-dependencies]
 ghosthub-contracts.workspace = true
 serde_json.workspace = true
+static_assertions.workspace = true
 
 [lints]
 workspace = true

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -4,10 +4,62 @@ use std::ffi::{OsStr, OsString};
 use std::fmt;
 
 use serde::Deserialize;
+use unicode_segmentation::UnicodeSegmentation;
 
 pub mod probe;
 
 pub const IDENTITY_MISMATCH_MARKER: &str = "__ghosthub_attach_identity_mismatch_v1__";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionName(String);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionNameError {
+    Empty,
+    TooLong,
+    ForbiddenCharacter,
+}
+
+impl SessionName {
+    /// Normalize and validate a user-supplied tmux session name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty name, a name longer than 100 Unicode
+    /// grapheme clusters, or a name containing a control character, period,
+    /// or colon.
+    pub fn parse(value: &str) -> Result<Self, SessionNameError> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(SessionNameError::Empty);
+        }
+        if value.graphemes(true).count() > 100 {
+            return Err(SessionNameError::TooLong);
+        }
+        if value
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '.' | ':'))
+        {
+            return Err(SessionNameError::ForbiddenCharacter);
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionNameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("Name the tmux session."),
+            Self::TooLong | Self::ForbiddenCharacter => formatter
+                .write_str("Use 1-100 characters without periods, colons, or control characters."),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SessionIdentity {
@@ -81,6 +133,35 @@ pub struct AttachPlan {
     args: Vec<OsString>,
     target_name: String,
     identity: SessionIdentity,
+}
+
+/// One atomic local create-or-attach launch. The authority is intentionally
+/// neither cloneable nor serializable and is consumed by the terminal launcher.
+#[derive(Debug, Eq, PartialEq)]
+pub struct CreateOnce {
+    program: OsString,
+    args: Vec<OsString>,
+    target_name: SessionName,
+}
+
+impl CreateOnce {
+    #[must_use]
+    pub fn local_atomic(
+        program: impl Into<OsString>,
+        args: Vec<OsString>,
+        target_name: SessionName,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            target_name,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (OsString, Vec<OsString>, SessionName) {
+        (self.program, self.args, self.target_name)
+    }
 }
 
 /// One isolated capability probe that may exercise otherwise unavailable mux
@@ -381,4 +462,68 @@ fn parse_revision(output: &str) -> Option<String> {
     let line = output.lines().find(|line| line.starts_with("psmux "))?;
     let parenthesized = line.split_once('(')?.1.strip_suffix(')')?;
     parenthesized.split_whitespace().next().map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateOnce, SessionName, SessionNameError};
+    use static_assertions::assert_not_impl_any;
+
+    assert_not_impl_any!(CreateOnce: Clone, serde::Serialize);
+
+    #[test]
+    fn session_names_match_the_shipped_creation_contract() {
+        assert_eq!(
+            SessionName::parse("  release work  ")
+                .expect("valid name")
+                .as_str(),
+            "release work"
+        );
+        assert_eq!(SessionName::parse("  "), Err(SessionNameError::Empty));
+        assert_eq!(
+            SessionName::parse("has.period"),
+            Err(SessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            SessionName::parse("has:colon"),
+            Err(SessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            SessionName::parse("has\nnewline"),
+            Err(SessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            SessionName::parse(&"x".repeat(101)),
+            Err(SessionNameError::TooLong)
+        );
+        assert!(
+            SessionName::parse(&"e\u{301}".repeat(100)).is_ok(),
+            "Swift-compatible character counting treats combining sequences as one name character"
+        );
+    }
+
+    #[test]
+    fn create_once_is_consumed_into_one_exact_argv() {
+        let plan = CreateOnce::local_atomic(
+            "wsl.exe",
+            vec![
+                "new-session".into(),
+                "-A".into(),
+                "-s".into(),
+                "demo".into(),
+            ],
+            SessionName::parse("demo").expect("valid name"),
+        );
+        let (program, args, target) = plan.into_parts();
+
+        assert_eq!(program, "wsl.exe");
+        assert_eq!(
+            args,
+            ["new-session", "-A", "-s", "demo"]
+                .into_iter()
+                .map(std::ffi::OsString::from)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(target.as_str(), "demo");
+    }
 }

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -27,7 +27,7 @@ impl SessionName {
     ///
     /// Returns an error for an empty name, a name longer than 100 Unicode
     /// grapheme clusters, or a name containing a control character, period,
-    /// or colon.
+    /// number sign, or colon.
     pub fn parse(value: &str) -> Result<Self, SessionNameError> {
         let value = value.trim();
         if value.is_empty() {
@@ -38,7 +38,7 @@ impl SessionName {
         }
         if value
             .chars()
-            .any(|character| character.is_control() || matches!(character, '.' | ':'))
+            .any(|character| character.is_control() || matches!(character, '#' | '.' | ':'))
         {
             return Err(SessionNameError::ForbiddenCharacter);
         }
@@ -56,7 +56,9 @@ impl fmt::Display for SessionNameError {
         match self {
             Self::Empty => formatter.write_str("Name the tmux session."),
             Self::TooLong | Self::ForbiddenCharacter => formatter
-                .write_str("Use 1-100 characters without periods, colons, or control characters."),
+                .write_str(
+                    "Use 1-100 characters without number signs, periods, colons, or control characters.",
+                ),
         }
     }
 }
@@ -494,6 +496,10 @@ mod tests {
         );
         assert_eq!(
             SessionName::parse("has:colon"),
+            Err(SessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            SessionName::parse("#(touch /tmp/ghosthub-owned)"),
             Err(SessionNameError::ForbiddenCharacter)
         );
         assert_eq!(

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -142,6 +142,7 @@ pub struct CreateOnce {
     program: OsString,
     args: Vec<OsString>,
     target_name: SessionName,
+    identity_marker: String,
 }
 
 impl CreateOnce {
@@ -150,17 +151,24 @@ impl CreateOnce {
         program: impl Into<OsString>,
         args: Vec<OsString>,
         target_name: SessionName,
+        identity_marker: impl Into<String>,
     ) -> Self {
         Self {
             program: program.into(),
             args,
             target_name,
+            identity_marker: identity_marker.into(),
         }
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (OsString, Vec<OsString>, SessionName) {
-        (self.program, self.args, self.target_name)
+    pub fn into_parts(self) -> (OsString, Vec<OsString>, SessionName, String) {
+        (
+            self.program,
+            self.args,
+            self.target_name,
+            self.identity_marker,
+        )
     }
 }
 
@@ -513,8 +521,9 @@ mod tests {
                 "demo".into(),
             ],
             SessionName::parse("demo").expect("valid name"),
+            "create-marker",
         );
-        let (program, args, target) = plan.into_parts();
+        let (program, args, target, marker) = plan.into_parts();
 
         assert_eq!(program, "wsl.exe");
         assert_eq!(
@@ -525,5 +534,6 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert_eq!(target.as_str(), "demo");
+        assert_eq!(marker, "create-marker");
     }
 }

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -6,10 +6,12 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, bounded, never, select};
+use crossbeam_channel::{
+    Receiver, RecvTimeoutError, Sender, TryRecvError, TrySendError, bounded, never, select,
+};
 use input::{EncodedInput, KeyInput, MouseAction, MouseInput, encode_input, encode_mouse};
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
-use session::{AdmissionPlan, AttachPlan, CreateOnce};
+use session::{AdmissionPlan, AttachPlan, CreateOnce, SessionIdentity};
 use surface::{GridSize, PixelSize, SurfaceStore};
 
 use crate::windows_job::RelayJob;
@@ -28,6 +30,7 @@ const CHILD_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const CHILD_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
 const REAP_ATTEMPTS: usize = 20;
 const REAP_POLL_DELAY: Duration = Duration::from_millis(25);
+const CREATION_IDENTITY_BUFFER_LIMIT: usize = 1024 * 1024;
 
 pub enum TerminalEvent {
     ClipboardWrite {
@@ -226,6 +229,7 @@ pub struct TerminalWorker {
     deferred_events: Mutex<VecDeque<TerminalEvent>>,
     surface: Arc<SurfaceStore>,
     confirmed_live: Arc<AtomicBool>,
+    creation_identity: Option<Receiver<Result<SessionIdentity, String>>>,
     clipboard_visibility: Arc<AtomicU64>,
     thread: Option<thread::JoinHandle<()>>,
 }
@@ -266,6 +270,7 @@ impl TerminalWorker {
         Self::launch(
             plan.program(),
             plan.args(),
+            None,
             size,
             resize_sequence,
             pixel_size,
@@ -290,10 +295,11 @@ impl TerminalWorker {
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
     ) -> Result<Self, WorkerError> {
-        let (program, args, _target_name) = plan.into_parts();
+        let (program, args, _target_name, identity_marker) = plan.into_parts();
         Self::launch(
             &program,
             &args,
+            Some(identity_marker),
             size,
             resize_sequence,
             pixel_size,
@@ -312,6 +318,7 @@ impl TerminalWorker {
         Self::launch(
             plan.program(),
             plan.args(),
+            None,
             size,
             0,
             PixelSize::default(),
@@ -320,9 +327,15 @@ impl TerminalWorker {
         )
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "PTY setup and ownership transfer stay together for lifecycle auditing"
+    )]
     fn launch(
         program: &std::ffi::OsStr,
         args: &[std::ffi::OsString],
+        creation_identity_marker: Option<String>,
         size: GridSize,
         resize_sequence: u64,
         pixel_size: PixelSize,
@@ -381,6 +394,14 @@ impl TerminalWorker {
         let (write_complete_sender, write_complete_receiver) = bounded(1);
         let confirmed_live = Arc::new(AtomicBool::new(false));
         let worker_confirmed_live = Arc::clone(&confirmed_live);
+        let (creation_capture, creation_identity) =
+            creation_identity_marker.map_or((None, None), |marker| {
+                let (sender, receiver) = bounded(1);
+                (
+                    Some(CreationIdentityCapture::new(marker, sender)),
+                    Some(receiver),
+                )
+            });
         let clipboard_visibility = Arc::new(AtomicU64::new(1));
         let worker_clipboard_visibility = Arc::clone(&clipboard_visibility);
 
@@ -414,6 +435,7 @@ impl TerminalWorker {
                     &write_complete_receiver,
                     &events_sender,
                     &worker_confirmed_live,
+                    creation_capture,
                     &worker_clipboard_visibility,
                 );
             })
@@ -429,6 +451,7 @@ impl TerminalWorker {
             deferred_events: Mutex::new(VecDeque::new()),
             surface,
             confirmed_live,
+            creation_identity,
             clipboard_visibility,
             thread: Some(worker_thread),
         })
@@ -448,6 +471,36 @@ impl TerminalWorker {
     #[must_use]
     pub fn is_confirmed_live(&self) -> bool {
         self.confirmed_live.load(Ordering::Acquire)
+    }
+
+    /// Wait for the exact tmux identity reported by a consumed creation client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this is not a creation worker, the client reports an
+    /// invalid identity, or the report does not arrive before `timeout`.
+    pub fn wait_for_creation_identity(
+        &self,
+        timeout: Duration,
+    ) -> Result<SessionIdentity, WorkerError> {
+        let receiver = self.creation_identity.as_ref().ok_or_else(|| {
+            WorkerError::new(
+                "receive tmux creation identity",
+                "worker was not created by CreateOnce",
+            )
+        })?;
+        match receiver.recv_timeout(timeout) {
+            Ok(Ok(identity)) => Ok(identity),
+            Ok(Err(error)) => Err(WorkerError::new("receive tmux creation identity", error)),
+            Err(RecvTimeoutError::Timeout) => Err(WorkerError::new(
+                "receive tmux creation identity",
+                "timed out waiting for the ordinary client",
+            )),
+            Err(RecvTimeoutError::Disconnected) => Err(WorkerError::new(
+                "receive tmux creation identity",
+                "terminal client exited before reporting its session",
+            )),
+        }
     }
 
     /// Enable or suppress clipboard writes emitted by this presentation.
@@ -688,6 +741,104 @@ fn write_pty(
     }
 }
 
+struct CreationIdentityCapture {
+    marker: Vec<u8>,
+    pending: Vec<u8>,
+    result: Option<Sender<Result<SessionIdentity, String>>>,
+}
+
+impl CreationIdentityCapture {
+    fn new(marker: String, result: Sender<Result<SessionIdentity, String>>) -> Self {
+        Self {
+            marker: marker.into_bytes(),
+            pending: Vec::new(),
+            result: Some(result),
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) -> Vec<u8> {
+        if self.result.is_none() {
+            return bytes.to_vec();
+        }
+        // Tmux sends terminal queries before its identity message and waits for
+        // their replies. Observe the raw stream without withholding it from the
+        // VT engine, otherwise creation deadlocks before the report is emitted.
+        self.pending.extend_from_slice(bytes);
+        let Some(start) = find_bytes(&self.pending, &self.marker) else {
+            if self.pending.len() > CREATION_IDENTITY_BUFFER_LIMIT {
+                self.finish(Err(
+                    "tmux did not report creation identity before emitting terminal output"
+                        .to_owned(),
+                ));
+                return bytes.to_vec();
+            }
+            return bytes.to_vec();
+        };
+        let payload_start = start + self.marker.len();
+        let Some(relative_end) = self.pending[payload_start..]
+            .iter()
+            .position(|byte| *byte == b'!')
+        else {
+            if self.pending.len() > CREATION_IDENTITY_BUFFER_LIMIT {
+                self.finish(Err(
+                    "tmux creation identity report was incomplete".to_owned()
+                ));
+                return bytes.to_vec();
+            }
+            return bytes.to_vec();
+        };
+        let end = payload_start + relative_end;
+        let identity = parse_creation_identity(&self.pending[payload_start..end]);
+        self.pending.clear();
+        if let Some(sender) = self.result.take() {
+            let _ignored = sender.try_send(identity);
+        }
+        bytes.to_vec()
+    }
+
+    fn finish(&mut self, result: Result<SessionIdentity, String>) {
+        if let Some(sender) = self.result.take() {
+            let _ignored = sender.try_send(result);
+        }
+        self.pending.clear();
+    }
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    (!needle.is_empty())
+        .then(|| {
+            haystack
+                .windows(needle.len())
+                .position(|bytes| bytes == needle)
+        })
+        .flatten()
+}
+
+fn parse_creation_identity(bytes: &[u8]) -> Result<SessionIdentity, String> {
+    let value = std::str::from_utf8(bytes)
+        .map_err(|error| format!("tmux creation identity was not UTF-8: {error}"))?;
+    let value = value
+        .strip_suffix('|')
+        .ok_or_else(|| "tmux creation identity had invalid framing".to_owned())?;
+    let mut fields = value.split('|');
+    let server_pid = fields
+        .next()
+        .and_then(|field| field.parse::<u32>().ok())
+        .ok_or_else(|| "tmux creation identity had an invalid server PID".to_owned())?;
+    let session_id = fields
+        .next()
+        .filter(|field| field.starts_with('$') && field.len() > 1)
+        .ok_or_else(|| "tmux creation identity had an invalid session ID".to_owned())?;
+    let created_at = fields
+        .next()
+        .and_then(|field| field.parse::<u64>().ok())
+        .ok_or_else(|| "tmux creation identity had an invalid creation time".to_owned())?;
+    if fields.next().is_some() {
+        return Err("tmux creation identity had extra fields".to_owned());
+    }
+    Ok(SessionIdentity::new(server_pid, session_id, created_at))
+}
+
 #[allow(clippy::too_many_arguments)]
 #[allow(
     clippy::too_many_lines,
@@ -709,6 +860,7 @@ fn run_worker(
     write_completions: &Receiver<WriterMessage>,
     events: &Sender<TerminalEvent>,
     confirmed_live: &AtomicBool,
+    mut creation_capture: Option<CreationIdentityCapture>,
     clipboard_visibility: &AtomicU64,
 ) {
     let mut report_exit = false;
@@ -873,7 +1025,15 @@ fn run_worker(
             recv(reader) -> message => match message {
                 Ok(ReaderMessage::Bytes(bytes)) => {
                     retain_output_tail(&mut output_tail, &bytes);
-                    let output = engine.process(&bytes);
+                    let visible = if let Some(capture) = &mut creation_capture {
+                        capture.push(&bytes)
+                    } else {
+                        bytes
+                    };
+                    if visible.is_empty() {
+                        continue;
+                    }
+                    let output = engine.process(&visible);
                     if engine.has_entered_alternate_screen() {
                         confirmed_live.store(true, Ordering::Release);
                     }
@@ -901,11 +1061,21 @@ fn run_worker(
                     }
                 }
                 Ok(ReaderMessage::Error(error)) => {
+                    if let Some(capture) = &mut creation_capture {
+                        capture.finish(Err(format!(
+                            "terminal client failed before reporting its session: {error}"
+                        )));
+                    }
                     let _ignored = emit_event(events, shutdown, TerminalEvent::Error(error));
                     report_exit = true;
                     break 'worker;
                 }
                 Ok(ReaderMessage::Eof) | Err(_) => {
+                    if let Some(capture) = &mut creation_capture {
+                        capture.finish(Err(
+                            "terminal client exited before reporting its session".to_owned(),
+                        ));
+                    }
                     report_exit = true;
                     break 'worker;
                 },
@@ -1433,6 +1603,44 @@ mod tests {
     }
 
     struct RecordingWriter(Arc<Mutex<Vec<&'static str>>>);
+
+    #[test]
+    fn creation_identity_capture_follows_the_client_report_across_chunks() {
+        let marker = "__ghc_0123456789abcdef__";
+        let (sender, receiver) = bounded(1);
+        let mut capture = CreationIdentityCapture::new(marker.to_owned(), sender);
+
+        assert_eq!(
+            capture.push(b"\x1b[?1049h__ghc_0123"),
+            b"\x1b[?1049h__ghc_0123"
+        );
+        let chunk = b"456789abcdef__321|$7|123456|!\x1b[2Jpane";
+        let visible = capture.push(chunk);
+
+        assert_eq!(visible, chunk);
+        assert_eq!(
+            receiver.recv().expect("creation identity report"),
+            Ok(SessionIdentity::new(321, "$7", 123_456))
+        );
+    }
+
+    #[test]
+    fn creation_identity_capture_rejects_malformed_reports() {
+        let marker = "__ghc_marker__";
+        let (sender, receiver) = bounded(1);
+        let mut capture = CreationIdentityCapture::new(marker.to_owned(), sender);
+
+        let visible = capture.push(b"prefix__ghc_marker__bad|$7|123|!suffix");
+
+        assert_eq!(visible, b"prefix__ghc_marker__bad|$7|123|!suffix");
+        assert!(
+            receiver
+                .recv()
+                .expect("creation identity report")
+                .expect_err("invalid server PID")
+                .contains("server PID")
+        );
+    }
 
     #[test]
     fn hiding_a_presentation_discards_queued_clipboard_writes_only() {

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, bounded, never, select};
 use input::{EncodedInput, KeyInput, MouseAction, MouseInput, encode_input, encode_mouse};
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
-use session::{AdmissionPlan, AttachPlan};
+use session::{AdmissionPlan, AttachPlan, CreateOnce};
 use surface::{GridSize, PixelSize, SurfaceStore};
 
 use crate::windows_job::RelayJob;
@@ -266,6 +266,34 @@ impl TerminalWorker {
         Self::launch(
             plan.program(),
             plan.args(),
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+        )
+    }
+
+    /// Consume one local create-or-attach authority and spawn its ordinary
+    /// client inside a native pseudoterminal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PTY, child process, or relay containment
+    /// cannot be established. The consumed creation authority is never
+    /// returned for a retry.
+    pub fn create_with_metadata(
+        plan: CreateOnce,
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+    ) -> Result<Self, WorkerError> {
+        let (program, args, _target_name) = plan.into_parts();
+        Self::launch(
+            &program,
+            &args,
             size,
             resize_sequence,
             pixel_size,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1721,22 +1721,10 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
         let draft = self.new_session.as_ref()?;
-        let host = snapshot
-            .hosts()
-            .iter()
-            .find(|host| host.id() == draft.host_id)?;
         let empty = draft.name.trim().is_empty();
         let validation = new_session_validation(snapshot, draft);
         let can_create = !empty && validation.is_none();
-        let helper_is_error = validation.is_some();
         let focused = self.create_focus.is_focused(window);
-        let helper = validation.unwrap_or_else(|| {
-            if empty {
-                "Name the session you want to create on this host.".to_owned()
-            } else {
-                format!("Create and attach on {}.", host.name())
-            }
-        });
 
         Some(
             div()
@@ -1773,18 +1761,14 @@ impl RootView {
                                 .child("New tmux session"),
                         )
                         .child(Self::new_session_name_input(draft, focused, cx))
-                        .child(
+                        .children(validation.map(|message| {
                             div()
                                 .px_4()
                                 .pb_3()
                                 .text_xs()
-                                .text_color(rgb(if helper_is_error {
-                                    0xd0_7070
-                                } else {
-                                    0x82_8995
-                                }))
-                                .child(helper),
-                        )
+                                .text_color(rgb(0xd0_7070))
+                                .child(message)
+                        }))
                         .child(Self::new_session_actions(can_create, cx)),
                 )
                 .into_any_element(),
@@ -1845,55 +1829,40 @@ impl RootView {
             .border_color(rgb(0x2a_2f39))
             .flex()
             .items_center()
-            .justify_between()
-            .gap_3()
+            .justify_end()
+            .gap_2()
             .child(
                 div()
-                    .min_w_0()
-                    .flex_1()
-                    .text_xs()
-                    .text_color(rgb(0x78_7f8b))
-                    .child("Tmux owns the session; closing Ghosthub only detaches."),
+                    .id("cancel-new-session")
+                    .px_3()
+                    .py_1()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .text_sm()
+                    .text_color(rgb(0xb6_bcc7))
+                    .hover(|style| style.bg(rgb(0x29_2e38)))
+                    .child("Cancel")
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.cancel_new_session(window, cx);
+                    })),
             )
             .child(
                 div()
-                    .flex_none()
-                    .flex()
-                    .items_center()
-                    .gap_2()
-                    .child(
-                        div()
-                            .id("cancel-new-session")
-                            .px_3()
-                            .py_1()
-                            .rounded_sm()
+                    .id("create-new-session")
+                    .px_3()
+                    .py_1()
+                    .rounded_sm()
+                    .bg(rgb(if can_create { 0x1d_5f9a } else { 0x2b_3039 }))
+                    .text_sm()
+                    .text_color(rgb(if can_create { 0xf1_f5fa } else { 0x72_7986 }))
+                    .child("Create")
+                    .when(can_create, |element| {
+                        element
                             .cursor_pointer()
-                            .text_sm()
-                            .text_color(rgb(0xb6_bcc7))
-                            .hover(|style| style.bg(rgb(0x29_2e38)))
-                            .child("Cancel")
                             .on_click(cx.listener(|this, _, window, cx| {
-                                this.cancel_new_session(window, cx);
-                            })),
-                    )
-                    .child(
-                        div()
-                            .id("create-new-session")
-                            .px_3()
-                            .py_1()
-                            .rounded_sm()
-                            .bg(rgb(if can_create { 0x1d_5f9a } else { 0x2b_3039 }))
-                            .text_sm()
-                            .text_color(rgb(if can_create { 0xf1_f5fa } else { 0x72_7986 }))
-                            .child("Create")
-                            .when(can_create, |element| {
-                                element.cursor_pointer().on_click(cx.listener(
-                                    |this, _, window, cx| {
-                                        this.submit_new_session(window, cx);
-                                    },
-                                ))
-                            }),
-                    ),
+                                this.submit_new_session(window, cx);
+                            }))
+                    }),
             )
             .into_any_element()
     }

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1732,12 +1732,9 @@ impl RootView {
         let focused = self.create_focus.is_focused(window);
         let helper = validation.unwrap_or_else(|| {
             if empty {
-                "Choose a short name for this tmux session.".to_owned()
+                "Name the session you want to create on this host.".to_owned()
             } else {
-                format!(
-                    "Create and attach on {}. Closing Ghosthub only detaches.",
-                    host.endpoint()
-                )
+                format!("Create and attach on {}.", host.name())
             }
         });
 
@@ -1773,7 +1770,7 @@ impl RootView {
                                 .text_sm()
                                 .font_weight(FontWeight::SEMIBOLD)
                                 .text_color(rgb(0xe0_e4eb))
-                                .child(format!("New tmux session · {}", host.endpoint())),
+                                .child("New tmux session"),
                         )
                         .child(Self::new_session_name_input(draft, focused, cx))
                         .child(
@@ -1824,6 +1821,14 @@ impl RootView {
             } else {
                 0xe1_e5ec
             }))
+            .child(
+                div()
+                    .mr_2()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(0x72_7986))
+                    .child(">_"),
+            )
             .child(input_text)
             .on_click(cx.listener(|this, _, window, cx| {
                 window.focus(&this.create_focus);
@@ -1839,40 +1844,56 @@ impl RootView {
             .border_t_1()
             .border_color(rgb(0x2a_2f39))
             .flex()
-            .justify_end()
-            .gap_2()
+            .items_center()
+            .justify_between()
+            .gap_3()
             .child(
                 div()
-                    .id("cancel-new-session")
-                    .px_3()
-                    .py_1()
-                    .rounded_sm()
-                    .cursor_pointer()
-                    .text_sm()
-                    .text_color(rgb(0xb6_bcc7))
-                    .hover(|style| style.bg(rgb(0x29_2e38)))
-                    .child("Cancel")
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.cancel_new_session(window, cx);
-                    })),
+                    .min_w_0()
+                    .flex_1()
+                    .text_xs()
+                    .text_color(rgb(0x78_7f8b))
+                    .child("Tmux owns the session; closing Ghosthub only detaches."),
             )
             .child(
                 div()
-                    .id("create-new-session")
-                    .px_3()
-                    .py_1()
-                    .rounded_sm()
-                    .bg(rgb(if can_create { 0x1d_5f9a } else { 0x2b_3039 }))
-                    .text_sm()
-                    .text_color(rgb(if can_create { 0xf1_f5fa } else { 0x72_7986 }))
-                    .child("Create")
-                    .when(can_create, |element| {
-                        element
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        div()
+                            .id("cancel-new-session")
+                            .px_3()
+                            .py_1()
+                            .rounded_sm()
                             .cursor_pointer()
+                            .text_sm()
+                            .text_color(rgb(0xb6_bcc7))
+                            .hover(|style| style.bg(rgb(0x29_2e38)))
+                            .child("Cancel")
                             .on_click(cx.listener(|this, _, window, cx| {
-                                this.submit_new_session(window, cx);
-                            }))
-                    }),
+                                this.cancel_new_session(window, cx);
+                            })),
+                    )
+                    .child(
+                        div()
+                            .id("create-new-session")
+                            .px_3()
+                            .py_1()
+                            .rounded_sm()
+                            .bg(rgb(if can_create { 0x1d_5f9a } else { 0x2b_3039 }))
+                            .text_sm()
+                            .text_color(rgb(if can_create { 0xf1_f5fa } else { 0x72_7986 }))
+                            .child("Create")
+                            .when(can_create, |element| {
+                                element.cursor_pointer().on_click(cx.listener(
+                                    |this, _, window, cx| {
+                                        this.submit_new_session(window, cx);
+                                    },
+                                ))
+                            }),
+                    ),
             )
             .into_any_element()
     }
@@ -2728,14 +2749,13 @@ fn new_session_validation(
     if draft.name.trim().is_empty() {
         return None;
     }
-    let name = match SessionName::parse(&draft.name) {
-        Ok(name) => name,
-        Err(error) => return Some(error.to_string()),
+    let Ok(name) = SessionName::parse(&draft.name) else {
+        return Some("Use 1–100 characters without periods, colons, or line breaks.".to_owned());
     };
     host.sessions()
         .iter()
         .any(|session| session.name() == name.as_str())
-        .then(|| "A tmux session with this name already exists.".to_owned())
+        .then(|| "A session with this name already exists on this host.".to_owned())
 }
 
 fn window_control(
@@ -3262,11 +3282,14 @@ mod tests {
 
         assert_eq!(new_session_validation(&snapshot, &draft), None);
         draft.name = "has.period".to_owned();
-        assert!(new_session_validation(&snapshot, &draft).is_some());
+        assert_eq!(
+            new_session_validation(&snapshot, &draft).as_deref(),
+            Some("Use 1–100 characters without periods, colons, or line breaks.")
+        );
         draft.name = "existing".to_owned();
         assert_eq!(
             new_session_validation(&snapshot, &draft).as_deref(),
-            Some("A tmux session with this name already exists.")
+            Some("A session with this name already exists on this host.")
         );
         draft.name = "  release work  ".to_owned();
         assert_eq!(new_session_validation(&snapshot, &draft), None);

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -842,6 +842,17 @@ impl RootView {
         cx.notify();
     }
 
+    fn detach_session(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.workspace.detach();
+        self.diagnostic = None;
+        self.observed_presentation_id = None;
+        self.clear_terminal_input();
+        self.paint_cache.clear();
+        self.resize_for_window(window);
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
     fn cancel_session_kill(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.workspace.cancel_session_kill();
         window.focus(&self.focus);
@@ -1797,7 +1808,8 @@ impl RootView {
         confirmation: &workspace::SessionKillConfirmation,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let session = confirmation.selection().session().to_owned();
+        let title = kill_confirmation_title(confirmation.selection());
+        let description = kill_confirmation_description(confirmation.selection());
         div()
             .absolute()
             .inset_0()
@@ -1832,7 +1844,7 @@ impl RootView {
                             .text_sm()
                             .font_weight(FontWeight::SEMIBOLD)
                             .text_color(rgb(0xe0_e4eb))
-                            .child(format!("Kill “{session}”?")),
+                            .child(title),
                     )
                     .child(
                         div()
@@ -1840,9 +1852,7 @@ impl RootView {
                             .py_4()
                             .text_sm()
                             .text_color(rgb(0xb6_bcc7))
-                            .child(
-                                "This permanently terminates every window, pane, and process in this tmux session on WSL.",
-                            ),
+                            .child(description),
                     )
                     .child(
                         div()
@@ -2228,9 +2238,7 @@ impl RootView {
             tree = tree.child(Self::tree_session_row(
                 host_index,
                 session_index,
-                &session.selection,
-                session.active,
-                session.show_endpoint,
+                session,
                 cx,
             ));
         }
@@ -2280,14 +2288,12 @@ impl RootView {
     fn tree_session_row(
         host_index: usize,
         index: usize,
-        selection: &SessionSelection,
-        is_active: bool,
-        show_endpoint: bool,
+        session: &TreeSession,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let selection = selection.clone();
-        let open_selection = selection.clone();
-        let kill_selection = selection.clone();
+        let selection = session.selection.clone();
+        let is_active = session.state.is_active();
+        let can_open = session.state.can_open();
         let name = selection.session().to_owned();
         let mut row = div()
             .id((
@@ -2301,9 +2307,13 @@ impl RootView {
             .gap_1()
             .pl(px(14.0))
             .pr_2()
-            .cursor_pointer()
             .bg(rgb(if is_active { 0x13_3d6a } else { 0x0f_1116 }))
-            .hover(|style| style.bg(rgb(if is_active { 0x17_477a } else { 0x1b_1f27 })))
+            .when(can_open, |element| {
+                element
+                    .cursor_pointer()
+                    .hover(|style| style.bg(rgb(if is_active { 0x17_477a } else { 0x1b_1f27 })))
+            })
+            .when(!can_open, |element| element.opacity(0.55))
             .child(
                 div()
                     .w(px(18.0))
@@ -2321,7 +2331,7 @@ impl RootView {
                     .text_color(rgb(if is_active { 0xe5_ed_f7 } else { 0xc4_c9_d2 }))
                     .child(name.clone()),
             );
-        if show_endpoint {
+        if session.show_endpoint {
             row = row.child(
                 div()
                     .flex_none()
@@ -2331,49 +2341,105 @@ impl RootView {
             );
         }
         if is_active {
-            row = row.child(
-                div()
-                    .id("kill-session")
-                    .flex_none()
-                    .size(px(24.0))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .rounded_sm()
-                    .text_color(rgb(0xa9_c9_ea))
-                    .hover(|style| style.bg(rgb(0x25_527f)).text_color(rgb(0xff_ff_ff)))
-                    .child("×")
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.request_session_kill(&kill_selection, cx);
-                        cx.stop_propagation();
-                    })),
-            );
-        } else {
-            row = row.child(
-                div()
-                    .id((
-                        gpui::ElementId::named_usize("open-tree-session-host", host_index),
-                        index.to_string(),
-                    ))
-                    .flex_none()
-                    .px_1()
-                    .py_1()
-                    .rounded_sm()
-                    .cursor_pointer()
-                    .text_xs()
-                    .text_color(rgb(0x79_aee3))
-                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xb6_d8_f8)))
-                    .child("Open")
-                    .on_click(cx.listener(move |this, _, window, cx| {
-                        this.select_session(&open_selection, window, cx);
-                        cx.stop_propagation();
-                    })),
-            );
+            row = row.child(Self::tree_detach_action(cx));
+        } else if can_open {
+            row = row.child(Self::tree_open_action(
+                host_index,
+                index,
+                selection.clone(),
+                cx,
+            ));
         }
-        row.on_click(cx.listener(move |this, _, window, cx| {
-            this.select_session(&selection, window, cx);
-        }))
+        if session.state.can_kill() {
+            row = row.child(Self::tree_kill_action(
+                host_index,
+                index,
+                selection.clone(),
+                cx,
+            ));
+        }
+        row.when(can_open, |element| {
+            element.on_click(cx.listener(move |this, _, window, cx| {
+                this.select_session(&selection, window, cx);
+            }))
+        })
         .into_any_element()
+    }
+
+    fn tree_detach_action(cx: &mut Context<Self>) -> gpui::AnyElement {
+        div()
+            .id("detach-session")
+            .flex_none()
+            .px_1()
+            .py_1()
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded_sm()
+            .cursor_pointer()
+            .text_xs()
+            .text_color(rgb(0xa9_c9_ea))
+            .hover(|style| style.bg(rgb(0x25_527f)).text_color(rgb(0xff_ff_ff)))
+            .child("Detach")
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.detach_session(window, cx);
+                cx.stop_propagation();
+            }))
+            .into_any_element()
+    }
+
+    fn tree_open_action(
+        host_index: usize,
+        index: usize,
+        selection: SessionSelection,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .id((
+                gpui::ElementId::named_usize("open-tree-session-host", host_index),
+                index.to_string(),
+            ))
+            .flex_none()
+            .px_1()
+            .py_1()
+            .rounded_sm()
+            .cursor_pointer()
+            .text_xs()
+            .text_color(rgb(0x79_aee3))
+            .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xb6_d8_f8)))
+            .child("Open")
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.select_session(&selection, window, cx);
+                cx.stop_propagation();
+            }))
+            .into_any_element()
+    }
+
+    fn tree_kill_action(
+        host_index: usize,
+        index: usize,
+        selection: SessionSelection,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .id((
+                gpui::ElementId::named_usize("kill-tree-session-host", host_index),
+                index.to_string(),
+            ))
+            .flex_none()
+            .px_1()
+            .py_1()
+            .rounded_sm()
+            .cursor_pointer()
+            .text_xs()
+            .text_color(rgb(0xc7_7378))
+            .hover(|style| style.bg(rgb(0x3a_2025)).text_color(rgb(0xff_a3_a8)))
+            .child("Kill")
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.request_session_kill(&selection, cx);
+                cx.stop_propagation();
+            }))
+            .into_any_element()
     }
 
     fn host_landing_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
@@ -2563,8 +2629,35 @@ fn terminal_presentation_id(content: &WorkspaceContent) -> Option<u64> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TreeSession {
     selection: SessionSelection,
-    active: bool,
+    state: TreeSessionState,
     show_endpoint: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TreeSessionState {
+    Active,
+    ActiveKillable,
+    Retained,
+    RetainedKillable,
+    Fresh,
+    Cached,
+}
+
+impl TreeSessionState {
+    const fn is_active(self) -> bool {
+        matches!(self, Self::Active | Self::ActiveKillable)
+    }
+
+    const fn can_open(self) -> bool {
+        !matches!(self, Self::Cached)
+    }
+
+    const fn can_kill(self) -> bool {
+        matches!(
+            self,
+            Self::ActiveKillable | Self::RetainedKillable | Self::Fresh
+        )
+    }
 }
 
 fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelection> {
@@ -2600,25 +2693,65 @@ fn tree_sessions(
     let mut selections = host
         .sessions()
         .iter()
-        .map(|session| SessionSelection::new(host.id(), host.endpoint(), session.name()))
+        .map(|session| {
+            (
+                SessionSelection::new(host.id(), host.endpoint(), session.name()),
+                true,
+            )
+        })
         .collect::<Vec<_>>();
     for selection in retained
         .iter()
         .filter(|selection| selection.host_id() == host.id())
         .chain(active_for_host)
     {
-        if !selections.contains(selection) {
-            selections.push(selection.clone());
+        if !selections
+            .iter()
+            .any(|(candidate, _)| candidate == selection)
+        {
+            selections.push((selection.clone(), false));
         }
     }
+    let host_accepts_actions = !matches!(
+        host.connection(),
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    );
     selections
         .into_iter()
-        .map(|selection| TreeSession {
-            active: active.as_ref() == Some(&selection),
-            show_endpoint: selection.endpoint() != host.endpoint(),
-            selection,
+        .map(|(selection, discovered)| {
+            let retained = retained.contains(&selection);
+            let is_active = active.as_ref() == Some(&selection);
+            let can_kill = discovered && host_accepts_actions;
+            let state = match (is_active, retained, host_accepts_actions, can_kill) {
+                (true, _, _, true) => TreeSessionState::ActiveKillable,
+                (true, _, _, false) => TreeSessionState::Active,
+                (false, true, _, true) => TreeSessionState::RetainedKillable,
+                (false, true, _, false) => TreeSessionState::Retained,
+                (false, false, true, _) => TreeSessionState::Fresh,
+                (false, false, false, _) => TreeSessionState::Cached,
+            };
+            TreeSession {
+                state,
+                show_endpoint: selection.endpoint() != host.endpoint(),
+                selection,
+            }
         })
         .collect()
+}
+
+fn kill_confirmation_title(selection: &SessionSelection) -> String {
+    format!(
+        "Kill “{}” on {}?",
+        selection.session(),
+        selection.endpoint()
+    )
+}
+
+fn kill_confirmation_description(selection: &SessionSelection) -> String {
+    format!(
+        "This permanently terminates every window, pane, and process in this tmux session on {}.",
+        selection.endpoint()
+    )
 }
 
 fn workspace_window_title(content: &WorkspaceContent) -> String {
@@ -2853,7 +2986,7 @@ fn new_session_validation(
         return None;
     }
     let Ok(name) = SessionName::parse(&draft.name) else {
-        return Some("Use 1–100 characters without periods, colons, or line breaks.".to_owned());
+        return Some("Use 1–100 characters without #, periods, colons, or line breaks.".to_owned());
     };
     host.sessions()
         .iter()
@@ -3352,11 +3485,12 @@ mod tests {
         UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_selection,
         application_navigation_width, canonical_terminal_key_with, clear_terminal_input_state,
         clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, input_queue_has_capacity, is_toggle_sidebar_shortcut, named_key,
-        new_session_validation, normalize_cell_width, queued_input_matches_presentation,
-        retained_key_event_with, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
-        transitioned_presentation, tree_sessions, workspace_window_title,
+        coalesce_last_wheel, input_queue_has_capacity, is_toggle_sidebar_shortcut,
+        kill_confirmation_description, kill_confirmation_title, named_key, new_session_validation,
+        normalize_cell_width, queued_input_matches_presentation, retained_key_event_with,
+        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
+        workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -3387,7 +3521,12 @@ mod tests {
         draft.name = "has.period".to_owned();
         assert_eq!(
             new_session_validation(&snapshot, &draft).as_deref(),
-            Some("Use 1–100 characters without periods, colons, or line breaks.")
+            Some("Use 1–100 characters without #, periods, colons, or line breaks.")
+        );
+        draft.name = "#(touch /tmp/ghosthub-owned)".to_owned();
+        assert_eq!(
+            new_session_validation(&snapshot, &draft).as_deref(),
+            Some("Use 1–100 characters without #, periods, colons, or line breaks.")
         );
         draft.name = "existing".to_owned();
         assert_eq!(
@@ -3528,10 +3667,33 @@ mod tests {
             let rows = tree_sessions(&host, &terminal, &[]);
             assert_eq!(rows.len(), 2);
             assert_eq!(rows[0].selection.session(), "other");
-            assert!(!rows[0].active);
+            assert!(!rows[0].state.is_active());
+            assert_eq!(
+                rows[0].state.can_open(),
+                state == HostConnectionState::Connecting
+            );
+            assert_eq!(
+                rows[0].state.can_kill(),
+                state == HostConnectionState::Connecting
+            );
             assert_eq!(rows[1].selection.session(), "demo");
-            assert!(rows[1].active);
+            assert!(rows[1].state.is_active());
+            assert!(rows[1].state.can_open());
         }
+    }
+
+    #[test]
+    fn kill_confirmation_names_the_exact_endpoint() {
+        let selection = SessionSelection::new("wsl", "Ubuntu-24.04", "release");
+
+        assert_eq!(
+            kill_confirmation_title(&selection),
+            "Kill “release” on Ubuntu-24.04?"
+        );
+        assert_eq!(
+            kill_confirmation_description(&selection),
+            "This permanently terminates every window, pane, and process in this tmux session on Ubuntu-24.04."
+        );
     }
 
     #[test]
@@ -3555,10 +3717,10 @@ mod tests {
         let rows = tree_sessions(&host, &terminal, &[]);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].selection.endpoint(), "Debian");
-        assert!(!rows[0].active);
+        assert!(!rows[0].state.is_active());
         assert!(!rows[0].show_endpoint);
         assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
-        assert!(rows[1].active);
+        assert!(rows[1].state.is_active());
         assert!(rows[1].show_endpoint);
     }
 
@@ -3578,8 +3740,11 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].selection.endpoint(), "Debian");
         assert!(!rows[0].show_endpoint);
+        assert!(rows[0].state.can_kill());
         assert_eq!(rows[1].selection.endpoint(), "Ubuntu");
         assert!(rows[1].show_endpoint);
+        assert!(rows[1].state.can_open());
+        assert!(!rows[1].state.can_kill());
     }
 
     #[test]
@@ -3601,7 +3766,27 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].selection.session(), "one");
         assert_eq!(rows[1].selection.session(), "two");
-        assert!(rows.iter().all(|row| !row.active));
+        assert!(rows.iter().all(|row| !row.state.is_active()));
+        assert!(rows.iter().all(|row| row.state.can_open()));
+        assert!(rows.iter().all(|row| !row.state.can_kill()));
+    }
+
+    #[test]
+    fn disconnected_cached_sessions_are_visible_but_cannot_start_fresh_actions() {
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Disconnected,
+            vec![SessionItem::new("cached", 0)],
+            None,
+        );
+
+        let rows = tree_sessions(&host, &WorkspaceContent::Shell, &[]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].selection.session(), "cached");
+        assert!(!rows[0].state.can_open());
+        assert!(!rows[0].state.can_kill());
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -28,7 +28,7 @@ const APP_NAVIGATION_WIDTH: f32 = 260.0;
 const APP_TITLEBAR_HEIGHT: f32 = 32.0;
 const APP_CHROME_BACKGROUND: u32 = 0x0f_1116;
 const NAVIGATION_HEADER_HEIGHT: f32 = 36.0;
-const HOST_ROW_HEIGHT: f32 = 42.0;
+const HOST_ROW_HEIGHT: f32 = 30.0;
 const SESSION_ROW_HEIGHT: f32 = 30.0;
 const CELL_LINE_GAP: f32 = 4.0;
 const UI_INPUT_CAPACITY: usize = 512;
@@ -2016,23 +2016,11 @@ impl RootView {
                 div()
                     .min_w_0()
                     .flex_1()
-                    .flex()
-                    .flex_col()
-                    .child(
-                        div()
-                            .truncate()
-                            .text_sm()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .text_color(rgb(0xd2_d7_df))
-                            .child(host.name().to_owned()),
-                    )
-                    .child(
-                        div()
-                            .truncate()
-                            .text_xs()
-                            .text_color(rgb(0x71_7885))
-                            .child(host.endpoint().to_owned()),
-                    ),
+                    .truncate()
+                    .text_sm()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(rgb(0xd2_d7_df))
+                    .child(host.name().to_owned()),
             );
         if host.connection() == HostConnectionState::Ready {
             let host_id = host.id().to_owned();

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -307,6 +307,7 @@ pub struct RootView {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct NewSessionDraft {
     host_id: String,
+    endpoint: String,
     name: String,
 }
 
@@ -706,9 +707,16 @@ impl RootView {
         cx.notify();
     }
 
-    fn open_new_session(&mut self, host_id: &str, window: &mut Window, cx: &mut Context<Self>) {
+    fn open_new_session(
+        &mut self,
+        host_id: &str,
+        endpoint: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.new_session = Some(NewSessionDraft {
             host_id: host_id.to_owned(),
+            endpoint: endpoint.to_owned(),
             name: String::new(),
         });
         self.diagnostic = None;
@@ -726,13 +734,19 @@ impl RootView {
         let Some(draft) = self.new_session.clone() else {
             return;
         };
+        if draft.name.trim().is_empty() {
+            return;
+        }
         let snapshot = self.workspace.snapshot();
         if let Some(error) = new_session_validation(&snapshot, &draft) {
             self.diagnostic = Some(error);
             cx.notify();
             return;
         }
-        match self.workspace.create_session(&draft.host_id, &draft.name) {
+        match self
+            .workspace
+            .create_session(&draft.host_id, &draft.endpoint, &draft.name)
+        {
             Ok(()) => {
                 self.new_session = None;
                 self.diagnostic = None;
@@ -752,6 +766,7 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.diagnostic = None;
         if is_paste_shortcut(&event.keystroke) {
             if !event.is_held
                 && let Some(text) = cx.read_from_clipboard().and_then(|item| item.text())
@@ -1702,6 +1717,7 @@ impl RootView {
     fn new_session_overlay(
         &self,
         snapshot: &workspace::WorkspaceSnapshot,
+        window: &Window,
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
         let draft = self.new_session.as_ref()?;
@@ -1709,18 +1725,20 @@ impl RootView {
             .hosts()
             .iter()
             .find(|host| host.id() == draft.host_id)?;
+        let empty = draft.name.trim().is_empty();
         let validation = new_session_validation(snapshot, draft);
-        let can_create = validation.is_none();
-        let input_text = if draft.name.is_empty() {
-            "Session name".to_owned()
-        } else {
-            format!("{}▏", draft.name)
-        };
+        let can_create = !empty && validation.is_none();
+        let helper_is_error = validation.is_some();
+        let focused = self.create_focus.is_focused(window);
         let helper = validation.unwrap_or_else(|| {
-            format!(
-                "Create and attach on {}. Closing Ghosthub only detaches.",
-                host.endpoint()
-            )
+            if empty {
+                "Choose a short name for this tmux session.".to_owned()
+            } else {
+                format!(
+                    "Create and attach on {}. Closing Ghosthub only detaches.",
+                    host.endpoint()
+                )
+            }
         });
 
         Some(
@@ -1757,37 +1775,61 @@ impl RootView {
                                 .text_color(rgb(0xe0_e4eb))
                                 .child(format!("New tmux session · {}", host.endpoint())),
                         )
-                        .child(
-                            div()
-                                .m_4()
-                                .px_3()
-                                .h(px(38.0))
-                                .flex()
-                                .items_center()
-                                .rounded_md()
-                                .border_1()
-                                .border_color(rgb(0x4a_79a8))
-                                .bg(rgb(0x0f_1218))
-                                .text_sm()
-                                .text_color(rgb(if draft.name.is_empty() {
-                                    0x72_7986
-                                } else {
-                                    0xe1_e5ec
-                                }))
-                                .child(input_text),
-                        )
+                        .child(Self::new_session_name_input(draft, focused, cx))
                         .child(
                             div()
                                 .px_4()
                                 .pb_3()
                                 .text_xs()
-                                .text_color(rgb(if can_create { 0x82_8995 } else { 0xd0_7070 }))
+                                .text_color(rgb(if helper_is_error {
+                                    0xd0_7070
+                                } else {
+                                    0x82_8995
+                                }))
                                 .child(helper),
                         )
                         .child(Self::new_session_actions(can_create, cx)),
                 )
                 .into_any_element(),
         )
+    }
+
+    fn new_session_name_input(
+        draft: &NewSessionDraft,
+        focused: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let input_text = if draft.name.is_empty() && focused {
+            "▏".to_owned()
+        } else if draft.name.is_empty() {
+            "Session name".to_owned()
+        } else {
+            format!("{}▏", draft.name)
+        };
+        div()
+            .id("new-session-name-input")
+            .m_4()
+            .px_3()
+            .h(px(38.0))
+            .flex()
+            .items_center()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(if focused { 0x4a_8f_cf } else { 0x3a_404c }))
+            .bg(rgb(0x0f_1218))
+            .cursor_text()
+            .text_sm()
+            .text_color(rgb(if draft.name.is_empty() && !focused {
+                0x72_7986
+            } else {
+                0xe1_e5ec
+            }))
+            .child(input_text)
+            .on_click(cx.listener(|this, _, window, cx| {
+                window.focus(&this.create_focus);
+                cx.notify();
+            }))
+            .into_any_element()
     }
 
     fn new_session_actions(can_create: bool, cx: &mut Context<Self>) -> gpui::AnyElement {
@@ -1994,6 +2036,7 @@ impl RootView {
             );
         if host.connection() == HostConnectionState::Ready {
             let host_id = host.id().to_owned();
+            let endpoint = host.endpoint().to_owned();
             host_header = host_header
                 .child(
                     div()
@@ -2010,7 +2053,7 @@ impl RootView {
                         .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
                         .child("+")
                         .on_click(cx.listener(move |this, _, window, cx| {
-                            this.open_new_session(&host_id, window, cx);
+                            this.open_new_session(&host_id, &endpoint, window, cx);
                         })),
                 )
                 .child(
@@ -2569,7 +2612,7 @@ impl Render for RootView {
             self.paint_cache.clear();
         }
         let content = self.content_element(&snapshot, cx);
-        let creation_overlay = self.new_session_overlay(&snapshot, cx);
+        let creation_overlay = self.new_session_overlay(&snapshot, window, cx);
         let mut root = div()
             .flex()
             .flex_col()
@@ -2683,8 +2726,19 @@ fn new_session_validation(
     else {
         return Some("The selected host is no longer available.".to_owned());
     };
-    if host.connection() != HostConnectionState::Ready {
-        return Some("Connect the WSL host before creating a session.".to_owned());
+    if host.endpoint() != draft.endpoint {
+        return Some(
+            "The WSL endpoint changed. Close this dialog and choose the host again.".to_owned(),
+        );
+    }
+    if matches!(
+        host.connection(),
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    ) {
+        return Some("Reconnect the WSL host before creating a session.".to_owned());
+    }
+    if draft.name.trim().is_empty() {
+        return None;
     }
     let name = match SessionName::parse(&draft.name) {
         Ok(name) => name,
@@ -3214,10 +3268,11 @@ mod tests {
         );
         let mut draft = NewSessionDraft {
             host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
             name: String::new(),
         };
 
-        assert!(new_session_validation(&snapshot, &draft).is_some());
+        assert_eq!(new_session_validation(&snapshot, &draft), None);
         draft.name = "has.period".to_owned();
         assert!(new_session_validation(&snapshot, &draft).is_some());
         draft.name = "existing".to_owned();
@@ -3227,6 +3282,20 @@ mod tests {
         );
         draft.name = "  release work  ".to_owned();
         assert_eq!(new_session_validation(&snapshot, &draft), None);
+
+        let refreshing = WorkspaceSnapshot::shell(
+            workspace::Appearance::default(),
+            vec![HostItem::wsl(
+                "Ubuntu",
+                None,
+                HostConnectionState::Connecting,
+                vec![SessionItem::new("existing", 0)],
+                None,
+            )],
+        );
+        assert_eq!(new_session_validation(&refreshing, &draft), None);
+        draft.endpoint = "Debian".to_owned();
+        assert!(new_session_validation(&refreshing, &draft).is_some());
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -583,6 +583,21 @@ impl RootView {
         })
         .detach();
 
+        cx.observe_window_activation(window, |view, window, cx| {
+            if !window.is_window_active() {
+                return;
+            }
+            match view.workspace.refresh_if_ready() {
+                Ok(true) => cx.notify(),
+                Ok(false) => {}
+                Err(error) => {
+                    view.diagnostic = Some(error.to_string());
+                    cx.notify();
+                }
+            }
+        })
+        .detach();
+
         cx.on_next_frame(window, |view, _window, cx| {
             if let Err(error) = view.workspace.connect_enabled_hosts() {
                 view.diagnostic = Some(error.to_string());
@@ -2167,14 +2182,11 @@ fn tree_sessions(
         .as_ref()
         .filter(|active| active.host_id() == host.id());
 
-    let mut selections = if host.connection() == HostConnectionState::Ready {
-        host.sessions()
-            .iter()
-            .map(|session| SessionSelection::new(host.id(), host.endpoint(), session.name()))
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
+    let mut selections = host
+        .sessions()
+        .iter()
+        .map(|session| SessionSelection::new(host.id(), host.endpoint(), session.name()))
+        .collect::<Vec<_>>();
     for selection in retained
         .iter()
         .filter(|selection| selection.host_id() == host.id())
@@ -2998,7 +3010,7 @@ mod tests {
     }
 
     #[test]
-    fn active_session_stays_in_the_tree_while_its_host_refreshes_or_fails() {
+    fn cached_and_active_sessions_stay_in_the_tree_while_the_host_refreshes_or_fails() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let terminal = WorkspaceContent::Terminal {
             host_id: "wsl".to_owned(),
@@ -3020,9 +3032,11 @@ mod tests {
             );
 
             let rows = tree_sessions(&host, &terminal, &[]);
-            assert_eq!(rows.len(), 1);
-            assert_eq!(rows[0].selection.session(), "demo");
-            assert!(rows[0].active);
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].selection.session(), "other");
+            assert!(!rows[0].active);
+            assert_eq!(rows[1].selection.session(), "demo");
+            assert!(rows[1].active);
         }
     }
 

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -286,6 +286,7 @@ pub struct RootView {
     workspace: Workspace,
     focus: FocusHandle,
     create_focus: FocusHandle,
+    kill_focus: FocusHandle,
     diagnostic: Option<String>,
     paste_confirmation: bool,
     observed_presentation_id: Option<u64>,
@@ -621,6 +622,7 @@ impl RootView {
             workspace,
             focus: cx.focus_handle(),
             create_focus: cx.focus_handle(),
+            kill_focus: cx.focus_handle(),
             diagnostic: None,
             paste_confirmation: false,
             observed_presentation_id: None,
@@ -832,11 +834,26 @@ impl RootView {
         cx.notify();
     }
 
-    fn detach(&mut self, cx: &mut Context<Self>) {
-        self.workspace.detach();
-        self.observed_presentation_id = None;
-        self.clear_terminal_input();
-        self.paint_cache.clear();
+    fn request_session_kill(&mut self, selection: &SessionSelection, cx: &mut Context<Self>) {
+        match self.workspace.request_session_kill(selection) {
+            Ok(()) => self.diagnostic = None,
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        cx.notify();
+    }
+
+    fn cancel_session_kill(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.workspace.cancel_session_kill();
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
+    fn confirm_session_kill(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.workspace.confirm_session_kill() {
+            Ok(()) => self.diagnostic = None,
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        window.focus(&self.focus);
         cx.notify();
     }
 
@@ -1775,6 +1792,125 @@ impl RootView {
         )
     }
 
+    fn session_kill_overlay(
+        &self,
+        confirmation: &workspace::SessionKillConfirmation,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let session = confirmation.selection().session().to_owned();
+        div()
+            .absolute()
+            .inset_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(rgba(0x00_00_00_80))
+            .child(
+                div()
+                    .id("kill-session-dialog")
+                    .track_focus(&self.kill_focus)
+                    .w(px(460.0))
+                    .flex()
+                    .flex_col()
+                    .rounded_lg()
+                    .border_1()
+                    .border_color(rgb(0x36_3c48))
+                    .bg(rgb(0x18_1b22))
+                    .shadow_lg()
+                    .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                        if event.keystroke.key.eq_ignore_ascii_case("escape") && !event.is_held {
+                            this.cancel_session_kill(window, cx);
+                            cx.stop_propagation();
+                        }
+                    }))
+                    .child(
+                        div()
+                            .px_4()
+                            .py_3()
+                            .border_b_1()
+                            .border_color(rgb(0x2a_2f39))
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(rgb(0xe0_e4eb))
+                            .child(format!("Kill “{session}”?")),
+                    )
+                    .child(
+                        div()
+                            .px_4()
+                            .py_4()
+                            .text_sm()
+                            .text_color(rgb(0xb6_bcc7))
+                            .child(
+                                "This permanently terminates every window, pane, and process in this tmux session on WSL.",
+                            ),
+                    )
+                    .child(
+                        div()
+                            .px_4()
+                            .py_3()
+                            .border_t_1()
+                            .border_color(rgb(0x2a_2f39))
+                            .flex()
+                            .items_center()
+                            .justify_end()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .id("cancel-kill-session")
+                                    .px_3()
+                                    .py_1()
+                                    .rounded_sm()
+                                    .cursor_pointer()
+                                    .text_sm()
+                                    .text_color(rgb(0xb6_bcc7))
+                                    .hover(|style| style.bg(rgb(0x29_2e38)))
+                                    .child("Cancel")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.cancel_session_kill(window, cx);
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .id("confirm-kill-session")
+                                    .px_3()
+                                    .py_1()
+                                    .rounded_sm()
+                                    .cursor_pointer()
+                                    .bg(rgb(0xa9_3038))
+                                    .hover(|style| style.bg(rgb(0xc1_3b43)))
+                                    .text_sm()
+                                    .text_color(rgb(0xff_f6f6))
+                                    .child("Kill Session")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.confirm_session_kill(window, cx);
+                                    })),
+                            ),
+                    ),
+            )
+            .into_any_element()
+    }
+
+    fn pending_session_kill_overlay(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let confirmation = self.workspace.session_kill_confirmation()?;
+        if !self.kill_focus.is_focused(window) {
+            window.focus(&self.kill_focus);
+        }
+        Some(self.session_kill_overlay(&confirmation, cx))
+    }
+
+    fn synchronize_render_state(&mut self, snapshot: &workspace::WorkspaceSnapshot) {
+        self.observed_revision = snapshot.revision();
+        if !matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
+            self.observed_surface_identity = None;
+            self.observed_surface_generation = 0;
+            self.paint_cache.clear();
+        }
+    }
+
     fn new_session_name_input(
         draft: &NewSessionDraft,
         focused: bool,
@@ -2151,6 +2287,7 @@ impl RootView {
     ) -> gpui::AnyElement {
         let selection = selection.clone();
         let open_selection = selection.clone();
+        let kill_selection = selection.clone();
         let name = selection.session().to_owned();
         let mut row = div()
             .id((
@@ -2196,7 +2333,7 @@ impl RootView {
         if is_active {
             row = row.child(
                 div()
-                    .id("detach-terminal")
+                    .id("kill-session")
                     .flex_none()
                     .size(px(24.0))
                     .flex()
@@ -2206,8 +2343,8 @@ impl RootView {
                     .text_color(rgb(0xa9_c9_ea))
                     .hover(|style| style.bg(rgb(0x25_527f)).text_color(rgb(0xff_ff_ff)))
                     .child("×")
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.detach(cx);
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.request_session_kill(&kill_selection, cx);
                         cx.stop_propagation();
                     })),
             );
@@ -2583,14 +2720,10 @@ impl Render for RootView {
         let snapshot = self.workspace.snapshot();
         let title = workspace_window_title(snapshot.content());
         window.set_window_title(&title);
-        self.observed_revision = snapshot.revision();
-        if !matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
-            self.observed_surface_identity = None;
-            self.observed_surface_generation = 0;
-            self.paint_cache.clear();
-        }
+        self.synchronize_render_state(&snapshot);
         let content = self.content_element(&snapshot, cx);
         let creation_overlay = self.new_session_overlay(&snapshot, window, cx);
+        let kill_overlay = self.pending_session_kill_overlay(window, cx);
         let mut root = div()
             .flex()
             .flex_col()
@@ -2602,7 +2735,8 @@ impl Render for RootView {
             }))
             .child(self.title_bar(title, cx))
             .child(div().flex_1().min_h_0().w_full().child(content))
-            .children(creation_overlay);
+            .children(creation_overlay)
+            .children(kill_overlay);
 
         if let Some(notice) = snapshot.notice() {
             root = root.child(

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -13,14 +13,14 @@ use gpui::{
     IntoElement, KeyBinding, KeyDownEvent, KeyUpEvent, MouseButton as GpuiMouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, ScrollWheelEvent, TitlebarOptions,
     Window, WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowDecorations,
-    WindowOptions, actions, div, font, prelude::*, px, rgb, size,
+    WindowOptions, actions, div, font, prelude::*, px, rgb, rgba, size,
 };
 use model::PortStatus;
 use surface::{CellStyle, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
 use workspace::{
     HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput,
-    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionSelection,
-    Workspace, WorkspaceContent, WorkspaceEvent,
+    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionName,
+    SessionSelection, Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -70,7 +70,7 @@ pub fn empty_inventory_text(host: &HostItem) -> String {
         .socket_directory()
         .unwrap_or("the default tmux socket namespace");
     format!(
-        "No tmux server is running in {} using {namespace}. Review WSL host settings or start a tmux session, then choose Refresh.",
+        "No tmux server is running in {} using {namespace}. Use + beside the host to create one, or review WSL host settings.",
         host.endpoint()
     )
 }
@@ -285,6 +285,7 @@ pub struct RootView {
     status: PortStatus,
     workspace: Workspace,
     focus: FocusHandle,
+    create_focus: FocusHandle,
     diagnostic: Option<String>,
     paste_confirmation: bool,
     observed_presentation_id: Option<u64>,
@@ -300,6 +301,13 @@ pub struct RootView {
     keyboard: TerminalKeyboard,
     pointer: TerminalPointer,
     sidebar_visible: bool,
+    new_session: Option<NewSessionDraft>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct NewSessionDraft {
+    host_id: String,
+    name: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -611,6 +619,7 @@ impl RootView {
             status,
             workspace,
             focus: cx.focus_handle(),
+            create_focus: cx.focus_handle(),
             diagnostic: None,
             paste_confirmation: false,
             observed_presentation_id: None,
@@ -626,6 +635,7 @@ impl RootView {
             keyboard: TerminalKeyboard::default(),
             pointer: TerminalPointer::default(),
             sidebar_visible: true,
+            new_session: None,
         };
         view.resize_for_window(window);
         view
@@ -694,6 +704,94 @@ impl RootView {
             self.diagnostic = None;
         }
         cx.notify();
+    }
+
+    fn open_new_session(&mut self, host_id: &str, window: &mut Window, cx: &mut Context<Self>) {
+        self.new_session = Some(NewSessionDraft {
+            host_id: host_id.to_owned(),
+            name: String::new(),
+        });
+        self.diagnostic = None;
+        window.focus(&self.create_focus);
+        cx.notify();
+    }
+
+    fn cancel_new_session(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.new_session = None;
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
+    fn submit_new_session(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(draft) = self.new_session.clone() else {
+            return;
+        };
+        let snapshot = self.workspace.snapshot();
+        if let Some(error) = new_session_validation(&snapshot, &draft) {
+            self.diagnostic = Some(error);
+            cx.notify();
+            return;
+        }
+        match self.workspace.create_session(&draft.host_id, &draft.name) {
+            Ok(()) => {
+                self.new_session = None;
+                self.diagnostic = None;
+                self.observed_presentation_id = None;
+                self.clear_terminal_input();
+                self.paint_cache.clear();
+                window.focus(&self.focus);
+            }
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        cx.notify();
+    }
+
+    fn on_new_session_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if is_paste_shortcut(&event.keystroke) {
+            if !event.is_held
+                && let Some(text) = cx.read_from_clipboard().and_then(|item| item.text())
+                && let Some(draft) = &mut self.new_session
+            {
+                draft
+                    .name
+                    .extend(text.chars().filter(|character| !character.is_control()));
+                cx.notify();
+            }
+            cx.stop_propagation();
+            return;
+        }
+        let key = event.keystroke.key.to_ascii_lowercase();
+        match key.as_str() {
+            "escape" if !event.is_held => self.cancel_new_session(window, cx),
+            "enter" if !event.is_held => self.submit_new_session(window, cx),
+            "backspace" => {
+                if let Some(draft) = &mut self.new_session {
+                    draft.name.pop();
+                }
+                cx.notify();
+            }
+            _ if !event.keystroke.modifiers.control
+                && !event.keystroke.modifiers.alt
+                && !event.keystroke.modifiers.platform
+                && !event.keystroke.modifiers.function =>
+            {
+                if let Some(text) = &event.keystroke.key_char
+                    && let Some(draft) = &mut self.new_session
+                {
+                    draft
+                        .name
+                        .extend(text.chars().filter(|character| !character.is_control()));
+                    cx.notify();
+                }
+            }
+            _ => {}
+        }
+        cx.stop_propagation();
     }
 
     fn toggle_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1601,6 +1699,142 @@ impl RootView {
             .into_any_element()
     }
 
+    fn new_session_overlay(
+        &self,
+        snapshot: &workspace::WorkspaceSnapshot,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let draft = self.new_session.as_ref()?;
+        let host = snapshot
+            .hosts()
+            .iter()
+            .find(|host| host.id() == draft.host_id)?;
+        let validation = new_session_validation(snapshot, draft);
+        let can_create = validation.is_none();
+        let input_text = if draft.name.is_empty() {
+            "Session name".to_owned()
+        } else {
+            format!("{}▏", draft.name)
+        };
+        let helper = validation.unwrap_or_else(|| {
+            format!(
+                "Create and attach on {}. Closing Ghosthub only detaches.",
+                host.endpoint()
+            )
+        });
+
+        Some(
+            div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .bg(rgba(0x00_00_00_80))
+                .child(
+                    div()
+                        .id("new-session-dialog")
+                        .track_focus(&self.create_focus)
+                        .w(px(460.0))
+                        .flex()
+                        .flex_col()
+                        .rounded_lg()
+                        .border_1()
+                        .border_color(rgb(0x36_3c48))
+                        .bg(rgb(0x18_1b22))
+                        .shadow_lg()
+                        .on_key_down(cx.listener(|this, event, window, cx| {
+                            this.on_new_session_key_down(event, window, cx);
+                        }))
+                        .child(
+                            div()
+                                .px_4()
+                                .py_3()
+                                .border_b_1()
+                                .border_color(rgb(0x2a_2f39))
+                                .text_sm()
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(rgb(0xe0_e4eb))
+                                .child(format!("New tmux session · {}", host.endpoint())),
+                        )
+                        .child(
+                            div()
+                                .m_4()
+                                .px_3()
+                                .h(px(38.0))
+                                .flex()
+                                .items_center()
+                                .rounded_md()
+                                .border_1()
+                                .border_color(rgb(0x4a_79a8))
+                                .bg(rgb(0x0f_1218))
+                                .text_sm()
+                                .text_color(rgb(if draft.name.is_empty() {
+                                    0x72_7986
+                                } else {
+                                    0xe1_e5ec
+                                }))
+                                .child(input_text),
+                        )
+                        .child(
+                            div()
+                                .px_4()
+                                .pb_3()
+                                .text_xs()
+                                .text_color(rgb(if can_create { 0x82_8995 } else { 0xd0_7070 }))
+                                .child(helper),
+                        )
+                        .child(Self::new_session_actions(can_create, cx)),
+                )
+                .into_any_element(),
+        )
+    }
+
+    fn new_session_actions(can_create: bool, cx: &mut Context<Self>) -> gpui::AnyElement {
+        div()
+            .px_4()
+            .py_3()
+            .border_t_1()
+            .border_color(rgb(0x2a_2f39))
+            .flex()
+            .justify_end()
+            .gap_2()
+            .child(
+                div()
+                    .id("cancel-new-session")
+                    .px_3()
+                    .py_1()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .text_sm()
+                    .text_color(rgb(0xb6_bcc7))
+                    .hover(|style| style.bg(rgb(0x29_2e38)))
+                    .child("Cancel")
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.cancel_new_session(window, cx);
+                    })),
+            )
+            .child(
+                div()
+                    .id("create-new-session")
+                    .px_3()
+                    .py_1()
+                    .rounded_sm()
+                    .bg(rgb(if can_create { 0x1d_5f9a } else { 0x2b_3039 }))
+                    .text_sm()
+                    .text_color(rgb(if can_create { 0xf1_f5fa } else { 0x72_7986 }))
+                    .child("Create")
+                    .when(can_create, |element| {
+                        element
+                            .cursor_pointer()
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.submit_new_session(window, cx);
+                            }))
+                    }),
+            )
+            .into_any_element()
+    }
+
     fn workspace_tree(
         snapshot: &workspace::WorkspaceSnapshot,
         cx: &mut Context<Self>,
@@ -1759,22 +1993,42 @@ impl RootView {
                     ),
             );
         if host.connection() == HostConnectionState::Ready {
-            host_header = host_header.child(
-                div()
-                    .id(("refresh-host", host_index))
-                    .flex_none()
-                    .size(px(24.0))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .rounded_sm()
-                    .cursor_pointer()
-                    .text_xs()
-                    .text_color(rgb(0x8f_96_a3))
-                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
-                    .child("↻")
-                    .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
-            );
+            let host_id = host.id().to_owned();
+            host_header = host_header
+                .child(
+                    div()
+                        .id(("create-session-host", host_index))
+                        .flex_none()
+                        .size(px(24.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_sm()
+                        .cursor_pointer()
+                        .text_sm()
+                        .text_color(rgb(0x8f_96_a3))
+                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                        .child("+")
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.open_new_session(&host_id, window, cx);
+                        })),
+                )
+                .child(
+                    div()
+                        .id(("refresh-host", host_index))
+                        .flex_none()
+                        .size(px(24.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded_sm()
+                        .cursor_pointer()
+                        .text_xs()
+                        .text_color(rgb(0x8f_96_a3))
+                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                        .child("↻")
+                        .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+                );
         }
         host_header.into_any_element()
     }
@@ -1967,7 +2221,7 @@ impl RootView {
     fn host_landing_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
         if host.connection() == HostConnectionState::Ready {
             return centered(if host.sessions().is_empty() {
-                "Start a tmux session in WSL, then refresh."
+                "Use + beside WSL to create a tmux session."
             } else {
                 "Choose a session to open its terminal."
             });
@@ -2082,7 +2336,10 @@ impl RootView {
             ));
         if sessions.is_empty() {
             let empty = host.map_or_else(
-                || "No tmux server is running in this distro. Start a tmux session in WSL, then choose Refresh.".to_owned(),
+                || {
+                    "No tmux server is running in this distro. Use + beside WSL to create one."
+                        .to_owned()
+                },
                 empty_inventory_text,
             );
             list = list.child(div().p_4().rounded_md().bg(rgb(0x1a_1d24)).child(empty));
@@ -2311,8 +2568,8 @@ impl Render for RootView {
             self.observed_surface_generation = 0;
             self.paint_cache.clear();
         }
-        let title_bar = self.title_bar(title, cx);
         let content = self.content_element(&snapshot, cx);
+        let creation_overlay = self.new_session_overlay(&snapshot, cx);
         let mut root = div()
             .flex()
             .flex_col()
@@ -2322,8 +2579,9 @@ impl Render for RootView {
             .on_action(cx.listener(|this, _: &ToggleSidebar, window, cx| {
                 this.toggle_sidebar(window, cx);
             }))
-            .child(title_bar)
-            .child(div().flex_1().min_h_0().w_full().child(content));
+            .child(self.title_bar(title, cx))
+            .child(div().flex_1().min_h_0().w_full().child(content))
+            .children(creation_overlay);
 
         if let Some(notice) = snapshot.notice() {
             root = root.child(
@@ -2412,6 +2670,30 @@ fn centered(text: impl Into<String>) -> gpui::AnyElement {
         .text_color(rgb(0xb7_bc_c6))
         .child(text.into())
         .into_any_element()
+}
+
+fn new_session_validation(
+    snapshot: &workspace::WorkspaceSnapshot,
+    draft: &NewSessionDraft,
+) -> Option<String> {
+    let Some(host) = snapshot
+        .hosts()
+        .iter()
+        .find(|host| host.id() == draft.host_id.as_str())
+    else {
+        return Some("The selected host is no longer available.".to_owned());
+    };
+    if host.connection() != HostConnectionState::Ready {
+        return Some("Connect the WSL host before creating a session.".to_owned());
+    }
+    let name = match SessionName::parse(&draft.name) {
+        Ok(name) => name,
+        Err(error) => return Some(error.to_string()),
+    };
+    host.sessions()
+        .iter()
+        .any(|session| session.name() == name.as_str())
+        .then(|| "A tmux session with this name already exists.".to_owned())
 }
 
 fn window_control(
@@ -2900,23 +3182,52 @@ mod tests {
 
     use super::{
         APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, INPUT_BUFFER_FULL_DIAGNOSTIC,
-        INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, PendingUiInput, QueuedUiInput,
-        TerminalKeyIdentity, TerminalKeyboard, TerminalPointer, TerminalResize,
+        INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, NewSessionDraft, PendingUiInput,
+        QueuedUiInput, TerminalKeyIdentity, TerminalKeyboard, TerminalPointer, TerminalResize,
         UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_selection,
         application_navigation_width, canonical_terminal_key_with, clear_terminal_input_state,
         clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
         coalesce_last_wheel, input_queue_has_capacity, is_toggle_sidebar_shortcut, named_key,
-        normalize_cell_width, queued_input_matches_presentation, retained_key_event_with,
-        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
-        workspace_window_title,
+        new_session_validation, normalize_cell_width, queued_input_matches_presentation,
+        retained_key_event_with, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
+        transitioned_presentation, tree_sessions, workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
         HostConnectionState, HostItem, KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton,
-        MouseInput, NamedKey, SessionItem, SessionSelection, WorkspaceContent,
+        MouseInput, NamedKey, SessionItem, SessionSelection, WorkspaceContent, WorkspaceSnapshot,
     };
+
+    #[test]
+    fn new_session_dialog_matches_the_shipped_name_and_duplicate_rules() {
+        let snapshot = WorkspaceSnapshot::shell(
+            workspace::Appearance::default(),
+            vec![HostItem::wsl(
+                "Ubuntu",
+                None,
+                HostConnectionState::Ready,
+                vec![SessionItem::new("existing", 0)],
+                None,
+            )],
+        );
+        let mut draft = NewSessionDraft {
+            host_id: "wsl".to_owned(),
+            name: String::new(),
+        };
+
+        assert!(new_session_validation(&snapshot, &draft).is_some());
+        draft.name = "has.period".to_owned();
+        assert!(new_session_validation(&snapshot, &draft).is_some());
+        draft.name = "existing".to_owned();
+        assert_eq!(
+            new_session_validation(&snapshot, &draft).as_deref(),
+            Some("A tmux session with this name already exists.")
+        );
+        draft.name = "  release work  ".to_owned();
+        assert_eq!(new_session_validation(&snapshot, &draft), None);
+    }
 
     #[test]
     fn a_refused_input_stays_visible_until_later_input_is_delivered() {

--- a/rust/ui/tests/root_view.rs
+++ b/rust/ui/tests/root_view.rs
@@ -36,7 +36,7 @@ fn empty_inventory_copy_names_the_socket_namespace() {
 
     assert_eq!(
         empty_inventory_text(&host),
-        "No tmux server is running in Ubuntu using /run/user/1000/tmux. Review WSL host settings or start a tmux session, then choose Refresh."
+        "No tmux server is running in Ubuntu using /run/user/1000/tmux. Use + beside the host to create one, or review WSL host settings."
     );
 }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -24,6 +24,8 @@ const REDUCED_COLOR_NOTICE: &str =
     "Using TERM=xterm because xterm-256color terminfo is unavailable in WSL";
 const CREATE_DISCOVERY_ATTEMPTS: usize = 5;
 const CREATE_DISCOVERY_DELAY: Duration = Duration::from_millis(40);
+const CREATE_IDENTITY_TIMEOUT: Duration = Duration::from_secs(5);
+const CREATE_IDENTITY_MIN_COLUMNS: usize = 120;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Appearance {
@@ -589,8 +591,8 @@ struct CreateRequest {
     host_id: String,
     host: RuntimeHost,
     endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
     name: SessionName,
-    inventory_generation: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2931,7 +2933,7 @@ fn capture_create_request(
     let context = host
         .as_ref()
         .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
-    context.map(|context, inventory_generation| {
+    context.map(|context, _inventory_generation| {
         if context.snapshot.endpoint().distro() != endpoint {
             return Err(WorkspaceError::new(
                 "the WSL endpoint changed; choose the host again before creating a session",
@@ -2941,8 +2943,8 @@ fn capture_create_request(
             host_id: host_id.to_owned(),
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
             name,
-            inventory_generation,
         })
     })
 }
@@ -3096,6 +3098,19 @@ fn run_create(
         return;
     }
 
+    let inventory_generation = match merge_created_inventory(inner, request, snapshot.clone()) {
+        Ok(generation) => generation,
+        Err(error) => {
+            drop(worker);
+            restore_inventory_after_creation_failure(
+                inner,
+                previous,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
     let attached = AttachRequest {
         host_id: request.host_id.clone(),
         host: request.host.clone(),
@@ -3103,7 +3118,7 @@ fn run_create(
         runtime: snapshot.runtime().clone(),
         identity: session.identity().clone(),
         name: session.name().to_owned(),
-        inventory_generation: request.inventory_generation,
+        inventory_generation,
     };
     let key = attached.presentation_key();
     let fallback = previous.map(|presentation| FallbackAuthority {
@@ -3136,7 +3151,6 @@ fn run_create(
         return;
     };
     let surface = worker.surface_handle();
-    publish_attach_inventory(inner, &attached, snapshot);
     if let Err(error) = publish_worker_at_latest_geometry(
         &inner.terminal_geometry,
         &inner.worker,
@@ -3191,27 +3205,39 @@ fn create_fresh(
             "the default WSL distro changed; refresh before creating the session",
         ));
     }
+    if before.runtime() != &request.runtime {
+        return Err(WorkspaceError::new(
+            "WSL restarted; refresh before creating the session",
+        ));
+    }
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
         return Err(WorkspaceError::new("tmux creation was superseded"));
     }
-    let authority = request.host.create_once_with_term(
-        before.endpoint(),
-        request.name.clone(),
-        AttachTerm::Xterm256Color,
-    );
+    let authority = request
+        .host
+        .create_once_with_term(
+            before.endpoint(),
+            request.name.clone(),
+            AttachTerm::Xterm256Color,
+        )
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
     let geometry = *inner
         .terminal_geometry
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let launch_geometry = creation_launch_geometry(geometry);
     let worker = TerminalWorker::create_with_metadata(
         authority,
-        geometry.grid,
-        geometry.sequence,
-        geometry.pixels,
+        launch_geometry.grid,
+        launch_geometry.sequence,
+        launch_geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         default_colors(&inner.appearance),
     )
     .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    let client_identity = worker
+        .wait_for_creation_identity(CREATE_IDENTITY_TIMEOUT)
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
     let cancellation = CancellationToken::new();
     for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
@@ -3220,15 +3246,10 @@ fn create_fresh(
         }
         let snapshot = request
             .host
-            .discover_after_create(before.endpoint(), before.runtime(), &cancellation)
+            .discover_after_create(before.endpoint(), &request.runtime, &cancellation)
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
-        if let Some(session) = snapshot
-            .sessions()
-            .iter()
-            .find(|session| session.name() == request.name.as_str())
-            .cloned()
-        {
-            return Ok((worker, snapshot, session, geometry));
+        if let Some(session) = created_session(&snapshot, &client_identity) {
+            return Ok((worker, snapshot, session, launch_geometry));
         }
         if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
             thread::sleep(CREATE_DISCOVERY_DELAY);
@@ -3236,8 +3257,30 @@ fn create_fresh(
     }
     drop(worker);
     Err(WorkspaceError::new(
-        "the one-shot tmux client started, but the session did not appear; refresh to inspect the host before trying again",
+        "the one-shot tmux client started, but its exact session did not appear; refresh to inspect the host before trying again",
     ))
+}
+
+fn creation_launch_geometry(geometry: TerminalGeometry) -> TerminalGeometry {
+    if geometry.grid.columns() >= CREATE_IDENTITY_MIN_COLUMNS {
+        return geometry;
+    }
+    TerminalGeometry {
+        grid: GridSize::new(CREATE_IDENTITY_MIN_COLUMNS, geometry.grid.rows())
+            .expect("creation identity grid is valid"),
+        ..geometry
+    }
+}
+
+fn created_session(
+    snapshot: &HostSnapshot,
+    client_identity: &session::SessionIdentity,
+) -> Option<session::DiscoveredSession> {
+    snapshot
+        .sessions()
+        .iter()
+        .find(|session| session.identity() == client_identity)
+        .cloned()
 }
 
 fn restore_inventory_after_creation_failure(
@@ -3480,6 +3523,72 @@ fn restore_attach_fallback_locked(inner: &Inner, fallback: Option<FallbackAuthor
             format!("could not restore the previous terminal presentation: {error}"),
         ),
     }
+}
+
+fn merge_created_inventory(
+    inner: &Inner,
+    request: &CreateRequest,
+    snapshot: HostSnapshot,
+) -> Result<u64, WorkspaceError> {
+    let _publication = inner
+        .refresh_publication
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if snapshot.endpoint() != &request.endpoint || snapshot.runtime() != &request.runtime {
+        return Err(WorkspaceError::new(
+            "WSL changed while publishing the created tmux session",
+        ));
+    }
+    let published_generation = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .and_then(|published| {
+            (published.value.snapshot.endpoint() == &request.endpoint
+                && published.value.snapshot.runtime() == &request.runtime)
+                .then_some(published.generation)
+        })
+        .ok_or_else(|| {
+            WorkspaceError::new(
+                "the WSL endpoint changed while creating the tmux session; refresh before trying again",
+            )
+        })?;
+    let current_generation = inner.refresh_generation.load(Ordering::Acquire);
+    let inventory_generation = match published_generation.cmp(&current_generation) {
+        std::cmp::Ordering::Equal => current_generation,
+        std::cmp::Ordering::Less => {
+            if let Some(cancellation) = inner
+                .discovery_cancel
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                cancellation.cancel();
+            }
+            inner.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1
+        }
+        std::cmp::Ordering::Greater => {
+            return Err(WorkspaceError::new(
+                "tmux inventory generation moved backwards during creation",
+            ));
+        }
+    };
+
+    let inventory_state = ready_content(&snapshot);
+    reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
+    *inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Published::new(
+        HostContext {
+            host: request.host.clone(),
+            snapshot,
+        },
+        inventory_generation,
+    ));
+    set_inventory_state(inner, inventory_state);
+    Ok(inventory_generation)
 }
 
 fn publish_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSnapshot) {
@@ -5098,6 +5207,203 @@ mod tests {
             WorkspaceContent::Ready { sessions, .. }
                 if sessions.len() == 1 && sessions[0].name() == "newer"
         ));
+    }
+
+    #[test]
+    fn created_session_is_resolved_by_client_identity_not_requested_name() {
+        let client_identity = session::SessionIdentity::new(100, "$1", 200);
+        let snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![
+                session::DiscoveredSession::new(
+                    "requested",
+                    session::SessionIdentity::new(100, "$2", 201),
+                    0,
+                ),
+                session::DiscoveredSession::new("renamed-by-hook", client_identity.clone(), 1),
+            ],
+        );
+
+        let created = created_session(&snapshot, &client_identity).expect("client session");
+
+        assert_eq!(created.name(), "renamed-by-hook");
+        assert_eq!(created.identity(), &client_identity);
+    }
+
+    #[test]
+    fn creation_identity_report_gets_a_bounded_startup_width() {
+        let narrow = TerminalGeometry {
+            grid: GridSize::new(20, 12).expect("valid narrow grid"),
+            pixels: PixelSize::new(200, 240),
+            sequence: 7,
+        };
+
+        let launch = creation_launch_geometry(narrow);
+
+        assert_eq!(launch.grid.columns(), CREATE_IDENTITY_MIN_COLUMNS);
+        assert_eq!(launch.grid.rows(), narrow.grid.rows());
+        assert_eq!(launch.pixels, narrow.pixels);
+        assert_eq!(launch.sequence, narrow.sequence);
+        assert_eq!(
+            creation_launch_geometry(launch),
+            launch,
+            "already-wide grids are unchanged"
+        );
+    }
+
+    #[test]
+    fn post_create_inventory_merges_into_a_completed_refresh_generation() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let runner: SharedCommandRunner = Arc::new(StdCommandRunner);
+        let runtime_host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            runner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute system WSL path"),
+        );
+        let initial_generation = workspace.inner.refresh_generation.load(Ordering::Acquire);
+        let initial_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "before",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        );
+        *workspace.inner.host.lock().expect("host context") = Some(Published::new(
+            HostContext {
+                host: runtime_host.clone(),
+                snapshot: initial_snapshot.clone(),
+            },
+            initial_generation,
+        ));
+        let request = CreateRequest {
+            host_id: "wsl".to_owned(),
+            host: runtime_host.clone(),
+            endpoint: initial_snapshot.endpoint().clone(),
+            runtime: initial_snapshot.runtime().clone(),
+            name: SessionName::parse("created").expect("valid name"),
+        };
+
+        let refresh_generation = begin_refresh(&workspace.inner, &CancellationToken::new());
+        let refreshed = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "refreshed",
+                session::SessionIdentity::new(100, "$2", 201),
+                0,
+            )],
+        );
+        assert!(publish_refresh(
+            &workspace.inner,
+            refresh_generation,
+            || {
+                *workspace.inner.host.lock().expect("host context") = Some(Published::new(
+                    HostContext {
+                        host: runtime_host,
+                        snapshot: refreshed,
+                    },
+                    refresh_generation,
+                ));
+            }
+        ));
+        let created = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "created",
+                session::SessionIdentity::new(100, "$3", 202),
+                1,
+            )],
+        );
+
+        let merged = merge_created_inventory(&workspace.inner, &request, created)
+            .expect("merge post-create inventory");
+
+        assert_eq!(merged, refresh_generation);
+        let host = workspace.inner.host.lock().expect("host context");
+        let published = host.as_ref().expect("published host");
+        assert_eq!(published.generation, refresh_generation);
+        assert_eq!(published.value.snapshot.sessions()[0].name(), "created");
+    }
+
+    #[test]
+    fn post_create_inventory_supersedes_an_inflight_refresh() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let runner: SharedCommandRunner = Arc::new(StdCommandRunner);
+        let runtime_host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            runner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute system WSL path"),
+        );
+        let initial_generation = workspace.inner.refresh_generation.load(Ordering::Acquire);
+        let initial_snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "before",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        );
+        *workspace.inner.host.lock().expect("host context") = Some(Published::new(
+            HostContext {
+                host: runtime_host.clone(),
+                snapshot: initial_snapshot.clone(),
+            },
+            initial_generation,
+        ));
+        let request = CreateRequest {
+            host_id: "wsl".to_owned(),
+            host: runtime_host,
+            endpoint: initial_snapshot.endpoint().clone(),
+            runtime: initial_snapshot.runtime().clone(),
+            name: SessionName::parse("created").expect("valid name"),
+        };
+        let cancellation = CancellationToken::new();
+        let refresh_generation = begin_refresh(&workspace.inner, &cancellation);
+        let created = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot-id",
+            42,
+            vec![session::DiscoveredSession::new(
+                "created",
+                session::SessionIdentity::new(100, "$2", 201),
+                1,
+            )],
+        );
+
+        let merged = merge_created_inventory(&workspace.inner, &request, created)
+            .expect("merge post-create inventory");
+
+        assert!(merged > refresh_generation);
+        assert!(cancellation.is_cancelled());
+        assert!(!publish_refresh(
+            &workspace.inner,
+            refresh_generation,
+            || panic!("superseded refresh must not publish")
+        ));
+        let host = workspace.inner.host.lock().expect("host context");
+        let published = host.as_ref().expect("published host");
+        assert_eq!(published.generation, merged);
+        assert_eq!(published.value.snapshot.sessions()[0].name(), "created");
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1962,8 +1962,11 @@ impl Workspace {
     /// Returns an error when the selection is not part of the current WSL
     /// inventory or the background query cannot be started.
     pub fn request_session_kill(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
+        let (generation, removed) = invalidate_pending_kill(&self.inner);
+        if removed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
         let request = capture_kill_request(&self.inner, selection)?;
-        let (generation, _) = invalidate_pending_kill(&self.inner);
         let workspace = self.clone();
         thread::Builder::new()
             .name("ghosthub-session-kill-identity".to_owned())
@@ -6267,7 +6270,9 @@ mod tests {
         workspace.inner.kill_generation.store(3, Ordering::Release);
         assert!(publish_pending_kill(&workspace.inner, pending(3)));
         assert!(workspace.session_kill_confirmation().is_some());
-        workspace.inner.kill_generation.store(4, Ordering::Release);
+        workspace
+            .request_session_kill(&SessionSelection::new("wsl", "Ubuntu", "missing"))
+            .expect_err("new invalid request still supersedes old confirmation");
         assert_eq!(workspace.session_kill_confirmation(), None);
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -13,6 +13,7 @@ use host::{
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
+pub use session::{SessionName, SessionNameError};
 use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
     ClipboardPolicy, ClipboardReadRequest as TerminalClipboardRead, ClipboardTarget, DefaultColors,
@@ -21,6 +22,8 @@ use terminal::{
 
 const REDUCED_COLOR_NOTICE: &str =
     "Using TERM=xterm because xterm-256color terminfo is unavailable in WSL";
+const CREATE_DISCOVERY_ATTEMPTS: usize = 5;
+const CREATE_DISCOVERY_DELAY: Duration = Duration::from_millis(40);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Appearance {
@@ -551,6 +554,15 @@ struct AttachRequest {
     runtime: host::WslRuntimeIdentity,
     identity: session::SessionIdentity,
     name: String,
+    inventory_generation: u64,
+}
+
+#[derive(Clone)]
+struct CreateRequest {
+    host_id: String,
+    host: RuntimeHost,
+    endpoint: host::WslEndpoint,
+    name: SessionName,
     inventory_generation: u64,
 }
 
@@ -1518,6 +1530,69 @@ impl Workspace {
             ));
         };
         self.start_attachment(request, fallback, navigation_generation)
+    }
+
+    /// Create or attach to one exact local WSL tmux session with a consumed
+    /// one-shot authority.
+    ///
+    /// Existing visible presentations are retained and restored if the new
+    /// client cannot be established. Once the atomic client is launched,
+    /// failure never reruns creation or destroys the resulting session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is invalid, the host is not ready, a
+    /// matching session is already present in current inventory, or the
+    /// creation task cannot be started.
+    pub fn create_session(&self, host_id: &str, name: &str) -> Result<(), WorkspaceError> {
+        let name =
+            SessionName::parse(name).map_err(|error| WorkspaceError::new(error.to_string()))?;
+        let navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let request = capture_create_request(&self.inner, host_id, name)?;
+        let navigation_generation = self.begin_navigation();
+        let in_flight_fallback = self.supersede_inflight_attachment()?;
+        let visible_previous = self.retain_active_presentation()?;
+        let previous = in_flight_fallback.or(visible_previous);
+        clear_terminal_notice(&self.inner);
+        set_inner_state(
+            &self.inner,
+            WorkspaceContent::Attaching {
+                host_id: request.host_id.clone(),
+                endpoint: request.endpoint.distro().to_owned(),
+                session: request.name.as_str().to_owned(),
+            },
+        );
+
+        let inner = Arc::clone(&self.inner);
+        let spawn_request = request.clone();
+        let spawn_previous = previous.clone();
+        if let Err(error) = thread::Builder::new()
+            .name("ghosthub-terminal-create".to_owned())
+            .spawn(move || {
+                run_create(
+                    &inner,
+                    &spawn_request,
+                    spawn_previous,
+                    navigation_generation,
+                );
+            })
+        {
+            drop(navigation);
+            restore_inventory_after_creation_failure(
+                &self.inner,
+                previous,
+                navigation_generation,
+                format!("start tmux creation task: {error}"),
+            );
+            return Err(WorkspaceError::new(format!(
+                "start tmux creation task: {error}"
+            )));
+        }
+        Ok(())
     }
 
     fn begin_navigation(&self) -> u64 {
@@ -2494,6 +2569,59 @@ fn capture_attach_request(
     })
 }
 
+fn capture_create_request(
+    inner: &Inner,
+    host_id: &str,
+    name: SessionName,
+) -> Result<CreateRequest, WorkspaceError> {
+    let selected_host = inner
+        .selected_host
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if selected_host.as_deref() != Some(host_id) {
+        return Err(WorkspaceError::new("host is not selected"));
+    }
+    let hosts = inner
+        .hosts
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let selected = hosts
+        .iter()
+        .find(|host| host.id == host_id)
+        .ok_or_else(|| WorkspaceError::new("host is not available"))?;
+    if selected.connection != HostConnectionState::Ready {
+        return Err(WorkspaceError::new(
+            "connect the WSL host before creating a tmux session",
+        ));
+    }
+    if selected
+        .sessions
+        .iter()
+        .any(|session| session.name == name.as_str())
+    {
+        return Err(WorkspaceError::new(
+            "a tmux session with this name already exists",
+        ));
+    }
+    drop(hosts);
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, inventory_generation| {
+        Ok(CreateRequest {
+            host_id: host_id.to_owned(),
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            name,
+            inventory_generation,
+        })
+    })
+}
+
 fn choose_navigation_target(
     retained: Option<PresentationKey>,
     current: Result<AttachRequest, WorkspaceError>,
@@ -2617,6 +2745,204 @@ fn fail_refresh_start(
             format!("{context}: {error}"),
         );
     });
+}
+
+fn run_create(
+    inner: &Inner,
+    request: &CreateRequest,
+    previous: Option<PresentationKey>,
+    navigation_generation: u64,
+) {
+    let created = create_fresh(inner, request, navigation_generation);
+    let (worker, snapshot, session, initial_geometry) = match created {
+        Ok(created) => created,
+        Err(error) => {
+            restore_inventory_after_creation_failure(
+                inner,
+                previous,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        drop(worker);
+        return;
+    }
+
+    let attached = AttachRequest {
+        host_id: request.host_id.clone(),
+        host: request.host.clone(),
+        endpoint: snapshot.endpoint().clone(),
+        runtime: snapshot.runtime().clone(),
+        identity: session.identity().clone(),
+        name: session.name().to_owned(),
+        inventory_generation: request.inventory_generation,
+    };
+    let key = attached.presentation_key();
+    let fallback = previous.map(|presentation| FallbackAuthority {
+        presentation,
+        target: key,
+        navigation_generation,
+    });
+    let mut attachment = inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        drop(attachment);
+        drop(worker);
+        return;
+    }
+    let Some(generation) = attachment.reserve_with_fallback(
+        attached.clone(),
+        AttachTerm::Xterm256Color,
+        fallback.clone(),
+    ) else {
+        drop(attachment);
+        drop(worker);
+        restore_inventory_after_creation_failure(
+            inner,
+            fallback.map(|fallback| fallback.presentation),
+            navigation_generation,
+            "another terminal presentation replaced the creation request".to_owned(),
+        );
+        return;
+    };
+    let surface = worker.surface_handle();
+    publish_attach_inventory(inner, &attached, snapshot);
+    if let Err(error) = publish_worker_at_latest_geometry(
+        &inner.terminal_geometry,
+        &inner.worker,
+        worker,
+        initial_geometry,
+        |worker, geometry| {
+            worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
+        },
+    ) {
+        attachment.clear_if_current(generation);
+        drop(attachment);
+        restore_inventory_after_creation_failure(
+            inner,
+            fallback.map(|fallback| fallback.presentation),
+            navigation_generation,
+            error.to_string(),
+        );
+        return;
+    }
+    set_terminal_notice(inner, AttachTerm::Xterm256Color);
+    set_inner_state(
+        inner,
+        WorkspaceContent::Terminal {
+            host_id: attached.host_id,
+            endpoint: attached.endpoint.distro().to_owned(),
+            session: attached.name,
+            presentation_id: next_presentation_id(inner),
+            surface,
+        },
+    );
+}
+
+fn create_fresh(
+    inner: &Inner,
+    request: &CreateRequest,
+    navigation_generation: u64,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        session::DiscoveredSession,
+        TerminalGeometry,
+    ),
+    WorkspaceError,
+> {
+    let before = request
+        .host
+        .discover(&ConptyAdmissionAttacher::new())
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    if before.endpoint() != &request.endpoint {
+        return Err(WorkspaceError::new(
+            "the default WSL distro changed; refresh before creating the session",
+        ));
+    }
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        return Err(WorkspaceError::new("tmux creation was superseded"));
+    }
+    let authority = request.host.create_once_with_term(
+        before.endpoint(),
+        request.name.clone(),
+        AttachTerm::Xterm256Color,
+    );
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::create_with_metadata(
+        authority,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+        default_colors(&inner.appearance),
+    )
+    .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    let cancellation = CancellationToken::new();
+    for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
+        if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+            drop(worker);
+            return Err(WorkspaceError::new("tmux creation was superseded"));
+        }
+        let snapshot = request
+            .host
+            .discover_after_create(before.endpoint(), before.runtime(), &cancellation)
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        if let Some(session) = snapshot
+            .sessions()
+            .iter()
+            .find(|session| session.name() == request.name.as_str())
+            .cloned()
+        {
+            return Ok((worker, snapshot, session, geometry));
+        }
+        if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
+            thread::sleep(CREATE_DISCOVERY_DELAY);
+        }
+    }
+    drop(worker);
+    Err(WorkspaceError::new(
+        "the one-shot tmux client started, but the session did not appear; refresh to inspect the host before trying again",
+    ))
+}
+
+fn restore_inventory_after_creation_failure(
+    inner: &Inner,
+    previous: Option<PresentationKey>,
+    navigation_generation: u64,
+    message: String,
+) {
+    let _navigation = inner
+        .navigation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        return;
+    }
+    restore_presentation_inventory(inner);
+    if let Some(previous) = previous {
+        match activate_retained_presentation(inner, &previous, None) {
+            Ok(true) => {}
+            Ok(false) => set_local_notice(
+                inner,
+                "the previous terminal presentation is no longer available".to_owned(),
+            ),
+            Err(error) => set_local_notice(
+                inner,
+                format!("could not restore the previous terminal presentation: {error}"),
+            ),
+        }
+    }
+    publish_local_notice(inner, message);
 }
 
 fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generation: u64) {

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use config::TerminalAppearance;
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HostError, HostSnapshot,
-    StdCommandRunner, WslConfig, WslExecutable, WslHost,
+    LiveSessionTarget, StdCommandRunner, WslConfig, WslExecutable, WslHost,
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
@@ -361,6 +361,18 @@ pub enum WorkspaceEvent {
     Error(String),
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionKillConfirmation {
+    selection: SessionSelection,
+}
+
+impl SessionKillConfirmation {
+    #[must_use]
+    pub const fn selection(&self) -> &SessionSelection {
+        &self.selection
+    }
+}
+
 const MAX_EVENTS_PER_DRAIN: usize = 32;
 const RETAINED_EVENT_RESERVE: usize = 8;
 const ACTIVE_EVENT_BUDGET: usize = MAX_EVENTS_PER_DRAIN - RETAINED_EVENT_RESERVE;
@@ -544,6 +556,21 @@ impl<T> Published<T> {
 struct PendingPaste {
     worker_generation: u64,
     input: input::EncodedInput,
+}
+
+#[derive(Clone)]
+struct KillCaptureRequest {
+    selection: SessionSelection,
+    host: RuntimeHost,
+    endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
+}
+
+struct PendingKill {
+    generation: u64,
+    selection: SessionSelection,
+    host: RuntimeHost,
+    target: Arc<LiveSessionTarget>,
 }
 
 #[derive(Clone)]
@@ -818,6 +845,16 @@ impl<T> RetainedPresentations<T> {
     fn take(&mut self, key: &PresentationKey) -> Option<RetainedPresentation<T>> {
         let index = self.entries.iter().position(|entry| &entry.key == key)?;
         Some(self.entries.remove(index))
+    }
+
+    fn remove_matching(&mut self, mut matches: impl FnMut(&PresentationKey) -> bool) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|entry| !matches(&entry.key));
+        let mut changed = self.entries.len() != before;
+        let restart_before = self.restarting.len();
+        self.restarting.retain(|entry| !matches(&entry.key));
+        changed |= self.restarting.len() != restart_before;
+        changed
     }
 
     fn contains(&self, key: &PresentationKey) -> bool {
@@ -1117,6 +1154,9 @@ struct Inner {
     worker: Mutex<WorkerState<TerminalWorker>>,
     retained_presentations: Mutex<RetainedPresentations<TerminalWorker>>,
     pending_paste: Mutex<Option<PendingPaste>>,
+    pending_kill: Mutex<Option<PendingKill>>,
+    kill_generation: AtomicU64,
+    operation_events: Mutex<std::collections::VecDeque<WorkspaceEvent>>,
     terminal_geometry: Mutex<TerminalGeometry>,
     allow_remote_clipboard_write: bool,
     refresh_generation: AtomicU64,
@@ -1177,6 +1217,9 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_kill: Mutex::new(None),
+                kill_generation: AtomicU64::new(0),
+                operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write: true,
                 refresh_generation: AtomicU64::new(0),
@@ -1235,6 +1278,9 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_kill: Mutex::new(None),
+                kill_generation: AtomicU64::new(0),
+                operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
                 refresh_generation: AtomicU64::new(0),
@@ -1277,6 +1323,9 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_kill: Mutex::new(None),
+                kill_generation: AtomicU64::new(0),
+                operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
                 refresh_generation: AtomicU64::new(0),
@@ -1601,6 +1650,12 @@ impl Workspace {
     }
 
     fn begin_navigation(&self) -> u64 {
+        self.inner.kill_generation.fetch_add(1, Ordering::AcqRel);
+        self.inner
+            .pending_kill
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         self.inner
             .navigation_generation
             .fetch_add(1, Ordering::AcqRel)
@@ -1876,6 +1931,177 @@ impl Workspace {
         }
     }
 
+    /// Query one session's live identity before exposing destructive
+    /// confirmation to the presentation layer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the selection is not part of the current WSL
+    /// inventory or the background query cannot be started.
+    pub fn request_session_kill(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
+        let request = capture_kill_request(&self.inner, selection)?;
+        let generation = self.inner.kill_generation.fetch_add(1, Ordering::AcqRel) + 1;
+        self.inner
+            .pending_kill
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let workspace = self.clone();
+        thread::Builder::new()
+            .name("ghosthub-session-kill-identity".to_owned())
+            .spawn(move || {
+                let result = request.host.capture_live_session(
+                    &request.endpoint,
+                    &request.runtime,
+                    request.selection.session(),
+                    &CancellationToken::new(),
+                );
+                if workspace.inner.kill_generation.load(Ordering::Acquire) != generation {
+                    return;
+                }
+                match result {
+                    Ok(target) => {
+                        *workspace
+                            .inner
+                            .pending_kill
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                            Some(PendingKill {
+                                generation,
+                                selection: request.selection,
+                                host: request.host,
+                                target: Arc::new(target),
+                            });
+                    }
+                    Err(error) => workspace.push_operation_error(error.to_string()),
+                }
+                workspace.inner.revision.fetch_add(1, Ordering::Release);
+            })
+            .map_err(|error| WorkspaceError::new(format!("verify tmux session: {error}")))?;
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn session_kill_confirmation(&self) -> Option<SessionKillConfirmation> {
+        self.inner
+            .pending_kill
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|pending| SessionKillConfirmation {
+                selection: pending.selection.clone(),
+            })
+    }
+
+    pub fn cancel_session_kill(&self) {
+        self.inner.kill_generation.fetch_add(1, Ordering::AcqRel);
+        if self
+            .inner
+            .pending_kill
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .is_some()
+        {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    /// Execute the identity-guarded kill approved by the user.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no live confirmation is pending or the kill task
+    /// cannot be started.
+    pub fn confirm_session_kill(&self) -> Result<(), WorkspaceError> {
+        let pending = self
+            .inner
+            .pending_kill
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .ok_or_else(|| WorkspaceError::new("no tmux session kill is awaiting confirmation"))?;
+        if self.inner.kill_generation.load(Ordering::Acquire) != pending.generation {
+            return Err(WorkspaceError::new(
+                "tmux session kill confirmation is no longer current",
+            ));
+        }
+        self.inner.revision.fetch_add(1, Ordering::Release);
+        let workspace = self.clone();
+        let retry = PendingKill {
+            generation: pending.generation,
+            selection: pending.selection.clone(),
+            host: pending.host.clone(),
+            target: Arc::clone(&pending.target),
+        };
+        if let Err(error) = thread::Builder::new()
+            .name("ghosthub-session-kill".to_owned())
+            .spawn(move || {
+                let result = pending
+                    .host
+                    .kill_live_session(&pending.target, &CancellationToken::new());
+                match result {
+                    Ok(()) => workspace.finish_session_kill(&pending.target),
+                    Err(error) => workspace.push_operation_error(error.to_string()),
+                }
+                let _refresh_started = workspace.refresh();
+                workspace.inner.revision.fetch_add(1, Ordering::Release);
+            })
+        {
+            *self
+                .inner
+                .pending_kill
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(retry);
+            self.inner.revision.fetch_add(1, Ordering::Release);
+            return Err(WorkspaceError::new(format!("kill tmux session: {error}")));
+        }
+        Ok(())
+    }
+
+    fn push_operation_error(&self, error: String) {
+        let mut events = self
+            .inner
+            .operation_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if events.len() >= MAX_EVENTS_PER_DRAIN {
+            events.pop_front();
+        }
+        events.push_back(WorkspaceEvent::Error(error));
+    }
+
+    fn finish_session_kill(&self, target: &LiveSessionTarget) {
+        let key_matches = |request: &AttachRequest| {
+            request.endpoint == *target.endpoint()
+                && request.runtime == *target.runtime()
+                && request.identity == *target.identity()
+        };
+        let active_matches = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some_and(|active| key_matches(&active.request));
+        if active_matches {
+            self.detach();
+        }
+        let changed = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove_matching(|key| {
+                key.endpoint == target.endpoint().distro()
+                    && key.runtime == *target.runtime()
+                    && key.identity == *target.identity()
+            });
+        if changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+    }
+
     /// Update the desired grid and resize an active VT/PTTY pair together.
     ///
     /// # Errors
@@ -1986,6 +2212,7 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut emitted = Vec::new();
+        let operation_has_more = self.drain_operation_events(&mut emitted);
         let mut exited = false;
         let mut exited_attachment = None;
         let mut exited_worker_generation = None;
@@ -2074,10 +2301,25 @@ impl Workspace {
         let active_processed = processed;
         let retained_budget = retained_event_budget(processed, exited);
         let retained_processed = self.drain_retained_events(retained_budget, &mut emitted);
-        let may_have_more =
-            event_source_may_have_more(active_processed, ACTIVE_EVENT_BUDGET, exited)
-                || event_source_may_have_more(retained_processed, retained_budget, false);
+        let may_have_more = operation_has_more
+            || event_source_may_have_more(active_processed, ACTIVE_EVENT_BUDGET, exited)
+            || event_source_may_have_more(retained_processed, retained_budget, false);
         (emitted, may_have_more)
+    }
+
+    fn drain_operation_events(&self, emitted: &mut Vec<WorkspaceEvent>) -> bool {
+        let mut events = self
+            .inner
+            .operation_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for _ in 0..RETAINED_EVENT_RESERVE {
+            let Some(event) = events.pop_front() else {
+                break;
+            };
+            emitted.push(event);
+        }
+        !events.is_empty()
     }
 
     fn next_terminal_event(
@@ -2570,6 +2812,70 @@ fn capture_attach_request(
             identity: session.identity().clone(),
             name: session.name().to_owned(),
             inventory_generation,
+        })
+    })
+}
+
+fn capture_kill_request(
+    inner: &Inner,
+    selection: &SessionSelection,
+) -> Result<KillCaptureRequest, WorkspaceError> {
+    if inner
+        .selected_host
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_deref()
+        != Some(selection.host_id())
+    {
+        return Err(WorkspaceError::new("host is not selected"));
+    }
+    if let Some(request) = inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .active()
+        .map(|active| active.request.clone())
+        .filter(|request| {
+            request.host_id == selection.host_id()
+                && request.endpoint.distro() == selection.endpoint()
+                && request.name == selection.session()
+        })
+    {
+        return Ok(KillCaptureRequest {
+            selection: selection.clone(),
+            host: request.host,
+            endpoint: request.endpoint,
+            runtime: request.runtime,
+        });
+    }
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, _inventory_generation| {
+        if context.snapshot.endpoint().distro() != selection.endpoint() {
+            return Err(WorkspaceError::new(
+                "host endpoint changed; refresh the session selection",
+            ));
+        }
+        if !context
+            .snapshot
+            .sessions()
+            .iter()
+            .any(|session| session.name() == selection.session())
+        {
+            return Err(WorkspaceError::new(
+                "session is not in the current inventory",
+            ));
+        }
+        Ok(KillCaptureRequest {
+            selection: selection.clone(),
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
         })
     })
 }

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -450,6 +450,7 @@ trait WslDiscovery: Send + Sync {
         &self,
         config: WslConfig,
         executable: WslExecutable,
+        existing_host: Option<RuntimeHost>,
         cancellation: &CancellationToken,
     ) -> Result<HostContext, HostError>;
 }
@@ -471,9 +472,11 @@ impl WslDiscovery for SystemWslDiscovery {
         &self,
         config: WslConfig,
         executable: WslExecutable,
+        existing_host: Option<RuntimeHost>,
         cancellation: &CancellationToken,
     ) -> Result<HostContext, HostError> {
-        let host = WslHost::new(config, Arc::clone(&self.runner), executable);
+        let host = existing_host
+            .unwrap_or_else(|| WslHost::new(config, Arc::clone(&self.runner), executable));
         host.discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
             .map(|snapshot| HostContext { host, snapshot })
     }
@@ -1319,6 +1322,30 @@ impl Workspace {
         Ok(())
     }
 
+    /// Refresh a connected WSL host without turning activation into an
+    /// automatic retry loop for disconnected or failed hosts.
+    ///
+    /// Returns `true` when a ready host started a refresh.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only when a ready host no longer has refresh
+    /// configuration.
+    pub fn refresh_if_ready(&self) -> Result<bool, WorkspaceError> {
+        let ready = self
+            .inner
+            .hosts
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .any(|host| host.id == "wsl" && host.connection == HostConnectionState::Ready);
+        if !ready {
+            return Ok(false);
+        }
+        self.refresh()?;
+        Ok(true)
+    }
+
     /// Cancel the active WSL inventory refresh, if one is connecting.
     ///
     /// Returns `true` when an active refresh was cancelled.
@@ -2142,6 +2169,12 @@ impl Workspace {
             return;
         }
         let discovery = Arc::clone(&inner.discovery);
+        let existing_host = inner
+            .host
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|published| published.value.host.clone());
         let task_inner = Arc::clone(&inner);
         let task_cancellation = cancellation.clone();
         let spawn_result = inner.refresh_runtime.spawn(
@@ -2154,7 +2187,12 @@ impl Workspace {
                     executable
                         .map_or_else(WslExecutable::system, Ok)
                         .and_then(|executable| {
-                            discovery.discover(config, executable, &task_cancellation)
+                            discovery.discover(
+                                config,
+                                executable,
+                                existing_host,
+                                &task_cancellation,
+                            )
                         });
                 if task_cancellation.is_cancelled() {
                     return;
@@ -3322,7 +3360,7 @@ fn default_terminal_geometry() -> TerminalGeometry {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::sync::Barrier;
+    use std::sync::{Barrier, atomic::AtomicUsize};
 
     #[derive(Default)]
     struct ManualRefreshRuntime {
@@ -3382,6 +3420,16 @@ mod tests {
 
     struct FixedDiscovery {
         snapshot: HostSnapshot,
+        reused_hosts: AtomicUsize,
+    }
+
+    impl FixedDiscovery {
+        fn new(snapshot: HostSnapshot) -> Self {
+            Self {
+                snapshot,
+                reused_hosts: AtomicUsize::new(0),
+            }
+        }
     }
 
     impl WslDiscovery for FixedDiscovery {
@@ -3389,11 +3437,19 @@ mod tests {
             &self,
             config: WslConfig,
             executable: WslExecutable,
+            existing_host: Option<RuntimeHost>,
             _cancellation: &CancellationToken,
         ) -> Result<HostContext, HostError> {
             let runner: SharedCommandRunner = Arc::new(StdCommandRunner);
+            let host = existing_host.map_or_else(
+                || WslHost::new(config, runner, executable),
+                |host| {
+                    self.reused_hosts.fetch_add(1, Ordering::AcqRel);
+                    host
+                },
+            );
             Ok(HostContext {
-                host: WslHost::new(config, runner, executable),
+                host,
                 snapshot: self.snapshot.clone(),
             })
         }
@@ -5079,18 +5135,16 @@ mod tests {
     #[test]
     fn refresh_deadlines_and_retry_order_are_manually_driven() {
         let runtime = Arc::new(ManualRefreshRuntime::default());
-        let discovery = Arc::new(FixedDiscovery {
-            snapshot: HostSnapshot::test_fixture(
-                "Ubuntu",
-                "boot",
-                42,
-                vec![session::DiscoveredSession::new(
-                    "work",
-                    session::SessionIdentity::new(100, "$1", 200),
-                    0,
-                )],
-            ),
-        });
+        let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            vec![session::DiscoveredSession::new(
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        )));
         let spec = WslHostSpec::available(
             WslConfig::with_distro("Ubuntu").expect("valid config"),
             WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
@@ -5150,20 +5204,62 @@ mod tests {
     }
 
     #[test]
+    fn activation_refreshes_only_ready_hosts_and_reuses_the_admitted_host() {
+        let runtime = Arc::new(ManualRefreshRuntime::default());
+        let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            vec![session::DiscoveredSession::new(
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        )));
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            Some(spec),
+            discovery.clone(),
+            runtime.clone(),
+        );
+
+        assert!(!workspace.refresh_if_ready().expect("disconnected no-op"));
+        workspace.connect_enabled_hosts().expect("connect host");
+        assert!(!workspace.refresh_if_ready().expect("connecting no-op"));
+        runtime.run_next_work();
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Ready
+        );
+
+        assert!(workspace.refresh_if_ready().expect("refresh ready host"));
+        runtime.run_next_work();
+
+        assert_eq!(discovery.reused_hosts.load(Ordering::Acquire), 1);
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Ready
+        );
+    }
+
+    #[test]
     fn cancelling_refresh_invalidates_work_and_restores_disconnected_host() {
         let runtime = Arc::new(ManualRefreshRuntime::default());
-        let discovery = Arc::new(FixedDiscovery {
-            snapshot: HostSnapshot::test_fixture(
-                "Ubuntu",
-                "boot",
-                42,
-                vec![session::DiscoveredSession::new(
-                    "work",
-                    session::SessionIdentity::new(100, "$1", 200),
-                    0,
-                )],
-            ),
-        });
+        let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            vec![session::DiscoveredSession::new(
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        )));
         let spec = WslHostSpec::available(
             WslConfig::with_distro("Ubuntu").expect("valid config"),
             WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -595,6 +595,12 @@ struct CreateRequest {
     name: SessionName,
 }
 
+struct PendingCreation {
+    navigation_generation: u64,
+    previous: Option<PresentationKey>,
+    cancellation: CancellationToken,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PresentationKey {
     host_id: String,
@@ -1156,6 +1162,7 @@ struct Inner {
     worker: Mutex<WorkerState<TerminalWorker>>,
     retained_presentations: Mutex<RetainedPresentations<TerminalWorker>>,
     pending_paste: Mutex<Option<PendingPaste>>,
+    pending_creation: Mutex<Option<PendingCreation>>,
     pending_kill: Mutex<Option<PendingKill>>,
     kill_generation: AtomicU64,
     operation_events: Mutex<std::collections::VecDeque<WorkspaceEvent>>,
@@ -1219,6 +1226,7 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
@@ -1280,6 +1288,7 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
@@ -1325,6 +1334,7 @@ impl Workspace {
                 worker: Mutex::new(WorkerState::new()),
                 retained_presentations: Mutex::new(RetainedPresentations::new()),
                 pending_paste: Mutex::new(None),
+                pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
@@ -1613,6 +1623,16 @@ impl Workspace {
         let in_flight_fallback = self.supersede_inflight_attachment()?;
         let visible_previous = self.retain_active_presentation()?;
         let previous = in_flight_fallback.or(visible_previous);
+        let cancellation = CancellationToken::new();
+        *self
+            .inner
+            .pending_creation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(PendingCreation {
+            navigation_generation,
+            previous: previous.clone(),
+            cancellation: cancellation.clone(),
+        });
         clear_terminal_notice(&self.inner);
         set_inner_state(
             &self.inner,
@@ -1625,22 +1645,16 @@ impl Workspace {
 
         let inner = Arc::clone(&self.inner);
         let spawn_request = request.clone();
-        let spawn_previous = previous.clone();
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-terminal-create".to_owned())
             .spawn(move || {
-                run_create(
-                    &inner,
-                    &spawn_request,
-                    spawn_previous,
-                    navigation_generation,
-                );
+                run_create(&inner, &spawn_request, navigation_generation, &cancellation);
             })
         {
             drop(navigation);
             restore_inventory_after_creation_failure(
                 &self.inner,
-                previous,
+                None,
                 navigation_generation,
                 format!("start tmux creation task: {error}"),
             );
@@ -1698,11 +1712,23 @@ impl Workspace {
         if !attaching {
             return Ok(None);
         }
-        let active = attachment.take_active().ok_or_else(|| {
-            WorkspaceError::new("the in-flight terminal presentation is not available")
-        })?;
-        let fallback = active.fallback.map(|fallback| fallback.presentation);
+        let active = attachment.take_active();
         drop(attachment);
+        let fallback = if let Some(active) = active {
+            active.fallback.map(|fallback| fallback.presentation)
+        } else {
+            let pending = self
+                .inner
+                .pending_creation
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+                .ok_or_else(|| {
+                    WorkspaceError::new("the in-flight terminal presentation is not available")
+                })?;
+            pending.cancellation.cancel();
+            pending.previous
+        };
         clear_pending_paste(&self.inner);
         self.restore_inventory_state();
         Ok(fallback)
@@ -3095,16 +3121,16 @@ fn fail_refresh_start(
 fn run_create(
     inner: &Inner,
     request: &CreateRequest,
-    previous: Option<PresentationKey>,
     navigation_generation: u64,
+    cancellation: &CancellationToken,
 ) {
-    let created = create_fresh(inner, request, navigation_generation);
+    let created = create_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry, term) = match created {
         Ok(created) => created,
         Err(error) => {
             restore_inventory_after_creation_failure(
                 inner,
-                previous,
+                None,
                 navigation_generation,
                 error.to_string(),
             );
@@ -3122,7 +3148,7 @@ fn run_create(
             drop(worker);
             restore_inventory_after_creation_failure(
                 inner,
-                previous,
+                None,
                 navigation_generation,
                 error.to_string(),
             );
@@ -3138,8 +3164,46 @@ fn run_create(
         name: session.name().to_owned(),
         inventory_generation,
     };
+    publish_created_presentation(
+        inner,
+        attached,
+        worker,
+        initial_geometry,
+        term,
+        navigation_generation,
+    );
+}
+
+fn publish_created_presentation(
+    inner: &Inner,
+    attached: AttachRequest,
+    worker: TerminalWorker,
+    initial_geometry: TerminalGeometry,
+    term: AttachTerm,
+    navigation_generation: u64,
+) {
+    let navigation = inner
+        .navigation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        drop(navigation);
+        drop(worker);
+        return;
+    }
+    let pending = inner
+        .pending_creation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+        .filter(|pending| pending.navigation_generation == navigation_generation);
+    let Some(pending) = pending else {
+        drop(navigation);
+        drop(worker);
+        return;
+    };
     let key = attached.presentation_key();
-    let fallback = previous.map(|presentation| FallbackAuthority {
+    let fallback = pending.previous.map(|presentation| FallbackAuthority {
         presentation,
         target: key,
         navigation_generation,
@@ -3148,15 +3212,11 @@ fn run_create(
         .attachment
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
-        drop(attachment);
-        drop(worker);
-        return;
-    }
     let Some(generation) =
         attachment.reserve_with_fallback(attached.clone(), term, fallback.clone())
     else {
         drop(attachment);
+        drop(navigation);
         drop(worker);
         restore_inventory_after_creation_failure(
             inner,
@@ -3178,6 +3238,7 @@ fn run_create(
     ) {
         attachment.clear_if_current(generation);
         drop(attachment);
+        drop(navigation);
         restore_inventory_after_creation_failure(
             inner,
             fallback.map(|fallback| fallback.presentation),
@@ -3197,12 +3258,15 @@ fn run_create(
             surface,
         },
     );
+    drop(attachment);
+    drop(navigation);
 }
 
 fn create_fresh(
     inner: &Inner,
     request: &CreateRequest,
     navigation_generation: u64,
+    cancellation: &CancellationToken,
 ) -> Result<
     (
         TerminalWorker,
@@ -3215,7 +3279,7 @@ fn create_fresh(
 > {
     let before = request
         .host
-        .discover(&ConptyAdmissionAttacher::new())
+        .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
         .map_err(|error| WorkspaceError::new(error.to_string()))?;
     if before.endpoint() != &request.endpoint {
         return Err(WorkspaceError::new(
@@ -3251,7 +3315,6 @@ fn create_fresh(
     let client_identity = worker
         .wait_for_creation_identity(CREATE_IDENTITY_TIMEOUT)
         .map_err(|error| WorkspaceError::new(error.to_string()))?;
-    let cancellation = CancellationToken::new();
     for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
             drop(worker);
@@ -3259,7 +3322,7 @@ fn create_fresh(
         }
         let snapshot = request
             .host
-            .discover_after_create(before.endpoint(), &request.runtime, &cancellation)
+            .discover_after_create(before.endpoint(), &request.runtime, cancellation)
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
         if let Some(session) = created_session(&snapshot, &client_identity) {
             return Ok((worker, snapshot, session, launch_geometry, term));
@@ -3309,6 +3372,16 @@ fn restore_inventory_after_creation_failure(
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
         return;
     }
+    let pending = inner
+        .pending_creation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+        .filter(|pending| pending.navigation_generation == navigation_generation);
+    if let Some(pending) = &pending {
+        pending.cancellation.cancel();
+    }
+    let previous = pending.and_then(|pending| pending.previous).or(previous);
     restore_presentation_inventory(inner);
     if let Some(previous) = previous {
         match activate_retained_presentation(inner, &previous, None) {
@@ -6026,6 +6099,62 @@ mod tests {
                 navigation_generation: selected_navigation,
             })
         );
+    }
+
+    #[test]
+    fn switching_sessions_cancels_pending_creation_and_restores_inventory() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            vec![SessionItem::new("selected", 0)],
+        ));
+        let creation_navigation = workspace.begin_navigation();
+        let cancellation = CancellationToken::new();
+        *workspace
+            .inner
+            .pending_creation
+            .lock()
+            .expect("pending creation") = Some(PendingCreation {
+            navigation_generation: creation_navigation,
+            previous: None,
+            cancellation: cancellation.clone(),
+        });
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "creating".to_owned(),
+            },
+        );
+
+        let _switch_navigation = workspace.begin_navigation();
+        let fallback = workspace
+            .supersede_inflight_attachment()
+            .expect("switch supersedes pending creation");
+
+        assert_eq!(fallback, None);
+        assert!(cancellation.is_cancelled());
+        assert!(
+            workspace
+                .inner
+                .pending_creation
+                .lock()
+                .expect("pending creation")
+                .is_none()
+        );
+        restore_inventory_after_creation_failure(
+            &workspace.inner,
+            None,
+            creation_navigation,
+            "stale creation failure".to_owned(),
+        );
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { sessions, .. }
+                if sessions.iter().any(|session| session.name() == "selected")
+        ));
+        assert_eq!(workspace.snapshot().notice(), None);
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1541,10 +1541,15 @@ impl Workspace {
     ///
     /// # Errors
     ///
-    /// Returns an error when the name is invalid, the host is not ready, a
-    /// matching session is already present in current inventory, or the
-    /// creation task cannot be started.
-    pub fn create_session(&self, host_id: &str, name: &str) -> Result<(), WorkspaceError> {
+    /// Returns an error when the name is invalid, the selected endpoint
+    /// changed, the host has no admitted inventory, a matching session is
+    /// already present, or the creation task cannot be started.
+    pub fn create_session(
+        &self,
+        host_id: &str,
+        endpoint: &str,
+        name: &str,
+    ) -> Result<(), WorkspaceError> {
         let name =
             SessionName::parse(name).map_err(|error| WorkspaceError::new(error.to_string()))?;
         let navigation = self
@@ -1552,7 +1557,7 @@ impl Workspace {
             .navigation
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let request = capture_create_request(&self.inner, host_id, name)?;
+        let request = capture_create_request(&self.inner, host_id, endpoint, name)?;
         let navigation_generation = self.begin_navigation();
         let in_flight_fallback = self.supersede_inflight_attachment()?;
         let visible_previous = self.retain_active_presentation()?;
@@ -2572,6 +2577,7 @@ fn capture_attach_request(
 fn capture_create_request(
     inner: &Inner,
     host_id: &str,
+    endpoint: &str,
     name: SessionName,
 ) -> Result<CreateRequest, WorkspaceError> {
     let selected_host = inner
@@ -2589,7 +2595,15 @@ fn capture_create_request(
         .iter()
         .find(|host| host.id == host_id)
         .ok_or_else(|| WorkspaceError::new("host is not available"))?;
-    if selected.connection != HostConnectionState::Ready {
+    if selected.endpoint != endpoint {
+        return Err(WorkspaceError::new(
+            "the WSL endpoint changed; choose the host again before creating a session",
+        ));
+    }
+    if matches!(
+        selected.connection,
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    ) {
         return Err(WorkspaceError::new(
             "connect the WSL host before creating a tmux session",
         ));
@@ -2612,6 +2626,11 @@ fn capture_create_request(
         .as_ref()
         .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
     context.map(|context, inventory_generation| {
+        if context.snapshot.endpoint().distro() != endpoint {
+            return Err(WorkspaceError::new(
+                "the WSL endpoint changed; choose the host again before creating a session",
+            ));
+        }
         Ok(CreateRequest {
             host_id: host_id.to_owned(),
             host: context.host.clone(),
@@ -5564,6 +5583,26 @@ mod tests {
         );
 
         assert!(workspace.refresh_if_ready().expect("refresh ready host"));
+        assert!(
+            capture_create_request(
+                &workspace.inner,
+                "wsl",
+                "Ubuntu",
+                SessionName::parse("new work").expect("valid name"),
+            )
+            .is_ok(),
+            "an admitted host remains available for creation while its inventory refreshes"
+        );
+        assert!(
+            capture_create_request(
+                &workspace.inner,
+                "wsl",
+                "Debian",
+                SessionName::parse("new work").expect("valid name"),
+            )
+            .is_err(),
+            "creation never follows a changed default distro implicitly"
+        );
         runtime.run_next_work();
 
         assert_eq!(discovery.reused_hosts.load(Ordering::Acquire), 1);

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1666,12 +1666,7 @@ impl Workspace {
     }
 
     fn begin_navigation(&self) -> u64 {
-        self.inner.kill_generation.fetch_add(1, Ordering::AcqRel);
-        self.inner
-            .pending_kill
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
+        invalidate_pending_kill(&self.inner);
         self.inner
             .navigation_generation
             .fetch_add(1, Ordering::AcqRel)
@@ -1968,12 +1963,7 @@ impl Workspace {
     /// inventory or the background query cannot be started.
     pub fn request_session_kill(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
         let request = capture_kill_request(&self.inner, selection)?;
-        let generation = self.inner.kill_generation.fetch_add(1, Ordering::AcqRel) + 1;
-        self.inner
-            .pending_kill
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
+        let (generation, _) = invalidate_pending_kill(&self.inner);
         let workspace = self.clone();
         thread::Builder::new()
             .name("ghosthub-session-kill-identity".to_owned())
@@ -1984,26 +1974,32 @@ impl Workspace {
                     request.selection.session(),
                     &CancellationToken::new(),
                 );
-                if workspace.inner.kill_generation.load(Ordering::Acquire) != generation {
-                    return;
-                }
                 match result {
                     Ok(target) => {
-                        *workspace
-                            .inner
-                            .pending_kill
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                            Some(PendingKill {
+                        publish_pending_kill(
+                            &workspace.inner,
+                            PendingKill {
                                 generation,
                                 selection: request.selection,
                                 host: request.host,
                                 target: Arc::new(target),
-                            });
+                            },
+                        );
                     }
-                    Err(error) => workspace.push_operation_error(error.to_string()),
+                    Err(error) => {
+                        let pending_kill = workspace
+                            .inner
+                            .pending_kill
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        if workspace.inner.kill_generation.load(Ordering::Acquire) != generation {
+                            return;
+                        }
+                        workspace.push_operation_error(error.to_string());
+                        workspace.inner.revision.fetch_add(1, Ordering::Release);
+                        drop(pending_kill);
+                    }
                 }
-                workspace.inner.revision.fetch_add(1, Ordering::Release);
             })
             .map_err(|error| WorkspaceError::new(format!("verify tmux session: {error}")))?;
         Ok(())
@@ -2011,26 +2007,23 @@ impl Workspace {
 
     #[must_use]
     pub fn session_kill_confirmation(&self) -> Option<SessionKillConfirmation> {
-        self.inner
+        let pending_kill = self
+            .inner
             .pending_kill
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let generation = self.inner.kill_generation.load(Ordering::Acquire);
+        pending_kill
             .as_ref()
+            .filter(|pending| pending.generation == generation)
             .map(|pending| SessionKillConfirmation {
                 selection: pending.selection.clone(),
             })
     }
 
     pub fn cancel_session_kill(&self) {
-        self.inner.kill_generation.fetch_add(1, Ordering::AcqRel);
-        if self
-            .inner
-            .pending_kill
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take()
-            .is_some()
-        {
+        let (_generation, removed) = invalidate_pending_kill(&self.inner);
+        if removed {
             self.inner.revision.fetch_add(1, Ordering::Release);
         }
     }
@@ -2235,6 +2228,15 @@ impl Workspace {
 
     fn detach_locked(&self) {
         self.begin_navigation();
+        if let Some(pending) = self
+            .inner
+            .pending_creation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        {
+            pending.cancellation.cancel();
+        }
         self.inner
             .attachment
             .lock()
@@ -2682,6 +2684,29 @@ impl Workspace {
     fn set_state(&self, state: WorkspaceContent) {
         set_inner_state(&self.inner, state);
     }
+}
+
+fn publish_pending_kill(inner: &Inner, pending: PendingKill) -> bool {
+    let mut pending_kill = inner
+        .pending_kill
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.kill_generation.load(Ordering::Acquire) != pending.generation {
+        return false;
+    }
+    *pending_kill = Some(pending);
+    drop(pending_kill);
+    inner.revision.fetch_add(1, Ordering::Release);
+    true
+}
+
+fn invalidate_pending_kill(inner: &Inner) -> (u64, bool) {
+    let mut pending_kill = inner
+        .pending_kill
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let generation = inner.kill_generation.fetch_add(1, Ordering::AcqRel) + 1;
+    (generation, pending_kill.take().is_some())
 }
 
 fn activate_retained_presentation(
@@ -6155,6 +6180,95 @@ mod tests {
                 if sessions.iter().any(|session| session.name() == "selected")
         ));
         assert_eq!(workspace.snapshot().notice(), None);
+    }
+
+    #[test]
+    fn detaching_during_creation_cancels_the_task_and_restores_inventory() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            vec![SessionItem::new("existing", 0)],
+        ));
+        let creation_navigation = workspace.begin_navigation();
+        let cancellation = CancellationToken::new();
+        *workspace
+            .inner
+            .pending_creation
+            .lock()
+            .expect("pending creation") = Some(PendingCreation {
+            navigation_generation: creation_navigation,
+            previous: None,
+            cancellation: cancellation.clone(),
+        });
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Attaching {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "creating".to_owned(),
+            },
+        );
+
+        workspace.detach();
+
+        assert!(cancellation.is_cancelled());
+        assert!(
+            workspace
+                .inner
+                .pending_creation
+                .lock()
+                .expect("pending creation")
+                .is_none()
+        );
+        restore_inventory_after_creation_failure(
+            &workspace.inner,
+            None,
+            creation_navigation,
+            "stale creation failure".to_owned(),
+        );
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { sessions, .. }
+                if sessions.iter().any(|session| session.name() == "existing")
+        ));
+        assert_eq!(workspace.snapshot().notice(), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stale_kill_identity_results_cannot_publish_confirmation() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let pending = |generation| PendingKill {
+            generation,
+            selection: SessionSelection::new("wsl", "Ubuntu", "work"),
+            host: host.clone(),
+            target: Arc::new(LiveSessionTarget::test_fixture(
+                &snapshot,
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+            )),
+        };
+
+        workspace.inner.kill_generation.store(2, Ordering::Release);
+        assert!(!publish_pending_kill(&workspace.inner, pending(1)));
+        assert_eq!(workspace.session_kill_confirmation(), None);
+
+        workspace.inner.kill_generation.store(3, Ordering::Release);
+        assert!(publish_pending_kill(&workspace.inner, pending(3)));
+        assert!(workspace.session_kill_confirmation().is_some());
+        workspace.inner.kill_generation.store(4, Ordering::Release);
+        assert_eq!(workspace.session_kill_confirmation(), None);
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -3099,7 +3099,7 @@ fn run_create(
     navigation_generation: u64,
 ) {
     let created = create_fresh(inner, request, navigation_generation);
-    let (worker, snapshot, session, initial_geometry) = match created {
+    let (worker, snapshot, session, initial_geometry, term) = match created {
         Ok(created) => created,
         Err(error) => {
             restore_inventory_after_creation_failure(
@@ -3153,11 +3153,9 @@ fn run_create(
         drop(worker);
         return;
     }
-    let Some(generation) = attachment.reserve_with_fallback(
-        attached.clone(),
-        AttachTerm::Xterm256Color,
-        fallback.clone(),
-    ) else {
+    let Some(generation) =
+        attachment.reserve_with_fallback(attached.clone(), term, fallback.clone())
+    else {
         drop(attachment);
         drop(worker);
         restore_inventory_after_creation_failure(
@@ -3188,7 +3186,7 @@ fn run_create(
         );
         return;
     }
-    set_terminal_notice(inner, AttachTerm::Xterm256Color);
+    set_terminal_notice(inner, term);
     set_inner_state(
         inner,
         WorkspaceContent::Terminal {
@@ -3211,6 +3209,7 @@ fn create_fresh(
         HostSnapshot,
         session::DiscoveredSession,
         TerminalGeometry,
+        AttachTerm,
     ),
     WorkspaceError,
 > {
@@ -3231,13 +3230,9 @@ fn create_fresh(
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
         return Err(WorkspaceError::new("tmux creation was superseded"));
     }
-    let authority = request
+    let (authority, term) = request
         .host
-        .create_once_with_term(
-            before.endpoint(),
-            request.name.clone(),
-            AttachTerm::Xterm256Color,
-        )
+        .create_once(before.endpoint(), before.runtime(), request.name.clone())
         .map_err(|error| WorkspaceError::new(error.to_string()))?;
     let geometry = *inner
         .terminal_geometry
@@ -3267,7 +3262,7 @@ fn create_fresh(
             .discover_after_create(before.endpoint(), &request.runtime, &cancellation)
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
         if let Some(session) = created_session(&snapshot, &client_identity) {
-            return Ok((worker, snapshot, session, launch_geometry));
+            return Ok((worker, snapshot, session, launch_geometry, term));
         }
         if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
             thread::sleep(CREATE_DISCOVERY_DELAY);

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -2074,10 +2074,24 @@ impl Workspace {
     }
 
     fn finish_session_kill(&self, target: &LiveSessionTarget) {
+        self.finish_killed_presentation(target.endpoint(), target.runtime(), target.identity());
+    }
+
+    fn finish_killed_presentation(
+        &self,
+        endpoint: &host::WslEndpoint,
+        runtime: &host::WslRuntimeIdentity,
+        identity: &session::SessionIdentity,
+    ) {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let key_matches = |request: &AttachRequest| {
-            request.endpoint == *target.endpoint()
-                && request.runtime == *target.runtime()
-                && request.identity == *target.identity()
+            request.endpoint == *endpoint
+                && request.runtime == *runtime
+                && request.identity == *identity
         };
         let active_matches = self
             .inner
@@ -2087,7 +2101,7 @@ impl Workspace {
             .active()
             .is_some_and(|active| key_matches(&active.request));
         if active_matches {
-            self.detach();
+            self.detach_locked();
         }
         let changed = self
             .inner
@@ -2095,9 +2109,9 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove_matching(|key| {
-                key.endpoint == target.endpoint().distro()
-                    && key.runtime == *target.runtime()
-                    && key.identity == *target.identity()
+                key.endpoint == endpoint.distro()
+                    && key.runtime == *runtime
+                    && key.identity == *identity
             });
         if changed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2190,6 +2204,10 @@ impl Workspace {
             .navigation
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.detach_locked();
+    }
+
+    fn detach_locked(&self) {
         self.begin_navigation();
         self.inner
             .attachment
@@ -6043,6 +6061,61 @@ mod tests {
             workspace.snapshot().content(),
             WorkspaceContent::Terminal { session, .. } if session == "work"
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn killed_presentation_cleanup_never_detaches_a_different_active_session() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let killed_identity = session::SessionIdentity::new(100, "$1", 200);
+        let active_identity = session::SessionIdentity::new(100, "$2", 201);
+        let active_request = attach_request_fixture(&snapshot, active_identity.clone(), "active");
+        workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve(active_request, AttachTerm::Xterm256Color)
+            .expect("reserve active attachment");
+        let size = GridSize::new(80, 24).expect("valid grid");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "active".to_owned(),
+                presentation_id: 1,
+                surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
+            },
+        );
+
+        workspace.finish_killed_presentation(
+            snapshot.endpoint(),
+            snapshot.runtime(),
+            &killed_identity,
+        );
+
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Terminal { session, .. } if session == "active"
+        ));
+        assert_eq!(
+            workspace
+                .inner
+                .attachment
+                .lock()
+                .expect("attachment")
+                .active()
+                .expect("active attachment")
+                .request
+                .identity,
+            active_identity
+        );
     }
 
     #[test]

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -25,6 +25,18 @@ fn isolated_namespace_includes_a_cross_process_nonce() {
 
 impl IsolatedServer {
     fn start(label: &str) -> Self {
+        let server = Self::empty(label);
+        server.run_tmux(["new-session", "-d", "-s", "workspace-live"]);
+        let socket = server.run_tmux(["display-message", "-p", "#{socket_path}"]);
+        let socket = String::from_utf8(socket.stdout).expect("UTF-8 tmux socket path");
+        assert!(
+            socket.trim().starts_with(&format!("{}/", server.tmpdir)),
+            "test tmux escaped its isolated directory: {socket:?}"
+        );
+        server
+    }
+
+    fn empty(label: &str) -> Self {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time")
@@ -40,15 +52,7 @@ impl IsolatedServer {
             "create isolated tmux directory: {}",
             String::from_utf8_lossy(&mkdir.stderr)
         );
-        let server = Self { tmpdir };
-        server.run_tmux(["new-session", "-d", "-s", "workspace-live"]);
-        let socket = server.run_tmux(["display-message", "-p", "#{socket_path}"]);
-        let socket = String::from_utf8(socket.stdout).expect("UTF-8 tmux socket path");
-        assert!(
-            socket.trim().starts_with(&format!("{}/", server.tmpdir)),
-            "test tmux escaped its isolated directory: {socket:?}"
-        );
-        server
+        Self { tmpdir }
     }
 
     fn run_tmux<I, S>(&self, args: I) -> Output
@@ -174,6 +178,125 @@ fn discovers_attaches_renders_and_detaches_through_workspace() {
         )
     });
     assert_eq!(server.identity(), identity);
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn creates_attaches_and_detaches_one_atomic_local_session() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::empty("create-once");
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+
+    wait_until_with_diagnostic(
+        || {
+            let snapshot = workspace.snapshot();
+            snapshot.hosts()[0].connection() == workspace::HostConnectionState::Ready
+                && snapshot.hosts()[0].sessions().is_empty()
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    workspace
+        .create_session("wsl", "  created live  ")
+        .expect("start one-shot local creation");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal { session, .. } if session == "created live"
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    let created_identity = server.run_tmux([
+        "display-message",
+        "-p",
+        "-t",
+        "=created live",
+        "#{pid}:#{session_id}:#{session_created}",
+    ]);
+    let created_identity = String::from_utf8(created_identity.stdout)
+        .expect("UTF-8 created identity")
+        .trim()
+        .to_owned();
+
+    workspace.detach();
+    wait_until(|| {
+        matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { sessions, .. }
+                if sessions.iter().any(|session| session.name() == "created live")
+        )
+    });
+    let surviving_identity = server.run_tmux([
+        "display-message",
+        "-p",
+        "-t",
+        "=created live",
+        "#{pid}:#{session_id}:#{session_created}",
+    ]);
+    assert_eq!(
+        String::from_utf8(surviving_identity.stdout)
+            .expect("UTF-8 surviving identity")
+            .trim(),
+        created_identity
+    );
+    assert!(
+        workspace.create_session("wsl", "created live").is_err(),
+        "current inventory prevents an accidental duplicate create action"
+    );
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn creation_race_attaches_the_exact_existing_session() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("create-race");
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+    wait_until_with_diagnostic(
+        || workspace.snapshot().hosts()[0].connection() == workspace::HostConnectionState::Ready,
+        || workspace_diagnostic(&workspace),
+    );
+
+    server.run_tmux(["new-session", "-d", "-s", "raced live"]);
+    let before = server.run_tmux([
+        "display-message",
+        "-p",
+        "-t",
+        "=raced live",
+        "#{pid}:#{session_id}:#{session_created}",
+    ]);
+    workspace
+        .create_session("wsl", "raced live")
+        .expect("the atomic action accepts a session absent from cached inventory");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal { session, .. } if session == "raced live"
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    let after = server.run_tmux([
+        "display-message",
+        "-p",
+        "-t",
+        "=raced live",
+        "#{pid}:#{session_id}:#{session_created}",
+    ]);
+
+    assert_eq!(
+        after.stdout, before.stdout,
+        "-A must preserve the raced identity"
+    );
 }
 
 #[test]

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -273,6 +273,45 @@ fn creates_attaches_and_detaches_one_atomic_local_session() {
 
 #[test]
 #[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn creation_follows_the_client_identity_when_a_hook_renames_the_session() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("create-hook-rename");
+    server.run_tmux([
+        "set-hook",
+        "-g",
+        "after-new-session",
+        "rename-session renamed-by-hook",
+    ]);
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+    wait_until_with_diagnostic(
+        || workspace.snapshot().hosts()[0].connection() == workspace::HostConnectionState::Ready,
+        || workspace_diagnostic(&workspace),
+    );
+    let endpoint = workspace.snapshot().hosts()[0].endpoint().to_owned();
+
+    workspace
+        .create_session("wsl", &endpoint, "requested-name")
+        .expect("start renamed one-shot creation");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal { session, .. } if session == "renamed-by-hook"
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+
+    assert!(server.has_session("renamed-by-hook"));
+    assert!(!server.has_session("requested-name"));
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
 fn creation_race_attaches_the_exact_existing_session() {
     let _serial = WSL_LIVE
         .lock()
@@ -767,7 +806,8 @@ fn wait_until_with_diagnostic(
 }
 
 fn workspace_diagnostic(workspace: &Workspace) -> String {
-    match workspace.snapshot().content() {
+    let snapshot = workspace.snapshot();
+    let state = match snapshot.content() {
         WorkspaceContent::Shell => "shell".to_owned(),
         WorkspaceContent::Loading => "loading".to_owned(),
         WorkspaceContent::Ready { endpoint, sessions } => {
@@ -782,7 +822,10 @@ fn workspace_diagnostic(workspace: &Workspace) -> String {
             endpoint, session, ..
         } => format!("attached to {session} in {endpoint}"),
         WorkspaceContent::Error { message } => format!("error: {message}"),
-    }
+    };
+    snapshot
+        .notice()
+        .map_or(state.clone(), |notice| format!("{state}; notice: {notice}"))
 }
 
 fn session_selection(workspace: &Workspace, session: &str) -> SessionSelection {

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -90,6 +90,24 @@ impl IsolatedServer {
             .trim()
             .to_owned()
     }
+
+    fn has_session(&self, name: &str) -> bool {
+        let output = Command::new("wsl.exe")
+            .args([
+                "--exec",
+                "/usr/bin/env",
+                &format!("TMUX_TMPDIR={}", self.tmpdir),
+                "/usr/bin/tmux",
+                "-f",
+                "/dev/null",
+                "has-session",
+                "-t",
+                &format!("={name}"),
+            ])
+            .output()
+            .expect("query isolated WSL tmux session");
+        output.status.success()
+    }
 }
 
 fn isolated_tmpdir(label: &str, process_id: u32, nonce: u128) -> String {
@@ -596,6 +614,75 @@ fn refuses_to_attach_when_the_discovered_session_was_replaced() {
                 .notice()
                 .is_some_and(|notice| notice.contains("identity changed"))
     });
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn confirms_fresh_identity_and_never_kills_a_replacement() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::start("kill-confirmation");
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Ready { sessions, .. }
+                    if sessions.iter().any(|session| session.name() == "workspace-live")
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    let selection = session_selection(&workspace, "workspace-live");
+
+    workspace
+        .request_session_kill(&selection)
+        .expect("begin live identity query");
+    wait_until(|| workspace.session_kill_confirmation().is_some());
+    workspace.cancel_session_kill();
+    assert!(server.has_session("workspace-live"), "cancel must not kill");
+
+    workspace
+        .request_session_kill(&selection)
+        .expect("begin second live identity query");
+    wait_until(|| workspace.session_kill_confirmation().is_some());
+    server.run_tmux(["kill-session", "-t", "=workspace-live"]);
+    server.run_tmux(["new-session", "-d", "-s", "workspace-live"]);
+    workspace
+        .confirm_session_kill()
+        .expect("begin guarded kill");
+    wait_until(|| {
+        workspace.drain_events().0.into_iter().any(|event| {
+            matches!(event, WorkspaceEvent::Error(message) if message.contains("replaced after confirmation"))
+        })
+    });
+    assert!(
+        server.has_session("workspace-live"),
+        "same-named replacement must survive"
+    );
+
+    wait_until_with_diagnostic(
+        || {
+            workspace.snapshot().hosts().first().is_some_and(|host| {
+                host.sessions()
+                    .iter()
+                    .any(|session| session.name() == "workspace-live")
+            })
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    workspace
+        .request_session_kill(&selection)
+        .expect("query replacement identity");
+    wait_until(|| workspace.session_kill_confirmation().is_some());
+    workspace
+        .confirm_session_kill()
+        .expect("kill confirmed replacement");
+    wait_until(|| !server.has_session("workspace-live"));
 }
 
 #[test]

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -199,8 +199,9 @@ fn creates_attaches_and_detaches_one_atomic_local_session() {
         },
         || workspace_diagnostic(&workspace),
     );
+    let endpoint = workspace.snapshot().hosts()[0].endpoint().to_owned();
     workspace
-        .create_session("wsl", "  created live  ")
+        .create_session("wsl", &endpoint, "  created live  ")
         .expect("start one-shot local creation");
     wait_until_with_diagnostic(
         || {
@@ -245,7 +246,9 @@ fn creates_attaches_and_detaches_one_atomic_local_session() {
         created_identity
     );
     assert!(
-        workspace.create_session("wsl", "created live").is_err(),
+        workspace
+            .create_session("wsl", &endpoint, "created live")
+            .is_err(),
         "current inventory prevents an accidental duplicate create action"
     );
 }
@@ -264,6 +267,7 @@ fn creation_race_attaches_the_exact_existing_session() {
         || workspace.snapshot().hosts()[0].connection() == workspace::HostConnectionState::Ready,
         || workspace_diagnostic(&workspace),
     );
+    let endpoint = workspace.snapshot().hosts()[0].endpoint().to_owned();
 
     server.run_tmux(["new-session", "-d", "-s", "raced live"]);
     let before = server.run_tmux([
@@ -274,7 +278,7 @@ fn creation_race_attaches_the_exact_existing_session() {
         "#{pid}:#{session_id}:#{session_created}",
     ]);
     workspace
-        .create_session("wsl", "raced live")
+        .create_session("wsl", &endpoint, "raced live")
         .expect("the atomic action accepts a session absent from cached inventory");
     wait_until_with_diagnostic(
         || {

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -108,6 +108,14 @@ impl IsolatedServer {
             .expect("query isolated WSL tmux session");
         output.status.success()
     }
+
+    fn path_exists(path: &str) -> bool {
+        Command::new("wsl.exe")
+            .args(["--exec", "/usr/bin/test", "-e", path])
+            .status()
+            .expect("query isolated WSL path")
+            .success()
+    }
 }
 
 fn isolated_tmpdir(label: &str, process_id: u32, nonce: u128) -> String {
@@ -269,6 +277,33 @@ fn creates_attaches_and_detaches_one_atomic_local_session() {
             .is_err(),
         "current inventory prevents an accidental duplicate create action"
     );
+}
+
+#[test]
+#[ignore = "requires WSL2 and tmux; creates only an isolated TMUX_TMPDIR server"]
+fn user_created_names_cannot_execute_tmux_format_jobs() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::empty("create-format-job");
+    let config = WslConfig::configured(None, "/usr/bin/tmux", Some(server.tmpdir.clone()))
+        .expect("valid isolated config");
+    let workspace = Workspace::start_wsl(config, TerminalAppearance::default());
+    wait_until_with_diagnostic(
+        || workspace.snapshot().hosts()[0].connection() == workspace::HostConnectionState::Ready,
+        || workspace_diagnostic(&workspace),
+    );
+    let endpoint = workspace.snapshot().hosts()[0].endpoint().to_owned();
+    let sentinel = format!("{}/owned", server.tmpdir);
+    let hostile_name = format!("#(touch {sentinel})");
+    assert!(hostile_name.chars().count() <= 100);
+
+    let error = workspace
+        .create_session("wsl", &endpoint, &hostile_name)
+        .expect_err("tmux format syntax must not enter the creation plan");
+
+    assert!(error.to_string().contains("number signs"));
+    assert!(!IsolatedServer::path_exists(&sentinel));
 }
 
 #[test]


### PR DESCRIPTION
- Keeps local WSL tmux sessions current when the Ghosthub window regains focus, so sessions created elsewhere appear without a manual refresh.
- Lets users create the first or an additional local tmux session from the compact `+` action beside a ready WSL host.
- Uses one atomic `new-session -A` ordinary client, then captures the exact WSL runtime, tmux server, session ID, and creation time before publishing the terminal.
- Preserves the current terminal during refresh and creation, restores it when a new client cannot be established, and never reruns or kills a session after an ambiguous launch.
- Keeps SSH and remote lifecycle work out of scope.
- Exercises empty-namespace creation and same-name creation races against isolated real WSL tmux servers; the full Rust workspace, Clippy, architecture contracts, strict docs, and license closure pass.