### PR TITLE
Fix command-center website screenshots

### DIFF
--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -85,8 +85,7 @@ static NSMenuItem *DemoMenuItemForShortcut(
              : nil;
 }
 
-static BOOL DemoClick(NSPoint point) {
-  NSWindow *window = DemoRootWindow();
+static BOOL DemoClickWindow(NSWindow *window, NSPoint point) {
   if (window == nil) return NO;
   NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
   NSEvent *down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
@@ -110,6 +109,20 @@ static BOOL DemoClick(NSPoint point) {
   [NSApp sendEvent:down];
   [NSApp sendEvent:up];
   return YES;
+}
+
+static BOOL DemoClick(NSPoint point) {
+  return DemoClickWindow(DemoRootWindow(), point);
+}
+
+static NSView *DemoFindViewWithIdentifier(
+    NSView *view, NSString *identifier) {
+  if ([view.identifier isEqualToString:identifier]) return view;
+  for (NSView *subview in view.subviews) {
+    NSView *match = DemoFindViewWithIdentifier(subview, identifier);
+    if (match != nil) return match;
+  }
+  return nil;
 }
 
 static BOOL DemoInsertText(NSString *text) {
@@ -184,9 +197,9 @@ static BOOL DemoContainsTextWalk(id element, NSString *text,
                                  NSUInteger depth, NSUInteger *budget) {
   if (element == nil || depth > 20 || *budget == 0) return NO;
   *budget -= 1;
-  if ([DemoAccessibilityLabel(element) isEqualToString:text] ||
-      [[DemoAccessibilityValue(element) description]
-          isEqualToString:text]) {
+  NSString *label = DemoAccessibilityLabel(element);
+  NSString *value = [DemoAccessibilityValue(element) description];
+  if ([label containsString:text] || [value containsString:text]) {
     return YES;
   }
   for (id child in DemoAccessibilityChildren(element)) {
@@ -406,14 +419,14 @@ static NSArray<NSWindow *> *DemoWorkspaceWindows(void) {
 }
 
 static void DemoArrangeMatrix(NSArray<NSWindow *> *windows) {
-  if (windows.count != 6) return;
+  if (windows.count != 4) return;
   NSRect screen = NSScreen.mainScreen.visibleFrame;
   CGFloat gap = 6;
-  CGFloat width = floor((screen.size.width - (2 * gap)) / 3);
+  CGFloat width = floor((screen.size.width - gap) / 2);
   CGFloat height = floor((screen.size.height - gap) / 2);
   for (NSUInteger index = 0; index < windows.count; index++) {
-    NSUInteger column = index % 3;
-    NSUInteger row = index / 3;
+    NSUInteger column = index % 2;
+    NSUInteger row = index / 2;
     CGFloat x = screen.origin.x + column * (width + gap);
     CGFloat y = screen.origin.y + (1 - row) * (height + gap);
     NSWindow *window = windows[index];
@@ -422,14 +435,14 @@ static void DemoArrangeMatrix(NSArray<NSWindow *> *windows) {
   }
 }
 
-static void DemoCapture(NSString *path, BOOL matrix) {
+static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
   if (!matrix) {
-    DemoCaptureWindow(DemoRootWindow(), path, NO);
+    DemoCaptureWindow(DemoRootWindow(), path, exactWindow);
     return;
   }
 
   NSArray<NSWindow *> *windows = DemoWorkspaceWindows();
-  if (windows.count != 6) return;
+  if (windows.count != 4) return;
   DemoArrangeMatrix(windows);
   dispatch_after(
       dispatch_time(DISPATCH_TIME_NOW, 1000 * NSEC_PER_MSEC),
@@ -464,10 +477,12 @@ static void DemoCapture(NSString *path, BOOL matrix) {
 
 - (void)capture:(NSNotification *)notification {
   NSString *path = notification.userInfo[@"path"];
-  BOOL matrix = [notification.userInfo[@"mode"] isEqualToString:@"matrix"];
+  NSString *mode = notification.userInfo[@"mode"] ?: @"window";
+  BOOL matrix = [mode isEqualToString:@"matrix"];
+  BOOL exactWindow = [mode isEqualToString:@"exact"];
   if (path.length == 0) return;
   dispatch_async(dispatch_get_main_queue(), ^{
-    DemoCapture(path, matrix);
+    DemoCapture(path, matrix, exactWindow);
   });
 }
 
@@ -653,31 +668,35 @@ static void DemoCapture(NSString *path, BOOL matrix) {
             });
       });
     } else if ([action isEqualToString:@"hide-sidebar"]) {
-      NSView *content = DemoRootWindow().contentView;
-      BOOL wasVisible = DemoContainsText(content, @"Workspaces", 0);
-      if (!wasVisible) {
-        [self acknowledge:requestID
-                  success:YES
-                  message:@"sidebar already hidden"];
-        return;
-      }
-      BOOL pressed = DemoPressLabel(
-          DemoRootWindow(), @"Hide Sidebar (Cmd+B)", 0);
-      if (!pressed) {
+      NSWindow *window = DemoRootWindow();
+      if (window == nil) {
         [self acknowledge:requestID
                   success:NO
-                  message:@"sidebar control was not available"];
+                  message:@"sidebar button was not available"];
         return;
       }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      [NSApp activateIgnoringOtherApps:YES];
+#pragma clang diagnostic pop
+      [window makeKeyAndOrderFront:nil];
       dispatch_after(
           dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
           dispatch_get_main_queue(), ^{
-            BOOL isVisible =
-                DemoContainsText(content, @"Workspaces", 0);
+            NSView *titlebar =
+                [window standardWindowButton:NSWindowCloseButton].superview;
+            NSView *control = DemoFindViewWithIdentifier(
+                titlebar, @"GhosthubCompactSidebarControl");
+            NSPoint point = control == nil
+                ? NSZeroPoint
+                : [control convertPoint:NSMakePoint(
+                    NSMidX(control.bounds), NSMidY(control.bounds))
+                                  toView:nil];
+            BOOL handled = control != nil && DemoClickWindow(window, point);
             [self acknowledge:requestID
-                      success:!isVisible
-                      message:isVisible ? @"sidebar remained visible"
-                                        : @"sidebar hidden"];
+                      success:handled
+                      message:handled ? @"sidebar toggle requested"
+                                      : @"sidebar action was not handled"];
           });
     } else if ([action isEqualToString:@"frame"]) {
 #pragma clang diagnostic push
@@ -707,6 +726,13 @@ static void DemoCapture(NSString *path, BOOL matrix) {
                 success:window != nil
                 message:window != nil ? @"window framed"
                                       : @"no workspace window"];
+    } else if ([action isEqualToString:@"expect-text"]) {
+      BOOL found = text.length > 0 &&
+          DemoContainsText(DemoRootWindow(), text, 0);
+      [self acknowledge:requestID
+                success:found
+                message:found ? @"expected text is visible"
+                              : @"expected text is not visible"];
     } else if ([action isEqualToString:@"click"]) {
       NSArray<NSString *> *parts =
           [text componentsSeparatedByString:@","];

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -125,6 +125,23 @@ static NSView *DemoFindViewWithIdentifier(
   return nil;
 }
 
+static NSView *DemoTitlebarView(
+    NSWindow *window, NSString *identifier) {
+  NSView *titlebar =
+      [window standardWindowButton:NSWindowCloseButton].superview;
+  return DemoFindViewWithIdentifier(titlebar, identifier);
+}
+
+static BOOL DemoSidebarIsHidden(NSWindow *window) {
+  NSView *title = DemoTitlebarView(
+      window, @"GhosthubCompactSessionTitle");
+  if (title == nil) return NO;
+  [title.superview layoutSubtreeIfNeeded];
+  // Ghosthub anchors the title at 120 points when the sidebar is collapsed;
+  // a visible sidebar moves it to the persisted sidebar width plus 12.
+  return NSMinX(title.frame) < 180;
+}
+
 static BOOL DemoInsertText(NSString *text) {
   id responder = DemoEventWindow().firstResponder;
   if (![responder respondsToSelector:
@@ -683,20 +700,35 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
       dispatch_after(
           dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
           dispatch_get_main_queue(), ^{
-            NSView *titlebar =
-                [window standardWindowButton:NSWindowCloseButton].superview;
-            NSView *control = DemoFindViewWithIdentifier(
-                titlebar, @"GhosthubCompactSidebarControl");
+            if (DemoSidebarIsHidden(window)) {
+              [self acknowledge:requestID
+                        success:YES
+                        message:@"sidebar already hidden"];
+              return;
+            }
+            NSView *control = DemoTitlebarView(
+                window, @"GhosthubCompactSidebarControl");
             NSPoint point = control == nil
                 ? NSZeroPoint
                 : [control convertPoint:NSMakePoint(
                     NSMidX(control.bounds), NSMidY(control.bounds))
                                   toView:nil];
             BOOL handled = control != nil && DemoClickWindow(window, point);
-            [self acknowledge:requestID
-                      success:handled
-                      message:handled ? @"sidebar toggle requested"
-                                      : @"sidebar action was not handled"];
+            if (!handled) {
+              [self acknowledge:requestID
+                        success:NO
+                        message:@"sidebar action was not handled"];
+              return;
+            }
+            dispatch_after(
+                dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+                dispatch_get_main_queue(), ^{
+                  BOOL hidden = DemoSidebarIsHidden(window);
+                  [self acknowledge:requestID
+                            success:hidden
+                            message:hidden ? @"sidebar hidden"
+                                           : @"sidebar remained visible"];
+                });
           });
     } else if ([action isEqualToString:@"frame"]) {
 #pragma clang diagnostic push
@@ -733,6 +765,13 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                 success:found
                 message:found ? @"expected text is visible"
                               : @"expected text is not visible"];
+    } else if ([action isEqualToString:@"expect-window-title"]) {
+      BOOL found = text.length > 0 &&
+          [DemoRootWindow().title containsString:text];
+      [self acknowledge:requestID
+                success:found
+                message:found ? @"expected window title is active"
+                              : @"expected window title is not active"];
     } else if ([action isEqualToString:@"click"]) {
       NSArray<NSString *> *parts =
           [text componentsSeparatedByString:@","];

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -766,12 +766,14 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                 message:found ? @"expected text is visible"
                               : @"expected text is not visible"];
     } else if ([action isEqualToString:@"expect-window-title"]) {
-      BOOL found = text.length > 0 &&
-          [DemoRootWindow().title containsString:text];
+      NSString *activeTitle = DemoRootWindow().title ?: @"";
+      BOOL found = text.length > 0 && [activeTitle containsString:text];
       [self acknowledge:requestID
                 success:found
                 message:found ? @"expected window title is active"
-                              : @"expected window title is not active"];
+                              : [NSString stringWithFormat:
+                                  @"expected %@ but active title is %@",
+                                  text, activeTitle]];
     } else if ([action isEqualToString:@"click"]) {
       NSArray<NSString *> *parts =
           [text componentsSeparatedByString:@","];

--- a/website/demo/capture.sh
+++ b/website/demo/capture.sh
@@ -23,7 +23,7 @@ demo_pid="$(demo_require_recorded_process "$scratch/app.pid" "$bin")"
 
 rm -f "$out" "$out.tmp"
 if [[ "$mode" == "matrix" ]]; then
-  for index in 1 2 3 4 5; do
+  for index in 1 2 3; do
     rm -f "$out.$index" "$out.$index.tmp"
   done
 fi
@@ -51,7 +51,7 @@ capture_complete() {
   [[ -s "$out" ]] || return 1
   [[ "$mode" != "matrix" ]] && return 0
   local index
-  for index in 1 2 3 4 5; do
+  for index in 1 2 3; do
     [[ -s "$out.$index" ]] || return 1
   done
 }
@@ -66,7 +66,7 @@ if ! capture_complete; then
 fi
 
 if [[ "$mode" == "matrix" ]]; then
-  echo "captured six-window demo matrix from process $demo_pid -> $out{,.1...5}"
+  echo "captured four-window demo matrix from process $demo_pid -> $out{,.1...3}"
 else
   echo "captured demo process $demo_pid -> $out"
   sips -g pixelWidth -g pixelHeight "$out" | tail -2

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -165,8 +165,9 @@ EOF
 
 capture_state() {
   local name="$1"
+  local mode="${2:-window}"
   local raw="$scratch/screenshots-raw/$name"
-  "$demo_root/capture.sh" "$raw"
+  "$demo_root/capture.sh" "$raw" "$mode"
   process_capture "$raw" "$out_dir/$name"
   sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
 }
@@ -180,7 +181,7 @@ process_matrix_capture() {
 const sharp = require("sharp");
 (async () => {
   const [raw, destination] = process.argv.slice(2);
-  const files = [raw, ...[1, 2, 3, 4, 5].map((index) => `${raw}.${index}`)];
+  const files = [raw, ...[1, 2, 3].map((index) => `${raw}.${index}`)];
   const metadata = await Promise.all(
     files.map((file) => sharp(file).metadata())
   );
@@ -193,7 +194,7 @@ const sharp = require("sharp");
   const gap = 6;
   await sharp({
     create: {
-      width: width * 3 + gap * 2,
+      width: width * 2 + gap,
       height: height * 2 + gap,
       channels: 4,
       background: "#080b0e",
@@ -201,8 +202,8 @@ const sharp = require("sharp");
   })
     .composite(files.map((input, index) => ({
       input,
-      left: (index % 3) * (width + gap),
-      top: Math.floor(index / 3) * (height + gap),
+      left: (index % 2) * (width + gap),
+      top: Math.floor(index / 2) * (height + gap),
     })))
     .resize({ width: 1800 })
     .png({ compressionLevel: 9 })
@@ -225,7 +226,8 @@ if [[ "${GHOSTHUB_DEMO_EXE_ONLY:-}" == "1" ]]; then
   exit 0
 fi
 
-if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
+if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" &&
+      "${GHOSTHUB_DEMO_COMMAND_CENTER_ONLY:-}" != "1" ]]; then
 echo "==> controller: unmatched palette commands fail validation"
 unmatched_command="__ghosthub_missing_command__"
 unmatched_error="$scratch/unmatched-command.error"
@@ -284,6 +286,7 @@ palette "Open Appearance Settings" true sheet
 sleep 2
 capture_state guide-terminal.png
 dismiss_sheet
+fi
 
 prepare_command_window() {
   local query="$1" create="${2:-true}" select="${3:-palette}"
@@ -296,9 +299,13 @@ prepare_command_window() {
   if [[ "$select" == "row" ]]; then
     case "$query" in
       add-session-filters)
-        demo_input click "32,222"
+        if [[ "${GHOSTHUB_DEMO_COMMAND_CENTER_ONLY:-}" == "1" ]]; then
+          demo_input click "32,249"
+          sleep 0.5
+        fi
+        demo_input click "32,165"
         sleep 0.5
-        demo_input click "80,155"
+        demo_input click "80,95"
         ;;
       docbank-export) demo_input click "80,603" ;;
       release-watch) demo_input click "80,558" ;;
@@ -315,21 +322,32 @@ prepare_command_window() {
     palette "$query"
   fi
   sleep 3
+  if [[ "$select" != "none" ]]; then
+    demo_input expect-text "$query"
+  fi
   demo_input hide-sidebar
 }
 
-echo "==> guide: six-window tmux command center"
-prepare_command_window "fix-reconnect-backoff" false none
-prepare_command_window "add-session-filters" true row
-prepare_command_window "scratch" true row
-prepare_command_window "docbank-export" true row
-prepare_command_window "release-watch" true row
-prepare_command_window "test-matrix" true row
-matrix_raw="$scratch/screenshots-raw/guide-command-center.png"
-"$demo_root/capture.sh" "$matrix_raw" matrix
-process_matrix_capture "$matrix_raw" "$out_dir/guide-command-center.png"
-sips -g pixelWidth -g pixelHeight \
-  "$out_dir/guide-command-center.png" | tail -2
+if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
+  echo "==> guide: four-window tmux command center"
+  if [[ "${GHOSTHUB_DEMO_COMMAND_CENTER_ONLY:-}" == "1" ]]; then
+    prepare_command_window "fix-reconnect-backoff" false palette
+  else
+    prepare_command_window "fix-reconnect-backoff" false none
+  fi
+  prepare_command_window "scratch" true row
+  prepare_command_window "docbank-export" true row
+  prepare_command_window "release-watch" true row
+  matrix_raw="$scratch/screenshots-raw/guide-command-center.png"
+  "$demo_root/capture.sh" "$matrix_raw" matrix
+  process_matrix_capture "$matrix_raw" "$out_dir/guide-command-center.png"
+  sips -g pixelWidth -g pixelHeight \
+    "$out_dir/guide-command-center.png" | tail -2
+
+  if [[ "${GHOSTHUB_DEMO_COMMAND_CENTER_ONLY:-}" == "1" ]]; then
+    echo "captured command-center website asset -> $out_dir"
+    exit 0
+  fi
 fi
 
 prepare_command_tab() {
@@ -343,18 +361,18 @@ prepare_command_tab() {
   if [[ "$select" == "row" ]]; then
     case "$query" in
       fix-reconnect-backoff)
-        demo_input click "32,365"
+        demo_input click "32,310"
         sleep 0.5
-        demo_input click "32,327"
+        demo_input click "32,268"
         sleep 0.5
-        demo_input click "80,258"
+        demo_input click "80,202"
         ;;
       add-session-filters)
-        demo_input click "32,293"
+        demo_input click "32,228"
         sleep 0.5
-        demo_input click "32,252"
+        demo_input click "32,185"
         sleep 0.5
-        demo_input click "80,174"
+        demo_input click "80,115"
         ;;
       docbank-export) demo_input click "80,613" ;;
       release-watch) demo_input click "80,569" ;;
@@ -371,6 +389,8 @@ prepare_command_tab() {
     palette "$query"
   fi
   sleep 3
+  demo_input expect-text "$query"
+  demo_input hide-sidebar
 }
 
 echo "==> guide: six-tab tmux workspace"
@@ -381,9 +401,9 @@ if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
   # agentsview disclosures expanded. Normalize the fresh window to the
   # collapsed state used by the focused tabs-only workflow.
   demo_input frame "110,145,1500,820"
-  demo_input click "32,283"
+  demo_input click "32,225"
   sleep 0.5
-  demo_input click "32,365"
+  demo_input click "32,310"
   sleep 0.5
 fi
 prepare_command_tab "fix-reconnect-backoff" false row
@@ -392,8 +412,12 @@ prepare_command_tab "scratch" true row
 prepare_command_tab "docbank-export" true row
 prepare_command_tab "release-watch" true row
 prepare_command_tab "test-matrix" true row
-demo_input hide-sidebar
-capture_state guide-native-tabs.png
+capture_state guide-native-tabs.png exact
+
+if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" == "1" ]]; then
+  echo "captured native-tabs website asset -> $out_dir"
+  exit 0
+fi
 
 echo "==> guide: passive session activity indicator"
 # Every session above is warm from its earlier attachment. Drive fresh

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -322,9 +322,7 @@ prepare_command_window() {
     palette "$query"
   fi
   sleep 3
-  if [[ "$select" != "none" ]]; then
-    demo_input expect-window-title "$query"
-  fi
+  demo_input expect-window-title "$query"
   demo_input hide-sidebar
 }
 
@@ -397,12 +395,9 @@ echo "==> guide: six-tab tmux workspace"
 demo_input new-window
 sleep 2
 if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
-  # The preceding command-center capture leaves the shared Projects and
-  # agentsview disclosures expanded. Normalize the fresh window to the
-  # collapsed state used by the focused tabs-only workflow.
+  # The Overview captures leave Projects expanded. Collapse it so the first
+  # tab starts from the same sidebar state as the focused tabs-only workflow.
   demo_input frame "110,145,1500,820"
-  demo_input click "32,225"
-  sleep 0.5
   demo_input click "32,310"
   sleep 0.5
 fi

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -323,7 +323,7 @@ prepare_command_window() {
   fi
   sleep 3
   if [[ "$select" != "none" ]]; then
-    demo_input expect-text "$query"
+    demo_input expect-window-title "$query"
   fi
   demo_input hide-sidebar
 }
@@ -389,7 +389,7 @@ prepare_command_tab() {
     palette "$query"
   fi
   sleep 3
-  demo_input expect-text "$query"
+  demo_input expect-window-title "$query"
   demo_input hide-sidebar
 }
 


### PR DESCRIPTION
Herdr changed the deterministic sidebar geometry, and the published command-center image consequently showed a blank overlapping scene with repeated sidebars. The product overview should show a credible terminal fleet instead of exposing capture drift.

- Uses a clearer four-session 2×2 command center with every sidebar closed.
- Verifies the intended session before capture so row drift fails instead of publishing a blank window.
- Captures native tabs from the exact active window, removing stale-window overlays; refreshed binaries are published on `website-assets`.

The isolated macOS captures were generated and visually inspected. All 41 demo-script tests, 16 website tests, Astro checks, and the production website build pass.