### PR TITLE
Add native Zellij session support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ This document is the foundational mandate for AI agents (Gemini, Codex, etc.) wo
 
 ## Core Mental Model
 
-Ghosthub is a **native terminal for local and remote tmux and Herdr fleets** on
-macOS. It gives equal status to three ways of working:
+Ghosthub is a **native terminal for local and remote tmux, Herdr, and Zellij
+fleets** on macOS. It gives equal status to four ways of working:
 
 - Create or attach to any tmux session on a configured host.
 - Create, attach to, stop, restart, or delete Herdr sessions on a supported host.
+- Create, attach to, or kill active Zellij sessions on a supported host.
 - Create tmux sessions bound to git worktrees and manage the worktree lifecycle,
   including imports from branches and GitHub pull requests.
 
@@ -17,8 +18,8 @@ Worktrees are optional; Ghosthub remains fully useful without them.
 - **Hosts:** Every machine is a Host. The local Mac is the default host. Remote machines (macOS/Linux) are added via SSH.
 - **Projects:** A Project is a git repository reported by kwt on a specific Host.
 - **Worktrees:** Projects contain kwt workspaces (standard checkouts or linked git worktrees), each with an exact tmux session name.
-- **Sessions:** Worktree sessions and otherwise-unbound tmux sessions open through an ordinary tmux client. Running and stopped Herdr sessions are host inventory; opening a running session attaches, while creating or restarting uses Herdr's launch path. Each backend owns its windows, tabs, panes, layout, history, key bindings, and process lifetime.
-- **Attachment:** Each scene presents at most one native tmux or Herdr client. Ghosthub owns discovery, local/SSH client presentation, keepalives, and reconnect. Closing a presentation detaches. Tmux destruction requires the explicit, confirmed Kill Session action. Herdr Stop and Delete are separate confirmed actions; Restart and Create are constructive actions.
+- **Sessions:** Worktree sessions and otherwise-unbound tmux sessions open through an ordinary tmux client. Running and stopped Herdr sessions are host inventory; opening a running session attaches, while creating or restarting uses Herdr's launch path. Active Zellij sessions are separate host inventory and open through an ordinary Zellij client. Each backend owns its windows, tabs, panes, layout, history, key bindings, and process lifetime.
+- **Attachment:** Each scene presents at most one native tmux, Herdr, or Zellij client. Ghosthub owns discovery, local/SSH client presentation, keepalives, and reconnect. Closing a presentation detaches. Tmux and Zellij destruction require explicit, confirmed Kill Session actions. Herdr Stop and Delete are separate confirmed actions; Restart and Create are constructive actions.
 - **Middleman:** Sessions created by Middleman remain discoverable because they are ordinary sessions on a host tmux server. Ghosthub does not use Middleman as session authority.
 - **Console Panel:** A host-scoped persistent terminal area (e.g., for `roborev`) that is independent of the active worktree.
 
@@ -30,7 +31,9 @@ layer, as subject to direct iteration.
   every otherwise-unbound session on each configured host. Herdr's
   machine-readable session list independently supplies running and stopped Herdr sessions
   on the local Mac and remote POSIX hosts; a missing Herdr installation is
-  normal and silent.
+  normal and silent. Zellij's session list independently supplies active
+  Zellij sessions on those hosts; exited/resurrectable sessions are excluded,
+  and a missing Zellij installation is also normal and silent.
 - Packaged builds invoke their revision-pinned bundled kwt for local operations.
   Configured remote macOS and Linux hosts automatically install or update
   Ghosthub's matching revision-pinned managed helper under `~/.ghosthub/`.
@@ -49,6 +52,15 @@ layer, as subject to direct iteration.
   focused pane and owns the resulting layout. Ghosthub never otherwise manages
   Herdr themes, workspaces, tabs, panes, agents, plugins, installation, updates,
   configuration, or server-wide state.
+- Ghosthub never reconstructs Zellij tabs, panes, layout, history, or terminal
+  output in Swift and never offers resurrection or deletion of exited Zellij
+  sessions. Whole-session create, attach, and confirmed kill are the only
+  Zellij lifecycle controls. Zellij has no atomic active-only attach command,
+  so an upstream attach may resurrect a session that exits after Ghosthub's
+  final active-state probe; this narrow race is documented, and confirmed
+  kills fence Ghosthub reconnects across scenes. Ghosthub does not manage
+  Zellij themes, plugins, installation, updates, configuration, or server-wide
+  state.
 - Ghosthub has no Middleman runtime or API dependency.
 
 ## Source of Truth Hierarchy
@@ -81,7 +93,7 @@ layer, as subject to direct iteration.
 - Never amend commits.
 - Do not leave the app build broken at the end of a turn.
 - If a turn touches Swift app code, terminal integration, `Package.swift`, or bootstrap logic, `make build` must pass before the turn is done.
-- If a turn changes kwt inventory, host resolution, tmux or Herdr discovery,
+- If a turn changes kwt inventory, host resolution, tmux, Herdr, or Zellij discovery,
   or native session attachment, run `make test-essential-workflows` before claiming the
   change is correct.
 - If a turn touches release packaging, signing, notarization, or `.github/workflows/release.yml`, update `docs/release.md` in the same turn.
@@ -242,7 +254,7 @@ Use non-interactive shell flags so agents do not hang on prompts: `cp -f`,
 - `Sources/`: Swift app modules (`GhosthubApp`, `GhosthubUI`,
   `GhosthubWorkspace`, `GhosthubSettings`, `GhosthubTerminal`,
   `GhosthubTerminalSupport`, `GhosthubPersistence`, `GhosthubTransport`,
-  `GhosthubTmux`, `GhosthubHerdr`).
+  `GhosthubTmux`, `GhosthubHerdr`, `GhosthubZellij`).
 - `Sources/App/`: Main macOS app logic and UI.
 - `Sources/UI/`: Reusable SwiftUI/AppKit presentation components.
 - `Sources/Workspace/`: Pure workspace, host, project, worktree, and session models.
@@ -253,6 +265,7 @@ Use non-interactive shell flags so agents do not hang on prompts: `cp -f`,
 - `Sources/Transport/`: Shared local/SSH command routing and shell helpers.
 - `Sources/Tmux/`: Native tmux attachment command model.
 - `Sources/Herdr/`: Native Herdr discovery and attachment command model.
+- `Sources/Zellij/`: Native Zellij discovery and attachment command model.
 - `tools/`: Python-based build, bootstrap (including `libghostty`), and
   packaging automation.
 - `Tests/`: Swift and Python test suites. Python tests are in `Tests/test_*.py`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ test, and documentation-only changes are omitted.
 - exe.dev accounts can limit discovery to VMs carrying specific exe.dev tags,
   so a fleet of dozens of VMs shows only the ones you work in.
 
+- Zellij joins Ghosthub's all-multiplexer fleet as a first-class peer on the
+  local Mac and remote macOS and Linux hosts. Ghosthub discovers active
+  sessions, creates or attaches through the ordinary Zellij client, reconnects
+  remote attachments after transport loss, and provides a confirmed Kill
+  Session action without exposing resurrection or pane management.
+
 ## [0.7.0] - 2026-08-09
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -85,6 +85,13 @@ var targets: [Target] = [
         path: "Sources/Herdr"
     ),
     .target(
+        name: "GhosthubZellij",
+        dependencies: [
+            "GhosthubTransport",
+        ],
+        path: "Sources/Zellij"
+    ),
+    .target(
         name: "GhosthubWorkspace",
         path: "Sources/Workspace"
     ),
@@ -179,6 +186,7 @@ targets.append(
             "GhosthubPersistence",
             "GhosthubTransport",
             "GhosthubTmux",
+            "GhosthubZellij",
             .product(name: "Sparkle", package: "Sparkle"),
         ],
 
@@ -257,6 +265,7 @@ targets.append(
             "GhosthubTransport",
             "GhosthubUI",
             "GhosthubWorkspace",
+            "GhosthubZellij",
             "GhosthubTestSupport",
         ],
         path: "Tests/App"
@@ -316,6 +325,16 @@ targets.append(
             "GhosthubTmux",
         ],
         path: "Tests/Tmux"
+    )
+)
+targets.append(
+    .testTarget(
+        name: "GhosthubZellijTests",
+        dependencies: [
+            "GhosthubTransport",
+            "GhosthubZellij",
+        ],
+        path: "Tests/Zellij"
     )
 )
 if hasBootstrappedLibghostty {

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 <h1 align="center">Ghosthub</h1>
 
 <p align="center">
-  <strong>A multiplexer-native power terminal for your fleet.</strong>
+  <strong>All your multiplexers. One native terminal.</strong>
   <br>
-  Create or attach to tmux and Herdr sessions across your Mac and SSH hosts, or
-  manage tmux-backed worktrees from Git branches and GitHub pull requests.
+  Ghosthub is multiplexer-native across your Mac and SSH hosts. Today it supports
+  tmux, Herdr, and Zellij, plus optional tmux-backed worktrees.
 </p>
 
 <p align="center">
@@ -39,15 +39,21 @@
   <img
     src="https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/hero.png?asset=hero"
     width="960"
-    alt="Ghosthub showing local and remote tmux sessions, Herdr sessions, and tmux-backed worktrees in its sidebar"
+    alt="Ghosthub showing local and remote tmux, Herdr, and Zellij sessions alongside tmux-backed worktrees"
   >
 </p>
 
-Ghosthub creates and attaches to ordinary tmux and Herdr sessions across your
-Mac and SSH hosts. Both can run side by side without Git setup. Each
+Ghosthub creates and attaches to ordinary tmux, Herdr, and Zellij sessions across your
+Mac and SSH hosts. All three can run side by side without Git setup. Each
 multiplexer continues to own its panes, layout, history, key bindings, and
 processes while Ghosthub provides native presentation, keepalives, and
 reconnect.
+
+The integration model is deliberately open-ended. Ghosthub is built to bring
+all multiplexers into one fleet without forcing them into a tmux-shaped
+abstraction—including the [terminal multiplexer Superlogical is
+building](https://www.superlogical.com/) when a public integration surface is
+available.
 
 Ghosthub also manages tmux sessions bound to Git worktrees. Register a
 repository, then continue a local or remote branch, create a branch, or import
@@ -64,17 +70,17 @@ we will do our best to fix them.
 
 ## Highlights
 
-- **Tmux and Herdr, together.** Create or attach to sessions on local and remote
-  hosts, including sessions created outside Ghosthub. No Git project or
-  worktree is required.
+- **All multiplexers, one fleet.** Create or attach to tmux, Herdr, and Zellij
+  sessions on local and remote hosts, including sessions created outside
+  Ghosthub. No Git project or worktree is required.
 - **Managed worktree sessions.** Register an existing checkout, continue a
   local or remote branch, create a branch, import a GitHub pull request, and
   remove a linked worktree through the bundled [kwt](https://kwt.sh)
   helper. No system kwt installation is required.
 - **Resilient SSH.** Keepalives and automatic reconnect preserve remote
   presentations through ordinary network interruptions.
-- **Deliberate session lifecycle.** Closing a presentation detaches. Tmux Kill
-  is confirmed, while Herdr exposes separate Stop, Restart, and Delete actions
+- **Deliberate session lifecycle.** Closing a presentation detaches. Tmux and
+  Zellij Kill are confirmed, while Herdr exposes separate Stop, Restart, and Delete actions
   that preserve each backend's ownership boundaries.
 - **Experimental native Windows hosts.** Connect to OpenSSH hosts running
   PowerShell and [psmux](https://github.com/marlocarlo/psmux), with managed
@@ -96,8 +102,9 @@ Ghosthub requires:
 - macOS 26 (Tahoe) or newer
 - tmux 3.2 or newer for tmux sessions
 - Herdr 0.8.0 or newer for Herdr sessions
+- Zellij 0.44 or newer for Zellij sessions
 
-Use either multiplexer or both. Cmd-D and Cmd-Shift-D pane splitting requires
+Use any supported multiplexer independently or together. Cmd-D and Cmd-Shift-D pane splitting requires
 tmux 3.4 or newer or Herdr 0.8.0 or newer on the attached session. With older
 versions, use the multiplexer's normal pane-splitting keys.
 
@@ -121,7 +128,13 @@ Install tmux locally if needed:
 brew install tmux
 ```
 
-Remote macOS and Linux hosts need tmux. Every remote host needs
+Install Zellij locally if needed:
+
+```sh
+brew install zellij
+```
+
+Remote macOS and Linux hosts need the multiplexer you plan to use. Every remote host needs
 non-interactive SSH authentication backed by a key or SSH agent; password-only
 hosts cannot populate the sidebar.
 

--- a/Sources/App/AccountCommandRunner.swift
+++ b/Sources/App/AccountCommandRunner.swift
@@ -3,6 +3,7 @@ import Foundation
 import GhosthubHerdr
 import GhosthubTmux
 import GhosthubTransport
+import GhosthubZellij
 
 struct AccountCommandOutput: Equatable, Sendable {
     var status: Int32
@@ -424,6 +425,7 @@ struct AccountCommandRunner: Sendable {
             $0.key != "TMUX"
                 && $0.key != "TMUX_PANE"
                 && !HerdrEnvironment.controlVariables.contains($0.key)
+                && !ZellijEnvironment.controlVariables.contains($0.key)
         }
     }
 

--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -481,6 +481,7 @@ struct GhosthubApp: App {
                 invoke(.commandPalette)
             }
             .keyboardShortcut(shortcut(.commandPalette))
+            .disabled(focusedSceneModel == nil)
 
             Divider()
 

--- a/Sources/App/BorrowedZellijSessionView.swift
+++ b/Sources/App/BorrowedZellijSessionView.swift
@@ -4,14 +4,48 @@ import SwiftUI
 
 struct BorrowedZellijSessionView: View {
     var handle: BorrowedZellijSessionHandle
+    var hostName: String
     var isRemoteHost: Bool
     var connectionState: ConnectionState?
+    var recoveryState: NativeSessionRecoveryState?
     var attachmentClosure: BorrowedZellijAttachmentClosure?
     var defersTerminalResize: Bool
     var surface: () -> TerminalSurfaceView?
     var onCloseRequest: () -> Void
     var onRetryRequest: () -> Void
+    var onReconnectNow: () -> Void
+    var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
+
+    init(
+        handle: BorrowedZellijSessionHandle,
+        hostName: String,
+        isRemoteHost: Bool,
+        connectionState: ConnectionState?,
+        recoveryState: NativeSessionRecoveryState? = nil,
+        attachmentClosure: BorrowedZellijAttachmentClosure? = nil,
+        defersTerminalResize: Bool = false,
+        surface: @escaping () -> TerminalSurfaceView?,
+        onCloseRequest: @escaping () -> Void,
+        onRetryRequest: @escaping () -> Void,
+        onReconnectNow: @escaping () -> Void = {},
+        onReviewConnection: @escaping () -> Void = {},
+        onHostSettingsRequest: @escaping () -> Void
+    ) {
+        self.handle = handle
+        self.hostName = hostName
+        self.isRemoteHost = isRemoteHost
+        self.connectionState = connectionState
+        self.recoveryState = recoveryState
+        self.attachmentClosure = attachmentClosure
+        self.defersTerminalResize = defersTerminalResize
+        self.surface = surface
+        self.onCloseRequest = onCloseRequest
+        self.onRetryRequest = onRetryRequest
+        self.onReconnectNow = onReconnectNow
+        self.onReviewConnection = onReviewConnection
+        self.onHostSettingsRequest = onHostSettingsRequest
+    }
 
     var body: some View {
         if let surfaceView = surface() {
@@ -20,6 +54,29 @@ struct BorrowedZellijSessionView: View {
                 defersTerminalResize: defersTerminalResize,
                 onCloseRequest: onCloseRequest
             )
+        } else if recoveryState != nil {
+            ContentUnavailableView {
+                Label(recoveryTitle, systemImage: "network.slash")
+            } description: {
+                VStack(spacing: 10) {
+                    if showsReconnectProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(recoveryMessage)
+                        .multilineTextAlignment(.center)
+                }
+            } actions: {
+                if primaryRecoveryActionTitle != nil {
+                    Button("Reconnect Now", action: onReconnectNow)
+                }
+                if showsReviewConnection {
+                    Button("Review Connection", action: onReviewConnection)
+                }
+                if showsHostSettingsAction {
+                    Button("Host Settings", action: onHostSettingsRequest)
+                }
+            }
         } else if let disconnectionReason {
             ContentUnavailableView {
                 Label(
@@ -36,7 +93,7 @@ struct BorrowedZellijSessionView: View {
                     attachmentClosure == .detached ? "Reconnect" : "Retry",
                     action: onRetryRequest
                 )
-                if isRemoteHost, attachmentClosure != .detached {
+                if showsHostSettingsAction {
                     Button("Host Settings", action: onHostSettingsRequest)
                 }
             }
@@ -44,6 +101,45 @@ struct BorrowedZellijSessionView: View {
             ProgressView("Opening \(handle.name)…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    var recoveryTitle: String {
+        switch recoveryState {
+        case .reconnecting:
+            "Connection interrupted"
+        case .needsAttention:
+            "Connection needs attention"
+        case nil:
+            attachmentClosure == .detached
+                ? "Attachment closed" : "Unable to attach"
+        }
+    }
+
+    var recoveryMessage: String {
+        switch recoveryState {
+        case let .reconnecting(message), let .needsAttention(message, _):
+            message
+        case nil:
+            disconnectionReason ?? "The Zellij session disconnected."
+        }
+    }
+
+    var showsReconnectProgress: Bool {
+        recoveryState?.isReconnecting == true
+    }
+
+    var primaryRecoveryActionTitle: String? {
+        recoveryState?.allowsReconnectNow == true ? "Reconnect Now" : nil
+    }
+
+    var showsReviewConnection: Bool {
+        guard case let .needsAttention(_, canReviewConnection) = recoveryState
+        else { return false }
+        return canReviewConnection
+    }
+
+    var showsHostSettingsAction: Bool {
+        isRemoteHost && attachmentClosure != .detached
     }
 
     private var disconnectionReason: String? {

--- a/Sources/App/BorrowedZellijSessionView.swift
+++ b/Sources/App/BorrowedZellijSessionView.swift
@@ -1,0 +1,88 @@
+import GhosthubTerminal
+import GhosthubTransport
+import SwiftUI
+
+struct BorrowedZellijSessionView: View {
+    var handle: BorrowedZellijSessionHandle
+    var isRemoteHost: Bool
+    var connectionState: ConnectionState?
+    var attachmentClosure: BorrowedZellijAttachmentClosure?
+    var defersTerminalResize: Bool
+    var surface: () -> TerminalSurfaceView?
+    var onCloseRequest: () -> Void
+    var onRetryRequest: () -> Void
+    var onHostSettingsRequest: () -> Void
+
+    var body: some View {
+        if let surfaceView = surface() {
+            NativeZellijTerminalView(
+                surfaceView: surfaceView,
+                defersTerminalResize: defersTerminalResize,
+                onCloseRequest: onCloseRequest
+            )
+        } else if let disconnectionReason {
+            ContentUnavailableView {
+                Label(
+                    attachmentClosure == .detached
+                        ? "Attachment closed" : "Unable to attach",
+                    systemImage: attachmentClosure == .detached
+                        ? "rectangle.portrait.and.arrow.right"
+                        : "network.slash"
+                )
+            } description: {
+                Text(disconnectionReason)
+            } actions: {
+                Button(
+                    attachmentClosure == .detached ? "Reconnect" : "Retry",
+                    action: onRetryRequest
+                )
+                if isRemoteHost, attachmentClosure != .detached {
+                    Button("Host Settings", action: onHostSettingsRequest)
+                }
+            }
+        } else {
+            ProgressView("Opening \(handle.name)…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var disconnectionReason: String? {
+        guard case let .disconnected(reason) = connectionState else {
+            return nil
+        }
+        return reason ?? "The Zellij session disconnected."
+    }
+}
+
+private struct NativeZellijTerminalView: View {
+    @ObservedObject var surfaceView: TerminalSurfaceView
+    var defersTerminalResize: Bool
+    var onCloseRequest: () -> Void
+    @State private var observerID = UUID()
+
+    var body: some View {
+        TerminalSurfaceSwiftUIView(
+            surfaceView: surfaceView,
+            defersSurfaceResize: defersTerminalResize
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+        .onAppear {
+            surfaceView.registerPaneCloseRequestObserver(
+                id: observerID,
+                onCloseRequest: onCloseRequest
+            )
+            surfaceView.suppressAutoFocus = false
+            DispatchQueue.main.async { [surfaceView] in
+                surfaceView.requestKeyboardFocus()
+            }
+        }
+        .onDisappear {
+            surfaceView.unregisterPaneFocusObserver(id: observerID)
+        }
+        .focusedSceneValue(
+            \.terminalHasEffectiveKeyboardFocus,
+            surfaceView.hasEffectiveKeyboardFocus
+        )
+    }
+}

--- a/Sources/App/ConfiguredHostOverlay.swift
+++ b/Sources/App/ConfiguredHostOverlay.swift
@@ -91,11 +91,15 @@ enum ConfiguredHostOverlay {
             if invalidatedHostIDs.contains(host.id) {
                 host.tmuxSessions = []
                 host.herdrSessions = []
+                host.zellijSessions = []
                 host.herdrAvailable = false
+                host.zellijAvailable = false
             }
             if host.platform == .windows {
                 host.herdrSessions = []
+                host.zellijSessions = []
                 host.herdrAvailable = false
+                host.zellijAvailable = false
             }
             hosts.append(host)
         }

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -753,7 +753,9 @@ enum HostInventoryOverlay {
         kwtAvailabilityByHost: [UUID: Bool] = [:],
         tmuxSessionsByHost: [UUID: [TmuxSessionSummary]],
         herdrSessionsByHost: [UUID: [HerdrSessionSummary]] = [:],
+        zellijSessionsByHost: [UUID: [ZellijSessionSummary]] = [:],
         herdrAvailabilityByHost: [UUID: Bool] = [:],
+        zellijAvailabilityByHost: [UUID: Bool] = [:],
         tmuxReachabilityByHost: [UUID: Bool] = [:],
         tmuxLastSeenByHost: [UUID: Date] = [:],
         to source: WorkspaceSnapshot
@@ -769,7 +771,9 @@ enum HostInventoryOverlay {
             kwtAvailabilityByHost: kwtAvailabilityByHost,
             tmuxSessionsByHost: tmuxSessionsByHost,
             herdrSessionsByHost: herdrSessionsByHost,
+            zellijSessionsByHost: zellijSessionsByHost,
             herdrAvailabilityByHost: herdrAvailabilityByHost,
+            zellijAvailabilityByHost: zellijAvailabilityByHost,
             tmuxReachabilityByHost: tmuxReachabilityByHost,
             tmuxLastSeenByHost: tmuxLastSeenByHost,
             to: updated
@@ -779,7 +783,9 @@ enum HostInventoryOverlay {
     static func applyRuntimeSessions(
         tmuxSessionsByHost: [UUID: [TmuxSessionSummary]],
         herdrSessionsByHost: [UUID: [HerdrSessionSummary]] = [:],
+        zellijSessionsByHost: [UUID: [ZellijSessionSummary]] = [:],
         herdrAvailabilityByHost: [UUID: Bool] = [:],
+        zellijAvailabilityByHost: [UUID: Bool] = [:],
         tmuxReachabilityByHost: [UUID: Bool] = [:],
         tmuxLastSeenByHost: [UUID: Date] = [:],
         to source: WorkspaceSnapshot
@@ -788,7 +794,9 @@ enum HostInventoryOverlay {
             kwtAvailabilityByHost: [:],
             tmuxSessionsByHost: tmuxSessionsByHost,
             herdrSessionsByHost: herdrSessionsByHost,
+            zellijSessionsByHost: zellijSessionsByHost,
             herdrAvailabilityByHost: herdrAvailabilityByHost,
+            zellijAvailabilityByHost: zellijAvailabilityByHost,
             tmuxReachabilityByHost: tmuxReachabilityByHost,
             tmuxLastSeenByHost: tmuxLastSeenByHost,
             to: source
@@ -799,7 +807,9 @@ enum HostInventoryOverlay {
         kwtAvailabilityByHost: [UUID: Bool],
         tmuxSessionsByHost: [UUID: [TmuxSessionSummary]],
         herdrSessionsByHost: [UUID: [HerdrSessionSummary]],
+        zellijSessionsByHost: [UUID: [ZellijSessionSummary]],
         herdrAvailabilityByHost: [UUID: Bool],
+        zellijAvailabilityByHost: [UUID: Bool],
         tmuxReachabilityByHost: [UUID: Bool],
         tmuxLastSeenByHost: [UUID: Date],
         to source: WorkspaceSnapshot
@@ -817,11 +827,23 @@ enum HostInventoryOverlay {
             }) else { continue }
             updated.hosts[index].herdrSessions = sessions
         }
+        for (hostID, sessions) in zellijSessionsByHost {
+            guard let index = updated.hosts.firstIndex(where: {
+                $0.id == hostID
+            }) else { continue }
+            updated.hosts[index].zellijSessions = sessions
+        }
         for (hostID, isAvailable) in herdrAvailabilityByHost {
             guard let index = updated.hosts.firstIndex(where: {
                 $0.id == hostID
             }) else { continue }
             updated.hosts[index].herdrAvailable = isAvailable
+        }
+        for (hostID, isAvailable) in zellijAvailabilityByHost {
+            guard let index = updated.hosts.firstIndex(where: {
+                $0.id == hostID
+            }) else { continue }
+            updated.hosts[index].zellijAvailable = isAvailable
         }
         for (hostID, isAvailable) in kwtAvailabilityByHost {
             guard let index = updated.hosts.firstIndex(where: {

--- a/Sources/App/NativeZellijSessionCoordinator.swift
+++ b/Sources/App/NativeZellijSessionCoordinator.swift
@@ -1,0 +1,422 @@
+import Foundation
+import GhosthubTerminal
+import GhosthubTerminalSupport
+import GhosthubTransport
+import GhosthubWorkspace
+import GhosthubZellij
+
+struct BorrowedZellijSessionHandle: Equatable, Sendable {
+    var id: UUID
+    var hostID: UUID
+    var name: String
+    var surfaceID: UUID
+}
+
+enum BorrowedZellijAttachmentClosure: Equatable {
+    case detached
+    case processExited(code: UInt32?)
+    case launchFailed
+}
+
+private struct NativeZellijSessionKey: Hashable {
+    var hostID: UUID
+    var name: String
+}
+
+private struct NativeZellijAttachment {
+    var id: UUID
+    var host: CommandHost
+    var zellijPath: String
+    var launchMode: ZellijAttachmentLaunchMode
+    var sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
+    var remoteExitStatusURL: URL?
+}
+
+/// Hosts disposable Zellij clients. Zellij owns the server, processes, tabs,
+/// panes, layout, history, and keybindings; this coordinator owns presentation.
+@MainActor
+final class NativeZellijSessionCoordinator {
+    private let terminalCoordinator: any NativeSessionSurfaceStoring
+    private let zellijPathProvider:
+        @Sendable (CommandHost, [String]) -> Result<String, ZellijCommandError>
+    private let sshConnectionArgumentsProvider:
+        @Sendable (SSHHostInfo) -> SSHConnectionArgumentsSnapshot
+    private let remoteExitStatusStore: RemoteExitStatusStore
+    private var handlesByKey: [
+        NativeZellijSessionKey: BorrowedZellijSessionHandle
+    ] = [:]
+    private var targetHostsByHandle: [UUID: CommandHost] = [:]
+    private var attachments: [UUID: NativeZellijAttachment] = [:]
+    private var attachmentClosures: [
+        UUID: BorrowedZellijAttachmentClosure
+    ] = [:]
+    private var launchedHandles: Set<UUID> = []
+    private var reportedConnectedAttachmentIDs: [UUID: UUID] = [:]
+    private var provisioningTasks: [UUID: Task<Void, Never>] = [:]
+    private var isShuttingDown = false
+
+    var onStateChanged: ((BorrowedZellijSessionHandle, ConnectionState) -> Void)?
+    var onSurfaceReady: ((BorrowedZellijSessionHandle) -> Void)?
+
+    init(
+        terminalCoordinator: any NativeSessionSurfaceStoring,
+        zellijPathProvider: @escaping @Sendable (CommandHost, [String])
+            -> Result<String, ZellijCommandError> = {
+                ZellijInventoryClient().resolveExecutable(
+                    on: $0,
+                    sshConnectionArguments: $1
+                )
+            },
+        sshConnectionArgumentsProvider:
+        @escaping @Sendable (SSHHostInfo)
+            -> SSHConnectionArgumentsSnapshot = {
+                SSHCommandArguments.connectionSnapshot(for: $0)
+            },
+        remoteExitStatusDirectory: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ghosthub-zellij-exit-\(UUID().uuidString)",
+                isDirectory: true
+            )
+    ) {
+        self.terminalCoordinator = terminalCoordinator
+        self.zellijPathProvider = zellijPathProvider
+        self.sshConnectionArgumentsProvider = sshConnectionArgumentsProvider
+        remoteExitStatusStore = RemoteExitStatusStore(
+            directory: remoteExitStatusDirectory
+        )
+    }
+
+    func attach(
+        hostID: UUID,
+        name: String,
+        host: CommandHost,
+        launchMode: ZellijAttachmentLaunchMode = .attachExisting,
+        sshConnectionSnapshot: SSHConnectionArgumentsSnapshot? = nil
+    ) -> BorrowedZellijSessionHandle {
+        let key = NativeZellijSessionKey(hostID: hostID, name: name)
+        if let existing = handlesByKey[key],
+           targetHostsByHandle[existing.id] != host {
+            removeHandle(existing, for: key)
+        }
+        let handle = handlesByKey[key]
+            ?? BorrowedZellijSessionHandle(
+                id: UUID(),
+                hostID: hostID,
+                name: name,
+                surfaceID: UUID()
+            )
+        handlesByKey[key] = handle
+        targetHostsByHandle[handle.id] = host
+        attachmentClosures.removeValue(forKey: handle.id)
+        guard !isShuttingDown,
+              attachments[handle.id] == nil,
+              provisioningTasks[handle.id] == nil
+        else { return handle }
+
+        onStateChanged?(handle, .connecting)
+        guard supportsAttachment(on: host) else {
+            onStateChanged?(handle, .disconnected(
+                reason: ZellijCommandError.unsupportedPlatform
+                    .localizedDescription
+            ))
+            return handle
+        }
+
+        let pathProvider = zellijPathProvider
+        let connectionProvider = sshConnectionArgumentsProvider
+        provisioningTasks[handle.id] = Task { [weak self] in
+            let probe = Task.detached(priority: .userInitiated) {
+                let connection: SSHConnectionArgumentsSnapshot
+                if let sshConnectionSnapshot {
+                    connection = sshConnectionSnapshot
+                } else if case let .ssh(info) = host {
+                    connection = connectionProvider(info)
+                } else {
+                    connection = SSHConnectionArgumentsSnapshot(arguments: [])
+                }
+                return (pathProvider(host, connection.arguments), connection)
+            }
+            let (resolution, connection) = await withTaskCancellationHandler {
+                await probe.value
+            } onCancel: {
+                probe.cancel()
+            }
+            self?.finishAttach(
+                handle: handle,
+                host: host,
+                launchMode: launchMode,
+                connection: connection,
+                resolution: resolution
+            )
+        }
+        return handle
+    }
+
+    func retainFailedAttachment(
+        hostID: UUID,
+        name: String,
+        host: CommandHost,
+        reason: String
+    ) -> BorrowedZellijSessionHandle {
+        let key = NativeZellijSessionKey(hostID: hostID, name: name)
+        if let existing = handlesByKey[key],
+           targetHostsByHandle[existing.id] != host {
+            removeHandle(existing, for: key)
+        }
+        let handle = handlesByKey[key]
+            ?? BorrowedZellijSessionHandle(
+                id: UUID(),
+                hostID: hostID,
+                name: name,
+                surfaceID: UUID()
+            )
+        handlesByKey[key] = handle
+        targetHostsByHandle[handle.id] = host
+        attachmentClosures[handle.id] = .launchFailed
+        onStateChanged?(handle, .disconnected(reason: reason))
+        return handle
+    }
+
+    private func finishAttach(
+        handle: BorrowedZellijSessionHandle,
+        host: CommandHost,
+        launchMode: ZellijAttachmentLaunchMode,
+        connection: SSHConnectionArgumentsSnapshot,
+        resolution: Result<String, ZellijCommandError>
+    ) {
+        provisioningTasks.removeValue(forKey: handle.id)
+        let key = sessionKey(handle)
+        guard handlesByKey[key] == handle,
+              targetHostsByHandle[handle.id] == host,
+              attachments[handle.id] == nil
+        else { return }
+        switch resolution {
+        case let .success(path):
+            attachments[handle.id] = NativeZellijAttachment(
+                id: UUID(),
+                host: host,
+                zellijPath: path,
+                launchMode: launchMode,
+                sshConnectionSnapshot: connection,
+                remoteExitStatusURL: host.isRemote
+                    ? remoteExitStatusStore.prepare() : nil
+            )
+            onSurfaceReady?(handle)
+        case let .failure(error):
+            attachmentClosures[handle.id] = .launchFailed
+            onStateChanged?(handle, .disconnected(
+                reason: error.localizedDescription
+            ))
+        }
+    }
+
+    func detach(hostID: UUID, name: String) {
+        let key = NativeZellijSessionKey(hostID: hostID, name: name)
+        guard let handle = handlesByKey.removeValue(forKey: key) else { return }
+        removeHandle(handle, for: key, keyAlreadyRemoved: true)
+    }
+
+    @discardableResult
+    func detachAll(hostID: UUID) -> [BorrowedZellijSessionHandle] {
+        let entries = handlesByKey.filter { $0.key.hostID == hostID }
+        for (key, handle) in entries {
+            removeHandle(handle, for: key)
+        }
+        return entries.map(\.value)
+    }
+
+    private func removeHandle(
+        _ handle: BorrowedZellijSessionHandle,
+        for key: NativeZellijSessionKey,
+        keyAlreadyRemoved: Bool = false
+    ) {
+        if !keyAlreadyRemoved {
+            handlesByKey.removeValue(forKey: key)
+        }
+        provisioningTasks.removeValue(forKey: handle.id)?.cancel()
+        targetHostsByHandle.removeValue(forKey: handle.id)
+        remoteExitStatusStore.remove(
+            attachments.removeValue(forKey: handle.id)?.remoteExitStatusURL
+        )
+        attachmentClosures.removeValue(forKey: handle.id)
+        launchedHandles.remove(handle.id)
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
+        terminalCoordinator.removeSurface(for: surfaceKey(handle))
+    }
+
+    func attachmentClosure(
+        _ handle: BorrowedZellijSessionHandle
+    ) -> BorrowedZellijAttachmentClosure? {
+        attachmentClosures[handle.id]
+    }
+
+    func hasLaunched(_ handle: BorrowedZellijSessionHandle) -> Bool {
+        launchedHandles.contains(handle.id)
+    }
+
+    func attachmentConnectionSnapshot(
+        _ handle: BorrowedZellijSessionHandle
+    ) -> SSHConnectionArgumentsSnapshot? {
+        attachments[handle.id]?.sshConnectionSnapshot
+    }
+
+    func surface(handle: BorrowedZellijSessionHandle) -> TerminalSurfaceView? {
+        guard attachmentClosures[handle.id] == nil,
+              let attachment = attachments[handle.id]
+        else { return nil }
+        let command: String
+        do {
+            command = try ZellijAttachmentInfo(
+                sessionName: handle.name,
+                host: attachment.host
+            ).attachCommand(
+                zellijPath: attachment.zellijPath,
+                launchMode: attachment.launchMode,
+                sshConnectionArguments:
+                attachment.sshConnectionSnapshot.arguments,
+                remoteExitStatusPath: attachment.remoteExitStatusURL?.path
+            )
+        } catch {
+            failSurfaceLaunch(handle, reason: error.localizedDescription)
+            return nil
+        }
+        let surface = terminalCoordinator.paneSurface(
+            for: surfaceKey(handle),
+            configuration: TerminalSurfaceConfiguration(
+                workingDirectory: NSHomeDirectory(),
+                command: command
+            )
+        )
+        guard let surface else {
+            failSurfaceLaunch(
+                handle,
+                reason: "Ghosthub could not create the terminal surface."
+            )
+            return nil
+        }
+        if let error = surface.launchError {
+            failSurfaceLaunch(handle, reason: error.localizedDescription)
+            return nil
+        }
+        surface.blocksClipboardReads = attachment.host.isRemote
+        surface.registerSurfaceCloseObserver(
+            id: handle.id,
+            onSurfaceClosed: { [weak self] processAlive, childExitCode in
+                self?.surfaceDidClose(
+                    handle,
+                    processAlive: processAlive,
+                    childExitCode: childExitCode
+                )
+            }
+        )
+        launchedHandles.insert(handle.id)
+        if reportedConnectedAttachmentIDs[handle.id] != attachment.id {
+            reportedConnectedAttachmentIDs[handle.id] = attachment.id
+            reportSurfaceStateLater(
+                handle,
+                state: .connected,
+                requiredAttachmentID: attachment.id
+            )
+        }
+        return surface as? TerminalSurfaceView
+    }
+
+    private func failSurfaceLaunch(
+        _ handle: BorrowedZellijSessionHandle,
+        reason: String
+    ) {
+        attachmentClosures[handle.id] = .launchFailed
+        remoteExitStatusStore.remove(
+            attachments.removeValue(forKey: handle.id)?.remoteExitStatusURL
+        )
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
+        terminalCoordinator.removeSurface(for: surfaceKey(handle))
+        reportSurfaceStateLater(handle, state: .disconnected(reason: reason))
+    }
+
+    private func reportSurfaceStateLater(
+        _ handle: BorrowedZellijSessionHandle,
+        state: ConnectionState,
+        requiredAttachmentID: UUID? = nil
+    ) {
+        Task { [weak self] in
+            guard let self, !isShuttingDown,
+                  handlesByKey[sessionKey(handle)] == handle
+            else { return }
+            if let requiredAttachmentID {
+                guard attachments[handle.id]?.id == requiredAttachmentID,
+                      launchedHandles.contains(handle.id),
+                      attachmentClosures[handle.id] == nil
+                else { return }
+            }
+            onStateChanged?(handle, state)
+        }
+    }
+
+    private func surfaceDidClose(
+        _ handle: BorrowedZellijSessionHandle,
+        processAlive: Bool,
+        childExitCode: UInt32?
+    ) {
+        guard handlesByKey[sessionKey(handle)] == handle else { return }
+        let attachment = attachments.removeValue(forKey: handle.id)
+        let recordedExitCode = remoteExitStatusStore.consume(
+            attachment?.remoteExitStatusURL
+        )
+        if let recordedExitCode {
+            attachmentClosures[handle.id] = recordedExitCode == 0
+                ? .detached : .processExited(code: recordedExitCode)
+        } else {
+            attachmentClosures[handle.id] = processAlive || childExitCode == 0
+                ? .detached : .processExited(code: childExitCode)
+        }
+        reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
+        terminalCoordinator.removeSurface(for: surfaceKey(handle))
+        onStateChanged?(handle, .disconnected(
+            reason: "The Zellij attachment to “\(handle.name)” closed."
+        ))
+    }
+
+    func shutdown() {
+        isShuttingDown = true
+        let handles = Array(handlesByKey.values)
+        provisioningTasks.values.forEach { $0.cancel() }
+        provisioningTasks.removeAll()
+        handlesByKey.removeAll()
+        targetHostsByHandle.removeAll()
+        for attachment in attachments.values {
+            remoteExitStatusStore.remove(attachment.remoteExitStatusURL)
+        }
+        attachments.removeAll()
+        attachmentClosures.removeAll()
+        launchedHandles.removeAll()
+        reportedConnectedAttachmentIDs.removeAll()
+        for handle in handles {
+            terminalCoordinator.removeSurface(for: surfaceKey(handle))
+        }
+    }
+
+    private func supportsAttachment(on host: CommandHost) -> Bool {
+        switch host {
+        case .local:
+            true
+        case let .ssh(info):
+            info.platform == .posix
+        }
+    }
+
+    private func surfaceKey(_ handle: BorrowedZellijSessionHandle) -> SurfaceKey {
+        SurfaceKey(
+            worktreeID: handle.id,
+            hostID: handle.hostID,
+            target: .zellijSession,
+            leafID: handle.surfaceID
+        )
+    }
+
+    private func sessionKey(
+        _ handle: BorrowedZellijSessionHandle
+    ) -> NativeZellijSessionKey {
+        NativeZellijSessionKey(hostID: handle.hostID, name: handle.name)
+    }
+}

--- a/Sources/App/NativeZellijSessionCoordinator.swift
+++ b/Sources/App/NativeZellijSessionCoordinator.swift
@@ -91,7 +91,8 @@ final class NativeZellijSessionCoordinator {
         name: String,
         host: CommandHost,
         launchMode: ZellijAttachmentLaunchMode = .attachExisting,
-        sshConnectionSnapshot: SSHConnectionArgumentsSnapshot? = nil
+        sshConnectionSnapshot: SSHConnectionArgumentsSnapshot? = nil,
+        resolvedZellijPath: String? = nil
     ) -> BorrowedZellijSessionHandle {
         let key = NativeZellijSessionKey(hostID: hostID, name: name)
         if let existing = handlesByKey[key],
@@ -134,7 +135,9 @@ final class NativeZellijSessionCoordinator {
                 } else {
                     connection = SSHConnectionArgumentsSnapshot(arguments: [])
                 }
-                return (pathProvider(host, connection.arguments), connection)
+                let resolution = resolvedZellijPath.map(Result.success)
+                    ?? pathProvider(host, connection.arguments)
+                return (resolution, connection)
             }
             let (resolution, connection) = await withTaskCancellationHandler {
                 await probe.value

--- a/Sources/App/WorkspaceSceneModel+Selection.swift
+++ b/Sources/App/WorkspaceSceneModel+Selection.swift
@@ -123,6 +123,9 @@ extension WorkspaceSceneModel {
     }
 
     private var activeNavigationTarget: WorkspaceNavigationTarget {
+        if let pending = pendingZellijPresentationSelection {
+            return .zellijSession(hostID: pending.hostID, name: pending.name)
+        }
         if let pending = pendingHerdrShortcutSelection {
             return .herdrSession(
                 hostID: pending.hostID,
@@ -131,6 +134,9 @@ extension WorkspaceSceneModel {
         }
         if let active = activeBorrowedHerdrSelection {
             return .herdrSession(hostID: active.hostID, name: active.name)
+        }
+        if let active = activeBorrowedZellijSelection {
+            return .zellijSession(hostID: active.hostID, name: active.name)
         }
         if let active = activeBorrowedTmuxSelection {
             if let worktreeID = active.worktreeID {

--- a/Sources/App/WorkspaceSceneModel+Selection.swift
+++ b/Sources/App/WorkspaceSceneModel+Selection.swift
@@ -159,7 +159,9 @@ extension WorkspaceSceneModel {
             tmuxSessionOrderRawValue: WorkspaceSidebarOrderStorage
                 .tmuxSessionRawValue(),
             herdrSessionOrderRawValue: WorkspaceSidebarOrderStorage
-                .herdrSessionRawValue()
+                .herdrSessionRawValue(),
+            zellijSessionOrderRawValue: WorkspaceSidebarOrderStorage
+                .zellijSessionRawValue()
         )
     }
 
@@ -238,6 +240,12 @@ extension WorkspaceSceneModel {
                 hostID: hostID,
                 name: name
             ))
+            return true
+        case let .zellijSession(hostID, name):
+            var updated = selection
+            updated.select(target, in: snapshot, visibility: worktreeVisibility)
+            selectFromUser(updated)
+            openBorrowedZellijSession(.init(hostID: hostID, name: name))
             return true
         case .host, .project:
             return false

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3833,6 +3833,12 @@ final class WorkspaceSceneModel: ObservableObject {
             if zellijPresentationIntent?.selection == selection {
                 invalidateZellijPresentationIntent()
             }
+            if let restoration = pendingRestoration?.zellij,
+               let host = snapshot.host(id: selection.hostID),
+               restoration.hostKey == host.configKey,
+               restoration.sessionName == selection.name {
+                cancelPendingRestoration()
+            }
             zellijDiscoveryGeneration += 1
             zellijDiscoveryTask?.cancel()
             zellijDiscoveryTask = nil

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -598,6 +598,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private var zellijKillAuthorities: [UUID: ZellijKillAuthority] = [:]
     private var pendingCreatedZellijSessions:
         [UUID: WorkspaceZellijSessionSelection] = [:]
+    private var failedZellijCreationIntent:
+        WorkspaceZellijSessionSelection?
     var zellijReconnectSupervisorIsRunning: Bool {
         zellijReconnectSupervisor.isRunning
     }
@@ -2323,6 +2325,7 @@ final class WorkspaceSceneModel: ObservableObject {
         cancelZellijReconnect()
         zellijKillAuthorities.removeAll()
         pendingCreatedZellijSessions.removeAll()
+        failedZellijCreationIntent = nil
         suppressedZellijKillPresentations.removeAll()
         activeBorrowedZellijSelection = nil
         activeBorrowedZellijHandle = nil
@@ -3837,6 +3840,9 @@ final class WorkspaceSceneModel: ObservableObject {
             pendingCreatedZellijSessions = pendingCreatedZellijSessions.filter {
                 $0.value != selection
             }
+            if failedZellijCreationIntent == selection {
+                failedZellijCreationIntent = nil
+            }
             if activeBorrowedZellijSelection == selection {
                 closeBorrowedZellijSession(selection)
             }
@@ -5081,6 +5087,9 @@ final class WorkspaceSceneModel: ObservableObject {
            hostIDs.contains(activeZellij.hostID) {
             invalidateZellijPresentationIntent()
             cancelZellijReconnect()
+            if failedZellijCreationIntent == activeZellij {
+                failedZellijCreationIntent = nil
+            }
             activeBorrowedZellijSelection = nil
             activeBorrowedZellijHandle = nil
         }
@@ -6171,6 +6180,16 @@ final class WorkspaceSceneModel: ObservableObject {
         ) else {
             throw ZellijSessionPresentationError.hostChanged(selection.name)
         }
+        publishPendingZellijCreation(handle: handle, selection: selection)
+    }
+
+    private func publishPendingZellijCreation(
+        handle: BorrowedZellijSessionHandle,
+        selection: WorkspaceZellijSessionSelection
+    ) {
+        if failedZellijCreationIntent == selection {
+            failedZellijCreationIntent = nil
+        }
         pendingCreatedZellijSessions[handle.id] = selection
         var sessions = snapshot.host(id: selection.hostID)?.zellijSessions ?? []
         if !sessions.contains(where: { $0.name == selection.name }) {
@@ -6256,6 +6275,9 @@ final class WorkspaceSceneModel: ObservableObject {
         invalidateZellijPresentationIntent()
         guard activeBorrowedZellijSelection == selection else { return }
         cancelZellijReconnect()
+        if failedZellijCreationIntent == selection {
+            failedZellijCreationIntent = nil
+        }
         var wasPendingCreation = false
         if let handle = activeBorrowedZellijHandle {
             wasPendingCreation = pendingCreatedZellijSessions
@@ -6278,11 +6300,15 @@ final class WorkspaceSceneModel: ObservableObject {
         _ selection: WorkspaceZellijSessionSelection
     ) {
         guard activeBorrowedZellijSelection == selection else { return }
-        validateAndPresentZellijSession(selection)
+        validateAndPresentZellijSession(
+            selection,
+            createsSessionIfMissing: failedZellijCreationIntent == selection
+        )
     }
 
     private func validateAndPresentZellijSession(
-        _ selection: WorkspaceZellijSessionSelection
+        _ selection: WorkspaceZellijSessionSelection,
+        createsSessionIfMissing: Bool = false
     ) {
         invalidateZellijPresentationIntent()
         let killKey = ZellijSessionKillCoordinator.Key(
@@ -6336,16 +6362,33 @@ final class WorkspaceSceneModel: ObservableObject {
             }
             let failureReason: String
             switch validation.result {
-            case let .available(names) where names.contains(selection.name):
-                _ = presentZellijSession(
+            case let .available(names):
+                let sessionIsActive = names.contains(selection.name)
+                guard sessionIsActive || createsSessionIfMissing else {
+                    failureReason =
+                        "The Zellij session is no longer running."
+                    break
+                }
+                let launchMode: ZellijAttachmentLaunchMode = sessionIsActive
+                    ? .attachExisting : .create
+                guard launchMode != .create
+                    || failedZellijCreationIntent == selection
+                else { return }
+                guard let handle = presentZellijSession(
                     selection,
-                    launchMode: .attachExisting,
+                    launchMode: launchMode,
                     validation: validation,
                     expectedKillRevision: killRevision
-                )
+                ) else { return }
+                if launchMode == .create {
+                    publishPendingZellijCreation(
+                        handle: handle,
+                        selection: selection
+                    )
+                } else if failedZellijCreationIntent == selection {
+                    failedZellijCreationIntent = nil
+                }
                 return
-            case .available:
-                failureReason = "The Zellij session is no longer running."
             case .unavailable:
                 failureReason = ZellijCommandError.unavailable
                     .localizedDescription
@@ -8206,6 +8249,10 @@ final class WorkspaceSceneModel: ObservableObject {
         case .connected:
             zellijReconnectSupervisor.cancel()
             activeBorrowedZellijRecoveryState = nil
+            if failedZellijCreationIntent
+                == activeBorrowedZellijSelection {
+                failedZellijCreationIntent = nil
+            }
             if var context = activeZellijReconnectContext,
                context.handleID == handle.id {
                 context.connection = nativeZellijSessionCoordinator
@@ -8219,6 +8266,7 @@ final class WorkspaceSceneModel: ObservableObject {
             guard nativeZellijSessionCoordinator.hasLaunched(handle) else {
                 if let selection = pendingCreatedZellijSessions
                     .removeValue(forKey: handle.id) {
+                    failedZellijCreationIntent = selection
                     zellijSessionsByHost[selection.hostID] = snapshot
                         .host(id: selection.hostID)?
                         .zellijSessions.filter {
@@ -8244,7 +8292,10 @@ final class WorkspaceSceneModel: ObservableObject {
                       context.host.isRemote,
                       code == 255
                 else {
-                    pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+                    if let selection = pendingCreatedZellijSessions
+                        .removeValue(forKey: handle.id) {
+                        failedZellijCreationIntent = selection
+                    }
                     zellijReconnectSupervisor.cancel()
                     activeBorrowedZellijRecoveryState = nil
                     scheduleZellijSessionDiscovery()
@@ -8254,7 +8305,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 activeZellijReconnectContext = context
                 startZellijReconnect(context)
             case .launchFailed, nil:
-                pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+                if let selection = pendingCreatedZellijSessions
+                    .removeValue(forKey: handle.id) {
+                    failedZellijCreationIntent = selection
+                }
                 zellijReconnectSupervisor.cancel()
                 activeBorrowedZellijRecoveryState = nil
                 scheduleZellijSessionDiscovery()
@@ -8378,9 +8432,11 @@ final class WorkspaceSceneModel: ObservableObject {
         switch result {
         case let .available(names):
             guard names.contains(context.selection.name) else {
-                pendingCreatedZellijSessions.removeValue(
+                if let selection = pendingCreatedZellijSessions.removeValue(
                     forKey: context.handleID
-                )
+                ) {
+                    failedZellijCreationIntent = selection
+                }
                 stopZellijReconnect(
                     "The Zellij session is no longer running."
                 )
@@ -8477,6 +8533,7 @@ final class WorkspaceSceneModel: ObservableObject {
         if let selection = pendingCreatedZellijSessions.removeValue(
             forKey: handle.id
         ) {
+            failedZellijCreationIntent = selection
             zellijSessionsByHost[selection.hostID] = snapshot
                 .host(id: selection.hostID)?
                 .zellijSessions.filter { $0.name != selection.name } ?? []

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -546,6 +546,10 @@ final class WorkspaceSceneModel: ObservableObject {
     }
     private var zellijPresentationIntent: ZellijPresentationIntent?
     private var zellijPresentationRevision: UInt64 = 0
+    var pendingZellijPresentationSelection:
+        WorkspaceZellijSessionSelection? {
+        zellijPresentationIntent?.selection
+    }
     private struct SuppressedZellijKillPresentation {
         var selection: WorkspaceZellijSessionSelection
         var navigationRevision: UInt64
@@ -1866,9 +1870,12 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func synchronizeSelection(_ newSelection: WorkspaceSelection) {
         guard newSelection != selection else { return }
-        userNavigationRevision &+= 1
         invalidateZellijPresentationIntent()
         selection = newSelection
+    }
+
+    func cancelPendingZellijPresentation() {
+        invalidateZellijPresentationIntent()
     }
 
     private func invalidateZellijPresentationIntent() {
@@ -6329,11 +6336,7 @@ final class WorkspaceSceneModel: ObservableObject {
         else {
             throw ZellijSessionPresentationError.hostChanged(selection.name)
         }
-        guard case let .available(names) = result,
-              names.contains(selection.name)
-        else {
-            throw ZellijSessionPresentationError.sessionMissing(selection.name)
-        }
+        try requireActiveZellijSession(selection.name, in: result)
         let authorityID = UUID()
         zellijKillAuthorities[authorityID] = ZellijKillAuthority(
             hostID: selection.hostID,
@@ -6408,11 +6411,7 @@ final class WorkspaceSceneModel: ObservableObject {
         else {
             throw ZellijSessionPresentationError.hostChanged(selection.name)
         }
-        guard case let .available(names) = result,
-              names.contains(selection.name)
-        else {
-            throw ZellijSessionPresentationError.sessionMissing(selection.name)
-        }
+        try requireActiveZellijSession(selection.name, in: result)
         let killResult = await zellijSessionKiller(
             selection.name,
             postDiscoveryHost,
@@ -6430,6 +6429,22 @@ final class WorkspaceSceneModel: ObservableObject {
         _ request: ZellijSessionKillRequest
     ) {
         zellijKillAuthorities.removeValue(forKey: request.authorityID)
+    }
+
+    private func requireActiveZellijSession(
+        _ name: String,
+        in result: ZellijDiscoveryResult
+    ) throws {
+        switch result {
+        case let .available(names):
+            guard names.contains(name) else {
+                throw ZellijSessionPresentationError.sessionMissing(name)
+            }
+        case .unavailable:
+            throw ZellijSessionPresentationError.unavailable
+        case let .failure(error):
+            throw error
+        }
     }
 
     private func zellijConnectionSnapshot(
@@ -8231,7 +8246,9 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             scheduleZellijSessionDiscovery()
             return .stop
-        case let .failure(.commandFailed(status, stderr)) where status == 255:
+        case let .failure(.commandFailed(status, stderr))
+            where status == 255
+            || status == AccountCommandRunner.timedOutStatus:
             let classification = SSHConnectionFailure.classify(
                 status: status,
                 output: stderr

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1186,12 +1186,17 @@ final class WorkspaceSceneModel: ObservableObject {
         },
         zellijSessionValidationDiscovery:
         @escaping ZellijSessionValidationDiscovery = { host, arguments in
-            await Task.detached(priority: .utility) {
+            let probe = Task.detached(priority: .utility) {
                 ZellijInventoryClient().discover(
                     on: host,
                     sshConnectionArguments: arguments
                 )
-            }.value
+            }
+            return await withTaskCancellationHandler {
+                await probe.value
+            } onCancel: {
+                probe.cancel()
+            }
         },
         zellijSessionKiller:
         @escaping ZellijSessionKilling = { name, host, arguments in
@@ -4544,7 +4549,12 @@ final class WorkspaceSceneModel: ObservableObject {
                         let probe = Task.detached(priority: .utility) {
                             discovery(host)
                         }
-                        return await (hostID, probe.value)
+                        let result = await withTaskCancellationHandler {
+                            await probe.value
+                        } onCancel: {
+                            probe.cancel()
+                        }
+                        return (hostID, result)
                     }
                 }
                 var results: [(UUID, ZellijDiscoveryResult)] = []
@@ -4690,7 +4700,12 @@ final class WorkspaceSceneModel: ObservableObject {
                         let probe = Task.detached(priority: .utility) {
                             discovery(host)
                         }
-                        return await (hostID, probe.value)
+                        let result = await withTaskCancellationHandler {
+                            await probe.value
+                        } onCancel: {
+                            probe.cancel()
+                        }
+                        return (hostID, result)
                     }
                 }
                 var results: [(UUID, ZellijDiscoveryResult)] = []
@@ -6356,10 +6371,16 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         let resolvedPath: Result<String, ZellijCommandError>
         if case .available = result {
+            guard !Task.isCancelled else { return nil }
             let resolver = zellijExecutableResolver
-            resolvedPath = await Task.detached(priority: .userInitiated) {
+            let probe = Task.detached(priority: .userInitiated) {
                 resolver(host, connection.arguments)
-            }.value
+            }
+            resolvedPath = await withTaskCancellationHandler {
+                await probe.value
+            } onCancel: {
+                probe.cancel()
+            }
         } else {
             resolvedPath = .failure(.unavailable)
         }
@@ -8305,10 +8326,16 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         let executablePath: String?
         if case .available = result {
+            guard !Task.isCancelled else { return .retry }
             let resolver = zellijExecutableResolver
-            let resolution = await Task.detached(priority: .userInitiated) {
+            let probe = Task.detached(priority: .userInitiated) {
                 resolver(context.host, connection.arguments)
-            }.value
+            }
+            let resolution = await withTaskCancellationHandler {
+                await probe.value
+            } onCancel: {
+                probe.cancel()
+            }
             switch resolution {
             case let .success(path):
                 executablePath = path

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -536,6 +536,8 @@ final class WorkspaceSceneModel: ObservableObject {
     @Published private(set) var activeBorrowedZellijSelection:
         WorkspaceZellijSessionSelection?
     private var activeBorrowedZellijHandle: BorrowedZellijSessionHandle?
+    @Published private(set) var activeBorrowedZellijRecoveryState:
+        NativeSessionRecoveryState?
     private var zellijPresentationTask: Task<Void, Never>?
     private struct ZellijPresentationIntent {
         var id: UUID
@@ -586,6 +588,7 @@ final class WorkspaceSceneModel: ObservableObject {
         var result: ZellijDiscoveryResult
         var host: CommandHost
         var connection: SSHConnectionArgumentsSnapshot
+        var executablePath: String?
     }
     private struct ZellijKillAuthority {
         var hostID: UUID
@@ -897,6 +900,9 @@ final class WorkspaceSceneModel: ObservableObject {
     private let zellijSessionDiscovery: ZellijSessionDiscovery
     private let zellijSessionValidationDiscovery:
         ZellijSessionValidationDiscovery
+    private let zellijExecutableResolver:
+        @Sendable (CommandHost, [String])
+        -> Result<String, ZellijCommandError>
     private let zellijSessionKiller: ZellijSessionKilling
     private let zellijSSHConnectionSnapshotProvider:
         @Sendable (SSHHostInfo) -> SSHConnectionArgumentsSnapshot
@@ -1331,6 +1337,18 @@ final class WorkspaceSceneModel: ObservableObject {
         self.zellijSessionDiscovery = zellijSessionDiscovery
         self.zellijSessionValidationDiscovery =
             zellijSessionValidationDiscovery
+        let zellijExecutableResolver:
+            @Sendable (CommandHost, [String])
+            -> Result<String, ZellijCommandError> = { host, arguments in
+                if let nativeZellijPathProvider {
+                    return nativeZellijPathProvider(host)
+                }
+                return ZellijInventoryClient().resolveExecutable(
+                    on: host,
+                    sshConnectionArguments: arguments
+                )
+            }
+        self.zellijExecutableResolver = zellijExecutableResolver
         self.zellijSessionKiller = zellijSessionKiller
         self.zellijSSHConnectionSnapshotProvider =
             zellijSSHConnectionSnapshotProvider
@@ -1525,15 +1543,7 @@ final class WorkspaceSceneModel: ObservableObject {
         nativeZellijSessionCoordinatorBacking = NativeZellijSessionCoordinator(
             terminalCoordinator: nativeZellijSurfaceStore
                 ?? terminalCoordinator,
-            zellijPathProvider: { host, arguments in
-                if let nativeZellijPathProvider {
-                    return nativeZellijPathProvider(host)
-                }
-                return ZellijInventoryClient().resolveExecutable(
-                    on: host,
-                    sshConnectionArguments: arguments
-                )
-            },
+            zellijPathProvider: zellijExecutableResolver,
             sshConnectionArgumentsProvider:
             zellijSSHConnectionSnapshotProvider
         )
@@ -5989,7 +5999,9 @@ final class WorkspaceSceneModel: ObservableObject {
     func borrowedZellijSessionView(
         host: HostSummary,
         sessionName: String,
-        defersTerminalResize: Bool
+        defersTerminalResize: Bool,
+        onReconnectNow: @escaping () -> Void = {},
+        onReviewConnection: @escaping () -> Void = {}
     ) -> AnyView? {
         guard CommandHostResolver.resolve(host) != nil else {
             return AnyView(
@@ -6010,8 +6022,10 @@ final class WorkspaceSceneModel: ObservableObject {
         return AnyView(
             BorrowedZellijSessionView(
                 handle: handle,
+                hostName: host.name,
                 isRemoteHost: host.kind == .remote,
                 connectionState: borrowedZellijConnectionStates[handle.id],
+                recoveryState: activeBorrowedZellijRecoveryState,
                 attachmentClosure:
                 nativeZellijSessionCoordinator.attachmentClosure(handle),
                 defersTerminalResize: defersTerminalResize,
@@ -6027,6 +6041,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 onRetryRequest: { [weak self] in
                     self?.retryBorrowedZellijSession(selection)
                 },
+                onReconnectNow: onReconnectNow,
+                onReviewConnection: onReviewConnection,
                 onHostSettingsRequest: { [weak self] in
                     SettingsStore.shared.selectedDomain = .hosts
                     self?.isSettingsPresented = true
@@ -6058,19 +6074,88 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func createZellijSession(
         _ selection: WorkspaceZellijSessionSelection
-    ) {
+    ) async throws {
+        let activityGeneration = try captureSceneActivity()
+        let navigationRevision = userNavigationRevision
         guard let host = snapshot.host(id: selection.hostID),
               host.zellijAvailable,
+              let resolvedHost = CommandHostResolver.resolve(host),
+              Self.supportsZellij(resolvedHost),
               !host.zellijSessions.contains(where: {
                   $0.name == selection.name
               })
-        else { return }
+        else {
+            if snapshot.host(id: selection.hostID)?.zellijSessions.contains(
+                where: { $0.name == selection.name }
+            ) == true {
+                throw ZellijSessionPresentationError.sessionExists(
+                    selection.name
+                )
+            }
+            throw ZellijSessionPresentationError.unavailable
+        }
+        let killKey = ZellijSessionKillCoordinator.Key(
+            hostID: selection.hostID,
+            sessionName: selection.name
+        )
+        guard !zellijSessionKillCoordinator.isPending(killKey) else {
+            throw ZellijSessionPresentationError.operationPending(
+                selection.name
+            )
+        }
+        let killRevision = zellijSessionKillCoordinator.revision(for: killKey)
+        let validation = await validatedZellijSession(on: resolvedHost)
+        try Task.checkCancellation()
+        try requireActiveScene(activityGeneration)
+        guard navigationRevision == userNavigationRevision else {
+            throw CancellationError()
+        }
+        guard let validation,
+              let currentHost = snapshot.host(id: selection.hostID),
+              currentHost.zellijAvailable,
+              CommandHostResolver.resolve(currentHost) == resolvedHost
+        else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
+        guard !currentHost.zellijSessions.contains(where: {
+            $0.name == selection.name
+        }) else {
+            throw ZellijSessionPresentationError.sessionExists(selection.name)
+        }
+        switch validation.result {
+        case let .available(names):
+            guard !names.contains(selection.name) else {
+                throw ZellijSessionPresentationError.sessionExists(
+                    selection.name
+                )
+            }
+        case .unavailable:
+            throw ZellijSessionPresentationError.unavailable
+        case let .failure(error):
+            if error == .unavailable {
+                throw ZellijSessionPresentationError.unavailable
+            }
+            throw error
+        }
+        guard !zellijSessionKillCoordinator.isPending(killKey),
+              killRevision == zellijSessionKillCoordinator.revision(
+                  for: killKey
+              )
+        else {
+            throw ZellijSessionPresentationError.operationPending(
+                selection.name
+            )
+        }
         cancelPendingRestoration()
         invalidateZellijPresentationIntent()
         guard let handle = presentZellijSession(
             selection,
-            launchMode: .create
-        ) else { return }
+            launchMode: .create,
+            validation: validation,
+            expectedKillRevision: killRevision
+        ) else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
         pendingCreatedZellijSessions[handle.id] = selection
         var sessions = snapshot.host(id: selection.hostID)?.zellijSessions ?? []
         if !sessions.contains(where: { $0.name == selection.name }) {
@@ -6098,7 +6183,6 @@ final class WorkspaceSceneModel: ObservableObject {
                   zellijSessionKillCoordinator.revision(for: killKey) == $0
               }) ?? true
         else { return nil }
-        closeActivePresentations(replacingWith: selection)
         if activeBorrowedZellijSelection == selection,
            let handle = activeBorrowedZellijHandle,
            nativeZellijSessionCoordinator.attachmentClosure(handle) == nil {
@@ -6106,29 +6190,29 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         guard let hostSummary = snapshot.host(id: selection.hostID),
               let currentHost = CommandHostResolver.resolve(hostSummary)
-        else {
-            activeBorrowedZellijSelection = selection
-            activeBorrowedZellijHandle = nil
-            return nil
-        }
-        let host = validation?.host ?? currentHost
-        guard currentHost == host else { return nil }
+        else { return nil }
+        guard let validation,
+              currentHost == validation.host,
+              let executablePath = validation.executablePath
+        else { return nil }
+        closeActivePresentations(replacingWith: selection)
         let handle = nativeZellijSessionCoordinator.attach(
             hostID: selection.hostID,
             name: selection.name,
-            host: host,
+            host: validation.host,
             launchMode: launchMode,
-            sshConnectionSnapshot: validation?.connection
+            sshConnectionSnapshot: validation.connection,
+            resolvedZellijPath: executablePath
         )
         activeBorrowedZellijSelection = selection
         activeBorrowedZellijHandle = handle
         borrowedZellijConnectionStates[handle.id] = .connecting
-        activeZellijReconnectContext = host.isRemote
+        activeZellijReconnectContext = validation.host.isRemote
             ? ActiveZellijReconnectContext(
                 selection: selection,
                 handleID: handle.id,
-                host: host,
-                connection: validation?.connection,
+                host: validation.host,
+                connection: validation.connection,
                 surfaceExitCode: nil
             )
             : nil
@@ -6270,14 +6354,38 @@ final class WorkspaceSceneModel: ObservableObject {
             host,
             connection.arguments
         )
+        let resolvedPath: Result<String, ZellijCommandError>
+        if case .available = result {
+            let resolver = zellijExecutableResolver
+            resolvedPath = await Task.detached(priority: .userInitiated) {
+                resolver(host, connection.arguments)
+            }.value
+        } else {
+            resolvedPath = .failure(.unavailable)
+        }
         let currentConnection = await zellijConnectionSnapshot(on: host)
         guard !Task.isCancelled,
               currentConnection.cacheKey == connection.cacheKey
         else { return nil }
+        let validatedResult: ZellijDiscoveryResult
+        let executablePath: String?
+        switch resolvedPath {
+        case let .success(path):
+            validatedResult = result
+            executablePath = path
+        case let .failure(error):
+            validatedResult = if case .available = result {
+                .failure(error)
+            } else {
+                result
+            }
+            executablePath = nil
+        }
         return ZellijSessionValidation(
-            result: result,
+            result: validatedResult,
             host: host,
-            connection: connection
+            connection: connection,
+            executablePath: executablePath
         )
     }
 
@@ -8076,6 +8184,7 @@ final class WorkspaceSceneModel: ObservableObject {
         switch state {
         case .connected:
             zellijReconnectSupervisor.cancel()
+            activeBorrowedZellijRecoveryState = nil
             if var context = activeZellijReconnectContext,
                context.handleID == handle.id {
                 context.connection = nativeZellijSessionCoordinator
@@ -8099,12 +8208,14 @@ final class WorkspaceSceneModel: ObservableObject {
                     )
                 }
                 zellijReconnectSupervisor.cancel()
+                activeBorrowedZellijRecoveryState = nil
                 return
             }
             switch nativeZellijSessionCoordinator.attachmentClosure(handle) {
             case .detached:
                 pendingCreatedZellijSessions.removeValue(forKey: handle.id)
                 zellijReconnectSupervisor.cancel()
+                activeBorrowedZellijRecoveryState = nil
                 scheduleZellijSessionDiscovery()
             case let .processExited(code):
                 guard var context = activeZellijReconnectContext,
@@ -8114,6 +8225,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 else {
                     pendingCreatedZellijSessions.removeValue(forKey: handle.id)
                     zellijReconnectSupervisor.cancel()
+                    activeBorrowedZellijRecoveryState = nil
                     scheduleZellijSessionDiscovery()
                     return
                 }
@@ -8123,6 +8235,7 @@ final class WorkspaceSceneModel: ObservableObject {
             case .launchFailed, nil:
                 pendingCreatedZellijSessions.removeValue(forKey: handle.id)
                 zellijReconnectSupervisor.cancel()
+                activeBorrowedZellijRecoveryState = nil
                 scheduleZellijSessionDiscovery()
             }
         case .connecting, .reconnecting:
@@ -8141,9 +8254,11 @@ final class WorkspaceSceneModel: ObservableObject {
                   sessionName: context.selection.name
               ))
         else { return }
+        let message = "Waiting for \(hostName(for: context.selection.hostID)). "
+            + "Ghosthub will reconnect automatically."
+        activeBorrowedZellijRecoveryState = .reconnecting(message: message)
         borrowedZellijConnectionStates[context.handleID] = .reconnecting(
-            reason: "Waiting for \(hostName(for: context.selection.hostID)). "
-                + "Ghosthub will reconnect automatically."
+            reason: message
         )
         sessionConnectionRecoveryRequest = nil
         zellijReconnectSupervisor.start { [weak self] in
@@ -8188,17 +8303,42 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             return .stop
         }
+        let executablePath: String?
+        if case .available = result {
+            let resolver = zellijExecutableResolver
+            let resolution = await Task.detached(priority: .userInitiated) {
+                resolver(context.host, connection.arguments)
+            }.value
+            switch resolution {
+            case let .success(path):
+                executablePath = path
+            case let .failure(error):
+                stopZellijReconnect(error.localizedDescription)
+                return .stop
+            }
+            let finalConnection = await zellijConnectionSnapshot(
+                on: context.host
+            )
+            guard !Task.isCancelled,
+                  activeZellijReconnectContext == context,
+                  finalConnection.cacheKey == connection.cacheKey
+            else { return .stop }
+        } else {
+            executablePath = nil
+        }
         return zellijReconnectDecision(
             for: context,
             result: result,
-            connection: connection
+            connection: connection,
+            executablePath: executablePath
         )
     }
 
     private func zellijReconnectDecision(
         for context: ActiveZellijReconnectContext,
         result: ZellijDiscoveryResult,
-        connection: SSHConnectionArgumentsSnapshot
+        connection: SSHConnectionArgumentsSnapshot,
+        executablePath: String?
     ) -> SessionReconnectDecision {
         guard !Task.isCancelled else { return .retry }
         guard activeZellijReconnectContext == context,
@@ -8231,7 +8371,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 validation: ZellijSessionValidation(
                     result: result,
                     host: context.host,
-                    connection: connection
+                    connection: connection,
+                    executablePath: executablePath
                 )
             ) != nil else {
                 stopZellijReconnect(
@@ -8255,16 +8396,24 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             switch classification.kind {
             case .transport:
+                let message = classification.diagnostic.summary + " "
+                    + "Ghosthub will reconnect automatically."
+                activeBorrowedZellijRecoveryState = .reconnecting(
+                    message: message
+                )
                 borrowedZellijConnectionStates[context.handleID] =
-                    .reconnecting(
-                        reason: classification.diagnostic.summary + " "
-                            + "Ghosthub will reconnect automatically."
-                    )
+                    .reconnecting(reason: message)
                 return .retry
             case .authenticationRequired, .hostKeyReviewRequired:
                 let message = classification.diagnostic.summary + " "
                     + classification.diagnostic.recoverySuggestion
-                stopZellijReconnect(message)
+                stopZellijReconnect(
+                    message,
+                    recoveryState: .needsAttention(
+                        message: message,
+                        canReviewConnection: true
+                    )
+                )
                 if sessionConnectionRecoveryRequest == nil {
                     sessionConnectionRecoveryRequest =
                         SessionConnectionRecoveryRequest(
@@ -8274,9 +8423,14 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
                 return .stop
             case .hostKeyChanged:
+                let message = classification.diagnostic.summary + " "
+                    + classification.diagnostic.recoverySuggestion
                 stopZellijReconnect(
-                    classification.diagnostic.summary + " "
-                        + classification.diagnostic.recoverySuggestion
+                    message,
+                    recoveryState: .needsAttention(
+                        message: message,
+                        canReviewConnection: false
+                    )
                 )
                 return .stop
             }
@@ -8286,8 +8440,12 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
-    private func stopZellijReconnect(_ reason: String) {
+    private func stopZellijReconnect(
+        _ reason: String,
+        recoveryState: NativeSessionRecoveryState? = nil
+    ) {
         sessionConnectionRecoveryRequest = nil
+        activeBorrowedZellijRecoveryState = recoveryState
         guard let handle = activeBorrowedZellijHandle else { return }
         if let selection = pendingCreatedZellijSessions.removeValue(
             forKey: handle.id
@@ -8306,7 +8464,22 @@ final class WorkspaceSceneModel: ObservableObject {
     private func cancelZellijReconnect() {
         zellijReconnectSupervisor.cancel()
         activeZellijReconnectContext = nil
+        activeBorrowedZellijRecoveryState = nil
         sessionConnectionRecoveryRequest = nil
+    }
+
+    func reconnectActiveZellijSessionNow() {
+        guard let recoveryState = activeBorrowedZellijRecoveryState,
+              recoveryState.allowsReconnectNow
+        else { return }
+        if recoveryState.isReconnecting {
+            zellijReconnectSupervisor.reconnectNow()
+            return
+        }
+        guard let context = activeZellijReconnectContext,
+              activeBorrowedZellijHandle?.id == context.handleID
+        else { return }
+        startZellijReconnect(context)
     }
 
     private func confirmHerdrLaunch(
@@ -8933,7 +9106,8 @@ final class WorkspaceSceneModel: ObservableObject {
             startHerdrReconnect(context)
             return
         }
-        if sessionConnectionRecoveryRequest == recoveryRequest,
+        if case .needsAttention(_, true) = activeBorrowedZellijRecoveryState,
+           sessionConnectionRecoveryRequest == recoveryRequest,
            var context = activeZellijReconnectContext,
            context.selection.hostID == recoveryRequest.hostID,
            activeBorrowedZellijHandle?.id == context.handleID {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -9,6 +9,7 @@ import GhosthubSettings
 import GhosthubTerminal
 import GhosthubTerminalSupport
 import GhosthubTmux
+import GhosthubZellij
 import GhosthubUI
 import GhosthubWorkspace
 #if canImport(AppKit)
@@ -98,10 +99,34 @@ enum HerdrSessionLifecycleRequestError: Error, Equatable, LocalizedError {
     }
 }
 
+enum ZellijSessionPresentationError: Error, Equatable, LocalizedError {
+    case unavailable
+    case sessionExists(String)
+    case sessionMissing(String)
+    case hostChanged(String)
+    case operationPending(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            "Zellij is unavailable on this host."
+        case let .sessionExists(name):
+            "A Zellij session named “\(name)” already exists."
+        case let .sessionMissing(name):
+            "Zellij session “\(name)” no longer exists."
+        case let .hostChanged(name):
+            "The connection for the host containing “\(name)” changed."
+        case let .operationPending(name):
+            "Another operation is already changing “\(name)”."
+        }
+    }
+}
+
 struct WorkspaceInventoryRefreshProgress: Equatable {
     var kwtCompleted = false
     var tmuxCompleted = false
     var herdrCompleted = false
+    var zellijCompleted = false
 }
 
 enum NativeSessionRecoveryState: Equatable {
@@ -280,6 +305,15 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias HerdrSessionDiscovery = @Sendable (
         CommandHost
     ) -> HerdrDiscoveryResult
+    typealias ZellijSessionDiscovery = @Sendable (
+        CommandHost
+    ) -> ZellijDiscoveryResult
+    typealias ZellijSessionValidationDiscovery = @Sendable (
+        CommandHost, [String]
+    ) async -> ZellijDiscoveryResult
+    typealias ZellijSessionKilling = @Sendable (
+        String, CommandHost, [String]
+    ) async -> Result<Void, ZellijCommandError>
     typealias HerdrSessionValidationDiscovery = @Sendable (
         CommandHost, [String]
     ) async -> HerdrDiscoveryResult
@@ -333,6 +367,17 @@ final class WorkspaceSceneModel: ObservableObject {
     private var herdrDiscoveryGeneration = 0
     private var herdrDiscoveryTask: Task<Void, Never>?
     private var herdrFreshHostIDs: Set<UUID> = []
+    private var zellijDiscoveryEnabled = false
+    private var zellijSessionsByHost: [UUID: [ZellijSessionSummary]] = [:]
+    private var zellijAvailabilityByHost: [UUID: Bool] = [:]
+    private var zellijDiscoveryFailuresByHost: [UUID: String] = [:]
+    private var isZellijDiscoveryLoading = false
+    private var zellijDiscoveryGeneration = 0
+    private var zellijDiscoveryTask: Task<Void, Never>?
+    private var zellijCreationDiscoveryRetryTask: Task<Void, Never>?
+    private var zellijCreationDiscoveryRetryID: UUID?
+    private var zellijCreationDiscoveryRetryAttempt = 0
+    private var zellijFreshHostIDs: Set<UUID> = []
     private var createdSessionDiscoveryTasks: [UUID: Task<Void, Never>] = [:]
     private var exhaustedCreatedTmuxSessionHandles: Set<UUID> = []
     private var endedCreatedTmuxSessionHandles: Set<UUID> = []
@@ -346,6 +391,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private let tmuxReconnectIntervals: [Duration]
     private let tmuxReconnectProbeDeadline: Duration
     private let herdrReconnectSupervisor: SessionReconnectSupervisor
+    private let zellijReconnectSupervisor: SessionReconnectSupervisor
     @Published private(set) var workspaceInventoryState:
         WorkspaceInventoryState = .loading
     @Published private(set) var workspaceInventoryWarning: String?
@@ -361,6 +407,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private var ownsWorktreeMutation = false
     private let worktreeMutationCoordinator: WorktreeMutationCoordinator
     private let herdrLifecycleCoordinator: HerdrSessionLifecycleCoordinator
+    private let zellijSessionKillCoordinator: ZellijSessionKillCoordinator
     private let herdrSessionRecordReader: HerdrSessionRecordReading
     private let herdrSessionMutator: HerdrSessionMutating
     private let herdrSSHConnectionSnapshotProvider:
@@ -393,12 +440,16 @@ final class WorkspaceSceneModel: ObservableObject {
             && inventoryRefreshProgress.tmuxCompleted
             && (!herdrDiscoveryEnabled
                 || inventoryRefreshProgress.herdrCompleted)
+            && (!zellijDiscoveryEnabled
+                || inventoryRefreshProgress.zellijCompleted)
             && !isKwtInventoryLoading
             && !isTmuxDiscoveryLoading
             && !isHerdrDiscoveryLoading
+            && !isZellijDiscoveryLoading
             && kwtInventoryFailuresByHost.isEmpty
             && tmuxDiscoveryFailuresByHost.isEmpty
             && herdrDiscoveryFailuresByHost.isEmpty
+            && zellijDiscoveryFailuresByHost.isEmpty
     }
 
     var workspaceResourceSummary: WorkspaceResourceSummary {
@@ -480,6 +531,69 @@ final class WorkspaceSceneModel: ObservableObject {
     private var failedHerdrLaunchIntent: FailedHerdrLaunchIntent?
     @Published private(set) var activeBorrowedHerdrRecoveryState:
         NativeSessionRecoveryState?
+    @Published private var borrowedZellijConnectionStates:
+        [UUID: ConnectionState] = [:]
+    @Published private(set) var activeBorrowedZellijSelection:
+        WorkspaceZellijSessionSelection?
+    private var activeBorrowedZellijHandle: BorrowedZellijSessionHandle?
+    private var zellijPresentationTask: Task<Void, Never>?
+    private struct ZellijPresentationIntent {
+        var id: UUID
+        var selection: WorkspaceZellijSessionSelection
+        var navigationRevision: UInt64
+        var revision: UInt64
+        var host: CommandHost
+    }
+    private var zellijPresentationIntent: ZellijPresentationIntent?
+    private var zellijPresentationRevision: UInt64 = 0
+    private struct SuppressedZellijKillPresentation {
+        var selection: WorkspaceZellijSessionSelection
+        var navigationRevision: UInt64
+        var host: CommandHost
+        var restoresActivePresentation: Bool
+        var presentationIntent: ZellijPresentationIntent?
+    }
+    private var suppressedZellijKillPresentations:
+        [UUID: SuppressedZellijKillPresentation] = [:]
+    var activeBorrowedZellijConnectionState: ConnectionState? {
+        guard let activeBorrowedZellijHandle else { return nil }
+        return borrowedZellijConnectionStates[activeBorrowedZellijHandle.id]
+    }
+    private struct ActiveZellijReconnectContext: Equatable {
+        var selection: WorkspaceZellijSessionSelection
+        var handleID: UUID
+        var host: CommandHost
+        var connection: SSHConnectionArgumentsSnapshot?
+        var surfaceExitCode: UInt32?
+
+        static func == (
+            lhs: ActiveZellijReconnectContext,
+            rhs: ActiveZellijReconnectContext
+        ) -> Bool {
+            lhs.selection == rhs.selection
+                && lhs.handleID == rhs.handleID
+                && lhs.host == rhs.host
+                && lhs.connection?.cacheKey == rhs.connection?.cacheKey
+                && lhs.surfaceExitCode == rhs.surfaceExitCode
+        }
+    }
+    private var activeZellijReconnectContext: ActiveZellijReconnectContext?
+    private struct ZellijSessionValidation {
+        var result: ZellijDiscoveryResult
+        var host: CommandHost
+        var connection: SSHConnectionArgumentsSnapshot
+    }
+    private struct ZellijKillAuthority {
+        var hostID: UUID
+        var host: CommandHost
+        var connection: SSHConnectionArgumentsSnapshot
+    }
+    private var zellijKillAuthorities: [UUID: ZellijKillAuthority] = [:]
+    private var pendingCreatedZellijSessions:
+        [UUID: WorkspaceZellijSessionSelection] = [:]
+    var zellijReconnectSupervisorIsRunning: Bool {
+        zellijReconnectSupervisor.isRunning
+    }
     private struct SuppressedHerdrStop {
         var selection: WorkspaceHerdrSessionSelection
         var reconnectContext: ActiveHerdrReconnectContext?
@@ -589,6 +703,14 @@ final class WorkspaceSceneModel: ObservableObject {
     private var protectedRestorationRefreshPending = false
     private var herdrRestorationValidationTask: Task<Void, Never>?
     private var herdrRestorationValidationID: UUID?
+    private var zellijRestorationValidationTask: Task<Void, Never>?
+    private var zellijRestorationValidationID: UUID?
+    private struct ZellijRestorationRoute {
+        var state: WorkspaceWindowState
+        var selection: WorkspaceZellijSessionSelection
+        var host: CommandHost
+    }
+    private var zellijRestorationRoute: ZellijRestorationRoute?
     var activeBorrowedTmuxSessionIsConnected: Bool {
         guard let handle = activeBorrowedTmuxHandle else {
             return false
@@ -768,6 +890,12 @@ final class WorkspaceSceneModel: ObservableObject {
     private let kwtPullRequestImporter: KwtPullRequestImporter
     private let kwtProjectRegistration: KwtProjectRegistration
     private let tmuxSessionDiscovery: TmuxSessionDiscovery
+    private let zellijSessionDiscovery: ZellijSessionDiscovery
+    private let zellijSessionValidationDiscovery:
+        ZellijSessionValidationDiscovery
+    private let zellijSessionKiller: ZellijSessionKilling
+    private let zellijSSHConnectionSnapshotProvider:
+        @Sendable (SSHHostInfo) -> SSHConnectionArgumentsSnapshot
     private let tmuxSessionKiller: TmuxSessionKilling
     private let tmuxSessionIdentityReader: TmuxSessionIdentityReading
     private let tmuxSessionStyler: TmuxSessionStyling
@@ -797,6 +925,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private let deferredTmuxPresentationRetryDelays: [Duration]
     private var worktreeMutationCancellable: AnyCancellable?
     private var herdrLifecycleCancellable: AnyCancellable?
+    private var zellijSessionKillCancellable: AnyCancellable?
     private var activityControllerBacking: ActivityMonitoringController?
     var activityController: ActivityMonitoringController {
         guard let activityControllerBacking else {
@@ -825,6 +954,16 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         }
         return nativeHerdrSessionCoordinatorBacking
+    }
+    private var nativeZellijSessionCoordinatorBacking:
+        NativeZellijSessionCoordinator?
+    private var nativeZellijSessionCoordinator: NativeZellijSessionCoordinator {
+        guard let nativeZellijSessionCoordinatorBacking else {
+            preconditionFailure(
+                "native Zellij session coordinator was not initialized"
+            )
+        }
+        return nativeZellijSessionCoordinatorBacking
     }
     private var activityCancellable: AnyCancellable?
     private var tmuxSessionActivityCancellable: AnyCancellable?
@@ -905,10 +1044,13 @@ final class WorkspaceSceneModel: ObservableObject {
         notificationService: NotificationService,
         nativeTmuxSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
         nativeHerdrSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
+        nativeZellijSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
         nativeTmuxPathProvider:
         (@Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>)? = nil,
         nativeHerdrPathProvider: (@Sendable (CommandHost)
             -> Result<String, HerdrCommandError>)? = nil,
+        nativeZellijPathProvider: (@Sendable (CommandHost)
+            -> Result<String, ZellijCommandError>)? = nil,
         herdrPaneSplitCapabilityProvider:
         NativeHerdrSessionCoordinator.PaneSplitCapabilityProvider? = nil,
         herdrPaneSplitter: HerdrPaneSplitter = HerdrPaneSplitter(),
@@ -952,6 +1094,7 @@ final class WorkspaceSceneModel: ObservableObject {
         },
         worktreeMutationCoordinator: WorktreeMutationCoordinator = .shared,
         herdrLifecycleCoordinator: HerdrSessionLifecycleCoordinator = .shared,
+        zellijSessionKillCoordinator: ZellijSessionKillCoordinator = .shared,
         herdrSessionRecordReader:
         @escaping HerdrSessionRecordReading = { name, host, arguments in
             await Task.detached(priority: .userInitiated) {
@@ -1028,6 +1171,33 @@ final class WorkspaceSceneModel: ObservableObject {
         herdrSessionDiscovery: @escaping HerdrSessionDiscovery = { host in
             HerdrInventoryClient().discover(on: host)
         },
+        zellijSessionDiscovery: @escaping ZellijSessionDiscovery = { host in
+            ZellijInventoryClient().discover(on: host)
+        },
+        zellijSessionValidationDiscovery:
+        @escaping ZellijSessionValidationDiscovery = { host, arguments in
+            await Task.detached(priority: .utility) {
+                ZellijInventoryClient().discover(
+                    on: host,
+                    sshConnectionArguments: arguments
+                )
+            }.value
+        },
+        zellijSessionKiller:
+        @escaping ZellijSessionKilling = { name, host, arguments in
+            await Task.detached(priority: .userInitiated) {
+                ZellijInventoryClient().kill(
+                    sessionName: name,
+                    on: host,
+                    sshConnectionArguments: arguments
+                )
+            }.value
+        },
+        zellijSSHConnectionSnapshotProvider:
+        @escaping @Sendable (SSHHostInfo)
+            -> SSHConnectionArgumentsSnapshot = {
+                SSHCommandArguments.connectionSnapshot(for: $0)
+            },
         herdrSessionValidationDiscovery:
         @escaping HerdrSessionValidationDiscovery = { host, arguments in
             await Task.detached(priority: .utility) {
@@ -1138,6 +1308,7 @@ final class WorkspaceSceneModel: ObservableObject {
         self.workspaceConfiguration = workspaceConfiguration
         self.worktreeMutationCoordinator = worktreeMutationCoordinator
         self.herdrLifecycleCoordinator = herdrLifecycleCoordinator
+        self.zellijSessionKillCoordinator = zellijSessionKillCoordinator
         self.herdrSessionRecordReader = herdrSessionRecordReader
         self.herdrSessionMutator = herdrSessionMutator
         self.herdrSSHConnectionSnapshotProvider =
@@ -1153,6 +1324,12 @@ final class WorkspaceSceneModel: ObservableObject {
         self.kwtPullRequestImporter = kwtPullRequestImporter
         self.kwtProjectRegistration = kwtProjectRegistration
         self.tmuxSessionDiscovery = tmuxSessionDiscovery
+        self.zellijSessionDiscovery = zellijSessionDiscovery
+        self.zellijSessionValidationDiscovery =
+            zellijSessionValidationDiscovery
+        self.zellijSessionKiller = zellijSessionKiller
+        self.zellijSSHConnectionSnapshotProvider =
+            zellijSSHConnectionSnapshotProvider
         tmuxSessionProbeBroker = TmuxSessionProbeBroker(
             discover: { host in
                 let probe = Task.detached(priority: .utility) {
@@ -1193,6 +1370,10 @@ final class WorkspaceSceneModel: ObservableObject {
             herdrSessionValidationDiscovery
         self.herdrSessionExactProbe = herdrSessionExactProbe
         herdrReconnectSupervisor = SessionReconnectSupervisor(
+            intervals: tmuxReconnectIntervals,
+            probeDeadline: tmuxReconnectProbeDeadline
+        )
+        zellijReconnectSupervisor = SessionReconnectSupervisor(
             intervals: tmuxReconnectIntervals,
             probeDeadline: tmuxReconnectProbeDeadline
         )
@@ -1337,6 +1518,37 @@ final class WorkspaceSceneModel: ObservableObject {
                 self?.prepareActiveBorrowedHerdrSurface()
             }
         }
+        nativeZellijSessionCoordinatorBacking = NativeZellijSessionCoordinator(
+            terminalCoordinator: nativeZellijSurfaceStore
+                ?? terminalCoordinator,
+            zellijPathProvider: { host, arguments in
+                if let nativeZellijPathProvider {
+                    return nativeZellijPathProvider(host)
+                }
+                return ZellijInventoryClient().resolveExecutable(
+                    on: host,
+                    sshConnectionArguments: arguments
+                )
+            },
+            sshConnectionArgumentsProvider:
+            zellijSSHConnectionSnapshotProvider
+        )
+        nativeZellijSessionCoordinatorBacking?.onStateChanged = {
+            [weak self] handle, state in
+            self?.nativeZellijStateChanged(handle: handle, state: state)
+        }
+        nativeZellijSessionCoordinatorBacking?.onSurfaceReady = {
+            [weak self] handle in
+            guard let self, activeBorrowedZellijHandle == handle else { return }
+            if var context = activeZellijReconnectContext,
+               context.handleID == handle.id {
+                context.connection = nativeZellijSessionCoordinator
+                    .attachmentConnectionSnapshot(handle)
+                activeZellijReconnectContext = context
+            }
+            objectWillChange.send()
+            prepareActiveBorrowedZellijSurface()
+        }
         activityControllerBacking = ActivityMonitoringController(
             notificationService: notificationService,
             snapshotProvider: { [weak self] in
@@ -1464,6 +1676,10 @@ final class WorkspaceSceneModel: ObservableObject {
             [weak self] event in
             self?.herdrLifecycleEvent(event)
         }
+        zellijSessionKillCancellable = zellijSessionKillCoordinator.events.sink {
+            [weak self] event in
+            self?.zellijSessionKillEvent(event)
+        }
         fencedWorktreeMutationScopes = worktreeMutationCoordinator.scopes
         pendingWorktreeRemovals = worktreeMutationCoordinator.pendingRemovals
         let sshHostsPublisher = configuredSSHHostsPublisher
@@ -1497,6 +1713,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 startExeHostInventory()
                 startTmuxSessionDiscovery()
                 startHerdrSessionDiscovery()
+                startZellijSessionDiscovery()
                 startKwtInventory()
                 syncTerminalConfig()
                 startResourceMonitoringLoop()
@@ -1529,10 +1746,17 @@ final class WorkspaceSceneModel: ObservableObject {
         terminalColorsCancellable?.cancel()
         worktreeMutationCancellable?.cancel()
         herdrLifecycleCancellable?.cancel()
+        zellijSessionKillCancellable?.cancel()
         kwtInventoryTask?.cancel()
         tmuxDiscoveryTask?.cancel()
         herdrDiscoveryTask?.cancel()
         herdrShortcutNavigationTask?.cancel()
+        zellijDiscoveryTask?.cancel()
+        zellijCreationDiscoveryRetryTask?.cancel()
+        zellijCreationDiscoveryRetryTask = nil
+        zellijCreationDiscoveryRetryID = nil
+        zellijPresentationTask?.cancel()
+        zellijRestorationValidationTask?.cancel()
         createdSessionDiscoveryTasks.values.forEach { $0.cancel() }
         herdrLaunchConfirmationTasks.values.forEach { $0.cancel() }
         deferredTmuxPresentationTasks.values.forEach { $0.cancel() }
@@ -1549,7 +1773,23 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func beginRestoration(_ state: WorkspaceWindowState) {
         guard state.navigation != nil || state.tmux != nil
-            || state.herdr != nil else { return }
+            || state.herdr != nil || state.zellij != nil else { return }
+        zellijRestorationRoute = state.zellij.flatMap { descriptor in
+            guard let hostSummary = snapshot.hosts.first(where: {
+                $0.configKey == descriptor.hostKey
+            }),
+                let host = CommandHostResolver.resolve(hostSummary),
+                Self.supportsZellij(host)
+            else { return nil }
+            return ZellijRestorationRoute(
+                state: state,
+                selection: WorkspaceZellijSessionSelection(
+                    hostID: hostSummary.id,
+                    name: descriptor.sessionName
+                ),
+                host: host
+            )
+        }
         pendingRestoration = state
         isWorkspaceRestorationPending = true
         suppressesAutomaticWorktreeSessionOpen = true
@@ -1567,6 +1807,10 @@ final class WorkspaceSceneModel: ObservableObject {
         herdrRestorationValidationTask?.cancel()
         herdrRestorationValidationTask = nil
         herdrRestorationValidationID = nil
+        zellijRestorationValidationTask?.cancel()
+        zellijRestorationValidationTask = nil
+        zellijRestorationValidationID = nil
+        zellijRestorationRoute = nil
     }
 
     func restorationState(windowID: UUID) -> WorkspaceWindowState {
@@ -1579,6 +1823,7 @@ final class WorkspaceSceneModel: ObservableObject {
             selection: selection,
             activeTmux: activeBorrowedTmuxSelection,
             activeHerdr: activeBorrowedHerdrSelection,
+            activeZellij: activeBorrowedZellijSelection,
             snapshot: snapshot
         )
     }
@@ -1586,6 +1831,7 @@ final class WorkspaceSceneModel: ObservableObject {
     func selectFromUser(_ newSelection: WorkspaceSelection) {
         cancelPendingRestoration()
         cancelPendingHerdrShortcutNavigation()
+        invalidateZellijPresentationIntent()
         userNavigationRevision &+= 1
         if let worktreeID = newSelection.selectedWorktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
@@ -1620,7 +1866,16 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func synchronizeSelection(_ newSelection: WorkspaceSelection) {
         guard newSelection != selection else { return }
+        userNavigationRevision &+= 1
+        invalidateZellijPresentationIntent()
         selection = newSelection
+    }
+
+    private func invalidateZellijPresentationIntent() {
+        zellijPresentationRevision &+= 1
+        zellijPresentationTask?.cancel()
+        zellijPresentationTask = nil
+        zellijPresentationIntent = nil
     }
 
     private func applyRestoredSelection(_ restored: WorkspaceSelection) {
@@ -1633,11 +1888,13 @@ final class WorkspaceSceneModel: ObservableObject {
             protectedRestorationRefreshPending = true
             return
         }
-        guard herdrRestorationValidationTask == nil else { return }
+        guard herdrRestorationValidationTask == nil,
+              zellijRestorationValidationTask == nil else { return }
         switch WorkspaceWindowRestorationResolver.resolve(
             pendingRestoration,
             in: snapshot,
             herdrFreshHostIDs: herdrFreshHostIDs,
+            zellijFreshHostIDs: zellijFreshHostIDs,
             pendingHerdrSessions: pendingHerdrSessionSelections
         ) {
         case .invalid:
@@ -1660,6 +1917,13 @@ final class WorkspaceSceneModel: ObservableObject {
                 beginHerdrRestorationValidation(
                     selection: resolvedSelection,
                     herdrSelection: herdrSelection,
+                    expectedState: pendingRestoration
+                )
+                return
+            case let .zellij(zellijSelection):
+                beginZellijRestorationValidation(
+                    selection: resolvedSelection,
+                    zellijSelection: zellijSelection,
                     expectedState: pendingRestoration
                 )
                 return
@@ -1782,6 +2046,128 @@ final class WorkspaceSceneModel: ObservableObject {
         scheduleHerdrSessionDiscovery()
     }
 
+    private func beginZellijRestorationValidation(
+        selection resolvedSelection: WorkspaceSelection,
+        zellijSelection: WorkspaceZellijSessionSelection,
+        expectedState: WorkspaceWindowState
+    ) {
+        guard zellijRestorationValidationTask == nil,
+              let hostSummary = snapshot.host(id: zellijSelection.hostID),
+              let host = CommandHostResolver.resolve(hostSummary),
+              Self.supportsZellij(host)
+        else { return }
+        let killKey = ZellijSessionKillCoordinator.Key(
+            hostID: zellijSelection.hostID,
+            sessionName: zellijSelection.name
+        )
+        if let route = zellijRestorationRoute,
+           route.state == expectedState {
+            guard route.selection == zellijSelection,
+                  route.host == host
+            else {
+                cancelPendingRestoration()
+                return
+            }
+        } else {
+            zellijRestorationRoute = ZellijRestorationRoute(
+                state: expectedState,
+                selection: zellijSelection,
+                host: host
+            )
+        }
+        guard !zellijSessionKillCoordinator.isPending(killKey) else { return }
+        let killRevision = zellijSessionKillCoordinator.revision(for: killKey)
+        let validationID = UUID()
+        zellijRestorationValidationID = validationID
+        zellijRestorationValidationTask = Task { [weak self] in
+            guard let self else { return }
+            let validation = await validatedZellijSession(on: host)
+            guard !Task.isCancelled,
+                  zellijRestorationValidationID == validationID,
+                  pendingRestoration == expectedState
+            else { return }
+            guard let validation else {
+                cancelZellijRestorationValidation(
+                    validationID,
+                    expectedState: expectedState
+                )
+                return
+            }
+            guard snapshot.host(id: zellijSelection.hostID)
+                .flatMap(CommandHostResolver.resolve) == host else {
+                cancelZellijRestorationValidation(
+                    validationID,
+                    expectedState: expectedState
+                )
+                return
+            }
+            let currentResolution = WorkspaceWindowRestorationResolver.resolve(
+                expectedState,
+                in: snapshot,
+                zellijFreshHostIDs: zellijFreshHostIDs
+            )
+            guard case let .ready(
+                currentSelection,
+                currentPresentation
+            ) = currentResolution,
+                case let .zellij(currentZellijSelection) = currentPresentation,
+                currentSelection == resolvedSelection,
+                currentZellijSelection == zellijSelection,
+                !zellijSessionKillCoordinator.isPending(killKey),
+                killRevision
+                == zellijSessionKillCoordinator.revision(for: killKey),
+                case let .available(names) = validation.result,
+                names.contains(zellijSelection.name)
+            else {
+                retryZellijRestorationValidation(
+                    validationID,
+                    expectedState: expectedState,
+                    hostID: zellijSelection.hostID
+                )
+                return
+            }
+            zellijRestorationValidationTask = nil
+            zellijRestorationValidationID = nil
+            applyRestoredSelection(resolvedSelection)
+            guard presentZellijSession(
+                zellijSelection,
+                validation: validation,
+                expectedKillRevision: killRevision
+            ) != nil else {
+                cancelPendingRestoration()
+                return
+            }
+            pendingRestoration = nil
+            isWorkspaceRestorationPending = false
+            suppressesAutomaticWorktreeSessionOpen = false
+            zellijRestorationRoute = nil
+        }
+    }
+
+    private func cancelZellijRestorationValidation(
+        _ validationID: UUID,
+        expectedState: WorkspaceWindowState
+    ) {
+        guard zellijRestorationValidationID == validationID else { return }
+        zellijRestorationValidationTask = nil
+        zellijRestorationValidationID = nil
+        guard pendingRestoration == expectedState else { return }
+        cancelPendingRestoration()
+    }
+
+    private func retryZellijRestorationValidation(
+        _ validationID: UUID,
+        expectedState: WorkspaceWindowState,
+        hostID: UUID
+    ) {
+        guard zellijRestorationValidationID == validationID else { return }
+        zellijRestorationValidationTask = nil
+        zellijRestorationValidationID = nil
+        guard pendingRestoration == expectedState else { return }
+        zellijFreshHostIDs.remove(hostID)
+        scheduleZellijSessionDiscovery()
+    }
+
     private func beginProtectedRestorationProbe(
         selection resolvedSelection: WorkspaceSelection,
         tmuxSelection: WorkspaceTmuxSessionSelection,
@@ -1888,9 +2274,14 @@ final class WorkspaceSceneModel: ObservableObject {
         failedHerdrLaunchIntent = nil
         herdrLifecycleAuthorities.removeAll()
         herdrLifecycleCancellable?.cancel()
+        zellijSessionKillCancellable?.cancel()
         kwtInventoryTask?.cancel()
         tmuxDiscoveryTask?.cancel()
         herdrDiscoveryTask?.cancel()
+        zellijDiscoveryTask?.cancel()
+        zellijCreationDiscoveryRetryTask?.cancel()
+        zellijCreationDiscoveryRetryTask = nil
+        zellijCreationDiscoveryRetryID = nil
         createdSessionDiscoveryTasks.values.forEach { $0.cancel() }
         createdSessionDiscoveryTasks.removeAll()
         herdrLaunchConfirmationTasks.values.forEach { $0.cancel() }
@@ -1906,6 +2297,14 @@ final class WorkspaceSceneModel: ObservableObject {
         nativeTmuxSessionCoordinatorBacking?.shutdown()
         failPendingHerdrLaunchOperations { _ in true }
         nativeHerdrSessionCoordinatorBacking?.shutdown()
+        invalidateZellijPresentationIntent()
+        cancelZellijReconnect()
+        zellijKillAuthorities.removeAll()
+        pendingCreatedZellijSessions.removeAll()
+        suppressedZellijKillPresentations.removeAll()
+        activeBorrowedZellijSelection = nil
+        activeBorrowedZellijHandle = nil
+        nativeZellijSessionCoordinatorBacking?.shutdown()
         sshAuthenticationCoordinator.cancelAll(
             scopeID: sshAuthenticationScopeID
         )
@@ -1922,6 +2321,7 @@ final class WorkspaceSceneModel: ObservableObject {
         scheduleKwtInventory()
         scheduleTmuxSessionDiscovery()
         refreshHerdrSessionDiscovery()
+        refreshZellijSessionDiscovery()
     }
 
     func startKwtInventory() {
@@ -2974,6 +3374,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 ? hostID
                 : nil
         })
+        let retainedZellijHostIDs = Set(resolved.compactMap { hostID, target in
+            inventoryHosts[hostID] == target && Self.supportsZellij(target)
+                ? hostID
+                : nil
+        })
         for (hostID, previousHost) in inventoryHosts
             where resolved[hostID] != previousHost
             && Self.supportsHerdr(previousHost) {
@@ -3013,6 +3418,19 @@ final class WorkspaceSceneModel: ObservableObject {
         for (hostID, target) in resolved where !Self.supportsHerdr(target) {
             herdrSessionsByHost[hostID] = []
         }
+        zellijSessionsByHost = zellijSessionsByHost.filter {
+            retainedZellijHostIDs.contains($0.key)
+        }
+        zellijAvailabilityByHost = zellijAvailabilityByHost.filter {
+            retainedZellijHostIDs.contains($0.key)
+        }
+        zellijDiscoveryFailuresByHost = zellijDiscoveryFailuresByHost.filter {
+            retainedZellijHostIDs.contains($0.key)
+        }
+        zellijFreshHostIDs.formIntersection(retainedZellijHostIDs)
+        for (hostID, target) in resolved where !Self.supportsZellij(target) {
+            zellijSessionsByHost[hostID] = []
+        }
         worktreeRemovalTombstones = worktreeRemovalTombstones.filter {
             retainedHostIDs.contains($0.key.hostID)
         }
@@ -3021,6 +3439,7 @@ final class WorkspaceSceneModel: ObservableObject {
         scheduleKwtInventory()
         scheduleTmuxSessionDiscovery()
         scheduleHerdrSessionDiscovery()
+        scheduleZellijSessionDiscovery()
     }
 
     private func applyInventoryOverlayIfNeeded() {
@@ -3044,7 +3463,9 @@ final class WorkspaceSceneModel: ObservableObject {
         let overlaid = HostInventoryOverlay.applyRuntimeSessions(
             tmuxSessionsByHost: tmuxSessionsByHost,
             herdrSessionsByHost: herdrSessionsByHost,
+            zellijSessionsByHost: zellijSessionsByHost,
             herdrAvailabilityByHost: herdrAvailabilityByHost,
+            zellijAvailabilityByHost: zellijAvailabilityByHost,
             tmuxReachabilityByHost: tmuxReachabilityByHost,
             tmuxLastSeenByHost: tmuxLastSeenByHost,
             to: snapshot
@@ -3077,8 +3498,16 @@ final class WorkspaceSceneModel: ObservableObject {
                 herdrSessionsByHost,
                 hostID: hostID
             ),
+            zellijSessionsByHost: hostScopedValue(
+                zellijSessionsByHost,
+                hostID: hostID
+            ),
             herdrAvailabilityByHost: hostScopedValue(
                 herdrAvailabilityByHost,
+                hostID: hostID
+            ),
+            zellijAvailabilityByHost: hostScopedValue(
+                zellijAvailabilityByHost,
                 hostID: hostID
             ),
             tmuxReachabilityByHost: hostScopedValue(
@@ -3333,6 +3762,117 @@ final class WorkspaceSceneModel: ObservableObject {
                         suppressed: suppressed
                     )
                 }
+            }
+        }
+    }
+
+    private func zellijSessionKillEvent(
+        _ event: ZellijSessionKillCoordinator.Event
+    ) {
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: event.operation.key.hostID,
+            name: event.operation.key.sessionName
+        )
+        switch event.phase {
+        case .began:
+            let restoresActivePresentation =
+                activeBorrowedZellijSelection == selection
+            let presentationIntent = zellijPresentationIntent.flatMap {
+                $0.selection == selection
+                    && $0.navigationRevision == userNavigationRevision
+                    ? $0
+                    : nil
+            }
+            guard restoresActivePresentation || presentationIntent != nil,
+                  let host = presentationIntent?.host
+                  ?? activeZellijReconnectContext?.host
+                  ?? snapshot.host(id: selection.hostID)
+                  .flatMap(CommandHostResolver.resolve)
+            else {
+                return
+            }
+            suppressedZellijKillPresentations[event.operation.id] = .init(
+                selection: selection,
+                navigationRevision: userNavigationRevision,
+                host: host,
+                restoresActivePresentation: restoresActivePresentation,
+                presentationIntent: presentationIntent
+            )
+            if restoresActivePresentation {
+                closeBorrowedZellijSession(selection)
+            }
+        case .succeeded:
+            suppressedZellijKillPresentations.removeValue(
+                forKey: event.operation.id
+            )
+            if zellijPresentationIntent?.selection == selection {
+                invalidateZellijPresentationIntent()
+            }
+            zellijDiscoveryGeneration += 1
+            zellijDiscoveryTask?.cancel()
+            zellijDiscoveryTask = nil
+            zellijFreshHostIDs.remove(selection.hostID)
+            pendingCreatedZellijSessions = pendingCreatedZellijSessions.filter {
+                $0.value != selection
+            }
+            if activeBorrowedZellijSelection == selection {
+                closeBorrowedZellijSession(selection)
+            }
+            let sessions = zellijSessionsByHost[selection.hostID]
+                ?? snapshot.host(id: selection.hostID)?.zellijSessions
+                ?? []
+            zellijSessionsByHost[selection.hostID] = sessions.filter {
+                $0.name != selection.name
+            }
+            applyRuntimeInventoryOverlayIfNeeded(hostID: selection.hostID)
+            updateWorkspaceInventoryState()
+            scheduleZellijSessionDiscovery()
+        case .failed:
+            let suppressed = suppressedZellijKillPresentations.removeValue(
+                forKey: event.operation.id
+            )
+            let pendingIntent = zellijPresentationIntent.flatMap {
+                $0.selection == selection
+                    && $0.navigationRevision == userNavigationRevision
+                    ? $0
+                    : nil
+            }
+            let resumableIntent = pendingIntent
+                ?? suppressed?.presentationIntent
+            let resumesValidation = resumableIntent.map {
+                $0.selection == selection
+                    && $0.navigationRevision == userNavigationRevision
+                    && $0.revision == zellijPresentationRevision
+                    && snapshot.host(id: selection.hostID)
+                    .flatMap(CommandHostResolver.resolve) == $0.host
+                    && activeBorrowedTmuxSelection == nil
+                    && activeBorrowedHerdrSelection == nil
+                    && (activeBorrowedZellijSelection == nil
+                        || activeBorrowedZellijSelection == selection)
+            } ?? false
+            let restoresSuppressedPresentation =
+                suppressed?.selection == selection
+                    && suppressed?.navigationRevision == userNavigationRevision
+                    && suppressed?.restoresActivePresentation == true
+                    && snapshot.host(id: selection.hostID)
+                    .flatMap(CommandHostResolver.resolve) == suppressed?.host
+                    && activeBorrowedTmuxSelection == nil
+                    && activeBorrowedHerdrSelection == nil
+                    && activeBorrowedZellijSelection == nil
+            if resumesValidation || restoresSuppressedPresentation {
+                validateAndPresentZellijSession(selection)
+                return
+            }
+            if let restoration = pendingRestoration?.zellij,
+               let host = snapshot.host(id: selection.hostID),
+               restoration.hostKey == host.configKey,
+               restoration.sessionName == selection.name {
+                if let route = zellijRestorationRoute,
+                   CommandHostResolver.resolve(host) != route.host {
+                    cancelPendingRestoration()
+                    return
+                }
+                attemptPendingRestoration()
             }
         }
     }
@@ -3762,7 +4302,9 @@ final class WorkspaceSceneModel: ObservableObject {
             kwtAvailabilityByHost: kwtAvailabilityByHost,
             tmuxSessionsByHost: tmuxSessionsByHost,
             herdrSessionsByHost: herdrSessionsByHost,
+            zellijSessionsByHost: zellijSessionsByHost,
             herdrAvailabilityByHost: herdrAvailabilityByHost,
+            zellijAvailabilityByHost: zellijAvailabilityByHost,
             tmuxReachabilityByHost: tmuxReachabilityByHost,
             tmuxLastSeenByHost: tmuxLastSeenByHost,
             to: source
@@ -3945,6 +4487,231 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    func startZellijSessionDiscovery() {
+        guard !isShutDown, !zellijDiscoveryEnabled else { return }
+        zellijDiscoveryEnabled = true
+        let generation = zellijDiscoveryGeneration
+        reconcileInventoryHosts()
+        if generation == zellijDiscoveryGeneration {
+            scheduleZellijSessionDiscovery()
+        }
+    }
+
+    private func refreshZellijSessionDiscovery() {
+        guard !isShutDown else { return }
+        zellijFreshHostIDs.removeAll()
+        scheduleZellijSessionDiscovery()
+    }
+
+    private func scheduleZellijSessionDiscovery() {
+        guard !isShutDown, zellijDiscoveryEnabled else { return }
+        let targets = inventoryHosts.filter { _, host in
+            Self.supportsZellij(host)
+        }
+        zellijCreationDiscoveryRetryTask?.cancel()
+        zellijCreationDiscoveryRetryTask = nil
+        zellijCreationDiscoveryRetryID = nil
+        zellijDiscoveryGeneration += 1
+        let generation = zellijDiscoveryGeneration
+        zellijDiscoveryTask?.cancel()
+        inventoryRefreshProgress.zellijCompleted = false
+        isZellijDiscoveryLoading = true
+        updateWorkspaceInventoryState()
+        let discovery = zellijSessionDiscovery
+        zellijDiscoveryTask = Task { [weak self] in
+            let results = await withTaskGroup(
+                of: (UUID, ZellijDiscoveryResult).self
+            ) { group -> [(UUID, ZellijDiscoveryResult)] in
+                for (hostID, host) in targets {
+                    group.addTask {
+                        let probe = Task.detached(priority: .utility) {
+                            discovery(host)
+                        }
+                        return await (hostID, probe.value)
+                    }
+                }
+                var results: [(UUID, ZellijDiscoveryResult)] = []
+                for await result in group {
+                    guard let self, !Task.isCancelled,
+                          generation == self.zellijDiscoveryGeneration
+                    else {
+                        group.cancelAll()
+                        return []
+                    }
+                    results.append(result)
+                }
+                return results
+            }
+            guard let self, !Task.isCancelled, !isShutDown,
+                  generation == zellijDiscoveryGeneration else { return }
+            for (hostID, result) in results {
+                applyZellijDiscoveryResult(
+                    result,
+                    hostID: hostID,
+                    publish: false
+                )
+            }
+            applyRuntimeInventoryOverlayIfNeeded()
+            isZellijDiscoveryLoading = false
+            inventoryRefreshProgress.zellijCompleted = true
+            updateWorkspaceInventoryState()
+            reconcileZellijCreationDiscoveryRetry()
+        }
+    }
+
+    private func applyZellijDiscoveryResult(
+        _ result: ZellijDiscoveryResult,
+        hostID: UUID,
+        publish: Bool = true
+    ) {
+        zellijFreshHostIDs.insert(hostID)
+        let pending = pendingCreatedZellijSessions.filter {
+            $0.value.hostID == hostID
+        }
+        switch result {
+        case let .available(names):
+            var sessions = names.map {
+                ZellijSessionSummary(name: $0)
+            }
+            for (handleID, selection) in pending {
+                if names.contains(selection.name) {
+                    pendingCreatedZellijSessions.removeValue(forKey: handleID)
+                } else if !sessions.contains(where: {
+                    $0.name == selection.name
+                }) {
+                    sessions.append(ZellijSessionSummary(name: selection.name))
+                }
+            }
+            zellijSessionsByHost[hostID] = sessions
+            zellijAvailabilityByHost[hostID] = true
+            zellijDiscoveryFailuresByHost.removeValue(forKey: hostID)
+        case .unavailable:
+            zellijSessionsByHost[hostID] = pendingZellijSessionSummaries(
+                pending
+            )
+            zellijAvailabilityByHost[hostID] = !pending.isEmpty
+            zellijDiscoveryFailuresByHost.removeValue(forKey: hostID)
+        case let .failure(error):
+            zellijSessionsByHost[hostID] = pendingZellijSessionSummaries(
+                pending
+            )
+            zellijAvailabilityByHost[hostID] = !pending.isEmpty
+            let hostName = snapshot.host(id: hostID)?.name ?? "Unknown host"
+            zellijDiscoveryFailuresByHost[hostID] =
+                "\(hostName): \(error.localizedDescription)"
+        }
+        if publish {
+            applyRuntimeInventoryOverlayIfNeeded(hostID: hostID)
+            updateWorkspaceInventoryState()
+        }
+    }
+
+    private func pendingZellijSessionSummaries(
+        _ pending: [UUID: WorkspaceZellijSessionSelection]
+    ) -> [ZellijSessionSummary] {
+        pending.values
+            .map { ZellijSessionSummary(name: $0.name) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private func reconcileZellijCreationDiscoveryRetry() {
+        let pendingHostIDs = Set(
+            pendingCreatedZellijSessions.values.map(\.hostID)
+        )
+        guard !pendingHostIDs.isEmpty else {
+            zellijCreationDiscoveryRetryTask?.cancel()
+            zellijCreationDiscoveryRetryTask = nil
+            zellijCreationDiscoveryRetryID = nil
+            zellijCreationDiscoveryRetryAttempt = 0
+            return
+        }
+        guard zellijCreationDiscoveryRetryTask == nil else { return }
+        let delays = createdSessionDiscoveryDelays.isEmpty
+            ? [.seconds(1)]
+            : createdSessionDiscoveryDelays
+        let delayIndex = min(
+            zellijCreationDiscoveryRetryAttempt,
+            delays.count - 1
+        )
+        let delay = delays[delayIndex]
+        if zellijCreationDiscoveryRetryAttempt < delays.count - 1 {
+            zellijCreationDiscoveryRetryAttempt += 1
+        }
+        let retryID = UUID()
+        zellijCreationDiscoveryRetryID = retryID
+        zellijCreationDiscoveryRetryTask = Task { [weak self] in
+            defer {
+                if let self, zellijCreationDiscoveryRetryID == retryID {
+                    zellijCreationDiscoveryRetryTask = nil
+                    zellijCreationDiscoveryRetryID = nil
+                }
+            }
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard let self, !isShutDown,
+                  zellijCreationDiscoveryRetryID == retryID else { return }
+            let currentPendingHostIDs = Set(
+                pendingCreatedZellijSessions.values.map(\.hostID)
+            )
+            guard !currentPendingHostIDs.isEmpty else {
+                zellijCreationDiscoveryRetryAttempt = 0
+                return
+            }
+            let targets = inventoryHosts.filter { hostID, host in
+                Self.supportsZellij(host)
+                    && currentPendingHostIDs.contains(hostID)
+            }
+            let discovery = zellijSessionDiscovery
+            let results = await withTaskGroup(
+                of: (UUID, ZellijDiscoveryResult).self
+            ) { group -> [(UUID, ZellijDiscoveryResult)] in
+                for (hostID, host) in targets {
+                    group.addTask {
+                        let probe = Task.detached(priority: .utility) {
+                            discovery(host)
+                        }
+                        return await (hostID, probe.value)
+                    }
+                }
+                var results: [(UUID, ZellijDiscoveryResult)] = []
+                for await result in group {
+                    guard !Task.isCancelled else {
+                        group.cancelAll()
+                        return []
+                    }
+                    results.append(result)
+                }
+                return results
+            }
+            guard !Task.isCancelled, !isShutDown,
+                  zellijCreationDiscoveryRetryID == retryID else { return }
+            for (hostID, result) in results {
+                applyZellijDiscoveryResult(
+                    result,
+                    hostID: hostID,
+                    publish: false
+                )
+            }
+            applyRuntimeInventoryOverlayIfNeeded()
+            updateWorkspaceInventoryState()
+            zellijCreationDiscoveryRetryTask = nil
+            zellijCreationDiscoveryRetryID = nil
+            reconcileZellijCreationDiscoveryRetry()
+        }
+    }
+
+    private static func supportsZellij(_ host: CommandHost) -> Bool {
+        switch host {
+        case .local:
+            true
+        case let .ssh(info):
+            info.platform == .posix
+        }
+    }
+
     private func applyTmuxDiscoveryResult(
         _ result: Result<[DiscoveredTmuxSession], TmuxBinaryError>,
         hostID: UUID,
@@ -4062,6 +4829,7 @@ final class WorkspaceSceneModel: ObservableObject {
             .union(projectListWarningsByHost.keys)
             .union(directoryWarningsByHost.keys)
             .union(herdrDiscoveryFailuresByHost.keys)
+            .union(zellijDiscoveryFailuresByHost.keys)
         workspaceInventoryWarningsByHost = Dictionary(
             uniqueKeysWithValues: hostIDs.compactMap { hostID in
                 let warnings = [
@@ -4070,6 +4838,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     projectListWarningsByHost[hostID],
                     directoryWarningsByHost[hostID],
                     herdrDiscoveryFailuresByHost[hostID],
+                    zellijDiscoveryFailuresByHost[hostID],
                 ].compactMap { $0 }
                 let unique = Array(Set(warnings)).sorted()
                 guard !unique.isEmpty else { return nil }
@@ -4083,13 +4852,16 @@ final class WorkspaceSceneModel: ObservableObject {
             || !snapshot.directoryWorkspaces.isEmpty
             || snapshot.hosts.contains { !$0.tmuxSessions.isEmpty }
             || snapshot.hosts.contains { !$0.herdrSessions.isEmpty }
+            || snapshot.hosts.contains { !$0.zellijSessions.isEmpty }
         let hasCachedInventory = hasVisibleInventory
             || !kwtInventoriesByHost.isEmpty
             || !tmuxSessionsByHost.isEmpty
             || herdrSessionsByHost.values.contains { !$0.isEmpty }
+            || zellijSessionsByHost.values.contains { !$0.isEmpty }
         let hasPendingSources = isKwtInventoryLoading
             || isTmuxDiscoveryLoading
             || isHerdrDiscoveryLoading
+            || isZellijDiscoveryLoading
         if hasPendingSources, !hasVisibleInventory {
             workspaceInventoryState = .loading
             return
@@ -4251,6 +5023,16 @@ final class WorkspaceSceneModel: ObservableObject {
             for handle in herdrHandles {
                 borrowedHerdrConnectionStates.removeValue(forKey: handle.id)
             }
+            let zellijHandles = nativeZellijSessionCoordinator.detachAll(
+                hostID: hostID
+            )
+            for handle in zellijHandles {
+                borrowedZellijConnectionStates.removeValue(forKey: handle.id)
+                pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+            }
+        }
+        zellijKillAuthorities = zellijKillAuthorities.filter {
+            !hostIDs.contains($0.value.hostID)
         }
         if let activeHerdr = activeBorrowedHerdrSelection,
            hostIDs.contains(activeHerdr.hostID) {
@@ -4258,6 +5040,17 @@ final class WorkspaceSceneModel: ObservableObject {
             failedHerdrLaunchIntent = nil
             activeBorrowedHerdrSelection = nil
             activeBorrowedHerdrHandle = nil
+        }
+        if let intent = zellijPresentationIntent,
+           hostIDs.contains(intent.selection.hostID) {
+            invalidateZellijPresentationIntent()
+        }
+        if let activeZellij = activeBorrowedZellijSelection,
+           hostIDs.contains(activeZellij.hostID) {
+            invalidateZellijPresentationIntent()
+            cancelZellijReconnect()
+            activeBorrowedZellijSelection = nil
+            activeBorrowedZellijHandle = nil
         }
         guard let active = activeBorrowedTmuxSelection,
               hostIDs.contains(active.hostID) else { return }
@@ -5096,6 +5889,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func openBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
         cancelPendingRestoration()
+        invalidateZellijPresentationIntent()
         userNavigationRevision &+= 1
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
@@ -5185,6 +5979,471 @@ final class WorkspaceSceneModel: ObservableObject {
         _ = nativeHerdrSessionCoordinator.surface(handle: handle)
     }
 
+    func borrowedZellijSessionView(
+        host: HostSummary,
+        sessionName: String,
+        defersTerminalResize: Bool
+    ) -> AnyView? {
+        guard CommandHostResolver.resolve(host) != nil else {
+            return AnyView(
+                ContentUnavailableView(
+                    "SSH unavailable",
+                    systemImage: "network.slash",
+                    description: Text(
+                        "Add an SSH address for \(host.name) in Hosts settings."
+                    )
+                )
+            )
+        }
+        guard let selection = activeBorrowedZellijSelection,
+              selection.hostID == host.id,
+              selection.name == sessionName,
+              let handle = activeBorrowedZellijHandle
+        else { return nil }
+        return AnyView(
+            BorrowedZellijSessionView(
+                handle: handle,
+                isRemoteHost: host.kind == .remote,
+                connectionState: borrowedZellijConnectionStates[handle.id],
+                attachmentClosure:
+                nativeZellijSessionCoordinator.attachmentClosure(handle),
+                defersTerminalResize: defersTerminalResize,
+                surface: { [weak self] in
+                    self?.nativeZellijSessionCoordinator.surface(handle: handle)
+                },
+                onCloseRequest: {
+                    NotificationCenter.default.post(
+                        name: .ghosthubCloseTab,
+                        object: nil
+                    )
+                },
+                onRetryRequest: { [weak self] in
+                    self?.retryBorrowedZellijSession(selection)
+                },
+                onHostSettingsRequest: { [weak self] in
+                    SettingsStore.shared.selectedDomain = .hosts
+                    self?.isSettingsPresented = true
+                }
+            )
+        )
+    }
+
+    func prepareActiveBorrowedZellijSurface() {
+        guard !isShutDown else { return }
+        guard let handle = activeBorrowedZellijHandle else { return }
+        _ = nativeZellijSessionCoordinator.surface(handle: handle)
+    }
+
+    func openBorrowedZellijSession(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        guard snapshot.host(id: selection.hostID)?.zellijSessions.contains(
+            where: { $0.name == selection.name }
+        ) == true else { return }
+        if activeBorrowedZellijSelection == selection,
+           let handle = activeBorrowedZellijHandle,
+           nativeZellijSessionCoordinator.attachmentClosure(handle) == nil {
+            return
+        }
+        cancelPendingRestoration()
+        validateAndPresentZellijSession(selection)
+    }
+
+    func createZellijSession(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        guard let host = snapshot.host(id: selection.hostID),
+              host.zellijAvailable,
+              !host.zellijSessions.contains(where: {
+                  $0.name == selection.name
+              })
+        else { return }
+        cancelPendingRestoration()
+        invalidateZellijPresentationIntent()
+        guard let handle = presentZellijSession(
+            selection,
+            launchMode: .create
+        ) else { return }
+        pendingCreatedZellijSessions[handle.id] = selection
+        var sessions = snapshot.host(id: selection.hostID)?.zellijSessions ?? []
+        if !sessions.contains(where: { $0.name == selection.name }) {
+            sessions.append(ZellijSessionSummary(name: selection.name))
+        }
+        zellijSessionsByHost[selection.hostID] = sessions
+        zellijAvailabilityByHost[selection.hostID] = true
+        applyRuntimeInventoryOverlayIfNeeded(hostID: selection.hostID)
+    }
+
+    @discardableResult
+    private func presentZellijSession(
+        _ selection: WorkspaceZellijSessionSelection,
+        launchMode: ZellijAttachmentLaunchMode = .attachExisting,
+        validation: ZellijSessionValidation? = nil,
+        expectedKillRevision: UInt64? = nil
+    ) -> BorrowedZellijSessionHandle? {
+        let killKey = ZellijSessionKillCoordinator.Key(
+            hostID: selection.hostID,
+            sessionName: selection.name
+        )
+        guard !isShutDown,
+              !zellijSessionKillCoordinator.isPending(killKey),
+              expectedKillRevision.map({
+                  zellijSessionKillCoordinator.revision(for: killKey) == $0
+              }) ?? true
+        else { return nil }
+        closeActivePresentations(replacingWith: selection)
+        if activeBorrowedZellijSelection == selection,
+           let handle = activeBorrowedZellijHandle,
+           nativeZellijSessionCoordinator.attachmentClosure(handle) == nil {
+            return handle
+        }
+        guard let hostSummary = snapshot.host(id: selection.hostID),
+              let currentHost = CommandHostResolver.resolve(hostSummary)
+        else {
+            activeBorrowedZellijSelection = selection
+            activeBorrowedZellijHandle = nil
+            return nil
+        }
+        let host = validation?.host ?? currentHost
+        guard currentHost == host else { return nil }
+        let handle = nativeZellijSessionCoordinator.attach(
+            hostID: selection.hostID,
+            name: selection.name,
+            host: host,
+            launchMode: launchMode,
+            sshConnectionSnapshot: validation?.connection
+        )
+        activeBorrowedZellijSelection = selection
+        activeBorrowedZellijHandle = handle
+        borrowedZellijConnectionStates[handle.id] = .connecting
+        activeZellijReconnectContext = host.isRemote
+            ? ActiveZellijReconnectContext(
+                selection: selection,
+                handleID: handle.id,
+                host: host,
+                connection: validation?.connection,
+                surfaceExitCode: nil
+            )
+            : nil
+        return handle
+    }
+
+    private func closeActivePresentations(
+        replacingWith selection: WorkspaceZellijSessionSelection
+    ) {
+        if let activeTmux = activeBorrowedTmuxSelection {
+            closeBorrowedTmuxSession(activeTmux)
+        }
+        if let activeHerdr = activeBorrowedHerdrSelection {
+            closeBorrowedHerdrSession(activeHerdr)
+        }
+        if let active = activeBorrowedZellijSelection,
+           active != selection {
+            closeBorrowedZellijSession(active)
+        }
+    }
+
+    func closeBorrowedZellijSession(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        cancelPendingRestoration()
+        invalidateZellijPresentationIntent()
+        guard activeBorrowedZellijSelection == selection else { return }
+        cancelZellijReconnect()
+        var wasPendingCreation = false
+        if let handle = activeBorrowedZellijHandle {
+            wasPendingCreation = pendingCreatedZellijSessions
+                .removeValue(forKey: handle.id) != nil
+            borrowedZellijConnectionStates.removeValue(forKey: handle.id)
+        }
+        activeBorrowedZellijSelection = nil
+        activeBorrowedZellijHandle = nil
+        nativeZellijSessionCoordinator.detach(
+            hostID: selection.hostID,
+            name: selection.name
+        )
+        if wasPendingCreation {
+            reconcileZellijCreationDiscoveryRetry()
+            scheduleZellijSessionDiscovery()
+        }
+    }
+
+    func retryBorrowedZellijSession(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        guard activeBorrowedZellijSelection == selection else { return }
+        validateAndPresentZellijSession(selection)
+    }
+
+    private func validateAndPresentZellijSession(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        invalidateZellijPresentationIntent()
+        let killKey = ZellijSessionKillCoordinator.Key(
+            hostID: selection.hostID,
+            sessionName: selection.name
+        )
+        let navigationRevision = userNavigationRevision
+        guard let hostSummary = snapshot.host(id: selection.hostID),
+              let host = CommandHostResolver.resolve(hostSummary),
+              Self.supportsZellij(host),
+              hostSummary.zellijAvailable
+              || activeBorrowedZellijSelection == selection
+        else { return }
+        let intent = ZellijPresentationIntent(
+            id: UUID(),
+            selection: selection,
+            navigationRevision: navigationRevision,
+            revision: zellijPresentationRevision,
+            host: host
+        )
+        zellijPresentationIntent = intent
+        guard !zellijSessionKillCoordinator.isPending(killKey) else { return }
+        let killRevision = zellijSessionKillCoordinator.revision(for: killKey)
+        zellijPresentationTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if zellijPresentationIntent?.id == intent.id {
+                    zellijPresentationTask = nil
+                    zellijPresentationIntent = nil
+                }
+            }
+            let validation = await validatedZellijSession(on: host)
+            guard !Task.isCancelled, !isShutDown,
+                  zellijPresentationIntent?.id == intent.id,
+                  zellijPresentationRevision == intent.revision,
+                  navigationRevision == userNavigationRevision,
+                  !zellijSessionKillCoordinator.isPending(killKey),
+                  killRevision
+                  == zellijSessionKillCoordinator.revision(for: killKey),
+                  snapshot.host(id: selection.hostID)
+                  .flatMap(CommandHostResolver.resolve) == host
+            else { return }
+            guard let validation else {
+                retainFailedZellijSession(
+                    selection,
+                    host: host,
+                    reason: "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+                )
+                scheduleZellijSessionDiscovery()
+                return
+            }
+            let failureReason: String
+            switch validation.result {
+            case let .available(names) where names.contains(selection.name):
+                _ = presentZellijSession(
+                    selection,
+                    launchMode: .attachExisting,
+                    validation: validation,
+                    expectedKillRevision: killRevision
+                )
+                return
+            case .available:
+                failureReason = "The Zellij session is no longer running."
+            case .unavailable:
+                failureReason = ZellijCommandError.unavailable
+                    .localizedDescription
+            case let .failure(error):
+                failureReason = error.localizedDescription
+            }
+            retainFailedZellijSession(
+                selection,
+                host: host,
+                reason: failureReason
+            )
+            scheduleZellijSessionDiscovery()
+        }
+    }
+
+    private func validatedZellijSession(
+        on host: CommandHost
+    ) async -> ZellijSessionValidation? {
+        let connection = await zellijConnectionSnapshot(on: host)
+        let result = await zellijSessionValidationDiscovery(
+            host,
+            connection.arguments
+        )
+        let currentConnection = await zellijConnectionSnapshot(on: host)
+        guard !Task.isCancelled,
+              currentConnection.cacheKey == connection.cacheKey
+        else { return nil }
+        return ZellijSessionValidation(
+            result: result,
+            host: host,
+            connection: connection
+        )
+    }
+
+    private func retainFailedZellijSession(
+        _ selection: WorkspaceZellijSessionSelection,
+        host: CommandHost,
+        reason: String
+    ) {
+        guard activeBorrowedTmuxSelection == nil,
+              activeBorrowedHerdrSelection == nil,
+              activeBorrowedZellijSelection == nil
+              || activeBorrowedZellijSelection == selection
+        else { return }
+        closeActivePresentations(replacingWith: selection)
+        let handle = nativeZellijSessionCoordinator.retainFailedAttachment(
+            hostID: selection.hostID,
+            name: selection.name,
+            host: host,
+            reason: reason
+        )
+        activeBorrowedZellijSelection = selection
+        activeBorrowedZellijHandle = handle
+        borrowedZellijConnectionStates[handle.id] = .disconnected(
+            reason: reason
+        )
+        activeZellijReconnectContext = host.isRemote
+            ? ActiveZellijReconnectContext(
+                selection: selection,
+                handleID: handle.id,
+                host: host,
+                connection: nil,
+                surfaceExitCode: nil
+            )
+            : nil
+    }
+
+    func prepareZellijSessionKill(
+        _ selection: WorkspaceZellijSessionSelection
+    ) async throws -> ZellijSessionKillRequest {
+        let activityGeneration = try captureSceneActivity()
+        guard let hostSummary = snapshot.host(id: selection.hostID),
+              hostSummary.zellijAvailable,
+              let host = CommandHostResolver.resolve(hostSummary)
+        else { throw ZellijSessionPresentationError.unavailable }
+        let connection = await zellijConnectionSnapshot(on: host)
+        try requireActiveScene(activityGeneration)
+        let result = await zellijSessionValidationDiscovery(
+            host,
+            connection.arguments
+        )
+        let currentConnection = await zellijConnectionSnapshot(on: host)
+        try requireActiveScene(activityGeneration)
+        guard snapshot.host(id: selection.hostID)
+            .flatMap(CommandHostResolver.resolve) == host,
+            currentConnection.cacheKey == connection.cacheKey
+        else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
+        guard case let .available(names) = result,
+              names.contains(selection.name)
+        else {
+            throw ZellijSessionPresentationError.sessionMissing(selection.name)
+        }
+        let authorityID = UUID()
+        zellijKillAuthorities[authorityID] = ZellijKillAuthority(
+            hostID: selection.hostID,
+            host: host,
+            connection: connection
+        )
+        return ZellijSessionKillRequest(
+            authorityID: authorityID,
+            session: selection,
+            confirmedHost: hostSummary
+        )
+    }
+
+    func killZellijSession(
+        _ request: ZellijSessionKillRequest
+    ) async throws {
+        let activityGeneration = try captureSceneActivity()
+        let selection = request.session
+        guard let authority = zellijKillAuthorities.removeValue(
+            forKey: request.authorityID
+        ),
+            authority.hostID == selection.hostID,
+            request.confirmedHost.id == selection.hostID,
+            let confirmedHost = CommandHostResolver.resolve(
+                request.confirmedHost
+            ),
+            let currentHostSummary = snapshot.host(id: selection.hostID),
+            currentHostSummary.zellijAvailable,
+            let currentHost = CommandHostResolver.resolve(currentHostSummary),
+            currentHost == confirmedHost,
+            authority.host == currentHost
+        else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
+        let currentConnection = await zellijConnectionSnapshot(on: currentHost)
+        try requireActiveScene(activityGeneration)
+        guard currentConnection.cacheKey == authority.connection.cacheKey else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
+        let key = ZellijSessionKillCoordinator.Key(
+            hostID: selection.hostID,
+            sessionName: selection.name
+        )
+        guard let operation = zellijSessionKillCoordinator.begin(key: key)
+        else {
+            throw ZellijSessionPresentationError.operationPending(
+                selection.name
+            )
+        }
+        var outcome = ZellijSessionKillCoordinator.Outcome.failed
+        defer {
+            zellijSessionKillCoordinator.finish(operation, outcome: outcome)
+        }
+        let result = await zellijSessionValidationDiscovery(
+            currentHost,
+            authority.connection.arguments
+        )
+        let postDiscoveryConnection = await zellijConnectionSnapshot(
+            on: authority.host
+        )
+        try requireActiveScene(activityGeneration)
+        guard let postDiscoveryHostSummary = snapshot.host(
+            id: selection.hostID
+        ),
+            postDiscoveryHostSummary.zellijAvailable,
+            let postDiscoveryHost = CommandHostResolver.resolve(
+                postDiscoveryHostSummary
+            ),
+            postDiscoveryHost == authority.host,
+            postDiscoveryConnection.cacheKey
+            == authority.connection.cacheKey
+        else {
+            throw ZellijSessionPresentationError.hostChanged(selection.name)
+        }
+        guard case let .available(names) = result,
+              names.contains(selection.name)
+        else {
+            throw ZellijSessionPresentationError.sessionMissing(selection.name)
+        }
+        let killResult = await zellijSessionKiller(
+            selection.name,
+            postDiscoveryHost,
+            authority.connection.arguments
+        )
+        try killResult.get()
+        outcome = .succeeded
+        try requireActiveScene(activityGeneration)
+        if activeBorrowedZellijSelection == selection {
+            closeBorrowedZellijSession(selection)
+        }
+    }
+
+    func cancelPreparedZellijSessionKill(
+        _ request: ZellijSessionKillRequest
+    ) {
+        zellijKillAuthorities.removeValue(forKey: request.authorityID)
+    }
+
+    private func zellijConnectionSnapshot(
+        on host: CommandHost
+    ) async -> SSHConnectionArgumentsSnapshot {
+        guard case let .ssh(info) = host else {
+            return SSHConnectionArgumentsSnapshot(arguments: [])
+        }
+        let provider = zellijSSHConnectionSnapshotProvider
+        return await Task.detached(priority: .userInitiated) {
+            provider(info)
+        }.value
+    }
+
     private func captureSceneActivity() throws -> UInt64 {
         guard !isShutDown else { throw CancellationError() }
         return sceneActivityGeneration
@@ -5200,6 +6459,7 @@ final class WorkspaceSceneModel: ObservableObject {
     func openBorrowedHerdrSession(
         _ selection: WorkspaceHerdrSessionSelection
     ) async throws {
+        invalidateZellijPresentationIntent()
         let activityGeneration = try captureSceneActivity()
         let navigationRevision = userNavigationRevision
         guard snapshot.host(id: selection.hostID)?.herdrSessions.contains(
@@ -5237,6 +6497,7 @@ final class WorkspaceSceneModel: ObservableObject {
     func createHerdrSession(
         _ selection: WorkspaceHerdrSessionSelection
     ) async throws {
+        invalidateZellijPresentationIntent()
         let activityGeneration = try captureSceneActivity()
         let navigationRevision = userNavigationRevision
         guard let host = snapshot.host(id: selection.hostID),
@@ -5621,6 +6882,9 @@ final class WorkspaceSceneModel: ObservableObject {
         if let activeTmux = activeBorrowedTmuxSelection {
             closeBorrowedTmuxSession(activeTmux)
         }
+        if let activeZellij = activeBorrowedZellijSelection {
+            closeBorrowedZellijSession(activeZellij)
+        }
         if let active = activeBorrowedHerdrSelection,
            active != selection {
             closeBorrowedHerdrSession(active)
@@ -5933,6 +7197,9 @@ final class WorkspaceSceneModel: ObservableObject {
     ) -> BorrowedTmuxSessionHandle? {
         if let activeHerdr = activeBorrowedHerdrSelection {
             closeBorrowedHerdrSession(activeHerdr)
+        }
+        if let activeZellij = activeBorrowedZellijSelection {
+            closeBorrowedZellijSession(activeZellij)
         }
         var selection = selection
         if let worktreeID = selection.worktreeID,
@@ -6784,6 +8051,247 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    private func nativeZellijStateChanged(
+        handle: BorrowedZellijSessionHandle,
+        state: ConnectionState
+    ) {
+        guard !isShutDown else { return }
+        borrowedZellijConnectionStates[handle.id] = state
+        guard activeBorrowedZellijHandle == handle else { return }
+        switch state {
+        case .connected:
+            zellijReconnectSupervisor.cancel()
+            if var context = activeZellijReconnectContext,
+               context.handleID == handle.id {
+                context.connection = nativeZellijSessionCoordinator
+                    .attachmentConnectionSnapshot(handle)
+                context.surfaceExitCode = nil
+                activeZellijReconnectContext = context
+            }
+            sessionConnectionRecoveryRequest = nil
+            scheduleZellijSessionDiscovery()
+        case .disconnected:
+            guard nativeZellijSessionCoordinator.hasLaunched(handle) else {
+                if let selection = pendingCreatedZellijSessions
+                    .removeValue(forKey: handle.id) {
+                    zellijSessionsByHost[selection.hostID] = snapshot
+                        .host(id: selection.hostID)?
+                        .zellijSessions.filter {
+                            $0.name != selection.name
+                        } ?? []
+                    applyRuntimeInventoryOverlayIfNeeded(
+                        hostID: selection.hostID
+                    )
+                }
+                zellijReconnectSupervisor.cancel()
+                return
+            }
+            switch nativeZellijSessionCoordinator.attachmentClosure(handle) {
+            case .detached:
+                pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+                zellijReconnectSupervisor.cancel()
+                scheduleZellijSessionDiscovery()
+            case let .processExited(code):
+                guard var context = activeZellijReconnectContext,
+                      context.handleID == handle.id,
+                      context.host.isRemote,
+                      code == 255
+                else {
+                    pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+                    zellijReconnectSupervisor.cancel()
+                    scheduleZellijSessionDiscovery()
+                    return
+                }
+                context.surfaceExitCode = code
+                activeZellijReconnectContext = context
+                startZellijReconnect(context)
+            case .launchFailed, nil:
+                pendingCreatedZellijSessions.removeValue(forKey: handle.id)
+                zellijReconnectSupervisor.cancel()
+                scheduleZellijSessionDiscovery()
+            }
+        case .connecting, .reconnecting:
+            break
+        }
+    }
+
+    private func startZellijReconnect(
+        _ context: ActiveZellijReconnectContext
+    ) {
+        guard !isShutDown,
+              activeZellijReconnectContext == context,
+              activeBorrowedZellijHandle?.id == context.handleID,
+              !zellijSessionKillCoordinator.isPending(.init(
+                  hostID: context.selection.hostID,
+                  sessionName: context.selection.name
+              ))
+        else { return }
+        borrowedZellijConnectionStates[context.handleID] = .reconnecting(
+            reason: "Waiting for \(hostName(for: context.selection.hostID)). "
+                + "Ghosthub will reconnect automatically."
+        )
+        sessionConnectionRecoveryRequest = nil
+        zellijReconnectSupervisor.start { [weak self] in
+            guard let self else { return .stop }
+            return await attemptZellijReconnect(context)
+        }
+    }
+
+    private func attemptZellijReconnect(
+        _ context: ActiveZellijReconnectContext
+    ) async -> SessionReconnectDecision {
+        guard activeZellijReconnectContext == context,
+              activeBorrowedZellijHandle?.id == context.handleID
+        else { return .stop }
+        guard let connection = context.connection else {
+            stopZellijReconnect(
+                "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+            )
+            return .stop
+        }
+        let before = await zellijConnectionSnapshot(on: context.host)
+        guard before.cacheKey == connection.cacheKey else {
+            stopZellijReconnect(
+                "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+            )
+            return .stop
+        }
+        let result = await zellijSessionValidationDiscovery(
+            context.host,
+            connection.arguments
+        )
+        let after = await zellijConnectionSnapshot(on: context.host)
+        guard !Task.isCancelled else { return .retry }
+        guard activeZellijReconnectContext == context,
+              activeBorrowedZellijHandle?.id == context.handleID,
+              snapshot.host(id: context.selection.hostID)
+              .flatMap(CommandHostResolver.resolve) == context.host
+        else { return .stop }
+        guard after.cacheKey == connection.cacheKey else {
+            stopZellijReconnect(
+                "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+            )
+            return .stop
+        }
+        return zellijReconnectDecision(
+            for: context,
+            result: result,
+            connection: connection
+        )
+    }
+
+    private func zellijReconnectDecision(
+        for context: ActiveZellijReconnectContext,
+        result: ZellijDiscoveryResult,
+        connection: SSHConnectionArgumentsSnapshot
+    ) -> SessionReconnectDecision {
+        guard !Task.isCancelled else { return .retry }
+        guard activeZellijReconnectContext == context,
+              activeBorrowedZellijHandle?.id == context.handleID,
+              !zellijSessionKillCoordinator.isPending(.init(
+                  hostID: context.selection.hostID,
+                  sessionName: context.selection.name
+              ))
+        else { return .stop }
+        switch result {
+        case let .available(names):
+            guard names.contains(context.selection.name) else {
+                pendingCreatedZellijSessions.removeValue(
+                    forKey: context.handleID
+                )
+                stopZellijReconnect(
+                    "The Zellij session is no longer running."
+                )
+                scheduleZellijSessionDiscovery()
+                return .stop
+            }
+            guard context.surfaceExitCode == 255 else {
+                stopZellijReconnect(
+                    "The remote Zellij client exited before it could attach."
+                )
+                return .stop
+            }
+            guard presentZellijSession(
+                context.selection,
+                validation: ZellijSessionValidation(
+                    result: result,
+                    host: context.host,
+                    connection: connection
+                )
+            ) != nil else {
+                stopZellijReconnect(
+                    "The remote host is no longer available."
+                )
+                return .stop
+            }
+            return .stop
+        case .unavailable:
+            stopZellijReconnect(
+                "Zellij is no longer available on this host."
+            )
+            scheduleZellijSessionDiscovery()
+            return .stop
+        case let .failure(.commandFailed(status, stderr)) where status == 255:
+            let classification = SSHConnectionFailure.classify(
+                status: status,
+                output: stderr
+            )
+            switch classification.kind {
+            case .transport:
+                borrowedZellijConnectionStates[context.handleID] =
+                    .reconnecting(
+                        reason: classification.diagnostic.summary + " "
+                            + "Ghosthub will reconnect automatically."
+                    )
+                return .retry
+            case .authenticationRequired, .hostKeyReviewRequired:
+                let message = classification.diagnostic.summary + " "
+                    + classification.diagnostic.recoverySuggestion
+                stopZellijReconnect(message)
+                if sessionConnectionRecoveryRequest == nil {
+                    sessionConnectionRecoveryRequest =
+                        SessionConnectionRecoveryRequest(
+                            hostID: context.selection.hostID,
+                            message: message
+                        )
+                }
+                return .stop
+            case .hostKeyChanged:
+                stopZellijReconnect(
+                    classification.diagnostic.summary + " "
+                        + classification.diagnostic.recoverySuggestion
+                )
+                return .stop
+            }
+        case let .failure(error):
+            stopZellijReconnect(error.localizedDescription)
+            return .stop
+        }
+    }
+
+    private func stopZellijReconnect(_ reason: String) {
+        sessionConnectionRecoveryRequest = nil
+        guard let handle = activeBorrowedZellijHandle else { return }
+        if let selection = pendingCreatedZellijSessions.removeValue(
+            forKey: handle.id
+        ) {
+            zellijSessionsByHost[selection.hostID] = snapshot
+                .host(id: selection.hostID)?
+                .zellijSessions.filter { $0.name != selection.name } ?? []
+            applyRuntimeInventoryOverlayIfNeeded(hostID: selection.hostID)
+            reconcileZellijCreationDiscoveryRetry()
+        }
+        borrowedZellijConnectionStates[handle.id] = .disconnected(
+            reason: reason
+        )
+    }
+
+    private func cancelZellijReconnect() {
+        zellijReconnectSupervisor.cancel()
+        activeZellijReconnectContext = nil
+        sessionConnectionRecoveryRequest = nil
+    }
+
     private func confirmHerdrLaunch(
         handle: BorrowedHerdrSessionHandle,
         operation: HerdrSessionLifecycleCoordinator.Operation,
@@ -7406,6 +8914,16 @@ final class WorkspaceSceneModel: ObservableObject {
             activeHerdrReconnectContext = context
             sessionConnectionRecoveryRequest = nil
             startHerdrReconnect(context)
+            return
+        }
+        if sessionConnectionRecoveryRequest == recoveryRequest,
+           var context = activeZellijReconnectContext,
+           context.selection.hostID == recoveryRequest.hostID,
+           activeBorrowedZellijHandle?.id == context.handleID {
+            context.surfaceExitCode = 255
+            activeZellijReconnectContext = context
+            sessionConnectionRecoveryRequest = nil
+            startZellijReconnect(context)
             return
         }
         guard let presentation = retainedTmuxPresentations.values.first(

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -668,6 +668,8 @@ struct WorkspaceWindow: View {
                 sceneModel.availablePaletteApplicationShortcuts,
                 activeHerdrSession:
                 sceneModel.activeBorrowedHerdrSelection,
+                activeZellijSession:
+                sceneModel.activeBorrowedZellijSelection,
                 pendingHerdrSessions:
                 sceneModel.pendingHerdrSessionSelections,
                 sessionConnectionRecoveryRequest:
@@ -696,6 +698,15 @@ struct WorkspaceWindow: View {
                         defersTerminalResize: defersTerminalResize,
                         onReconnectNow: actions.reconnectNow,
                         onReviewConnection: actions.reviewConnection
+                    )
+                },
+                zellijSessionContentBuilder: {
+                    [sceneModel]
+                    host, sessionName, defersTerminalResize, _ in
+                    sceneModel.borrowedZellijSessionView(
+                        host: host,
+                        sessionName: sessionName,
+                        defersTerminalResize: defersTerminalResize
                     )
                 },
                 settingsSheetBuilder: { settingsStore in
@@ -864,6 +875,24 @@ struct WorkspaceWindow: View {
                 closeHerdrSession: { [sceneModel] selection in
                     sceneModel.closeBorrowedHerdrSession(selection)
                 },
+                openZellijSession: { [sceneModel] selection in
+                    sceneModel.openBorrowedZellijSession(selection)
+                },
+                createZellijSession: { [sceneModel] selection in
+                    sceneModel.createZellijSession(selection)
+                },
+                closeZellijSession: { [sceneModel] selection in
+                    sceneModel.closeBorrowedZellijSession(selection)
+                },
+                prepareZellijSessionKill: { [sceneModel] selection in
+                    try await sceneModel.prepareZellijSessionKill(selection)
+                },
+                killZellijSession: { [sceneModel] request in
+                    try await sceneModel.killZellijSession(request)
+                },
+                cancelZellijSessionKill: { [sceneModel] request in
+                    sceneModel.cancelPreparedZellijSessionKill(request)
+                },
                 prepareHerdrSessionLifecycle: {
                     [sceneModel] selection, action in
                     try await sceneModel.prepareHerdrSessionLifecycle(
@@ -1024,6 +1053,8 @@ struct WorkspaceWindow: View {
                     sceneModel.activeBorrowedTmuxSelection,
                     activeHerdrSession:
                     sceneModel.activeBorrowedHerdrSelection,
+                    activeZellijSession:
+                    sceneModel.activeBorrowedZellijSelection,
                     in: sceneModel.snapshot
                 ),
                 onToggleSidebar: {
@@ -1035,7 +1066,7 @@ struct WorkspaceWindow: View {
                 onQuickLaunch: {
                     NotificationCenter.default.post(
                         name: .ghosthubCommandPalette,
-                        object: nil
+                        object: sceneModel
                     )
                 },
                 onSettings: {

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -884,6 +884,9 @@ struct WorkspaceWindow: View {
                 closeZellijSession: { [sceneModel] selection in
                     sceneModel.closeBorrowedZellijSession(selection)
                 },
+                cancelPendingZellijPresentation: { [sceneModel] in
+                    sceneModel.cancelPendingZellijPresentation()
+                },
                 prepareZellijSessionKill: { [sceneModel] selection in
                     try await sceneModel.prepareZellijSessionKill(selection)
                 },

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -702,11 +702,13 @@ struct WorkspaceWindow: View {
                 },
                 zellijSessionContentBuilder: {
                     [sceneModel]
-                    host, sessionName, defersTerminalResize, _ in
+                    host, sessionName, defersTerminalResize, actions in
                     sceneModel.borrowedZellijSessionView(
                         host: host,
                         sessionName: sessionName,
-                        defersTerminalResize: defersTerminalResize
+                        defersTerminalResize: defersTerminalResize,
+                        onReconnectNow: actions.reconnectNow,
+                        onReviewConnection: actions.reviewConnection
                     )
                 },
                 settingsSheetBuilder: { settingsStore in
@@ -879,7 +881,7 @@ struct WorkspaceWindow: View {
                     sceneModel.openBorrowedZellijSession(selection)
                 },
                 createZellijSession: { [sceneModel] selection in
-                    sceneModel.createZellijSession(selection)
+                    try await sceneModel.createZellijSession(selection)
                 },
                 closeZellijSession: { [sceneModel] selection in
                     sceneModel.closeBorrowedZellijSession(selection)
@@ -932,6 +934,9 @@ struct WorkspaceWindow: View {
                 },
                 reconnectActiveHerdrSessionNow: { [sceneModel] in
                     sceneModel.reconnectActiveHerdrSessionNow()
+                },
+                reconnectActiveZellijSessionNow: { [sceneModel] in
+                    sceneModel.reconnectActiveZellijSessionNow()
                 },
                 resumeSessionReconnectAfterSSHRecovery: {
                     [sceneModel] request in

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -61,11 +61,17 @@ struct WorkspaceHerdrDescriptor: Codable, Hashable, Sendable {
     var sessionName: String
 }
 
+struct WorkspaceZellijDescriptor: Codable, Hashable, Sendable {
+    var hostKey: String
+    var sessionName: String
+}
+
 struct WorkspaceWindowState: Codable, Hashable, Sendable {
     var windowID: UUID
     var navigation: WorkspaceNavigationDescriptor?
     var tmux: WorkspaceTmuxDescriptor?
     var herdr: WorkspaceHerdrDescriptor? = nil
+    var zellij: WorkspaceZellijDescriptor? = nil
 
     static func fresh(windowID: UUID = UUID()) -> Self {
         Self(windowID: windowID, navigation: nil, tmux: nil)
@@ -76,6 +82,7 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
         selection: WorkspaceSelection,
         activeTmux: WorkspaceTmuxSessionSelection?,
         activeHerdr: WorkspaceHerdrSessionSelection? = nil,
+        activeZellij: WorkspaceZellijSessionSelection? = nil,
         snapshot: WorkspaceSnapshot
     ) -> Self {
         let host = snapshot.host(id: selection.selectedHostID)
@@ -117,6 +124,8 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
         // emitting a combination the resolver rejects outright.
         let hasContradictoryPresentations = activeTmux != nil
             && activeHerdr != nil
+            || activeTmux != nil && activeZellij != nil
+            || activeHerdr != nil && activeZellij != nil
         let tmux = activeTmux.flatMap { active -> WorkspaceTmuxDescriptor? in
             guard !hasContradictoryPresentations else { return nil }
             guard let activeHost = snapshot.host(id: active.hostID),
@@ -179,11 +188,30 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
                 sessionName: active.name
             )
         }
+        let zellij = activeZellij.flatMap {
+            active -> WorkspaceZellijDescriptor? in
+            guard !hasContradictoryPresentations,
+                  let activeHost = snapshot.host(id: active.hostID),
+                  let navigation,
+                  activeHost.configKey == navigation.hostKey,
+                  selection.selectedProjectID == nil,
+                  selection.selectedWorktreeID == nil,
+                  selection.selectedDirectoryWorkspaceID == nil,
+                  !active.name.trimmingCharacters(
+                      in: .whitespacesAndNewlines
+                  ).isEmpty
+            else { return nil }
+            return WorkspaceZellijDescriptor(
+                hostKey: activeHost.configKey,
+                sessionName: active.name
+            )
+        }
         return Self(
             windowID: windowID,
             navigation: navigation,
             tmux: tmux,
-            herdr: herdr
+            herdr: herdr,
+            zellij: zellij
         )
     }
 }
@@ -245,6 +273,7 @@ struct WorkspaceWindowStateBuffer {
 enum WorkspaceRestoredPresentation: Equatable, Sendable {
     case tmux(WorkspaceTmuxSessionSelection)
     case herdr(WorkspaceHerdrSessionSelection)
+    case zellij(WorkspaceZellijSessionSelection)
 }
 
 enum WorkspaceRestorationResolution: Equatable, Sendable {
@@ -265,6 +294,7 @@ enum WorkspaceWindowRestorationResolver {
         _ state: WorkspaceWindowState,
         in snapshot: WorkspaceSnapshot,
         herdrFreshHostIDs: Set<UUID> = [],
+        zellijFreshHostIDs: Set<UUID> = [],
         pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection> = []
     ) -> WorkspaceRestorationResolution {
         guard let navigation = state.navigation,
@@ -281,7 +311,12 @@ enum WorkspaceWindowRestorationResolver {
               isValidOptional(navigation.directoryWorkspacePath)
         else { return .invalid }
 
-        guard state.tmux == nil || state.herdr == nil else {
+        let presentationCount = [
+            state.tmux != nil,
+            state.herdr != nil,
+            state.zellij != nil,
+        ].filter { $0 }.count
+        guard presentationCount <= 1 else {
             return .invalid
         }
 
@@ -316,6 +351,15 @@ enum WorkspaceWindowRestorationResolver {
             guard isNonblank(herdr.hostKey),
                   isNonblank(herdr.sessionName),
                   herdr.hostKey == navigation.hostKey,
+                  navigation.projectKey == nil,
+                  navigation.worktreeGeneration == nil,
+                  navigation.directoryWorkspacePath == nil
+            else { return .invalid }
+        }
+        if let zellij = state.zellij {
+            guard isNonblank(zellij.hostKey),
+                  isNonblank(zellij.sessionName),
+                  zellij.hostKey == navigation.hostKey,
                   navigation.projectKey == nil,
                   navigation.worktreeGeneration == nil,
                   navigation.directoryWorkspacePath == nil
@@ -376,6 +420,22 @@ enum WorkspaceWindowRestorationResolver {
             return .ready(
                 selection: selection,
                 presentation: .herdr(herdrSelection)
+            )
+        }
+
+        if let zellij = state.zellij {
+            let zellijSelection = WorkspaceZellijSessionSelection(
+                hostID: host.id,
+                name: zellij.sessionName
+            )
+            guard zellijFreshHostIDs.contains(host.id),
+                  host.zellijSessions.contains(where: {
+                      $0.name == zellij.sessionName
+                  })
+            else { return .pending(selection: selection) }
+            return .ready(
+                selection: selection,
+                presentation: .zellij(zellijSelection)
             )
         }
 

--- a/Sources/App/ZellijInventoryClient.swift
+++ b/Sources/App/ZellijInventoryClient.swift
@@ -1,0 +1,160 @@
+import Foundation
+import GhosthubTransport
+import GhosthubZellij
+
+struct ZellijInventoryClient: Sendable {
+    typealias ConnectionArgumentsProvider = @Sendable (SSHHostInfo) -> [String]
+
+    private let commandRunner: AccountCommandRunner
+    private let connectionArgumentsProvider: ConnectionArgumentsProvider
+    private let processTimeout: TimeInterval
+
+    init(
+        commandRunner: AccountCommandRunner = AccountCommandRunner(),
+        connectionArgumentsProvider: @escaping ConnectionArgumentsProvider = {
+            SSHCommandArguments.noninteractive(for: $0)
+        },
+        processTimeout: TimeInterval = 15
+    ) {
+        self.commandRunner = commandRunner
+        self.connectionArgumentsProvider = connectionArgumentsProvider
+        self.processTimeout = processTimeout
+    }
+
+    func resolveExecutable(
+        on host: CommandHost,
+        sshConnectionArguments: [String]? = nil
+    ) -> Result<String, ZellijCommandError> {
+        guard supportsZellij(host) else {
+            return .failure(.unsupportedPlatform)
+        }
+        let output = run(
+            ZellijExecutable.command(),
+            on: host,
+            sshConnectionArguments: sshConnectionArguments
+        )
+        switch ZellijExecutable.parse(
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr
+        ) {
+        case let .available(path):
+            return .success(path)
+        case .unavailable:
+            return .failure(.unavailable)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    func discover(
+        on host: CommandHost,
+        sshConnectionArguments: [String]? = nil
+    ) -> ZellijDiscoveryResult {
+        guard supportsZellij(host) else { return .unavailable }
+        let connectionArguments = resolvedConnectionArguments(
+            on: host,
+            override: sshConnectionArguments
+        )
+        let zellijPath: String
+        switch resolveExecutable(
+            on: host,
+            sshConnectionArguments: connectionArguments
+        ) {
+        case let .success(path):
+            zellijPath = path
+        case .failure(.unavailable), .failure(.unsupportedPlatform):
+            return .unavailable
+        case let .failure(error):
+            return .failure(error)
+        }
+        let output = run(
+            ZellijSessionList.command(zellijPath: zellijPath),
+            on: host,
+            sshConnectionArguments: connectionArguments
+        )
+        return ZellijSessionList.parse(
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr
+        )
+    }
+
+    func kill(
+        sessionName: String,
+        on host: CommandHost,
+        sshConnectionArguments: [String]? = nil
+    ) -> Result<Void, ZellijCommandError> {
+        let connectionArguments = resolvedConnectionArguments(
+            on: host,
+            override: sshConnectionArguments
+        )
+        let zellijPath: String
+        switch resolveExecutable(
+            on: host,
+            sshConnectionArguments: connectionArguments
+        ) {
+        case let .success(path):
+            zellijPath = path
+        case let .failure(error):
+            return .failure(error)
+        }
+        let output = run(
+            ZellijSessionLifecycle.killCommand(
+                zellijPath: zellijPath,
+                sessionName: sessionName
+            ),
+            on: host,
+            sshConnectionArguments: connectionArguments
+        )
+        guard output.status == 0 else {
+            return .failure(.commandFailed(
+                status: output.status,
+                stderr: output.stderr
+            ))
+        }
+        return .success(())
+    }
+
+    private func supportsZellij(_ host: CommandHost) -> Bool {
+        switch host {
+        case .local:
+            true
+        case let .ssh(info):
+            info.platform == .posix
+        }
+    }
+
+    private func resolvedConnectionArguments(
+        on host: CommandHost,
+        override: [String]?
+    ) -> [String]? {
+        if let override {
+            return override
+        }
+        guard case let .ssh(info) = host else { return nil }
+        return connectionArgumentsProvider(info)
+    }
+
+    private func run(
+        _ command: String,
+        on host: CommandHost,
+        sshConnectionArguments: [String]? = nil
+    ) -> AccountCommandOutput {
+        switch host {
+        case .local:
+            commandRunner.runLocalLoginShell(
+                command: command,
+                timeout: processTimeout
+            )
+        case let .ssh(info):
+            commandRunner.runRemoteLoginShell(
+                host: info,
+                connectionArguments: sshConnectionArguments
+                    ?? connectionArgumentsProvider(info),
+                command: command,
+                timeout: processTimeout
+            )
+        }
+    }
+}

--- a/Sources/App/ZellijSessionKillCoordinator.swift
+++ b/Sources/App/ZellijSessionKillCoordinator.swift
@@ -1,0 +1,67 @@
+@preconcurrency import Combine
+import Foundation
+
+@MainActor
+final class ZellijSessionKillCoordinator {
+    struct Key: Hashable, Sendable {
+        let hostID: UUID
+        let sessionName: String
+    }
+
+    enum Phase: Equatable, Sendable {
+        case began
+        case succeeded
+        case failed
+    }
+
+    enum Outcome: Equatable, Sendable {
+        case succeeded
+        case failed
+    }
+
+    struct Operation: Identifiable, Equatable, Sendable {
+        let id: UUID
+        let key: Key
+    }
+
+    struct Event: Equatable, Sendable {
+        let operation: Operation
+        let phase: Phase
+    }
+
+    static let shared = ZellijSessionKillCoordinator()
+
+    private var activeOperations: [Key: Operation] = [:]
+    private var revisions: [Key: UInt64] = [:]
+    private let eventSubject = PassthroughSubject<Event, Never>()
+
+    var events: AnyPublisher<Event, Never> {
+        eventSubject.eraseToAnyPublisher()
+    }
+
+    func begin(key: Key) -> Operation? {
+        guard activeOperations[key] == nil else { return nil }
+        let operation = Operation(id: UUID(), key: key)
+        activeOperations[key] = operation
+        revisions[key, default: 0] &+= 1
+        eventSubject.send(Event(operation: operation, phase: .began))
+        return operation
+    }
+
+    func finish(_ operation: Operation, outcome: Outcome) {
+        guard activeOperations[operation.key] == operation else { return }
+        activeOperations.removeValue(forKey: operation.key)
+        eventSubject.send(Event(
+            operation: operation,
+            phase: outcome == .succeeded ? .succeeded : .failed
+        ))
+    }
+
+    func isPending(_ key: Key) -> Bool {
+        activeOperations[key] != nil
+    }
+
+    func revision(for key: Key) -> UInt64 {
+        revisions[key, default: 0]
+    }
+}

--- a/Sources/UI/CommandPaletteModel.swift
+++ b/Sources/UI/CommandPaletteModel.swift
@@ -9,13 +9,16 @@ public enum WorkspaceCommandAction: Equatable, Sendable {
     case reloadTerminalConfig
     case newTmuxSession(UUID)
     case newHerdrSession(UUID)
+    case newZellijSession(UUID)
     case addProject(UUID)
     case openTmuxSession(WorkspaceTmuxSessionSelection)
     case openHerdrSession(WorkspaceHerdrSessionSelection)
+    case openZellijSession(WorkspaceZellijSessionSelection)
     case restartHerdrSession(WorkspaceHerdrSessionSelection)
     case stopHerdrSession(WorkspaceHerdrSessionSelection)
     case deleteHerdrSession(WorkspaceHerdrSessionSelection)
     case killTmuxSession(WorkspaceTmuxSessionSelection)
+    case killZellijSession(WorkspaceZellijSessionSelection)
     case applyThemeToCurrentTmuxSession(
         WorkspaceTmuxSessionSelection
     )
@@ -112,6 +115,7 @@ public enum CommandPaletteModel {
             .splitDown,
         ],
         herdrSessionOrderRawValue: String = "",
+        zellijSessionOrderRawValue: String = "",
         pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection> = [],
         shortcuts: ResolvedApplicationShortcuts =
             ApplicationShortcutCatalog.compiledDefaults
@@ -228,6 +232,15 @@ public enum CommandPaletteModel {
             tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
             herdrSessionOrderRawValue: herdrSessionOrderRawValue,
             pendingHerdrSessions: pendingHerdrSessions
+        ))
+        commands.append(contentsOf: zellijSessionCommands(
+            in: snapshot,
+            visibility: worktreeVisibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
         ))
         commands.append(contentsOf: newWorktreeCommands(
             in: snapshot,
@@ -421,6 +434,18 @@ public enum CommandPaletteModel {
                     shortcut: host.id == selection.selectedHostID
                         ? shortcuts[.newHerdrSession] : nil,
                     action: .newHerdrSession(host.id)
+                ))
+            }
+            if host.zellijAvailable {
+                commands.append(WorkspaceCommandItem(
+                    id: "new-zellij-session-\(host.id.uuidString)",
+                    title: "New Zellij session on \(host.name)",
+                    subtitle: "Create and attach on \(host.commandPaletteSubtitle)",
+                    keywords: [
+                        "new", "create", "zellij", "session",
+                        host.name, host.sshDestination ?? "",
+                    ],
+                    action: .newZellijSession(host.id)
                 ))
             }
             if host.canRegisterProjects {
@@ -676,6 +701,56 @@ public enum CommandPaletteModel {
                 case nil:
                     return []
                 }
+            }
+        }
+    }
+
+    private static func zellijSessionCommands(
+        in snapshot: WorkspaceSnapshot,
+        visibility: WorktreeVisibility,
+        tmuxSessionVisibility: TmuxSessionVisibility,
+        worktreeOrderRawValue: String,
+        tmuxSessionOrderRawValue: String,
+        herdrSessionOrderRawValue: String,
+        zellijSessionOrderRawValue: String
+    ) -> [WorkspaceCommandItem] {
+        WorkspaceSidebarModel.sections(
+            in: snapshot,
+            visibility: visibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
+        ).flatMap { section in
+            section.zellijSessionRows.flatMap { row -> [WorkspaceCommandItem] in
+                guard case let .zellijSession(hostID, name) = row.target else {
+                    return []
+                }
+                let session = WorkspaceZellijSessionSelection(
+                    hostID: hostID,
+                    name: name
+                )
+                let keywords = [
+                    "zellij", "session", name,
+                    section.host.name, section.row.title,
+                ]
+                return [
+                    WorkspaceCommandItem(
+                        id: "open-zellij-session-\(session.id)",
+                        title: "Open Zellij session: \(name)",
+                        subtitle: "Attach on \(section.host.name).",
+                        keywords: ["open", "attach"] + keywords,
+                        action: .openZellijSession(session)
+                    ),
+                    WorkspaceCommandItem(
+                        id: "kill-zellij-session-\(session.id)",
+                        title: "Kill Zellij session: \(name)",
+                        subtitle: "Terminate every pane and process on \(section.host.name).",
+                        keywords: ["kill", "terminate", "stop"] + keywords,
+                        action: .killZellijSession(session)
+                    ),
+                ]
             }
         }
     }

--- a/Sources/UI/KeyboardNavigationModel.swift
+++ b/Sources/UI/KeyboardNavigationModel.swift
@@ -8,6 +8,7 @@ public struct KeyboardNavigationContext: Sendable {
     public var worktreeOrderRawValue: String
     public var tmuxSessionOrderRawValue: String
     public var herdrSessionOrderRawValue: String
+    public var zellijSessionOrderRawValue: String
 
     public init(
         snapshot: WorkspaceSnapshot,
@@ -15,7 +16,8 @@ public struct KeyboardNavigationContext: Sendable {
         tmuxSessionVisibility: TmuxSessionVisibility = .init(),
         worktreeOrderRawValue: String = "",
         tmuxSessionOrderRawValue: String = "",
-        herdrSessionOrderRawValue: String = ""
+        herdrSessionOrderRawValue: String = "",
+        zellijSessionOrderRawValue: String = ""
     ) {
         self.snapshot = snapshot
         self.visibility = visibility
@@ -23,6 +25,7 @@ public struct KeyboardNavigationContext: Sendable {
         self.worktreeOrderRawValue = worktreeOrderRawValue
         self.tmuxSessionOrderRawValue = tmuxSessionOrderRawValue
         self.herdrSessionOrderRawValue = herdrSessionOrderRawValue
+        self.zellijSessionOrderRawValue = zellijSessionOrderRawValue
     }
 }
 
@@ -37,7 +40,8 @@ public enum KeyboardNavigationModel {
             tmuxSessionVisibility: context.tmuxSessionVisibility,
             worktreeOrderRawValue: context.worktreeOrderRawValue,
             tmuxSessionOrderRawValue: context.tmuxSessionOrderRawValue,
-            herdrSessionOrderRawValue: context.herdrSessionOrderRawValue
+            herdrSessionOrderRawValue: context.herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: context.zellijSessionOrderRawValue
         )
 
         switch currentTarget {
@@ -70,6 +74,13 @@ public enum KeyboardNavigationModel {
                 if running.contains(where: { $0.target == currentTarget }) {
                     return running.map(\.target)
                 }
+            }
+        case .zellijSession:
+            for section in sections where
+                section.zellijSessionRows.contains(where: {
+                    $0.target == currentTarget
+                }) {
+                return section.zellijSessionRows.map(\.target)
             }
         case .host, .project:
             break

--- a/Sources/UI/NewZellijSessionSheet.swift
+++ b/Sources/UI/NewZellijSessionSheet.swift
@@ -1,0 +1,146 @@
+import Foundation
+import GhosthubWorkspace
+import SwiftUI
+
+enum ZellijSessionName {
+    static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func isValid(_ value: String) -> Bool {
+        let name = normalized(value)
+        guard name != ".", name != "..",
+              !name.isEmpty,
+              !name.contains("/")
+        else { return false }
+        return !name.unicodeScalars.contains(where: {
+            CharacterSet.controlCharacters.contains($0)
+        })
+    }
+}
+
+struct NewZellijSessionSheet: View {
+    let hosts: [HostSummary]
+    let onCreate: (HostSummary, String) -> Void
+    let onCancel: () -> Void
+
+    @State private var selectedHost: HostSummary
+    @State private var sessionName = ""
+    @FocusState private var isNameFieldFocused: Bool
+
+    init(
+        host: HostSummary,
+        hosts: [HostSummary],
+        onCreate: @escaping (HostSummary, String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        let availableHosts = hosts.filter(\.zellijAvailable)
+        self.hosts = availableHosts
+        _selectedHost = State(initialValue:
+            availableHosts.first(where: { $0.id == host.id })
+                ?? availableHosts.first ?? host)
+        self.onCreate = onCreate
+        self.onCancel = onCancel
+    }
+
+    private var normalizedName: String {
+        ZellijSessionName.normalized(sessionName)
+    }
+
+    private var existingNames: Set<String> {
+        Set(selectedHost.zellijSessions.map(\.name))
+    }
+
+    private var canCreate: Bool {
+        selectedHost.zellijAvailable
+            && ZellijSessionName.isValid(normalizedName)
+            && !existingNames.contains(normalizedName)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("New Zellij session")
+                    .font(.headline)
+                Spacer()
+                NativePopupMenuButton(
+                    groups: [hosts.map { host in
+                        NativePopupMenuAction(host.sidebarTitle) {
+                            selectedHost = host
+                        }
+                    }]
+                ) {
+                    Label(
+                        selectedHost.sidebarTitle,
+                        systemImage: selectedHost.kind == .selfHost
+                            ? "laptopcomputer" : "server.rack"
+                    )
+                }
+                .buttonStyle(.borderless)
+                .fixedSize()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            HStack(spacing: 10) {
+                Image(systemName: "rectangle.split.3x1")
+                    .foregroundStyle(.secondary)
+                TextField("Session name", text: $sessionName)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 16))
+                    .focused($isNameFieldFocused)
+                    .onSubmit(create)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+
+            Text(validationMessage)
+                .font(.caption)
+                .foregroundStyle(canCreate || normalizedName.isEmpty
+                    ? Color.secondary : Color.red)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+
+            Divider()
+
+            HStack {
+                Text("Zellij creates the session and Ghosthub attaches immediately.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Create", action: create)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canCreate)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .frame(width: 500)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .onAppear { isNameFieldFocused = true }
+    }
+
+    private var validationMessage: String {
+        if normalizedName.isEmpty {
+            return "Name the Zellij session you want to create."
+        }
+        if existingNames.contains(normalizedName) {
+            return "A Zellij session named “\(normalizedName)” already exists on this host."
+        }
+        if !ZellijSessionName.isValid(normalizedName) {
+            return "Use a nonempty name without slashes or control characters."
+        }
+        return "Create and attach to “\(normalizedName)”."
+    }
+
+    private func create() {
+        guard canCreate else { return }
+        onCreate(selectedHost, normalizedName)
+    }
+}

--- a/Sources/UI/NewZellijSessionSheet.swift
+++ b/Sources/UI/NewZellijSessionSheet.swift
@@ -21,6 +21,7 @@ enum ZellijSessionName {
 
 struct NewZellijSessionSheet: View {
     let hosts: [HostSummary]
+    let isCreating: Bool
     let onCreate: (HostSummary, String) -> Void
     let onCancel: () -> Void
 
@@ -31,11 +32,13 @@ struct NewZellijSessionSheet: View {
     init(
         host: HostSummary,
         hosts: [HostSummary],
+        isCreating: Bool = false,
         onCreate: @escaping (HostSummary, String) -> Void,
         onCancel: @escaping () -> Void
     ) {
         let availableHosts = hosts.filter(\.zellijAvailable)
         self.hosts = availableHosts
+        self.isCreating = isCreating
         _selectedHost = State(initialValue:
             availableHosts.first(where: { $0.id == host.id })
                 ?? availableHosts.first ?? host)
@@ -78,6 +81,7 @@ struct NewZellijSessionSheet: View {
                 }
                 .buttonStyle(.borderless)
                 .fixedSize()
+                .disabled(isCreating)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
@@ -92,6 +96,7 @@ struct NewZellijSessionSheet: View {
                     .font(.system(size: 16))
                     .focused($isNameFieldFocused)
                     .onSubmit(create)
+                    .disabled(isCreating)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 13)
@@ -114,7 +119,7 @@ struct NewZellijSessionSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Create", action: create)
                     .keyboardShortcut(.defaultAction)
-                    .disabled(!canCreate)
+                    .disabled(!canCreate || isCreating)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
@@ -140,7 +145,7 @@ struct NewZellijSessionSheet: View {
     }
 
     private func create() {
-        guard canCreate else { return }
+        guard canCreate, !isCreating else { return }
         onCreate(selectedHost, normalizedName)
     }
 }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -28,14 +28,18 @@ public struct RootView: View {
     @State private var sidePanelAutoCollapsed = false
     @State private var sidePanelUserOverride = false
     @State private var tmuxSelectionBaseline: WorkspaceSelection?
+    @State private var peerTakeoverNavigationSelection: WorkspaceSelection?
     @StateObject private var herdrPresentationIntent =
         HerdrPresentationIntentController()
     @StateObject private var herdrLifecyclePreparation =
-        HerdrLifecyclePreparationController()
+        SessionPreparationController<HerdrSessionLifecycleRequest>()
+    @StateObject private var zellijKillPreparation =
+        SessionPreparationController<ZellijSessionKillRequest>()
     @State private var newWorktreeProject: ProjectSummary?
     @State private var newWorktreeMode: NewWorktreeMode = .branch
     @State private var newTmuxSessionHost: HostSummary?
     @State private var newHerdrSessionHost: HostSummary?
+    @State private var newZellijSessionHost: HostSummary?
     @State private var herdrCreationTask: Task<Void, Never>?
     @State private var herdrCreationRevision: UInt64 = 0
     @State private var addProjectHost: HostSummary?
@@ -55,6 +59,8 @@ public struct RootView: View {
     private var tmuxSessionOrderRawValue = ""
     @AppStorage(WorkspaceSidebarOrderStorage.herdrSessionKey)
     private var herdrSessionOrderRawValue = ""
+    @AppStorage(WorkspaceSidebarOrderStorage.zellijSessionKey)
+    private var zellijSessionOrderRawValue = ""
 
     public init(
         display: WorkspaceDisplayState,
@@ -107,6 +113,9 @@ public struct RootView: View {
         )
     }
 
+    private var activeZellijSession: WorkspaceZellijSessionSelection? {
+        display.activeZellijSession
+    }
     public var body: some View {
         contentWithNotifications
             .onAppear {
@@ -231,6 +240,25 @@ public struct RootView: View {
                     onCancel: { cancelHerdrCreation() }
                 )
             }
+            .sheet(item: $newZellijSessionHost) { host in
+                NewZellijSessionSheet(
+                    host: host,
+                    hosts: snapshot.hosts,
+                    onCreate: { selectedHost, name in
+                        let session = WorkspaceZellijSessionSelection(
+                            hostID: selectedHost.id,
+                            name: name
+                        )
+                        selectWorkspace(.zellijSession(
+                            hostID: selectedHost.id,
+                            name: name
+                        ))
+                        handlers.createZellijSession?(session)
+                        newZellijSessionHost = nil
+                    },
+                    onCancel: { newZellijSessionHost = nil }
+                )
+            }
             .sheet(item: $addProjectHost) { host in
                 AddProjectSheet(
                     host: host,
@@ -255,6 +283,7 @@ public struct RootView: View {
                 cancelHerdrPresentationIntents()
                 cancelHerdrCreation()
                 cancelHerdrLifecyclePreparation()
+                cancelZellijKillPreparation()
             }
     }
 
@@ -289,6 +318,11 @@ public struct RootView: View {
                     selection: selection,
                     selectionBaseline: tmuxSelectionBaseline,
                     activeSession: activeTmuxSession,
+                    suppressesHide:
+                    Self.isPeerTakeoverNavigation(
+                        selection,
+                        pending: peerTakeoverNavigationSelection
+                    ),
                     hide: hideTmuxSession
                 )
             )
@@ -296,9 +330,35 @@ public struct RootView: View {
                 HerdrSessionPresentationLifecycleModifier(
                     selection: selection,
                     activeSession: activeHerdrSession,
+                    suppressesDeactivation:
+                    Self.isPeerTakeoverNavigation(
+                        selection,
+                        pending: peerTakeoverNavigationSelection
+                    ),
                     deactivate: deactivateHerdrSession(_:)
                 )
             )
+            .modifier(
+                ZellijSessionPresentationLifecycleModifier(
+                    selection: selection,
+                    activeSession: activeZellijSession,
+                    suppressesDeactivation:
+                    Self.isPeerTakeoverNavigation(
+                        selection,
+                        pending: peerTakeoverNavigationSelection
+                    ),
+                    deactivate: { _ in deactivateZellijSession() }
+                )
+            )
+            .onChange(of: selection) { _, newSelection in
+                guard !Self.isPeerTakeoverNavigation(
+                    newSelection,
+                    pending: peerTakeoverNavigationSelection
+                ) else {
+                    return
+                }
+                peerTakeoverNavigationSelection = nil
+            }
             .onAppear {
                 sidebarWidthChanged(sidebarWidth)
                 normalizeSelectionForWorktreeVisibilityChanges()
@@ -339,7 +399,16 @@ public struct RootView: View {
                 NotificationCenter.default.publisher(
                     for: .ghosthubCommandPalette
                 )
-            ) { _ in handleCommandPalette() }
+            ) { notification in
+                let matchesTarget =
+                    notification.object as AnyObject? === sidebarToggleTarget
+                let isFocusedBroadcast =
+                    notification.object == nil && controlActiveState == .key
+                guard matchesTarget || isFocusedBroadcast else {
+                    return
+                }
+                handleCommandPalette()
+            }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: .ghosthubToggleSidebar,
@@ -574,6 +643,7 @@ public struct RootView: View {
             tmuxSessionVisibility: tmuxSessionVisibility,
             activeTmuxSession: activeTmuxSession,
             activeHerdrSession: activeHerdrSession,
+            activeZellijSession: activeZellijSession,
             activeTmuxSessionIsConnected:
             display.activeTmuxSessionIsConnected,
             workingTmuxSessionIDs:
@@ -584,14 +654,19 @@ public struct RootView: View {
             onOpenHerdrSession: { session in
                 activateHerdrSession(session)
             },
+            onOpenZellijSession: { session in
+                activateZellijSession(session)
+            },
             pendingHerdrSessions: display.pendingHerdrSessions,
             onRestartHerdrSession: restartHerdrSession,
             onRequestHerdrSessionLifecycle: requestHerdrSessionLifecycle,
             onNavigateAwayFromSession: {
                 hideTmuxSession()
                 deactivateHerdrSession()
+                deactivateZellijSession()
             },
             onRequestKillTmuxSession: requestSessionKill,
+            onRequestKillZellijSession: requestZellijSessionKill,
             onRequestRemoveWorktree: requestWorktreeRemoval,
             onNewWorktree: openNewWorktree,
             onImportPullRequest: openImportPullRequest,
@@ -600,6 +675,9 @@ public struct RootView: View {
             },
             onNewHerdrSession: { host in
                 newHerdrSessionHost = host
+            },
+            onNewZellijSession: { host in
+                newZellijSessionHost = host
             },
             onAddProject: { host in
                 addProjectHost = host
@@ -624,6 +702,7 @@ public struct RootView: View {
             worktreeOrderRawValue: $worktreeOrderRawValue,
             tmuxSessionOrderRawValue: $tmuxSessionOrderRawValue,
             herdrSessionOrderRawValue: $herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: $zellijSessionOrderRawValue,
             onOpen: { worktree in
                 selectWorkspace(.worktree(worktree.id))
             }
@@ -788,6 +867,7 @@ public struct RootView: View {
 
     private func activateTmuxSession(_ session: WorkspaceTmuxSessionSelection) {
         deactivateHerdrSession()
+        deactivateZellijSession()
         if activeTmuxSession == session {
             tmuxSelectionBaseline = selection
             handlers.openTmuxSession?(session)
@@ -800,6 +880,10 @@ public struct RootView: View {
     private func activateHerdrSession(
         _ session: WorkspaceHerdrSessionSelection
     ) {
+        peerTakeoverNavigationSelection = WorkspaceSelection(
+            selectedHostID: session.hostID
+        )
+        // The scene model closes the current peer only after validation.
         Self.transitionHerdrSession(
             to: session,
             from: activeHerdrSession,
@@ -807,6 +891,19 @@ public struct RootView: View {
         ) {
             startHerdrSessionActivation(session)
         }
+    }
+
+    private func activateZellijSession(
+        _ session: WorkspaceZellijSessionSelection
+    ) {
+        peerTakeoverNavigationSelection = WorkspaceSelection(
+            selectedHostID: session.hostID
+        )
+        // The scene model closes the current peer only after validation.
+        Self.startZellijSessionActivation(
+            session,
+            open: { handlers.openZellijSession?($0) }
+        )
     }
 
     private func startHerdrSessionActivation(
@@ -1021,6 +1118,48 @@ public struct RootView: View {
         }
     }
 
+    private func requestZellijSessionKill(
+        _ session: WorkspaceZellijSessionSelection
+    ) {
+        cancelZellijKillPreparation()
+        guard let prepare = handlers.prepareZellijSessionKill else {
+            presentNonWorktreeWorkspaceAlert(.zellijKillFailure(
+                session: session.name,
+                message: "Zellij session termination is unavailable."
+            ))
+            return
+        }
+        zellijKillPreparation.start(
+            prepare: {
+                try await prepare(session)
+            },
+            cancelPrepared: { request in
+                handlers.cancelZellijSessionKill?(request)
+            },
+            onPrepared: { request in
+                presentNonWorktreeWorkspaceAlert(
+                    .zellijKillConfirmation(request)
+                )
+            },
+            onFailure: { error in
+                presentNonWorktreeWorkspaceAlert(.zellijKillFailure(
+                    session: session.name,
+                    message: error.localizedDescription
+                ))
+            }
+        )
+    }
+
+    private func cancelZellijKillPreparation() {
+        zellijKillPreparation.cancel()
+        Self.cancelPreparedZellijKill(
+            workspaceAlert: &workspaceAlert,
+            cancel: { request in
+                handlers.cancelZellijSessionKill?(request)
+            }
+        )
+    }
+
     private func requestThemeApplication(
         _ tmuxSession: WorkspaceTmuxSessionSelection
     ) {
@@ -1042,12 +1181,29 @@ public struct RootView: View {
     }
 
     private func presentNonWorktreeWorkspaceAlert(_ alert: WorkspaceAlert) {
+        Self.cancelPreparedZellijKill(
+            workspaceAlert: &workspaceAlert,
+            cancel: { request in
+                handlers.cancelZellijSessionKill?(request)
+            }
+        )
         Self.presentNonWorktreeWorkspaceAlert(
             alert,
             workspaceAlert: &workspaceAlert,
             pendingWorktreeRemoval: &pendingWorktreeRemoval,
             pendingWorktrees: &pendingWorktreeRemovals
         )
+    }
+
+    @MainActor
+    static func cancelPreparedZellijKill(
+        workspaceAlert: inout WorkspaceAlert?,
+        cancel: (ZellijSessionKillRequest) -> Void
+    ) {
+        guard case let .zellijKillConfirmation(request) = workspaceAlert
+        else { return }
+        cancel(request)
+        workspaceAlert = nil
     }
 
     private func workspaceAlertView(
@@ -1085,6 +1241,39 @@ public struct RootView: View {
                 secondaryButton: .cancel()
             )
         case let .sessionKillFailure(session, message):
+            return Alert(
+                title: Text("Could Not Kill “\(session)”"),
+                message: Text(message),
+                dismissButton: .default(Text("OK"))
+            )
+        case let .zellijKillConfirmation(request):
+            return Alert(
+                title: Text("Kill “\(request.session.name)”?”"),
+                message: Text(
+                    "This permanently terminates every tab, pane, and process in this Zellij session on \(request.confirmedHost.sidebarTitle)."
+                ),
+                primaryButton: .destructive(Text("Kill Session")) {
+                    Task {
+                        do {
+                            guard let kill = handlers.killZellijSession else {
+                                throw SessionKillUnavailableError()
+                            }
+                            try await kill(request)
+                        } catch {
+                            presentNonWorktreeWorkspaceAlert(
+                                .zellijKillFailure(
+                                    session: request.session.name,
+                                    message: error.localizedDescription
+                                )
+                            )
+                        }
+                    }
+                },
+                secondaryButton: .cancel {
+                    handlers.cancelZellijSessionKill?(request)
+                }
+            )
+        case let .zellijKillFailure(session, message):
             return Alert(
                 title: Text("Could Not Kill “\(session)”"),
                 message: Text(message),
@@ -1394,6 +1583,11 @@ public struct RootView: View {
         deactivateHerdrSession(previous)
     }
 
+    private func deactivateZellijSession() {
+        guard let previous = activeZellijSession else { return }
+        handlers.closeZellijSession?(previous)
+    }
+
     private func deactivateHerdrSession(
         _ expected: WorkspaceHerdrSessionSelection
     ) {
@@ -1446,34 +1640,50 @@ public struct RootView: View {
     @ViewBuilder
     private var terminalWorkspaceContent: some View {
         if activeTmuxSession == nil,
-           let activeHerdrSession,
-           let host = snapshot.host(id: activeHerdrSession.hostID),
-           let view = content.herdrSessionContentBuilder?(
+           activeHerdrSession == nil,
+           let activeZellijSession,
+           let host = snapshot.host(id: activeZellijSession.hostID),
+           let view = content.zellijSessionContentBuilder?(
                host,
-               activeHerdrSession.name,
+               activeZellijSession.name,
                isSidebarTransitioning,
                NativeSessionContentActions(
-                   reconnectNow: {
-                       handlers.reconnectActiveHerdrSessionNow?()
-                   },
-                   reviewConnection: {
-                       reviewSSHHostKey(
-                           host.id,
-                           inventoryWarning: sessionRecoveryWarning(
-                               for: host.id
-                           ),
-                           sessionRecoveryRequestID:
-                           sessionRecoveryRequestRouter.recoveryRequestID(
-                               for: host.id,
-                               activeRequest:
-                               display.sessionConnectionRecoveryRequest
-                           )
-                       )
-                   }
+                   reconnectNow: {},
+                   reviewConnection: {}
                )
            ) {
             view
+        } else if activeTmuxSession == nil,
+                  activeZellijSession == nil,
+                  let activeHerdrSession,
+                  let host = snapshot.host(id: activeHerdrSession.hostID),
+                  let view = content.herdrSessionContentBuilder?(
+                      host,
+                      activeHerdrSession.name,
+                      isSidebarTransitioning,
+                      NativeSessionContentActions(
+                          reconnectNow: {
+                              handlers.reconnectActiveHerdrSessionNow?()
+                          },
+                          reviewConnection: {
+                              reviewSSHHostKey(
+                                  host.id,
+                                  inventoryWarning: sessionRecoveryWarning(
+                                      for: host.id
+                                  ),
+                                  sessionRecoveryRequestID:
+                                  sessionRecoveryRequestRouter.recoveryRequestID(
+                                      for: host.id,
+                                      activeRequest:
+                                      display.sessionConnectionRecoveryRequest
+                                  )
+                              )
+                          }
+                      )
+                  ) {
+            view
         } else if activeHerdrSession == nil,
+                  activeZellijSession == nil,
                   let presentedSession = selectedWorktreeTmuxSession
                   ?? activeTmuxSession,
                   let host = snapshot.host(id: presentedSession.hostID),
@@ -1544,18 +1754,22 @@ public struct RootView: View {
                 }
             }
         } else if snapshot.projects.isEmpty,
-                  snapshot.hosts.allSatisfy(\.tmuxSessions.isEmpty) {
+                  snapshot.hosts.allSatisfy({
+                      $0.tmuxSessions.isEmpty
+                          && $0.herdrSessions.isEmpty
+                          && $0.zellijSessions.isEmpty
+                  }) {
             VStack(spacing: 14) {
                 Text("Welcome to Ghosthub")
                     .font(.system(size: 24, weight: .semibold))
                 Text(
-                    "Your kwt workspaces and tmux sessions will appear in the sidebar."
+                    "Your kwt workspaces and multiplexer sessions will appear in the sidebar."
                 )
                 .font(.system(size: 14))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 Text(
-                    "Register projects with kwt, or add an SSH host in Settings. Ghosthub attaches without taking over tmux windows, panes, or history."
+                    "Register projects with kwt, or add an SSH host in Settings. Ghosthub attaches without taking over multiplexer tabs, panes, layouts, or history."
                 )
                 .font(.system(size: 13))
                 .foregroundStyle(.tertiary)
@@ -1568,7 +1782,7 @@ public struct RootView: View {
                 "No Active Session",
                 systemImage: "terminal",
                 description: Text(
-                    "Select a tmux session or kwt workspace from the sidebar."
+                    "Select a multiplexer session or kwt workspace from the sidebar."
                 )
             )
         }
@@ -1611,6 +1825,7 @@ public struct RootView: View {
             availableApplicationShortcuts:
             display.availableApplicationShortcuts,
             herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue,
             pendingHerdrSessions: display.pendingHerdrSessions,
             shortcuts: settingsStore.shortcutPreferences.resolved
         )
@@ -1658,6 +1873,9 @@ public struct RootView: View {
             guard let host = snapshot.host(id: hostID),
                   host.herdrAvailable else { return }
             newHerdrSessionHost = host
+        case let .newZellijSession(hostID):
+            guard let host = snapshot.host(id: hostID) else { return }
+            newZellijSessionHost = host
         case let .addProject(hostID):
             guard let host = snapshot.host(id: hostID) else { return }
             addProjectHost = host
@@ -1681,6 +1899,12 @@ public struct RootView: View {
                 name: herdrSession.name
             ))
             activateHerdrSession(herdrSession)
+        case let .openZellijSession(zellijSession):
+            selectWorkspace(.zellijSession(
+                hostID: zellijSession.hostID,
+                name: zellijSession.name
+            ))
+            activateZellijSession(zellijSession)
         case let .restartHerdrSession(herdrSession):
             restartHerdrSession(herdrSession)
         case let .stopHerdrSession(herdrSession):
@@ -1689,6 +1913,8 @@ public struct RootView: View {
             requestHerdrSessionLifecycle(herdrSession, action: .delete)
         case let .killTmuxSession(tmuxSession):
             requestSessionKill(tmuxSession)
+        case let .killZellijSession(zellijSession):
+            requestZellijSessionKill(zellijSession)
         case let .applyThemeToCurrentTmuxSession(tmuxSession):
             requestThemeApplication(tmuxSession)
         case let .newWorktree(projectID):
@@ -1704,8 +1930,11 @@ public struct RootView: View {
         case let .setInterfaceAppearance(appearance):
             settingsStore.setInterfaceAppearance(appearance)
         case let .select(target):
-            hideTmuxSession()
-            deactivateHerdrSession()
+            Self.deactivateSessionsForNavigation(
+                hideTmux: hideTmuxSession,
+                deactivateHerdr: deactivateHerdrSession,
+                deactivateZellij: deactivateZellijSession
+            )
             selectWorkspace(target)
         case .showLogViewer:
             isLogViewerPresented = true
@@ -1927,6 +2156,10 @@ public struct RootView: View {
             deactivateHerdrSession()
             return
         }
+        if activeZellijSession != nil {
+            deactivateZellijSession()
+            return
+        }
         if Self.closeBorrowedSessionIfActive(
             activeTmuxSession,
             deactivate: deactivateTmuxSession
@@ -1949,6 +2182,16 @@ public struct RootView: View {
         return true
     }
 
+    static func deactivateSessionsForNavigation(
+        hideTmux: () -> Void,
+        deactivateHerdr: () -> Void,
+        deactivateZellij: () -> Void
+    ) {
+        hideTmux()
+        deactivateHerdr()
+        deactivateZellij()
+    }
+
     static func openHerdrSession(
         _ session: WorkspaceHerdrSessionSelection,
         replacing tmuxSession: WorkspaceTmuxSessionSelection?,
@@ -1962,6 +2205,20 @@ public struct RootView: View {
             closeTmux(tmuxSession)
         }
         return true
+    }
+
+    static func startZellijSessionActivation(
+        _ session: WorkspaceZellijSessionSelection,
+        open: (WorkspaceZellijSessionSelection) -> Void
+    ) {
+        open(session)
+    }
+
+    static func isPeerTakeoverNavigation(
+        _ selection: WorkspaceSelection,
+        pending: WorkspaceSelection?
+    ) -> Bool {
+        pending?.navigationTarget == selection.navigationTarget
     }
 
     static func transitionHerdrSession(
@@ -1986,12 +2243,14 @@ struct TmuxSessionPresentationLifecycleModifier: ViewModifier {
     let selection: WorkspaceSelection
     let selectionBaseline: WorkspaceSelection?
     let activeSession: WorkspaceTmuxSessionSelection?
+    var suppressesHide = false
     let hide: () -> Void
 
     func body(content: Content) -> some View {
         content
             .onChange(of: selection) { _, newSelection in
-                if activeSession != nil,
+                if !suppressesHide,
+                   activeSession != nil,
                    let selectionBaseline,
                    newSelection != selectionBaseline {
                     hide()
@@ -2040,14 +2299,14 @@ final class HerdrPresentationIntentController: ObservableObject {
 }
 
 @MainActor
-final class HerdrLifecyclePreparationController: ObservableObject {
+final class SessionPreparationController<Request>: ObservableObject {
     private var revision: UInt64 = 0
     private var task: Task<Void, Never>?
 
     func start(
-        prepare: @escaping () async throws -> HerdrSessionLifecycleRequest,
-        cancelPrepared: @escaping (HerdrSessionLifecycleRequest) -> Void,
-        onPrepared: @escaping (HerdrSessionLifecycleRequest) -> Void,
+        prepare: @escaping () async throws -> Request,
+        cancelPrepared: @escaping (Request) -> Void,
+        onPrepared: @escaping (Request) -> Void,
         onFailure: @escaping (any Error) -> Void
     ) {
         cancel()
@@ -2090,12 +2349,36 @@ final class HerdrLifecyclePreparationController: ObservableObject {
 struct HerdrSessionPresentationLifecycleModifier: ViewModifier {
     let selection: WorkspaceSelection
     let activeSession: WorkspaceHerdrSessionSelection?
+    var suppressesDeactivation = false
     let deactivate: (WorkspaceHerdrSessionSelection) -> Void
 
     func body(content: Content) -> some View {
         content
             .onChange(of: selection) { _, newSelection in
-                guard let activeSession,
+                guard !suppressesDeactivation,
+                      let activeSession,
+                      newSelection.selectedHostID != activeSession.hostID
+                      || newSelection.selectedProjectID != nil
+                      || newSelection.selectedWorktreeID != nil
+                      || newSelection.selectedDirectoryWorkspaceID != nil
+                else { return }
+                deactivate(activeSession)
+            }
+    }
+}
+
+/// Closes an active Zellij client when navigation leaves its host-level route.
+struct ZellijSessionPresentationLifecycleModifier: ViewModifier {
+    let selection: WorkspaceSelection
+    let activeSession: WorkspaceZellijSessionSelection?
+    var suppressesDeactivation = false
+    let deactivate: (WorkspaceZellijSessionSelection) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: selection) { _, newSelection in
+                guard !suppressesDeactivation,
+                      let activeSession,
                       newSelection.selectedHostID != activeSession.hostID
                       || newSelection.selectedProjectID != nil
                       || newSelection.selectedWorktreeID != nil
@@ -2109,6 +2392,8 @@ struct HerdrSessionPresentationLifecycleModifier: ViewModifier {
 enum WorkspaceAlert: Identifiable {
     case sessionKillConfirmation(TmuxSessionKillRequest)
     case sessionKillFailure(session: String, message: String)
+    case zellijKillConfirmation(ZellijSessionKillRequest)
+    case zellijKillFailure(session: String, message: String)
     case herdrLifecycleConfirmation(HerdrSessionLifecycleRequest)
     case herdrLifecycleFailure(
         session: String,
@@ -2125,6 +2410,10 @@ enum WorkspaceAlert: Identifiable {
             return "session:confirm:\(request.session.id)"
         case let .sessionKillFailure(session, message):
             return "session:failure:\(session):\(message)"
+        case let .zellijKillConfirmation(request):
+            return "zellij:confirm:\(request.session.id)"
+        case let .zellijKillFailure(session, message):
+            return "zellij:failure:\(session):\(message)"
         case let .herdrLifecycleConfirmation(request):
             return "herdr:confirm:\(request.session.id):\(request.action)"
         case let .herdrLifecycleFailure(session, action, message):

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -42,6 +42,8 @@ public struct RootView: View {
     @State private var newZellijSessionHost: HostSummary?
     @State private var herdrCreationTask: Task<Void, Never>?
     @State private var herdrCreationRevision: UInt64 = 0
+    @State private var zellijCreationTask: Task<Void, Never>?
+    @State private var zellijCreationRevision: UInt64 = 0
     @State private var addProjectHost: HostSummary?
     @State private var workspaceAlert: WorkspaceAlert?
     @State private var pendingWorktreeRemoval: WorktreeRemovalRequest?
@@ -240,23 +242,20 @@ public struct RootView: View {
                     onCancel: { cancelHerdrCreation() }
                 )
             }
-            .sheet(item: $newZellijSessionHost) { host in
+            .sheet(
+                item: $newZellijSessionHost,
+                onDismiss: {
+                    cancelZellijCreation(dismissSheet: false)
+                }
+            ) { host in
                 NewZellijSessionSheet(
                     host: host,
                     hosts: snapshot.hosts,
+                    isCreating: zellijCreationTask != nil,
                     onCreate: { selectedHost, name in
-                        let session = WorkspaceZellijSessionSelection(
-                            hostID: selectedHost.id,
-                            name: name
-                        )
-                        selectWorkspace(.zellijSession(
-                            hostID: selectedHost.id,
-                            name: name
-                        ))
-                        handlers.createZellijSession?(session)
-                        newZellijSessionHost = nil
+                        createZellijSession(on: selectedHost, name: name)
                     },
-                    onCancel: { newZellijSessionHost = nil }
+                    onCancel: { cancelZellijCreation() }
                 )
             }
             .sheet(item: $addProjectHost) { host in
@@ -282,6 +281,7 @@ public struct RootView: View {
             .onDisappear {
                 cancelHerdrPresentationIntents()
                 cancelHerdrCreation()
+                cancelZellijCreation()
                 cancelHerdrLifecyclePreparation()
                 cancelZellijKillPreparation()
             }
@@ -1011,6 +1011,55 @@ public struct RootView: View {
         }
     }
 
+    private func createZellijSession(
+        on host: HostSummary,
+        name: String
+    ) {
+        guard zellijCreationTask == nil else { return }
+        let session = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: name
+        )
+        zellijCreationRevision &+= 1
+        let creationRevision = zellijCreationRevision
+        zellijCreationTask = Task { @MainActor in
+            do {
+                guard let create = handlers.createZellijSession else {
+                    throw ZellijLifecycleUnavailableError()
+                }
+                try await create(session)
+                guard zellijCreationRevision == creationRevision else {
+                    return
+                }
+                zellijCreationTask = nil
+                newZellijSessionHost = nil
+                selectWorkspace(.zellijSession(
+                    hostID: host.id,
+                    name: name
+                ))
+            } catch {
+                guard zellijCreationRevision == creationRevision else {
+                    return
+                }
+                zellijCreationTask = nil
+                guard !(error is CancellationError) else { return }
+                presentNonWorktreeWorkspaceAlert(.zellijCreationFailure(
+                    session: name,
+                    message: error.localizedDescription
+                ))
+            }
+        }
+    }
+
+    private func cancelZellijCreation(dismissSheet: Bool = true) {
+        zellijCreationRevision &+= 1
+        zellijCreationTask?.cancel()
+        zellijCreationTask = nil
+        if dismissSheet {
+            newZellijSessionHost = nil
+        }
+    }
+
     private func restartHerdrSession(
         _ session: WorkspaceHerdrSessionSelection
     ) {
@@ -1277,6 +1326,12 @@ public struct RootView: View {
         case let .zellijKillFailure(session, message):
             return Alert(
                 title: Text("Could Not Kill “\(session)”"),
+                message: Text(message),
+                dismissButton: .default(Text("OK"))
+            )
+        case let .zellijCreationFailure(session, message):
+            return Alert(
+                title: Text("Could Not Create “\(session)”"),
                 message: Text(message),
                 dismissButton: .default(Text("OK"))
             )
@@ -1649,8 +1704,23 @@ public struct RootView: View {
                activeZellijSession.name,
                isSidebarTransitioning,
                NativeSessionContentActions(
-                   reconnectNow: {},
-                   reviewConnection: {}
+                   reconnectNow: {
+                       handlers.reconnectActiveZellijSessionNow?()
+                   },
+                   reviewConnection: {
+                       reviewSSHHostKey(
+                           host.id,
+                           inventoryWarning: sessionRecoveryWarning(
+                               for: host.id
+                           ),
+                           sessionRecoveryRequestID:
+                           sessionRecoveryRequestRouter.recoveryRequestID(
+                               for: host.id,
+                               activeRequest:
+                               display.sessionConnectionRecoveryRequest
+                           )
+                       )
+                   }
                )
            ) {
             view
@@ -2065,6 +2135,9 @@ public struct RootView: View {
         if herdrCreationTask != nil {
             cancelHerdrCreation()
         }
+        if zellijCreationTask != nil {
+            cancelZellijCreation()
+        }
         cancelHerdrPresentationIntents()
         if let selectWorkspace = handlers.selectWorkspace {
             selectWorkspace(updatedSelection)
@@ -2395,6 +2468,7 @@ enum WorkspaceAlert: Identifiable {
     case sessionKillFailure(session: String, message: String)
     case zellijKillConfirmation(ZellijSessionKillRequest)
     case zellijKillFailure(session: String, message: String)
+    case zellijCreationFailure(session: String, message: String)
     case herdrLifecycleConfirmation(HerdrSessionLifecycleRequest)
     case herdrLifecycleFailure(
         session: String,
@@ -2415,6 +2489,8 @@ enum WorkspaceAlert: Identifiable {
             return "zellij:confirm:\(request.session.id)"
         case let .zellijKillFailure(session, message):
             return "zellij:failure:\(session):\(message)"
+        case let .zellijCreationFailure(session, message):
+            return "zellij:create:failure:\(session):\(message)"
         case let .herdrLifecycleConfirmation(request):
             return "herdr:confirm:\(request.session.id):\(request.action)"
         case let .herdrLifecycleFailure(session, action, message):
@@ -2444,6 +2520,12 @@ private struct SessionThemeUnavailableError: LocalizedError {
 private struct HerdrLifecycleUnavailableError: LocalizedError {
     var errorDescription: String? {
         "Herdr session lifecycle actions are unavailable."
+    }
+}
+
+private struct ZellijLifecycleUnavailableError: LocalizedError {
+    var errorDescription: String? {
+        "Zellij session creation is unavailable."
     }
 }
 

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -663,6 +663,7 @@ public struct RootView: View {
             onNavigateAwayFromSession: {
                 hideTmuxSession()
                 deactivateHerdrSession()
+                handlers.cancelPendingZellijPresentation?()
                 deactivateZellijSession()
             },
             onRequestKillTmuxSession: requestSessionKill,

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -29,6 +29,7 @@ public struct WorkspaceDisplayState {
     public let availableApplicationShortcuts:
         Set<ApplicationShortcutAction>
     public let activeHerdrSession: WorkspaceHerdrSessionSelection?
+    public let activeZellijSession: WorkspaceZellijSessionSelection?
     public let pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection>
     public let sessionConnectionRecoveryRequest:
         SessionConnectionRecoveryRequest?
@@ -58,6 +59,7 @@ public struct WorkspaceDisplayState {
         availableApplicationShortcuts:
         Set<ApplicationShortcutAction> = [],
         activeHerdrSession: WorkspaceHerdrSessionSelection? = nil,
+        activeZellijSession: WorkspaceZellijSessionSelection? = nil,
         pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection> = [],
         sessionConnectionRecoveryRequest:
         SessionConnectionRecoveryRequest? = nil,
@@ -92,6 +94,7 @@ public struct WorkspaceDisplayState {
         self.availableApplicationShortcuts =
             availableApplicationShortcuts
         self.activeHerdrSession = activeHerdrSession
+        self.activeZellijSession = activeZellijSession
         self.pendingHerdrSessions = pendingHerdrSessions
         self.sessionConnectionRecoveryRequest =
             sessionConnectionRecoveryRequest
@@ -118,6 +121,8 @@ public struct ContentBuilders {
         ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)?
     public let herdrSessionContentBuilder:
         ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)?
+    public let zellijSessionContentBuilder:
+        ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)?
     public let settingsSheetBuilder: ((SettingsStore) -> AnyView)?
     public let logViewerBuilder: (() -> AnyView?)?
     public let sshAuthenticationBuilder: ((UUID) -> AnyView?)?
@@ -127,12 +132,15 @@ public struct ContentBuilders {
         ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)? = nil,
         herdrSessionContentBuilder:
         ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)? = nil,
+        zellijSessionContentBuilder:
+        ((HostSummary, String, Bool, NativeSessionContentActions) -> AnyView?)? = nil,
         settingsSheetBuilder: ((SettingsStore) -> AnyView)? = nil,
         logViewerBuilder: (() -> AnyView?)? = nil,
         sshAuthenticationBuilder: ((UUID) -> AnyView?)? = nil
     ) {
         self.tmuxSessionContentBuilder = tmuxSessionContentBuilder
         self.herdrSessionContentBuilder = herdrSessionContentBuilder
+        self.zellijSessionContentBuilder = zellijSessionContentBuilder
         self.settingsSheetBuilder = settingsSheetBuilder
         self.logViewerBuilder = logViewerBuilder
         self.sshAuthenticationBuilder = sshAuthenticationBuilder
@@ -278,6 +286,22 @@ public struct WorkspaceTmuxSessionCreationRequest: Equatable, Sendable {
     }
 }
 
+public struct ZellijSessionKillRequest: Equatable, Sendable {
+    public let authorityID: UUID
+    public let session: WorkspaceZellijSessionSelection
+    public let confirmedHost: HostSummary
+
+    public init(
+        authorityID: UUID,
+        session: WorkspaceZellijSessionSelection,
+        confirmedHost: HostSummary
+    ) {
+        self.authorityID = authorityID
+        self.session = session
+        self.confirmedHost = confirmedHost
+    }
+}
+
 public enum HerdrSessionDestructiveAction: Equatable, Sendable {
     case stop
     case delete
@@ -328,6 +352,16 @@ public struct InteractionHandlers {
         ((WorkspaceHerdrSessionSelection) async throws -> Void)?
     public let closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let closeHerdrSession: ((WorkspaceHerdrSessionSelection) -> Void)?
+    public let openZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
+    public let createZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
+    public let closeZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
+    public let prepareZellijSessionKill:
+        ((WorkspaceZellijSessionSelection) async throws
+            -> ZellijSessionKillRequest)?
+    public let killZellijSession:
+        ((ZellijSessionKillRequest) async throws -> Void)?
+    public let cancelZellijSessionKill:
+        ((ZellijSessionKillRequest) -> Void)?
     public let prepareHerdrSessionLifecycle:
         ((WorkspaceHerdrSessionSelection, HerdrSessionDestructiveAction)
             async throws -> HerdrSessionLifecycleRequest)?
@@ -391,6 +425,19 @@ public struct InteractionHandlers {
         ((WorkspaceHerdrSessionSelection) async throws -> Void)? = nil,
         closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)? = nil,
         closeHerdrSession: ((WorkspaceHerdrSessionSelection) -> Void)? = nil,
+        openZellijSession:
+        ((WorkspaceZellijSessionSelection) -> Void)? = nil,
+        createZellijSession:
+        ((WorkspaceZellijSessionSelection) -> Void)? = nil,
+        closeZellijSession:
+        ((WorkspaceZellijSessionSelection) -> Void)? = nil,
+        prepareZellijSessionKill:
+        ((WorkspaceZellijSessionSelection) async throws
+            -> ZellijSessionKillRequest)? = nil,
+        killZellijSession:
+        ((ZellijSessionKillRequest) async throws -> Void)? = nil,
+        cancelZellijSessionKill:
+        ((ZellijSessionKillRequest) -> Void)? = nil,
         prepareHerdrSessionLifecycle:
         ((WorkspaceHerdrSessionSelection, HerdrSessionDestructiveAction)
             async throws -> HerdrSessionLifecycleRequest)? = nil,
@@ -449,6 +496,12 @@ public struct InteractionHandlers {
         self.restartHerdrSession = restartHerdrSession
         self.closeTmuxSession = closeTmuxSession
         self.closeHerdrSession = closeHerdrSession
+        self.openZellijSession = openZellijSession
+        self.createZellijSession = createZellijSession
+        self.closeZellijSession = closeZellijSession
+        self.prepareZellijSessionKill = prepareZellijSessionKill
+        self.killZellijSession = killZellijSession
+        self.cancelZellijSessionKill = cancelZellijSessionKill
         self.prepareHerdrSessionLifecycle = prepareHerdrSessionLifecycle
         self.performHerdrSessionLifecycle = performHerdrSessionLifecycle
         self.cancelHerdrSessionLifecycle = cancelHerdrSessionLifecycle

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -355,6 +355,7 @@ public struct InteractionHandlers {
     public let openZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
     public let createZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
     public let closeZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
+    public let cancelPendingZellijPresentation: (() -> Void)?
     public let prepareZellijSessionKill:
         ((WorkspaceZellijSessionSelection) async throws
             -> ZellijSessionKillRequest)?
@@ -431,6 +432,7 @@ public struct InteractionHandlers {
         ((WorkspaceZellijSessionSelection) -> Void)? = nil,
         closeZellijSession:
         ((WorkspaceZellijSessionSelection) -> Void)? = nil,
+        cancelPendingZellijPresentation: (() -> Void)? = nil,
         prepareZellijSessionKill:
         ((WorkspaceZellijSessionSelection) async throws
             -> ZellijSessionKillRequest)? = nil,
@@ -499,6 +501,7 @@ public struct InteractionHandlers {
         self.openZellijSession = openZellijSession
         self.createZellijSession = createZellijSession
         self.closeZellijSession = closeZellijSession
+        self.cancelPendingZellijPresentation = cancelPendingZellijPresentation
         self.prepareZellijSessionKill = prepareZellijSessionKill
         self.killZellijSession = killZellijSession
         self.cancelZellijSessionKill = cancelZellijSessionKill

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -353,7 +353,8 @@ public struct InteractionHandlers {
     public let closeTmuxSession: ((WorkspaceTmuxSessionSelection) -> Void)?
     public let closeHerdrSession: ((WorkspaceHerdrSessionSelection) -> Void)?
     public let openZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
-    public let createZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
+    public let createZellijSession:
+        ((WorkspaceZellijSessionSelection) async throws -> Void)?
     public let closeZellijSession: ((WorkspaceZellijSessionSelection) -> Void)?
     public let cancelPendingZellijPresentation: (() -> Void)?
     public let prepareZellijSessionKill:
@@ -383,6 +384,7 @@ public struct InteractionHandlers {
     public let refreshWorkspaceInventory: (() -> Void)?
     public let reconnectActiveTmuxSessionNow: (() -> Void)?
     public let reconnectActiveHerdrSessionNow: (() -> Void)?
+    public let reconnectActiveZellijSessionNow: (() -> Void)?
     public let resumeSessionReconnectAfterSSHRecovery:
         ((SessionConnectionRecoveryRequest) -> Void)?
     public let reviewSSHHostKey:
@@ -429,7 +431,7 @@ public struct InteractionHandlers {
         openZellijSession:
         ((WorkspaceZellijSessionSelection) -> Void)? = nil,
         createZellijSession:
-        ((WorkspaceZellijSessionSelection) -> Void)? = nil,
+        ((WorkspaceZellijSessionSelection) async throws -> Void)? = nil,
         closeZellijSession:
         ((WorkspaceZellijSessionSelection) -> Void)? = nil,
         cancelPendingZellijPresentation: (() -> Void)? = nil,
@@ -460,6 +462,7 @@ public struct InteractionHandlers {
         refreshWorkspaceInventory: (() -> Void)? = nil,
         reconnectActiveTmuxSessionNow: (() -> Void)? = nil,
         reconnectActiveHerdrSessionNow: (() -> Void)? = nil,
+        reconnectActiveZellijSessionNow: (() -> Void)? = nil,
         resumeSessionReconnectAfterSSHRecovery:
         ((SessionConnectionRecoveryRequest) -> Void)? = nil,
         reviewSSHHostKey:
@@ -516,6 +519,7 @@ public struct InteractionHandlers {
         self.refreshWorkspaceInventory = refreshWorkspaceInventory
         self.reconnectActiveTmuxSessionNow = reconnectActiveTmuxSessionNow
         self.reconnectActiveHerdrSessionNow = reconnectActiveHerdrSessionNow
+        self.reconnectActiveZellijSessionNow = reconnectActiveZellijSessionNow
         self.resumeSessionReconnectAfterSSHRecovery =
             resumeSessionReconnectAfterSSHRecovery
         self.reviewSSHHostKey = reviewSSHHostKey

--- a/Sources/UI/SessionTitlebarPresentation.swift
+++ b/Sources/UI/SessionTitlebarPresentation.swift
@@ -23,10 +23,24 @@ public struct SessionTitlebarPresentation: Equatable, Sendable {
     public static func resolve(
         activeTmuxSession: WorkspaceTmuxSessionSelection?,
         activeHerdrSession: WorkspaceHerdrSessionSelection?,
+        activeZellijSession: WorkspaceZellijSessionSelection? = nil,
         in snapshot: WorkspaceSnapshot
     ) -> SessionTitlebarPresentation? {
-        guard activeTmuxSession == nil || activeHerdrSession == nil else {
+        let activeCount = [
+            activeTmuxSession != nil,
+            activeHerdrSession != nil,
+            activeZellijSession != nil,
+        ].filter { $0 }.count
+        guard activeCount <= 1 else {
             return nil
+        }
+        if let activeZellijSession,
+           let host = snapshot.host(id: activeZellijSession.hostID) {
+            return SessionTitlebarPresentation(
+                sessionName: activeZellijSession.name,
+                hostname: hostname(for: host),
+                icon: .zellijSession
+            )
         }
         if let activeHerdrSession {
             return resolve(

--- a/Sources/UI/WorkspaceAccessibilityModel.swift
+++ b/Sources/UI/WorkspaceAccessibilityModel.swift
@@ -71,6 +71,8 @@ enum WorkspaceAccessibilityModel {
             hint = row.herdrSessionState == .stopped
                 ? "Restart and attach to this Herdr session."
                 : "Attach to this Herdr session."
+        case .zellijSession:
+            hint = "Attach to this Zellij session."
         }
         return WorkspaceAccessibilityDescriptor(
             label: row.title,

--- a/Sources/UI/WorkspaceSidebarDisclosureState.swift
+++ b/Sources/UI/WorkspaceSidebarDisclosureState.swift
@@ -67,6 +67,7 @@ struct WorkspaceSidebarDisclosureState: Equatable {
         key.hasPrefix("host:")
             || key.hasPrefix("sessions:")
             || key.hasPrefix("herdr-sessions:")
+            || key.hasPrefix("zellij-sessions:")
     }
 
     static func host(_ hostID: UUID) -> String {
@@ -79,6 +80,10 @@ struct WorkspaceSidebarDisclosureState: Equatable {
 
     static func herdrSessions(_ hostID: UUID) -> String {
         "herdr-sessions:\(hostID.uuidString)"
+    }
+
+    static func zellijSessions(_ hostID: UUID) -> String {
+        "zellij-sessions:\(hostID.uuidString)"
     }
 
     static func projects(_ hostID: UUID) -> String {

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -5,6 +5,7 @@ public enum WorkspaceSidebarOrderStorage {
     public static let worktreeKey = "workspaceSidebarWorktreeOrderV1"
     public static let tmuxSessionKey = "workspaceSidebarTmuxSessionOrderV1"
     public static let herdrSessionKey = "workspaceSidebarHerdrSessionOrderV1"
+    public static let zellijSessionKey = "workspaceSidebarZellijSessionOrderV1"
 
     public static func worktreeRawValue(
         in defaults: UserDefaults = .standard
@@ -22,6 +23,12 @@ public enum WorkspaceSidebarOrderStorage {
         in defaults: UserDefaults = .standard
     ) -> String {
         defaults.string(forKey: herdrSessionKey) ?? ""
+    }
+
+    public static func zellijSessionRawValue(
+        in defaults: UserDefaults = .standard
+    ) -> String {
+        defaults.string(forKey: zellijSessionKey) ?? ""
     }
 }
 
@@ -230,6 +237,7 @@ public enum WorkspaceSidebarRowIcon: Equatable, Sendable {
     case directoryWorkspace
     case tmuxSession
     case herdrSession
+    case zellijSession
 
     public var systemImageName: String {
         switch self {
@@ -251,6 +259,8 @@ public enum WorkspaceSidebarRowIcon: Equatable, Sendable {
             return "terminal"
         case .herdrSession:
             return "rectangle.3.group"
+        case .zellijSession:
+            return "rectangle.split.3x1"
         }
     }
 }
@@ -258,6 +268,7 @@ public enum WorkspaceSidebarRowIcon: Equatable, Sendable {
 public enum WorkspaceSidebarGroup: Equatable, Sendable {
     case tmuxSessions
     case herdrSessions
+    case zellijSessions
     case projects
 }
 
@@ -307,6 +318,7 @@ public struct WorkspaceSidebarSection: Equatable, Identifiable, Sendable {
     public var directoryWorkspaceRows: [WorkspaceSidebarRow]
     public var tmuxSessionRows: [WorkspaceSidebarRow]
     public var herdrSessionRows: [WorkspaceSidebarRow]
+    public var zellijSessionRows: [WorkspaceSidebarRow]
 
     public var id: UUID { host.id }
     public var isEmpty: Bool {
@@ -314,6 +326,7 @@ public struct WorkspaceSidebarSection: Equatable, Identifiable, Sendable {
             && directoryWorkspaceRows.isEmpty
             && tmuxSessionRows.isEmpty
             && herdrSessionRows.isEmpty
+            && zellijSessionRows.isEmpty
     }
 
     public var visibleGroups: [WorkspaceSidebarGroup] {
@@ -323,6 +336,9 @@ public struct WorkspaceSidebarSection: Equatable, Identifiable, Sendable {
         }
         if !herdrSessionRows.isEmpty {
             groups.append(.herdrSessions)
+        }
+        if !zellijSessionRows.isEmpty {
+            groups.append(.zellijSessions)
         }
         if !projects.isEmpty || !directoryWorkspaceRows.isEmpty {
             groups.append(.projects)
@@ -447,7 +463,8 @@ public enum WorkspaceSidebarModel {
         tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
         worktreeOrderRawValue: String = "",
         tmuxSessionOrderRawValue: String = "",
-        herdrSessionOrderRawValue: String = ""
+        herdrSessionOrderRawValue: String = "",
+        zellijSessionOrderRawValue: String = ""
     ) -> [WorkspaceSidebarSection] {
         let worktreeOrder = WorkspaceSidebarOrder(
             rawValue: worktreeOrderRawValue
@@ -457,6 +474,9 @@ public enum WorkspaceSidebarModel {
         )
         let herdrSessionOrder = WorkspaceSidebarOrder(
             rawValue: herdrSessionOrderRawValue
+        )
+        let zellijSessionOrder = WorkspaceSidebarOrder(
+            rawValue: zellijSessionOrderRawValue
         )
         return snapshot.hosts.map { host in
             // Discovery only lists the host's default tmux server. A
@@ -534,7 +554,20 @@ public enum WorkspaceSidebarModel {
                         )
                     }
                 )
-                .map { herdrSessionRow($0, hostID: host.id) }
+                .map { herdrSessionRow($0, hostID: host.id) },
+                zellijSessionRows: zellijSessionOrder.ordered(
+                    host.zellijSessions.sorted {
+                        $0.name.localizedStandardCompare($1.name)
+                            == .orderedAscending
+                    },
+                    identifiedBy: {
+                        zellijSessionOrderID(
+                            hostID: host.id,
+                            name: $0.name
+                        )
+                    }
+                )
+                .map { zellijSessionRow($0, hostID: host.id) }
             )
         }
     }
@@ -566,6 +599,25 @@ public enum WorkspaceSidebarModel {
         name: String
     ) -> String {
         "herdr:\(hostID.uuidString):\(name)"
+    }
+
+    static func zellijSessionOrderID(
+        hostID: UUID,
+        name: String
+    ) -> String {
+        "zellij:\(hostID.uuidString):\(name)"
+    }
+
+    private static func zellijSessionRow(
+        _ session: ZellijSessionSummary,
+        hostID: UUID
+    ) -> WorkspaceSidebarRow {
+        WorkspaceSidebarRow(
+            target: .zellijSession(hostID: hostID, name: session.name),
+            icon: .zellijSession,
+            title: session.name,
+            subtitle: "Zellij session"
+        )
     }
 
     private static func herdrSessionRow(

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -46,6 +46,7 @@ enum WorkspaceSidebarRowAction: Hashable {
     case stopHerdrSession(WorkspaceHerdrSessionSelection)
     case restartHerdrSession(WorkspaceHerdrSessionSelection)
     case deleteHerdrSession(WorkspaceHerdrSessionSelection)
+    case killZellijSession(WorkspaceZellijSessionSelection)
 }
 
 enum WorkspaceSidebarRowActionModel {
@@ -77,6 +78,16 @@ enum WorkspaceSidebarRowActionModel {
                     ]
             }
         }
+        if case let .zellijSession(hostID, name) = row.target {
+            let selection = WorkspaceZellijSessionSelection(
+                hostID: hostID,
+                name: name
+            )
+            guard snapshot.host(id: hostID)?.zellijSessions.contains(
+                where: { $0.name == name }
+            ) == true else { return [] }
+            return [.killZellijSession(selection)]
+        }
         guard case let .tmuxSession(hostID, name) = row.target else {
             return []
         }
@@ -106,6 +117,7 @@ private enum WorkspaceSidebarDragItem: Equatable {
     case worktree(UUID)
     case tmuxSession(hostID: UUID, name: String)
     case herdrSession(hostID: UUID, name: String)
+    case zellijSession(hostID: UUID, name: String)
 
     init?(rawValue: String) {
         let parts = rawValue.split(
@@ -136,6 +148,14 @@ private enum WorkspaceSidebarDragItem: Equatable {
                 hostID: hostID,
                 name: String(parts[2])
             )
+        case "zellij":
+            guard parts.count == 3,
+                  let hostID = UUID(uuidString: String(parts[1]))
+            else { return nil }
+            self = .zellijSession(
+                hostID: hostID,
+                name: String(parts[2])
+            )
         default:
             return nil
         }
@@ -149,6 +169,8 @@ private enum WorkspaceSidebarDragItem: Equatable {
             return "tmux:\(hostID.uuidString):\(name)"
         case let .herdrSession(hostID, name):
             return "herdr:\(hostID.uuidString):\(name)"
+        case let .zellijSession(hostID, name):
+            return "zellij:\(hostID.uuidString):\(name)"
         }
     }
 
@@ -166,6 +188,11 @@ private enum WorkspaceSidebarDragItem: Equatable {
                 hostID: hostID,
                 name: name
             )
+        case let .zellijSession(hostID, name):
+            return WorkspaceSidebarModel.zellijSessionOrderID(
+                hostID: hostID,
+                name: name
+            )
         }
     }
 }
@@ -178,6 +205,7 @@ private struct WorkspaceSidebarReorderIndicator: Equatable {
 enum WorkspaceSidebarInventorySection: Hashable {
     case tmuxSessions
     case herdrSessions
+    case zellijSessions
     case projects
 }
 
@@ -199,6 +227,8 @@ enum WorkspaceSidebarSectionActionModel {
             true
         case .herdrSessions:
             host.herdrAvailable
+        case .zellijSessions:
+            host.zellijAvailable
         case .projects:
             hasProjects || host.canRegisterProjects
         }
@@ -209,6 +239,7 @@ enum WorkspaceSidebarSectionActionModel {
         host: HostSummary,
         onNewTmuxSession: @escaping (HostSummary) -> Void,
         onNewHerdrSession: @escaping (HostSummary) -> Void,
+        onNewZellijSession: @escaping (HostSummary) -> Void,
         onAddProject: @escaping (HostSummary) -> Void
     ) -> WorkspaceSidebarSectionAction? {
         switch section {
@@ -230,6 +261,16 @@ enum WorkspaceSidebarSectionActionModel {
                 "New Herdr session on \(host.sidebarTitle)",
                 help: "New Herdr session…",
                 perform: { onNewHerdrSession(host) }
+            )
+        case .zellijSessions:
+            guard host.zellijAvailable else { return nil }
+            return WorkspaceSidebarSectionAction(
+                accessibilityIdentifier:
+                "sidebar-section-action-zellij-\(host.id.uuidString)",
+                accessibilityLabel:
+                "New Zellij session on \(host.sidebarTitle)",
+                help: "New Zellij session…",
+                perform: { onNewZellijSession(host) }
             )
         case .projects:
             guard host.canRegisterProjects else { return nil }
@@ -258,21 +299,25 @@ struct WorkspaceSidebarView: View {
     let onOpen: (WorktreeSummary) -> Void
     let activeTmuxSession: WorkspaceTmuxSessionSelection?
     let activeHerdrSession: WorkspaceHerdrSessionSelection?
+    let activeZellijSession: WorkspaceZellijSessionSelection?
     let activeTmuxSessionIsConnected: Bool
     let workingTmuxSessionIDs: Set<String>
     let onOpenTmuxSession: (WorkspaceTmuxSessionSelection) -> Void
     let onOpenHerdrSession: (WorkspaceHerdrSessionSelection) -> Void
+    let onOpenZellijSession: (WorkspaceZellijSessionSelection) -> Void
     let pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection>
     let onRestartHerdrSession: (WorkspaceHerdrSessionSelection) -> Void
     let onRequestHerdrSessionLifecycle:
         (WorkspaceHerdrSessionSelection, HerdrSessionDestructiveAction) -> Void
     let onNavigateAwayFromSession: () -> Void
     let onRequestKillTmuxSession: (WorkspaceTmuxSessionSelection) -> Void
+    let onRequestKillZellijSession: (WorkspaceZellijSessionSelection) -> Void
     let onRequestRemoveWorktree: (WorktreeSummary) -> Void
     let onNewWorktree: (ProjectSummary) -> Void
     let onImportPullRequest: (ProjectSummary) -> Void
     let onNewTmuxSession: (HostSummary) -> Void
     let onNewHerdrSession: (HostSummary) -> Void
+    let onNewZellijSession: (HostSummary) -> Void
     let onAddProject: (HostSummary) -> Void
     let onRefreshInventory: () -> Void
     let onOpenHostSettings: () -> Void
@@ -299,6 +344,7 @@ struct WorkspaceSidebarView: View {
     @Binding private var worktreeOrderRawValue: String
     @Binding private var tmuxSessionOrderRawValue: String
     @Binding private var herdrSessionOrderRawValue: String
+    @Binding private var zellijSessionOrderRawValue: String
 
     init(
         snapshot: WorkspaceSnapshot,
@@ -307,6 +353,7 @@ struct WorkspaceSidebarView: View {
         tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
         activeTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeHerdrSession: WorkspaceHerdrSessionSelection? = nil,
+        activeZellijSession: WorkspaceZellijSessionSelection? = nil,
         activeTmuxSessionIsConnected: Bool = false,
         workingTmuxSessionIDs: Set<String> = [],
         onOpenTmuxSession: @escaping (
@@ -314,6 +361,9 @@ struct WorkspaceSidebarView: View {
         ) -> Void = { _ in },
         onOpenHerdrSession: @escaping (
             WorkspaceHerdrSessionSelection
+        ) -> Void = { _ in },
+        onOpenZellijSession: @escaping (
+            WorkspaceZellijSessionSelection
         ) -> Void = { _ in },
         pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection> = [],
         onRestartHerdrSession: @escaping (
@@ -327,6 +377,9 @@ struct WorkspaceSidebarView: View {
         onRequestKillTmuxSession: @escaping (
             WorkspaceTmuxSessionSelection
         ) -> Void = { _ in },
+        onRequestKillZellijSession: @escaping (
+            WorkspaceZellijSessionSelection
+        ) -> Void = { _ in },
         onRequestRemoveWorktree: @escaping (
             WorktreeSummary
         ) -> Void = { _ in },
@@ -334,6 +387,7 @@ struct WorkspaceSidebarView: View {
         onImportPullRequest: @escaping (ProjectSummary) -> Void = { _ in },
         onNewTmuxSession: @escaping (HostSummary) -> Void = { _ in },
         onNewHerdrSession: @escaping (HostSummary) -> Void = { _ in },
+        onNewZellijSession: @escaping (HostSummary) -> Void = { _ in },
         onAddProject: @escaping (HostSummary) -> Void = { _ in },
         onRefreshInventory: @escaping () -> Void = {},
         onOpenHostSettings: @escaping () -> Void = {},
@@ -344,6 +398,7 @@ struct WorkspaceSidebarView: View {
         worktreeOrderRawValue: Binding<String> = .constant(""),
         tmuxSessionOrderRawValue: Binding<String> = .constant(""),
         herdrSessionOrderRawValue: Binding<String> = .constant(""),
+        zellijSessionOrderRawValue: Binding<String> = .constant(""),
         onOpen: @escaping (WorktreeSummary) -> Void = { _ in }
     ) {
         self.snapshot = snapshot
@@ -352,20 +407,24 @@ struct WorkspaceSidebarView: View {
         self.tmuxSessionVisibility = tmuxSessionVisibility
         self.activeTmuxSession = activeTmuxSession
         self.activeHerdrSession = activeHerdrSession
+        self.activeZellijSession = activeZellijSession
         self.activeTmuxSessionIsConnected = activeTmuxSessionIsConnected
         self.workingTmuxSessionIDs = workingTmuxSessionIDs
         self.onOpenTmuxSession = onOpenTmuxSession
         self.onOpenHerdrSession = onOpenHerdrSession
+        self.onOpenZellijSession = onOpenZellijSession
         self.pendingHerdrSessions = pendingHerdrSessions
         self.onRestartHerdrSession = onRestartHerdrSession
         self.onRequestHerdrSessionLifecycle = onRequestHerdrSessionLifecycle
         self.onNavigateAwayFromSession = onNavigateAwayFromSession
         self.onRequestKillTmuxSession = onRequestKillTmuxSession
+        self.onRequestKillZellijSession = onRequestKillZellijSession
         self.onRequestRemoveWorktree = onRequestRemoveWorktree
         self.onNewWorktree = onNewWorktree
         self.onImportPullRequest = onImportPullRequest
         self.onNewTmuxSession = onNewTmuxSession
         self.onNewHerdrSession = onNewHerdrSession
+        self.onNewZellijSession = onNewZellijSession
         self.onAddProject = onAddProject
         self.onRefreshInventory = onRefreshInventory
         self.onOpenHostSettings = onOpenHostSettings
@@ -376,6 +435,7 @@ struct WorkspaceSidebarView: View {
         _worktreeOrderRawValue = worktreeOrderRawValue
         _tmuxSessionOrderRawValue = tmuxSessionOrderRawValue
         _herdrSessionOrderRawValue = herdrSessionOrderRawValue
+        _zellijSessionOrderRawValue = zellijSessionOrderRawValue
         self.onOpen = onOpen
     }
 
@@ -388,7 +448,8 @@ struct WorkspaceSidebarView: View {
             tmuxSessionVisibility: tmuxSessionVisibility,
             worktreeOrderRawValue: worktreeOrderRawValue,
             tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
-            herdrSessionOrderRawValue: herdrSessionOrderRawValue
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
         )
     }
 
@@ -530,6 +591,30 @@ struct WorkspaceSidebarView: View {
                             herdrSessionButton(
                                 row,
                                 orderedRows: section.herdrSessionRows
+                            )
+                        }
+                    }
+                }
+                if WorkspaceSidebarSectionActionModel.isVisible(
+                    .zellijSessions,
+                    host: section.host,
+                    hasProjects: !section.projects.isEmpty
+                ) {
+                    let zellijSessionsKey = WorkspaceSidebarDisclosureState
+                        .zellijSessions(section.host.id)
+                    sidebarGroupLabel(
+                        "Zellij Sessions",
+                        disclosureKey: zellijSessionsKey,
+                        action: sectionAction(
+                            for: .zellijSessions,
+                            host: section.host
+                        )
+                    )
+                    if isExpanded(zellijSessionsKey) {
+                        ForEach(section.zellijSessionRows) { row in
+                            zellijSessionButton(
+                                row,
+                                orderedRows: section.zellijSessionRows
                             )
                         }
                     }
@@ -755,6 +840,39 @@ struct WorkspaceSidebarView: View {
         )
     }
 
+    private func zellijSessionButton(
+        _ row: WorkspaceSidebarRow,
+        orderedRows: [WorkspaceSidebarRow]
+    ) -> some View {
+        guard case let .zellijSession(hostID, name) = row.target else {
+            return AnyView(sidebarButton(row))
+        }
+        let item = WorkspaceSidebarDragItem.zellijSession(
+            hostID: hostID,
+            name: name
+        )
+        let groupItems: [WorkspaceSidebarDragItem] = orderedRows.compactMap {
+            orderedRow in
+            guard case let .zellijSession(orderedHostID, orderedName) =
+                orderedRow.target
+            else { return nil }
+            return WorkspaceSidebarDragItem.zellijSession(
+                hostID: orderedHostID,
+                name: orderedName
+            )
+        }
+        return AnyView(
+            reorderableRow(
+                sidebarButton(row),
+                item: item,
+                groupItems: groupItems,
+                orderRawValue: zellijSessionOrderRawValue
+            ) { updatedRawValue in
+                zellijSessionOrderRawValue = updatedRawValue
+            }
+        )
+    }
+
     private func sidebarButton(
         _ row: WorkspaceSidebarRow,
         reservedTrailingActionWidth: CGFloat = 0
@@ -777,6 +895,9 @@ struct WorkspaceSidebarView: View {
             if case .killTmuxSession = $0 {
                 return false
             }
+            if case .killZellijSession = $0 {
+                return false
+            }
             return true
         }
         let herdrSelection: WorkspaceHerdrSessionSelection? = {
@@ -785,6 +906,12 @@ struct WorkspaceSidebarView: View {
             }
             return WorkspaceHerdrSessionSelection(hostID: hostID, name: name)
         }()
+        let zellijSelection: WorkspaceZellijSessionSelection? = {
+            guard case let .zellijSession(hostID, name) = row.target else {
+                return nil
+            }
+            return WorkspaceZellijSessionSelection(hostID: hostID, name: name)
+        }()
         let herdrOperationIsPending = herdrSelection.map {
             pendingHerdrSessions.contains($0)
         } ?? false
@@ -792,7 +919,8 @@ struct WorkspaceSidebarView: View {
             row,
             selection: selection,
             activeTmuxSession: activeTmuxSession,
-            activeHerdrSession: activeHerdrSession
+            activeHerdrSession: activeHerdrSession,
+            activeZellijSession: activeZellijSession
         )
         let isTmuxSessionWorking = tmuxSession.map {
             workingTmuxSessionIDs.contains($0.id)
@@ -800,11 +928,14 @@ struct WorkspaceSidebarView: View {
         let usesDirectKillAction: Bool
         if case .tmuxSession = row.target {
             usesDirectKillAction = true
+        } else if case .zellijSession = row.target {
+            usesDirectKillAction = true
         } else {
             usesDirectKillAction = false
         }
         let hasSessionActions = runningTmuxSession != nil
             || !herdrActions.isEmpty
+            || zellijSelection != nil
         let isActionHovered = hasSessionActions
             && hoveredSessionActionControlRowID == row.id
         let actionPresentation = WorkspaceSessionActionPresentation(
@@ -830,6 +961,19 @@ struct WorkspaceSidebarView: View {
                     } else {
                         onOpenHerdrSession(herdrSelection)
                     }
+                    return
+                }
+                if case let .zellijSession(hostID, name) = row.target {
+                    let zellijSelection = WorkspaceZellijSessionSelection(
+                        hostID: hostID,
+                        name: name
+                    )
+                    selection.select(
+                        row.target,
+                        in: snapshot,
+                        visibility: visibility
+                    )
+                    onOpenZellijSession(zellijSelection)
                     return
                 }
                 if case let .tmuxSession(hostID, name) = row.target {
@@ -1005,6 +1149,19 @@ struct WorkspaceSidebarView: View {
                         .accessibilityHint(
                             "Includes the option to kill this session."
                         )
+                    } else if let zellijSelection {
+                        Button {
+                            onRequestKillZellijSession(zellijSelection)
+                        } label: {
+                            sessionActionLabel(
+                                actionPresentation,
+                                isActionHovered: isActionHovered,
+                                imageName: "xmark"
+                            )
+                        }
+                        .accessibilityLabel(
+                            "Kill Zellij session \(zellijSelection.name)"
+                        )
                     } else {
                         NativePopupMenuButton(
                             groups: [herdrActions.compactMap(
@@ -1057,6 +1214,11 @@ struct WorkspaceSidebarView: View {
                     onRequestKillTmuxSession(tmuxSession)
                 }
             }
+            if let zellijSelection {
+                Button("Kill Session…", role: .destructive) {
+                    onRequestKillZellijSession(zellijSelection)
+                }
+            }
             ForEach(herdrActions, id: \.self) { action in
                 herdrContextMenuButton(action)
             }
@@ -1065,6 +1227,11 @@ struct WorkspaceSidebarView: View {
             if let tmuxSession = runningTmuxSession {
                 Button("Kill Session") {
                     onRequestKillTmuxSession(tmuxSession)
+                }
+            }
+            if let zellijSelection {
+                Button("Kill Session") {
+                    onRequestKillZellijSession(zellijSelection)
                 }
             }
             ForEach(herdrActions, id: \.self) { action in
@@ -1092,6 +1259,10 @@ struct WorkspaceSidebarView: View {
             }
         case .killTmuxSession:
             EmptyView()
+        case let .killZellijSession(selection):
+            Button("Kill Session…", role: .destructive) {
+                onRequestKillZellijSession(selection)
+            }
         }
     }
 
@@ -1113,6 +1284,10 @@ struct WorkspaceSidebarView: View {
             }
         case .killTmuxSession:
             nil
+        case let .killZellijSession(selection):
+            NativePopupMenuAction("Kill Session…", role: .destructive) {
+                onRequestKillZellijSession(selection)
+            }
         }
     }
 
@@ -1135,6 +1310,10 @@ struct WorkspaceSidebarView: View {
             }
         case .killTmuxSession:
             EmptyView()
+        case let .killZellijSession(selection):
+            Button("Kill Session") {
+                onRequestKillZellijSession(selection)
+            }
         }
     }
 
@@ -1142,7 +1321,8 @@ struct WorkspaceSidebarView: View {
         _ row: WorkspaceSidebarRow,
         selection: WorkspaceSelection,
         activeTmuxSession: WorkspaceTmuxSessionSelection?,
-        activeHerdrSession: WorkspaceHerdrSessionSelection?
+        activeHerdrSession: WorkspaceHerdrSessionSelection?,
+        activeZellijSession: WorkspaceZellijSessionSelection? = nil
     ) -> Bool {
         if case let .herdrSession(hostID, name) = row.target {
             return activeHerdrSession == WorkspaceHerdrSessionSelection(
@@ -1152,6 +1332,12 @@ struct WorkspaceSidebarView: View {
         }
         if case let .tmuxSession(hostID, name) = row.target {
             return activeTmuxSession == WorkspaceTmuxSessionSelection(
+                hostID: hostID,
+                name: name
+            )
+        }
+        if case let .zellijSession(hostID, name) = row.target {
+            return activeZellijSession == WorkspaceZellijSessionSelection(
                 hostID: hostID,
                 name: name
             )
@@ -1166,6 +1352,7 @@ struct WorkspaceSidebarView: View {
         }
         return activeTmuxSession == nil
             && activeHerdrSession == nil
+            && activeZellijSession == nil
             && selection.navigationTarget == row.target
     }
 
@@ -1231,7 +1418,7 @@ struct WorkspaceSidebarView: View {
                 id: directoryWorkspaceID
             ) else { return nil }
             return WorkspaceSidebarModel.tmuxSessionSelection(for: workspace)
-        case .host, .project, .herdrSession:
+        case .host, .project, .herdrSession, .zellijSession:
             return nil
         }
     }
@@ -1679,6 +1866,7 @@ struct WorkspaceSidebarView: View {
             host: host,
             onNewTmuxSession: onNewTmuxSession,
             onNewHerdrSession: onNewHerdrSession,
+            onNewZellijSession: onNewZellijSession,
             onAddProject: onAddProject
         )
     }
@@ -1819,6 +2007,21 @@ struct WorkspaceSidebarView: View {
         })
         if herdrSessionOrder.prune(keeping: herdrSessionIDs) {
             herdrSessionOrderRawValue = herdrSessionOrder.rawValue
+        }
+
+        var zellijSessionOrder = WorkspaceSidebarOrder(
+            rawValue: zellijSessionOrderRawValue
+        )
+        let zellijSessionIDs = Set(snapshot.hosts.flatMap { host in
+            host.zellijSessions.map {
+                WorkspaceSidebarModel.zellijSessionOrderID(
+                    hostID: host.id,
+                    name: $0.name
+                )
+            }
+        })
+        if zellijSessionOrder.prune(keeping: zellijSessionIDs) {
+            zellijSessionOrderRawValue = zellijSessionOrder.rawValue
         }
     }
 

--- a/Sources/Workspace/HostModels.swift
+++ b/Sources/Workspace/HostModels.swift
@@ -409,6 +409,8 @@ public struct HostSummary: Identifiable, Equatable, Sendable {
     public var tmuxSessions: [TmuxSessionSummary]
     public var herdrSessions: [HerdrSessionSummary]
     public var herdrAvailable: Bool
+    public var zellijSessions: [ZellijSessionSummary]
+    public var zellijAvailable: Bool
     public var decodedConnectionState: HostConnectionState?
     public var transientOverride: HostConnectionState?
     public var operationAvailability:
@@ -433,6 +435,8 @@ public struct HostSummary: Identifiable, Equatable, Sendable {
         tmuxSessions: [TmuxSessionSummary] = [],
         herdrSessions: [HerdrSessionSummary] = [],
         herdrAvailable: Bool = false,
+        zellijSessions: [ZellijSessionSummary] = [],
+        zellijAvailable: Bool = false,
         decodedConnectionState: HostConnectionState? = nil,
         transientOverride: HostConnectionState? = nil,
         operationAvailability:
@@ -456,6 +460,8 @@ public struct HostSummary: Identifiable, Equatable, Sendable {
         self.tmuxSessions = tmuxSessions
         self.herdrSessions = herdrSessions
         self.herdrAvailable = herdrAvailable
+        self.zellijSessions = zellijSessions
+        self.zellijAvailable = zellijAvailable
         self.decodedConnectionState = decodedConnectionState
         self.transientOverride = transientOverride
         self.operationAvailability = operationAvailability

--- a/Sources/Workspace/TerminalSurfaceTarget.swift
+++ b/Sources/Workspace/TerminalSurfaceTarget.swift
@@ -7,6 +7,7 @@ public enum TerminalSurfaceTarget: String, CaseIterable, Identifiable, Equatable
     case logViewer
     case tmuxSession
     case herdrSession
+    case zellijSession
 
     public var id: String {
         rawValue

--- a/Sources/Workspace/WorkspaceSelectionModel.swift
+++ b/Sources/Workspace/WorkspaceSelectionModel.swift
@@ -12,6 +12,9 @@ public enum WorkspaceNavigationTarget: Hashable, Sendable {
     /// A running Herdr session discovered independently of tmux and projects.
     /// Selection remains host-scoped; Herdr owns its internal workspace state.
     case herdrSession(hostID: UUID, name: String)
+    /// A running Zellij session discovered independently of tmux and projects.
+    /// Zellij owns its tabs, panes, layout, history, and process lifetime.
+    case zellijSession(hostID: UUID, name: String)
 }
 
 public extension WorkspaceSelection {
@@ -84,7 +87,8 @@ public extension WorkspaceSelection {
             selectedWorktreeID = nil
             selectedDirectoryWorkspaceID = workspace.id
         case let .tmuxSession(hostID, _),
-             let .herdrSession(hostID, _):
+             let .herdrSession(hostID, _),
+             let .zellijSession(hostID, _):
             guard snapshot.host(id: hostID) != nil else {
                 return
             }

--- a/Sources/Workspace/ZellijSessionModels.swift
+++ b/Sources/Workspace/ZellijSessionModels.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct ZellijSessionSummary: Codable, Equatable, Hashable, Sendable {
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+public struct WorkspaceZellijSessionSelection:
+    Equatable, Hashable, Identifiable, Sendable {
+    public var hostID: UUID
+    public var name: String
+
+    public init(hostID: UUID, name: String) {
+        self.hostID = hostID
+        self.name = name
+    }
+
+    public var id: String {
+        "\(hostID.uuidString):\(name)"
+    }
+}

--- a/Sources/Zellij/ZellijAttachmentInfo.swift
+++ b/Sources/Zellij/ZellijAttachmentInfo.swift
@@ -1,0 +1,114 @@
+import GhosthubTransport
+
+public enum ZellijAttachmentLaunchMode: Equatable, Sendable {
+    case attachExisting
+    case create
+}
+
+public struct ZellijAttachmentInfo: Equatable, Sendable {
+    public let sessionName: String
+    public let host: CommandHost
+
+    public init(sessionName: String, host: CommandHost) {
+        self.sessionName = sessionName
+        self.host = host
+    }
+
+    public func attachCommand(
+        zellijPath: String,
+        launchMode: ZellijAttachmentLaunchMode = .attachExisting,
+        sshConnectionArguments: [String] = [],
+        remoteExitStatusPath: String? = nil
+    ) throws -> String {
+        let attach = localAttachCommand(
+            zellijPath: zellijPath,
+            launchMode: launchMode
+        )
+        switch host {
+        case .local:
+            return attach
+        case let .ssh(info):
+            guard info.platform == .posix else {
+                throw ZellijCommandError.unsupportedPlatform
+            }
+            let remoteAttach = accountLoginShellCommand(attach)
+            let sshAttach = shellCommand(
+                [
+                    "/bin/sh", "-c", Self.sshAttachScript,
+                    "ghosthub-ssh-zellij",
+                ] + sshArguments(
+                    info: info,
+                    remoteCommand: remoteAttach,
+                    sshConnectionArguments: sshConnectionArguments
+                )
+            )
+            guard let remoteExitStatusPath, !remoteExitStatusPath.isEmpty else {
+                return surfaceAccountLoginShellCommand(sshAttach)
+            }
+            return surfaceAccountLoginShellCommand(shellCommand([
+                "/bin/sh", "-c", Self.remoteExitStatusScript,
+                "ghosthub-ssh-status", remoteExitStatusPath, sshAttach,
+            ]))
+        }
+    }
+
+    private func localAttachCommand(
+        zellijPath: String,
+        launchMode: ZellijAttachmentLaunchMode
+    ) -> String {
+        let arguments: [String]
+        switch launchMode {
+        case .attachExisting:
+            // Zellij has no atomic active-only client command. Callers must
+            // validate active inventory first; the scene-wide kill fence
+            // prevents Ghosthub reconnects from racing a confirmed kill.
+            arguments = [zellijPath, "attach", "--", sessionName]
+        case .create:
+            arguments = [zellijPath, "--session=\(sessionName)"]
+        }
+        let invocation = arguments.map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        return shellCommand([
+            "/bin/sh", "-c",
+            "\(ZellijEnvironment.unsetCommand); exec \(invocation)",
+        ])
+    }
+
+    private func sshArguments(
+        info: SSHHostInfo,
+        remoteCommand: String,
+        sshConnectionArguments: [String]
+    ) -> [String] {
+        var arguments = [
+            "/usr/bin/ssh", "-tt",
+            "-o", "BatchMode=yes",
+            "-o", "ServerAliveInterval=15",
+            "-o", "ServerAliveCountMax=3",
+            "-o", "TCPKeepAlive=yes",
+            "-o", "ConnectTimeout=15",
+        ]
+        arguments.append(contentsOf: sshConnectionArguments)
+        if let port = info.port {
+            arguments.append(contentsOf: ["-p", "\(port)"])
+        }
+        arguments.append(contentsOf: [
+            "--",
+            info.user.map { "\($0)@\(info.hostname)" } ?? info.hostname,
+            remoteCommand,
+        ])
+        return arguments
+    }
+
+    private func shellCommand(_ arguments: [String]) -> String {
+        arguments.map(shellQuotedCommandArgument).joined(separator: " ")
+    }
+
+    static let remoteExitStatusScript = """
+    /bin/sh -c "$2"
+    ghosthub_status=$?
+    printf '%s\\n' "$ghosthub_status" > "$1"
+    exit "$ghosthub_status"
+    """
+
+    static let sshAttachScript = "exec \"$@\""
+}

--- a/Sources/Zellij/ZellijCommandError.swift
+++ b/Sources/Zellij/ZellijCommandError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public enum ZellijCommandError:
+    Error, Equatable, LocalizedError, Sendable {
+    case unavailable
+    case commandFailed(status: Int32, stderr: String)
+    case missingMarker
+    case malformedInventory(line: String)
+    case unsupportedPlatform
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Zellij is unavailable on this host."
+        case let .commandFailed(status, stderr):
+            let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return detail.isEmpty
+                ? "Zellij exited with status \(status)."
+                : "Zellij exited with status \(status): \(detail)"
+        case .missingMarker:
+            return "Zellij returned output without Ghosthub's inventory marker."
+        case let .malformedInventory(line):
+            return "Zellij returned an unrecognized session entry: \(line)"
+        case .unsupportedPlatform:
+            return "Native Zellij sessions are unavailable on Windows hosts."
+        }
+    }
+}

--- a/Sources/Zellij/ZellijExecutable.swift
+++ b/Sources/Zellij/ZellijExecutable.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum ZellijEnvironment {
+    public static let controlVariables = [
+        "ZELLIJ",
+        "ZELLIJ_PANE_ID",
+        "ZELLIJ_SESSION_NAME",
+    ]
+
+    public static var unsetCommand: String {
+        "unset " + controlVariables.joined(separator: " ")
+    }
+}
+
+public enum ZellijExecutableResult: Equatable, Sendable {
+    case available(String)
+    case unavailable
+    case failure(ZellijCommandError)
+}
+
+public enum ZellijExecutable {
+    public static let marker = "GHOSTHUB_ZELLIJ_PATH"
+
+    public static func command() -> String {
+        [
+            ZellijEnvironment.unsetCommand,
+            "ghosthub_zellij_path=$(command -v zellij) || exit 127",
+            "[ -n \"$ghosthub_zellij_path\" ] || exit 127",
+            "case \"$ghosthub_zellij_path\" in /*) ;; *) exit 127 ;; esac",
+            "[ -x \"$ghosthub_zellij_path\" ] || exit 127",
+            "printf '%s\\n%s\\n' '\(marker)' \"$ghosthub_zellij_path\"",
+        ].joined(separator: "; ")
+    }
+
+    public static func parse(
+        status: Int32,
+        stdout: String,
+        stderr: String
+    ) -> ZellijExecutableResult {
+        if status == 127 {
+            return .unavailable
+        }
+        guard status == 0 else {
+            return .failure(.commandFailed(status: status, stderr: stderr))
+        }
+        let lines = stdout.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ).map(String.init)
+        guard let markerIndex = lines.lastIndex(of: marker),
+              lines.indices.contains(markerIndex + 1)
+        else { return .unavailable }
+        let path = lines[markerIndex + 1]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard path.hasPrefix("/") else { return .unavailable }
+        return .available(path)
+    }
+}

--- a/Sources/Zellij/ZellijExecutable.swift
+++ b/Sources/Zellij/ZellijExecutable.swift
@@ -49,7 +49,7 @@ public enum ZellijExecutable {
         ).map(String.init)
         guard let markerIndex = lines.lastIndex(of: marker),
               lines.indices.contains(markerIndex + 1)
-        else { return .unavailable }
+        else { return .failure(.missingMarker) }
         let path = lines[markerIndex + 1]
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard path.hasPrefix("/") else { return .unavailable }

--- a/Sources/Zellij/ZellijSessionLifecycle.swift
+++ b/Sources/Zellij/ZellijSessionLifecycle.swift
@@ -1,0 +1,12 @@
+import GhosthubTransport
+
+public enum ZellijSessionLifecycle {
+    public static func killCommand(
+        zellijPath: String,
+        sessionName: String
+    ) -> String {
+        [zellijPath, "kill-session", "--", sessionName]
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+    }
+}

--- a/Sources/Zellij/ZellijSessionList.swift
+++ b/Sources/Zellij/ZellijSessionList.swift
@@ -1,0 +1,74 @@
+import Foundation
+import GhosthubTransport
+
+public enum ZellijDiscoveryResult: Equatable, Sendable {
+    case available([String])
+    case unavailable
+    case failure(ZellijCommandError)
+}
+
+public enum ZellijSessionList {
+    public static let marker = "GHOSTHUB_ZELLIJ_SESSIONS"
+    public static let errorMarker = "GHOSTHUB_ZELLIJ_ERRORS"
+
+    public static func command(zellijPath: String) -> String {
+        let invocation = [zellijPath, "list-sessions", "--no-formatting"]
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        return [
+            "printf '\\n%s\\n' '\(marker)'",
+            "printf '\\n%s\\n' '\(errorMarker)' >&2",
+            "exec \(invocation)",
+        ].joined(separator: "; ")
+    }
+
+    public static func parse(
+        status: Int32,
+        stdout: String,
+        stderr: String
+    ) -> ZellijDiscoveryResult {
+        if status == 127 {
+            return .unavailable
+        }
+        if status != 0 {
+            let errorLines = stderr.split(
+                separator: "\n",
+                omittingEmptySubsequences: false
+            )
+            let payload = errorLines.lastIndex(where: { $0 == errorMarker })
+                .map { errorLines[($0 + 1)...].joined(separator: "\n") }
+                ?? stderr
+            let detail = payload.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            if detail == "No active zellij sessions found." {
+                return .available([])
+            }
+            return .failure(.commandFailed(status: status, stderr: payload))
+        }
+        let lines = stdout.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        )
+        guard let markerIndex = lines.lastIndex(where: { $0 == marker }) else {
+            return .failure(.missingMarker)
+        }
+
+        var names = [String]()
+        for rawLine in lines[(markerIndex + 1)...] where !rawLine.isEmpty {
+            let line = String(rawLine)
+            guard let metadata = line.range(
+                of: " [Created ",
+                options: .backwards
+            ) else {
+                return .failure(.malformedInventory(line: line))
+            }
+            let suffix = line[metadata.lowerBound...]
+            if suffix.contains("(EXITED - attach to resurrect)") {
+                continue
+            }
+            names.append(String(line[..<metadata.lowerBound]))
+        }
+        return .available(names)
+    }
+}

--- a/Tests/App/AccountCommandRunnerTests.swift
+++ b/Tests/App/AccountCommandRunnerTests.swift
@@ -115,6 +115,9 @@ struct AccountCommandRunnerTests {
             "HERDR_ACTIVE_TAB_ID": "tab-1",
             "HERDR_ACTIVE_PANE_ID": "pane-1",
             "HERDR_ACTIVE_PANE_CWD": "/tmp/review",
+            "ZELLIJ": "0",
+            "ZELLIJ_PANE_ID": "7",
+            "ZELLIJ_SESSION_NAME": "review",
         ])
 
         #expect(sanitized == ["PATH": "/usr/bin"])

--- a/Tests/App/BorrowedZellijSessionViewTests.swift
+++ b/Tests/App/BorrowedZellijSessionViewTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import GhosthubTransport
+import Testing
+@testable import GhosthubApp
+
+@Suite("Borrowed Zellij presentation")
+@MainActor
+struct BorrowedZellijSessionViewTests {
+    @Test("automatic transport recovery offers immediate reconnect")
+    func reconnectingPresentation() {
+        let view = makeView(
+            recoveryState: .reconnecting(message: "Waiting for build-box.")
+        )
+
+        #expect(view.recoveryTitle == "Connection interrupted")
+        #expect(view.showsReconnectProgress)
+        #expect(view.primaryRecoveryActionTitle == "Reconnect Now")
+        #expect(!view.showsReviewConnection)
+        #expect(view.showsHostSettingsAction)
+    }
+
+    @Test("authentication recovery offers connection review")
+    func attentionPresentation() {
+        let view = makeView(
+            recoveryState: .needsAttention(
+                message: "SSH authentication is required.",
+                canReviewConnection: true
+            )
+        )
+
+        #expect(view.recoveryTitle == "Connection needs attention")
+        #expect(!view.showsReconnectProgress)
+        #expect(view.showsReviewConnection)
+        #expect(view.showsHostSettingsAction)
+    }
+
+    private func makeView(
+        recoveryState: NativeSessionRecoveryState
+    ) -> BorrowedZellijSessionView {
+        BorrowedZellijSessionView(
+            handle: BorrowedZellijSessionHandle(
+                id: UUID(),
+                hostID: UUID(),
+                name: "api",
+                surfaceID: UUID()
+            ),
+            hostName: "build-box",
+            isRemoteHost: true,
+            connectionState: .reconnecting(reason: "Recovering."),
+            recoveryState: recoveryState,
+            surface: { nil },
+            onCloseRequest: {},
+            onRetryRequest: {},
+            onReconnectNow: {},
+            onReviewConnection: {},
+            onHostSettingsRequest: {}
+        )
+    }
+}

--- a/Tests/App/ConfiguredHostOverlayTests.swift
+++ b/Tests/App/ConfiguredHostOverlayTests.swift
@@ -89,7 +89,9 @@ struct ConfiguredHostOverlayTests {
                     state: .running
                 ),
             ],
-            herdrAvailable: true
+            herdrAvailable: true,
+            zellijSessions: [.init(name: "old-zellij")],
+            zellijAvailable: true
         )
         let project = ProjectSummary.fixture(hostID: host.id)
         let worktree = WorktreeSummary.fixture(
@@ -121,7 +123,9 @@ struct ConfiguredHostOverlayTests {
         #expect(result.hosts[0].id == host.id)
         #expect(result.hosts[0].tmuxSessions.isEmpty)
         #expect(result.hosts[0].herdrSessions.isEmpty)
+        #expect(result.hosts[0].zellijSessions.isEmpty)
         #expect(!result.hosts[0].herdrAvailable)
+        #expect(!result.hosts[0].zellijAvailable)
         #expect(result.projects.isEmpty)
         #expect(result.worktrees.isEmpty)
         #expect(result.sessions.isEmpty)
@@ -185,7 +189,9 @@ struct ConfiguredHostOverlayTests {
                     state: .running
                 ),
             ],
-            herdrAvailable: true
+            herdrAvailable: true,
+            zellijSessions: [.init(name: "old-zellij")],
+            zellijAvailable: true
         )
         let project = ProjectSummary.fixture(hostID: host.id)
         let worktree = WorktreeSummary.fixture(
@@ -218,7 +224,9 @@ struct ConfiguredHostOverlayTests {
         #expect(result.hosts[0].platform == to)
         #expect(result.hosts[0].tmuxSessions.isEmpty)
         #expect(result.hosts[0].herdrSessions.isEmpty)
+        #expect(result.hosts[0].zellijSessions.isEmpty)
         #expect(!result.hosts[0].herdrAvailable)
+        #expect(!result.hosts[0].zellijAvailable)
         #expect(result.projects.isEmpty)
         #expect(result.worktrees.isEmpty)
         #expect(result.sessions.isEmpty)
@@ -242,7 +250,9 @@ struct ConfiguredHostOverlayTests {
                     state: .running
                 ),
             ],
-            herdrAvailable: true
+            herdrAvailable: true,
+            zellijSessions: [.init(name: "stale-zellij")],
+            zellijAvailable: true
         )
 
         let result = ConfiguredHostOverlay.apply([
@@ -256,7 +266,9 @@ struct ConfiguredHostOverlayTests {
 
         #expect(result.hosts[0].tmuxSessions == host.tmuxSessions)
         #expect(result.hosts[0].herdrSessions.isEmpty)
+        #expect(result.hosts[0].zellijSessions.isEmpty)
         #expect(!result.hosts[0].herdrAvailable)
+        #expect(!result.hosts[0].zellijAvailable)
     }
 
     @Test("duplicate destinations receive distinct host identities")

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -1384,4 +1384,106 @@ struct KwtInventoryClientTests {
         #expect(overlaid.hosts[0].lastKnownReachable)
         #expect(overlaid.hosts[0].remoteDiagnostics == [diagnostic])
     }
+
+    @Test("Zellij inventory overlays only Zellij runtime state")
+    func zellijInventoryIsAdditive() {
+        let hostID = UUID()
+        let project = ProjectSummary(
+            id: UUID(),
+            hostID: hostID,
+            scopedKey: "repo",
+            name: "repo",
+            rootPath: "/code/repo"
+        )
+        let worktree = WorktreeSummary(
+            id: UUID(),
+            hostID: hostID,
+            projectID: project.id,
+            name: "main",
+            path: "/code/repo",
+            branch: "main"
+        )
+        let tmux = TmuxSessionSummary(
+            name: "tmux-kept",
+            managed: false,
+            windows: []
+        )
+        let herdr = HerdrSessionSummary(
+            name: "herdr-kept",
+            isDefault: false,
+            state: .running
+        )
+        let stored = WorkspaceSnapshot(
+            hosts: [HostSummary(
+                id: hostID,
+                name: "build-box",
+                kind: .remote,
+                platform: .linux,
+                tmuxSessions: [tmux],
+                herdrSessions: [herdr],
+                herdrAvailable: true,
+                zellijSessions: [ZellijSessionSummary(name: "stale")]
+            )],
+            projects: [project],
+            worktrees: [worktree]
+        )
+        let zellij = ZellijSessionSummary(name: "editor")
+
+        let overlaid = HostInventoryOverlay.applyRuntimeSessions(
+            tmuxSessionsByHost: [:],
+            zellijSessionsByHost: [hostID: [zellij]],
+            zellijAvailabilityByHost: [hostID: true],
+            to: stored
+        )
+
+        #expect(overlaid.hosts[0].zellijSessions == [zellij])
+        #expect(overlaid.hosts[0].zellijAvailable)
+        #expect(overlaid.hosts[0].tmuxSessions == [tmux])
+        #expect(overlaid.hosts[0].herdrSessions == [herdr])
+        #expect(overlaid.hosts[0].herdrAvailable)
+        #expect(overlaid.projects == [project])
+        #expect(overlaid.worktrees == [worktree])
+    }
+
+    @Test("Zellij runtime inventory preserves noncanonical KWT paths")
+    func zellijRuntimeInventorySkipsKwtPathNormalization() {
+        let hostID = UUID()
+        let project = ProjectSummary(
+            id: UUID(),
+            hostID: hostID,
+            scopedKey: "repo",
+            name: "repo",
+            rootPath: "/code/./repo"
+        )
+        let worktree = WorktreeSummary(
+            id: UUID(),
+            hostID: hostID,
+            projectID: project.id,
+            name: "main",
+            path: "/code/repo/../repo",
+            branch: "main"
+        )
+        let stored = WorkspaceSnapshot(
+            hosts: [HostSummary(
+                id: hostID,
+                name: "build-box",
+                kind: .remote,
+                platform: .linux
+            )],
+            projects: [project],
+            worktrees: [worktree]
+        )
+
+        let overlaid = HostInventoryOverlay.applyRuntimeSessions(
+            tmuxSessionsByHost: [:],
+            zellijSessionsByHost: [
+                hostID: [ZellijSessionSummary(name: "editor")],
+            ],
+            zellijAvailabilityByHost: [hostID: true],
+            to: stored
+        )
+
+        #expect(overlaid.projects[0].rootPath == "/code/./repo")
+        #expect(overlaid.worktrees[0].path == "/code/repo/../repo")
+    }
 }

--- a/Tests/App/NativeHerdrSessionCoordinatorTests.swift
+++ b/Tests/App/NativeHerdrSessionCoordinatorTests.swift
@@ -328,7 +328,7 @@ struct NativeHerdrSessionCoordinatorTests {
         let retryCommand = store.requestedConfigurations.last?.command ?? ""
         #expect(retryCommand.contains(
             "/new/bin/herdr"
-        ))
+        ) == true)
     }
 
     @Test("fresh attachment attempts resolve the Herdr executable again")
@@ -371,7 +371,7 @@ struct NativeHerdrSessionCoordinatorTests {
         let retryCommand = store.requestedConfigurations.last?.command ?? ""
         #expect(retryCommand.contains(
             "/new/bin/herdr"
-        ))
+        ) == true)
     }
 
     @Test("Windows is rejected before surface creation")

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -10,6 +10,7 @@ import GhosthubPersistence
 import GhosthubSettings
 import GhosthubTmux
 import GhosthubWorkspace
+import GhosthubZellij
 @testable import GhosthubTerminal
 import GhosthubTerminalSupport
 @testable import GhosthubApp
@@ -304,10 +305,13 @@ func makeModel(
     notificationService: any NotificationService = NotificationServiceStub(),
     nativeTmuxSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
     nativeHerdrSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
+    nativeZellijSurfaceStore: (any NativeSessionSurfaceStoring)? = nil,
     nativeTmuxPathProvider:
     (@Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>)? = nil,
     nativeHerdrPathProvider: (@Sendable (CommandHost)
         -> Result<String, HerdrCommandError>)? = nil,
+    nativeZellijPathProvider: (@Sendable (CommandHost)
+        -> Result<String, ZellijCommandError>)? = nil,
     herdrPaneSplitCapabilityProvider:
     NativeHerdrSessionCoordinator.PaneSplitCapabilityProvider? = nil,
     herdrPaneSplitter: HerdrPaneSplitter = HerdrPaneSplitter(),
@@ -349,6 +353,8 @@ func makeModel(
         WorktreeMutationCoordinator(),
     herdrLifecycleCoordinator: HerdrSessionLifecycleCoordinator =
         HerdrSessionLifecycleCoordinator(),
+    zellijSessionKillCoordinator: ZellijSessionKillCoordinator =
+        ZellijSessionKillCoordinator(),
     herdrSessionRecordReader:
     @escaping WorkspaceSceneModel.HerdrSessionRecordReading = { name, _, _ in
         .failure(.sessionMissing(name))
@@ -390,6 +396,16 @@ func makeModel(
     WorkspaceSceneModel.TmuxSessionDiscovery = { _ in .success([]) },
     herdrSessionDiscovery: @escaping
     WorkspaceSceneModel.HerdrSessionDiscovery = { _ in .unavailable },
+    zellijSessionDiscovery: @escaping
+    WorkspaceSceneModel.ZellijSessionDiscovery = { _ in .unavailable },
+    zellijSessionValidationDiscovery:
+    WorkspaceSceneModel.ZellijSessionValidationDiscovery? = nil,
+    zellijSessionKiller: @escaping
+    WorkspaceSceneModel.ZellijSessionKilling = { _, _, _ in .success(()) },
+    zellijSSHConnectionSnapshotProvider:
+    @escaping @Sendable (SSHHostInfo) -> SSHConnectionArgumentsSnapshot = {
+        _ in SSHConnectionArgumentsSnapshot(arguments: [])
+    },
     herdrSessionValidationDiscovery:
     WorkspaceSceneModel.HerdrSessionValidationDiscovery? = nil,
     herdrSessionExactProbe:
@@ -459,8 +475,10 @@ func makeModel(
         notificationService: notificationService,
         nativeTmuxSurfaceStore: nativeTmuxSurfaceStore,
         nativeHerdrSurfaceStore: nativeHerdrSurfaceStore,
+        nativeZellijSurfaceStore: nativeZellijSurfaceStore,
         nativeTmuxPathProvider: nativeTmuxPathProvider,
         nativeHerdrPathProvider: nativeHerdrPathProvider,
+        nativeZellijPathProvider: nativeZellijPathProvider,
         herdrPaneSplitCapabilityProvider: herdrPaneSplitCapabilityProvider,
         herdrPaneSplitter: herdrPaneSplitter,
         localKwtPathProvider: localKwtPathProvider,
@@ -474,6 +492,7 @@ func makeModel(
         kwtWorktreeRemover: kwtWorktreeRemover,
         worktreeMutationCoordinator: worktreeMutationCoordinator,
         herdrLifecycleCoordinator: herdrLifecycleCoordinator,
+        zellijSessionKillCoordinator: zellijSessionKillCoordinator,
         herdrSessionRecordReader: herdrSessionRecordReader,
         herdrSessionMutator: herdrSessionMutator,
         herdrSSHConnectionSnapshotProvider:
@@ -483,6 +502,14 @@ func makeModel(
         kwtProjectRegistration: kwtProjectRegistration,
         tmuxSessionDiscovery: tmuxSessionDiscovery,
         herdrSessionDiscovery: herdrSessionDiscovery,
+        zellijSessionDiscovery: zellijSessionDiscovery,
+        zellijSessionValidationDiscovery:
+        zellijSessionValidationDiscovery ?? { host, _ in
+            zellijSessionDiscovery(host)
+        },
+        zellijSessionKiller: zellijSessionKiller,
+        zellijSSHConnectionSnapshotProvider:
+        zellijSSHConnectionSnapshotProvider,
         herdrSessionValidationDiscovery:
         herdrSessionValidationDiscovery ?? { host, _ in
             herdrSessionDiscovery(host)
@@ -529,8 +556,14 @@ final class RecordingNativeSessionSurfaceStore: NativeSessionSurfaceStoring {
 
     var lastCommand: String? { requestedConfigurations.last?.command }
 
-    init(launchError: Error? = nil) {
-        surface = RecordingNativeSessionPaneSurface(launchError: launchError)
+    init(
+        launchError: Error? = nil,
+        closeOnRegistrationCode: UInt32? = nil
+    ) {
+        surface = RecordingNativeSessionPaneSurface(
+            launchError: launchError,
+            closeOnRegistrationCode: closeOnRegistrationCode
+        )
     }
 
     func paneSurface(
@@ -560,11 +593,16 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     var hasEffectiveKeyboardFocus = false
     var paneSplitShortcutHandler: ((TerminalPaneSplitShortcut) -> Void)?
     let launchError: Error?
+    private var closeOnRegistrationCode: UInt32?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
 
-    init(launchError: Error? = nil) {
+    init(
+        launchError: Error? = nil,
+        closeOnRegistrationCode: UInt32? = nil
+    ) {
         self.launchError = launchError
+        self.closeOnRegistrationCode = closeOnRegistrationCode
     }
 
     func registerSurfaceCloseObserver(
@@ -572,6 +610,11 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
         onSurfaceClosed: @escaping (Bool, UInt32?) -> Void
     ) {
         closeObservers[id] = onSurfaceClosed
+        guard let code = closeOnRegistrationCode else { return }
+        closeOnRegistrationCode = nil
+        Task { @MainActor in
+            onSurfaceClosed(false, code)
+        }
     }
 }
 

--- a/Tests/App/WorkspaceApplicationShortcutTests.swift
+++ b/Tests/App/WorkspaceApplicationShortcutTests.swift
@@ -72,6 +72,53 @@ struct WorkspaceApplicationShortcutTests {
         await model.shutdown()
     }
 
+    @Test("Zellij presentation enables sibling navigation")
+    func zellijSiblingNavigation() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS,
+            zellijSessions: [
+                ZellijSessionSummary(name: "first"),
+                ZellijSessionSummary(name: "second"),
+            ],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: host.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [host], projects: [], worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["first", "second"])
+            }
+        )
+        let first = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "first"
+        )
+
+        model.openBorrowedZellijSession(first)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == first
+        }
+        model.isFocusedWindow = true
+
+        #expect(model.canPerformSiblingShortcut(.nextSibling))
+        #expect(model.performApplicationShortcut(.nextSibling))
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection?.name == "second"
+        }
+        #expect(model.activeBorrowedZellijSelection?.name == "second")
+        await model.shutdown()
+    }
+
     @Test("menu sibling navigation uses its captured scene")
     func menuSiblingNavigation() async throws {
         let host = HostSummary.fixture()

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -297,6 +297,52 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("automatic selection normalization preserves Herdr activation")
+    func automaticSelectionPreservesHerdrActivation() async throws {
+        var environment = try environment()
+        let project = ProjectSummary.fixture(hostID: environment.hostID)
+        environment.snapshot.projects.append(project)
+        let store = RecordingNativeSessionSurfaceStore()
+        let probeStarted = Mutex(false)
+        let releaseProbe = DispatchSemaphore(value: 0)
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            discovery: { _ in
+                probeStarted.withLock { $0 = true }
+                releaseProbe.wait()
+                return .available([
+                    HerdrSessionSummary(
+                        name: "api",
+                        isDefault: true,
+                        state: .running
+                    ),
+                ])
+            }
+        )
+        model.selection = WorkspaceSelection(
+            selectedHostID: environment.hostID,
+            selectedProjectID: project.id
+        )
+        let selection = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+
+        let activation = Task {
+            try await model.openBorrowedHerdrSession(selection)
+        }
+        await waitUntilMainActor { probeStarted.withLock { $0 } }
+        model.synchronizeSelection(WorkspaceSelection(
+            selectedHostID: environment.hostID
+        ))
+        releaseProbe.signal()
+        try await activation.value
+
+        #expect(model.activeBorrowedHerdrSelection == selection)
+        await model.shutdown()
+    }
+
     @Test(
         "scene shutdown fences delayed Herdr intents",
         arguments: [

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -602,6 +602,349 @@ struct WorkspaceRestorationTests {
         await model.shutdown()
     }
 
+    @Test("Zellij restoration reuses its validated SSH route")
+    func zellijRestorationUsesValidatedSSHRoute() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config", "dev@build.example.test",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-zellij-config", "dev@other.example.test",
+        ])
+        let connectionReads = Mutex(0)
+        let validationArguments = Mutex([[String]]())
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, arguments in
+                validationArguments.withLock { $0.append(arguments) }
+                return .available(["editor"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                connectionReads.withLock {
+                    $0 += 1
+                    return $0 <= 2 ? frozen : changed
+                }
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedZellijSurface()
+            return store.lastCommand != nil
+        }
+
+        #expect(connectionReads.withLock { $0 } == 2)
+        #expect(validationArguments.withLock { $0 } == [frozen.arguments])
+        #expect(store.lastCommand?.contains("/tmp/frozen-zellij-config") == true)
+        #expect(store.lastCommand?.contains("/tmp/changed-zellij-config") == false)
+        #expect(!model.isWorkspaceRestorationPending)
+        await model.shutdown()
+    }
+
+    @Test("Zellij restoration rejects SSH route drift during validation")
+    func zellijRestorationRejectsSSHRouteDrift() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config", "dev@build.example.test",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-zellij-config", "dev@other.example.test",
+        ])
+        let connectionReads = Mutex(0)
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                connectionReads.withLock {
+                    $0 += 1
+                    return $0 == 1 ? frozen : changed
+                }
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            !model.isWorkspaceRestorationPending
+        }
+        model.prepareActiveBorrowedZellijSurface()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(connectionReads.withLock { $0 } >= 2)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("Zellij restoration cancels when its host endpoint changes")
+    func zellijRestorationRejectsHostEndpointDrift() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let validationAttempts = Mutex(0)
+        let firstValidationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let configuredHost = Mutex(SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        ))
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = validationAttempts.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 1 {
+                    await withCheckedContinuation { continuation in
+                        firstValidationContinuation.withLock {
+                            $0 = continuation
+                        }
+                    }
+                }
+                return .available(["editor"])
+            },
+            configuredSSHHostsProvider: {
+                [configuredHost.withLock { $0 }]
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            firstValidationContinuation.withLock { $0 != nil }
+        }
+        configuredHost.withLock {
+            $0.sshDestination = "dev@other.example.test"
+        }
+        model.refreshHosts()
+        #expect(model.snapshot.host(id: environment.host.id)?.sshDestination
+            == "dev@other.example.test")
+        let continuation = firstValidationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        await waitUntilMainActor {
+            !model.isWorkspaceRestorationPending
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(validationAttempts.withLock { $0 } == 1)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("Zellij restoration resumes after a concurrent kill fails")
+    func zellijRestorationResumesAfterFailedKill() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let discoveryAttempts = Mutex(0)
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                discoveryAttempts.withLock { $0 += 1 }
+                return .available(["editor"])
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+        let key = ZellijSessionKillCoordinator.Key(
+            hostID: environment.host.id,
+            sessionName: "editor"
+        )
+        let operation = try #require(killCoordinator.begin(key: key))
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            discoveryAttempts.withLock { $0 } >= 1
+                && model.isWorkspaceRestorationPending
+        }
+        killCoordinator.finish(operation, outcome: .failed)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedZellijSurface()
+            return store.lastCommand != nil
+        }
+
+        #expect(model.activeBorrowedZellijSelection?.name == "editor")
+        #expect(!model.isWorkspaceRestorationPending)
+        await model.shutdown()
+    }
+
+    @Test("Zellij restoration cancels when a pending kill outlives its route")
+    func zellijRestorationRejectsRouteDriftDuringPendingKill() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let configuredHost = Mutex(SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        ))
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let discoveries = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                discoveries.withLock { $0 += 1 }
+                return .available(["editor"])
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            },
+            configuredSSHHostsProvider: {
+                [configuredHost.withLock { $0 }]
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+        let operation = try #require(killCoordinator.begin(key: .init(
+            hostID: environment.host.id,
+            sessionName: "editor"
+        )))
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            discoveries.withLock { $0 } >= 1
+                && model.isWorkspaceRestorationPending
+        }
+        configuredHost.withLock {
+            $0.sshDestination = "dev@other.example.test"
+        }
+        model.refreshHosts()
+        killCoordinator.finish(operation, outcome: .failed)
+        await waitUntilMainActor { !model.isWorkspaceRestorationPending }
+
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
     @Test("explicit navigation cancels pending Herdr restoration")
     func navigationCancelsPendingHerdrRestoration() async throws {
         let environment = try setupStandardEnvironment()

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -875,6 +875,80 @@ struct WorkspaceRestorationTests {
         await model.shutdown()
     }
 
+    @Test("successful Zellij kill rejects a same-name restoration replacement")
+    func zellijRestorationStopsAfterSuccessfulKill() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let discoveryAttempts = Mutex(0)
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                let attempt = discoveryAttempts.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 2
+                    ? .available([])
+                    : .available(["editor"])
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+        let operation = try #require(killCoordinator.begin(key: .init(
+            hostID: environment.host.id,
+            sessionName: "editor"
+        )))
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            discoveryAttempts.withLock { $0 } >= 1
+                && model.isWorkspaceRestorationPending
+        }
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            discoveryAttempts.withLock { $0 } >= 2
+        }
+        model.refreshKwtInventory()
+        await waitUntilMainActor {
+            discoveryAttempts.withLock { $0 } >= 3
+                && model.snapshot.host(id: environment.host.id)?
+                .zellijSessions.map(\.name) == ["editor"]
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(!model.isWorkspaceRestorationPending)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
     @Test("Zellij restoration cancels when a pending kill outlives its route")
     func zellijRestorationRejectsRouteDriftDuringPendingKill() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -229,6 +229,32 @@ struct WorkspaceWindowStateTests {
         #expect(decoded.herdr?.sessionName == "editor")
     }
 
+    @Test("Zellij descriptor round-trips through scene state")
+    func zellijDescriptorRoundTrips() throws {
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "local",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: "local",
+                sessionName: "editor"
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(
+            WorkspaceWindowState.self,
+            from: encoded
+        )
+
+        #expect(decoded == state)
+        #expect(decoded.zellij?.sessionName == "editor")
+    }
+
     @Test("invalid Herdr descriptors are rejected")
     func invalidHerdrDescriptorsAreRejected() {
         let fixture = RestorationFixture.local(sessionName: "editor")
@@ -452,6 +478,48 @@ struct WorkspaceWindowStateTests {
                 ))
             )
         )
+    }
+
+    @Test("Zellij restoration requires fresh exact active inventory")
+    func zellijRestorationRequiresFreshExactInventory() {
+        let fixture = RestorationFixture.local(sessionName: "editor")
+        let hostID = fixture.selection.selectedHostID
+        var snapshot = fixture.snapshot
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        snapshot.hosts[0].zellijAvailable = true
+        let selection = WorkspaceSelection(selectedHostID: hostID)
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: "local",
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: "local",
+                sessionName: "editor"
+            )
+        )
+
+        #expect(WorkspaceWindowRestorationResolver.resolve(
+            state,
+            in: snapshot
+        ) == .pending(selection: selection))
+
+        #expect(WorkspaceWindowRestorationResolver.resolve(
+            state,
+            in: snapshot,
+            zellijFreshHostIDs: [hostID]
+        ) == .ready(
+            selection: selection,
+            presentation: .zellij(WorkspaceZellijSessionSelection(
+                hostID: hostID,
+                name: "editor"
+            ))
+        ))
     }
 
     @Test("same-ID stale update payloads are rewritten")

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -317,6 +317,61 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test(
+        "failed creation retry follows the live Zellij session state",
+        arguments: [false, true]
+    )
+    func failedCreationRetryUsesLiveState(
+        sessionBecameActive: Bool
+    ) async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let store = RecordingNativeSessionSurfaceStore(
+            launchError: ZellijCommandError.unavailable
+        )
+        let validations = Mutex<[ZellijDiscoveryResult]>([
+            .available([]),
+            .available(sessionBecameActive ? ["release"] : []),
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available([]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                validations.withLock { $0.removeFirst() }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+
+        try await model.createZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && model.activeBorrowedZellijConnectionState == .disconnected(
+                    reason: ZellijCommandError.unavailable.localizedDescription
+                )
+        }
+
+        model.retryBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 2
+        }
+
+        let retryCommand = try #require(store.lastCommand)
+        if sessionBecameActive {
+            #expect(retryCommand.contains("'attach'"))
+            #expect(!retryCommand.contains("--session=release"))
+        } else {
+            #expect(retryCommand.contains("--session=release"))
+            #expect(!retryCommand.contains("'attach'"))
+        }
+        await model.shutdown()
+    }
+
     @Test("creation rejects a newly conflicting name without replacing tmux")
     func creationConflictPreservesTmux() async throws {
         var environment = try zellijEnvironment(sessions: [])

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -46,6 +46,49 @@ struct ZellijKillValidationFailureCase:
     var testDescription: String { name }
 }
 
+private final class CancellableZellijDiscoveryProbe: @unchecked Sendable {
+    private struct State {
+        var calls = 0
+        var cancelled = false
+        var released = false
+    }
+
+    private let blockingCall: Int
+    private let state = Mutex(State())
+
+    init(blockingCall: Int) {
+        self.blockingCall = blockingCall
+    }
+
+    func discover(_: CommandHost) -> ZellijDiscoveryResult {
+        let call = state.withLock {
+            $0.calls += 1
+            return $0.calls
+        }
+        guard call == blockingCall else {
+            return .available(call > blockingCall ? ["replacement"] : [])
+        }
+        while !state.withLock({ $0.released }) {
+            if Task.isCancelled {
+                state.withLock { $0.cancelled = true }
+                return .failure(.commandFailed(
+                    status: -1,
+                    stderr: "cancelled"
+                ))
+            }
+            Thread.sleep(forTimeInterval: 0.001)
+        }
+        return .available([])
+    }
+
+    var calls: Int { state.withLock { $0.calls } }
+    var didCancel: Bool { state.withLock { $0.cancelled } }
+
+    func release() {
+        state.withLock { $0.released = true }
+    }
+}
+
 @Suite("Workspace Zellij support", .serialized)
 @MainActor
 struct WorkspaceZellijTests {
@@ -70,6 +113,65 @@ struct WorkspaceZellijTests {
 
         #expect(discoveries.withLock { $0 } == 1)
         await model.shutdown()
+    }
+
+    @Test("explicit refresh cancels the superseded Zellij probe")
+    func refreshCancelsSupersededDiscovery() async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let discovery = CancellableZellijDiscoveryProbe(blockingCall: 1)
+        defer { discovery.release() }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            zellijSessionDiscovery: discovery.discover
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor { discovery.calls == 1 }
+        model.refreshWorkspaceInventory()
+        await waitUntilMainActor {
+            discovery.didCancel
+                && discovery.calls == 2
+                && model.snapshot.host(id: environment.host.id)?
+                .zellijSessions.map(\.name) == ["replacement"]
+        }
+
+        #expect(discovery.didCancel)
+        await model.shutdown()
+    }
+
+    @Test("shutdown cancels detached Zellij creation retry discovery")
+    func shutdownCancelsCreationRetryDiscovery() async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let discovery = CancellableZellijDiscoveryProbe(blockingCall: 3)
+        defer { discovery.release() }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: RecordingNativeSessionSurfaceStore(),
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: discovery.discover,
+            zellijSessionValidationDiscovery: { _, _ in .available([]) },
+            createdSessionDiscoveryDelays: [.zero]
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor { discovery.calls == 1 }
+        try await model.createZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            discovery.calls == 3
+        }
+
+        await model.shutdown()
+        await waitUntilMainActor { discovery.didCancel }
+
+        #expect(discovery.didCancel)
     }
 
     @Test("multi-host discovery publishes one completed Zellij inventory")
@@ -469,13 +571,17 @@ struct WorkspaceZellijTests {
         let zellijStore = RecordingNativeSessionSurfaceStore()
         let probeStarted = Mutex(false)
         let probeFinished = Mutex(false)
+        let executableResolutions = Mutex(0)
         let probeContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeZellijSurfaceStore: zellijStore,
-            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            nativeZellijPathProvider: { _ in
+                executableResolutions.withLock { $0 += 1 }
+                return .success("/usr/bin/zellij")
+            },
             zellijSessionValidationDiscovery: { _, _ in
                 probeStarted.withLock { $0 = true }
                 await withCheckedContinuation { continuation in
@@ -506,6 +612,55 @@ struct WorkspaceZellijTests {
         try await Task.sleep(for: .milliseconds(50))
 
         #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        #expect(executableResolutions.withLock { $0 } == 0)
+        await model.shutdown()
+    }
+
+    @Test("navigation cancellation terminates Zellij executable resolution")
+    func navigationCancelsExecutableResolution() async throws {
+        let environment = try zellijEnvironment(sessions: ["zellij-work"])
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let resolverState = Mutex((
+            started: false,
+            cancelled: false,
+            released: false
+        ))
+        defer { resolverState.withLock { $0.released = true } }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeZellijPathProvider: { _ in
+                resolverState.withLock { $0.started = true }
+                while !resolverState.withLock({ $0.released }) {
+                    if Task.isCancelled {
+                        resolverState.withLock { $0.cancelled = true }
+                        return .failure(.unavailable)
+                    }
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return .failure(.unavailable)
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["zellij-work"])
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "zellij-work"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            resolverState.withLock { $0.started }
+        }
+        model.cancelPendingZellijPresentation()
+        await waitUntilMainActor {
+            resolverState.withLock { $0.cancelled }
+        }
+
         #expect(zellijStore.requestedConfigurations.isEmpty)
         await model.shutdown()
     }

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -196,14 +196,15 @@ struct WorkspaceZellijTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             nativeZellijSurfaceStore: store,
-            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") }
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) }
         )
         let selection = WorkspaceZellijSessionSelection(
             hostID: environment.host.id,
             name: "release work"
         )
 
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor { store.lastCommand != nil }
 
         let command = try #require(store.lastCommand)
@@ -211,6 +212,154 @@ struct WorkspaceZellijTests {
         #expect(command.contains("release work"))
         #expect(!command.contains("'attach'"))
         #expect(model.activeBorrowedZellijSelection == selection)
+        await model.shutdown()
+    }
+
+    @Test("creation rejects a newly conflicting name without replacing tmux")
+    func creationConflictPreservesTmux() async throws {
+        var environment = try zellijEnvironment(sessions: [])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["release"])
+            }
+        )
+        let tmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+        model.openBorrowedTmuxSession(tmux)
+
+        await #expect(throws: ZellijSessionPresentationError.sessionExists(
+            "release"
+        )) {
+            try await model.createZellijSession(zellij)
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == tmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("creation rejects executable failure without replacing tmux")
+    func creationExecutableFailurePreservesTmux() async throws {
+        var environment = try zellijEnvironment(sessions: [])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .failure(.unavailable) },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) }
+        )
+        let tmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+        model.openBorrowedTmuxSession(tmux)
+
+        await #expect(throws: ZellijSessionPresentationError.unavailable) {
+            try await model.createZellijSession(zellij)
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == tmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("a delayed create cannot replace newer tmux navigation")
+    func delayedCreateRespectsNewerNavigation() async throws {
+        var environment = try zellijEnvironment(sessions: [])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let probeStarted = Mutex(false)
+        let probeContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionValidationDiscovery: { _, _ in
+                probeStarted.withLock { $0 = true }
+                await withCheckedContinuation { continuation in
+                    probeContinuation.withLock { $0 = continuation }
+                }
+                return .available([])
+            }
+        )
+        let createTarget = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+        let newerTmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+
+        let create = Task {
+            try await model.createZellijSession(createTarget)
+        }
+        await waitUntilMainActor { probeStarted.withLock { $0 } }
+        model.openBorrowedTmuxSession(newerTmux)
+        let continuation = probeContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+
+        await #expect(throws: CancellationError.self) {
+            try await create.value
+        }
+        #expect(model.activeBorrowedTmuxSelection == newerTmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
         await model.shutdown()
     }
 
@@ -417,6 +566,69 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("Reconnect Now interrupts the Zellij retry delay")
+    func reconnectNowInterruptsRetryDelay() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let results = Mutex<[ZellijDiscoveryResult]>([
+            .available(["api"]),
+            .failure(.commandFailed(
+                status: 255,
+                stderr: "Connection timed out."
+            )),
+            .available(["api"]),
+        ])
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host], projects: [], worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                results.withLock { $0.removeFirst() }
+            },
+            tmuxReconnectIntervals: [.seconds(30)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijRecoveryState?.isReconnecting == true
+                && results.withLock { $0.count } == 1
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        model.reconnectActiveZellijSessionNow()
+
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 2
+                && model.activeBorrowedZellijConnectionState == .connected
+        }
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
+        await model.shutdown()
+    }
+
     @Test("initial validation retains an actionable failure", arguments: [
         ZellijValidationFailureCase(
             name: "missing session",
@@ -536,7 +748,8 @@ struct WorkspaceZellijTests {
             zellijSessionDiscovery: { _ in
                 probes.withLock { $0 += 1 }
                 return .available([])
-            }
+            },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) }
         )
         let tmux = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -549,7 +762,9 @@ struct WorkspaceZellijTests {
 
         model.openBorrowedTmuxSession(tmux)
         model.openBorrowedZellijSession(zellij)
-        await waitUntilMainActor { probes.withLock { $0 } == 1 }
+        await waitUntilMainActor {
+            model.pendingZellijPresentationSelection == nil
+        }
         try await Task.sleep(for: .milliseconds(50))
 
         #expect(model.activeBorrowedTmuxSelection == tmux)
@@ -785,7 +1000,7 @@ struct WorkspaceZellijTests {
         )
 
         model.startZellijSessionDiscovery()
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor {
             store.lastCommand != nil && probes.withLock { $0 } >= 2
         }
@@ -840,6 +1055,7 @@ struct WorkspaceZellijTests {
                     return .available(["release", "confirmed"])
                 }
             },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) },
             createdSessionDiscoveryDelays: [.zero]
         )
         let selection = WorkspaceZellijSessionSelection(
@@ -849,7 +1065,7 @@ struct WorkspaceZellijTests {
 
         model.startZellijSessionDiscovery()
         await waitUntilMainActor { probes.withLock { $0 } >= 1 }
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor(timeout: .seconds(1)) {
             probes.withLock { $0 } >= 3
         }
@@ -924,6 +1140,7 @@ struct WorkspaceZellijTests {
                 }
                 return .available([])
             },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) },
             createdSessionDiscoveryDelays: [
                 .milliseconds(20),
                 .seconds(60),
@@ -934,7 +1151,7 @@ struct WorkspaceZellijTests {
             name: "release"
         )
 
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor {
             model.activeBorrowedZellijConnectionState == .connected
         }
@@ -1037,6 +1254,7 @@ struct WorkspaceZellijTests {
                 }
                 return .available([])
             },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) },
             createdSessionDiscoveryDelays: [
                 .milliseconds(100),
                 .seconds(60),
@@ -1058,7 +1276,7 @@ struct WorkspaceZellijTests {
             model.snapshot.host(id: remote.id)?.zellijSessions.map(\.name)
                 == ["initial"]
         }
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor(timeout: .seconds(1)) {
             localProbes.withLock { $0 } == 2
                 && remoteProbes.withLock { $0 } == 2
@@ -1774,6 +1992,15 @@ struct WorkspaceZellijTests {
         await waitUntilMainActor {
             model.sessionConnectionRecoveryRequest?.hostID == host.id
         }
+        guard case let .needsAttention(message, canReviewConnection) =
+            model.activeBorrowedZellijRecoveryState
+        else {
+            Issue.record("Expected Zellij SSH recovery to need attention")
+            await model.shutdown()
+            return
+        }
+        #expect(message.contains("SSH authentication"))
+        #expect(canReviewConnection)
         let recoveryRequest = try #require(
             model.sessionConnectionRecoveryRequest
         )
@@ -1785,6 +2012,7 @@ struct WorkspaceZellijTests {
                 && model.activeBorrowedZellijConnectionState == .connected
         }
         #expect(model.sessionConnectionRecoveryRequest == nil)
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
         #expect(model.activeBorrowedZellijConnectionState == .connected)
         await model.shutdown()
     }
@@ -1817,6 +2045,7 @@ struct WorkspaceZellijTests {
                 probes.withLock { $0 += 1 }
                 return .available([])
             },
+            zellijSessionValidationDiscovery: { _, _ in .available([]) },
             tmuxReconnectIntervals: [.zero],
             tmuxReconnectProbeDeadline: .seconds(1)
         )
@@ -1828,7 +2057,7 @@ struct WorkspaceZellijTests {
         model.startZellijSessionDiscovery()
         await waitUntilMainActor { probes.withLock { $0 } >= 1 }
         let initialProbeCount = probes.withLock { $0 }
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor {
             store.requestedConfigurations.count == 1
                 && !store.surface.closeObservers.isEmpty
@@ -1874,9 +2103,14 @@ struct WorkspaceZellijTests {
             ),
             nativeZellijSurfaceStore: store,
             nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
-            zellijSessionDiscovery: { _ in
-                probes.withLock { $0 += 1 }
-                return .available(["api"])
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = probes.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 1
+                    ? .available([]) : .available(["api"])
             },
             zellijSSHConnectionSnapshotProvider: { _ in frozen },
             tmuxReconnectIntervals: [.zero],
@@ -1887,7 +2121,7 @@ struct WorkspaceZellijTests {
             name: "api"
         )
 
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor(timeout: .seconds(1)) {
             probes.withLock { $0 } >= 1
                 && store.requestedConfigurations.count == 2
@@ -1930,6 +2164,7 @@ struct WorkspaceZellijTests {
         )
         let store = RecordingNativeSessionSurfaceStore()
         let probes = Mutex(0)
+        let validations = Mutex(0)
         let model = try makeModel(
             database: database,
             localHostID: UUID(),
@@ -1947,6 +2182,13 @@ struct WorkspaceZellijTests {
                 }
                 return attempt == 1 ? failure.result : .available([])
             },
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = validations.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 1 ? .available([]) : failure.result
+            },
             tmuxReconnectIntervals: [.zero],
             tmuxReconnectProbeDeadline: .seconds(1)
         )
@@ -1955,7 +2197,7 @@ struct WorkspaceZellijTests {
             name: "api"
         )
 
-        model.createZellijSession(selection)
+        try await model.createZellijSession(selection)
         await waitUntilMainActor {
             store.requestedConfigurations.count == 1
                 && !store.surface.closeObservers.isEmpty

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -1,0 +1,2140 @@
+import Combine
+import Foundation
+import GhosthubPersistence
+import GhosthubSettings
+import GhosthubTestSupport
+import GhosthubTransport
+import GhosthubUI
+import GhosthubWorkspace
+import GhosthubZellij
+import Synchronization
+import Testing
+@testable import GhosthubApp
+
+struct ZellijValidationFailureCase:
+    Sendable, CustomTestStringConvertible {
+    var name: String
+    var result: ZellijDiscoveryResult
+    var reason: String
+
+    var testDescription: String { name }
+}
+
+struct ZellijPendingDiscoveryFailureCase:
+    Sendable, CustomTestStringConvertible {
+    var name: String
+    var result: ZellijDiscoveryResult
+
+    var testDescription: String { name }
+}
+
+struct ZellijTerminalReconnectFailureCase:
+    Sendable, CustomTestStringConvertible {
+    var name: String
+    var result: ZellijDiscoveryResult
+    var reason: String
+
+    var testDescription: String { name }
+}
+
+@Suite("Workspace Zellij support", .serialized)
+@MainActor
+struct WorkspaceZellijTests {
+    @Test("application activation does not refresh Zellij inventory")
+    func applicationActivationDoesNotRefreshZellijInventory() async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let discoveries = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            zellijSessionDiscovery: { _ in
+                discoveries.withLock { $0 += 1 }
+                return .available([])
+            }
+        )
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor { discoveries.withLock { $0 } == 1 }
+
+        model.handleApplicationDidBecomeActiveForResourceMonitoring()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(discoveries.withLock { $0 } == 1)
+        await model.shutdown()
+    }
+
+    @Test("multi-host discovery publishes one completed Zellij inventory")
+    func multiHostDiscoveryPublishesOnce() async throws {
+        let local = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS
+        )
+        let remote = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder"
+        )
+        let model = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: local.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [local, remote],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionDiscovery: { host in
+                .available([host.displayName])
+            }
+        )
+        let publications = Mutex<[WorkspaceSnapshot]>([])
+        let updates = model.$snapshot.dropFirst().sink { snapshot in
+            guard snapshot.hosts.contains(where: {
+                !$0.zellijSessions.isEmpty
+            }) else { return }
+            publications.withLock { $0.append(snapshot) }
+        }
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor {
+            model.snapshot.hosts.allSatisfy {
+                $0.zellijSessions.count == 1
+            }
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(publications.withLock { $0.count } == 1)
+        #expect(publications.withLock { snapshots in
+            snapshots.first?.hosts.allSatisfy {
+                $0.zellijSessions.count == 1
+            } == true
+        })
+        withExtendedLifetime(updates) {}
+        await model.shutdown()
+    }
+
+    @Test("discovery probes local and POSIX hosts but excludes Windows")
+    func supportedDiscoveryHosts() async throws {
+        let local = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS
+        )
+        let linux = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder"
+        )
+        let windows = HostSummary(
+            id: UUID(),
+            configKey: "windows",
+            name: "Windows",
+            kind: .remote,
+            platform: .windows,
+            sshDestination: "dev@windows"
+        )
+        let hosts = Mutex(Set<CommandHost>())
+        let database = try WorkspaceDatabase.inMemory()
+        let model = try makeModel(
+            database: database,
+            localHostID: local.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [local, linux, windows],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionDiscovery: { host in
+                _ = hosts.withLock { $0.insert(host) }
+                return .available([host.displayName])
+            }
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor {
+            model.snapshot.host(id: local.id)?.zellijSessions.count == 1
+                && model.snapshot.host(id: linux.id)?.zellijSessions.count == 1
+        }
+
+        #expect(hosts.withLock { $0 } == Set([
+            CommandHost.local,
+            CommandHost.ssh(SSHHostInfo(
+                user: "dev",
+                hostname: "builder",
+                port: nil
+            )),
+        ]))
+        #expect(model.snapshot.host(id: local.id)?.zellijAvailable == true)
+        #expect(model.snapshot.host(id: windows.id)?.zellijAvailable == false)
+        await model.shutdown()
+    }
+
+    @Test("new session presentation creates and attaches through Zellij")
+    func createAndAttach() async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release work"
+        )
+
+        model.createZellijSession(selection)
+        await waitUntilMainActor { store.lastCommand != nil }
+
+        let command = try #require(store.lastCommand)
+        #expect(command.contains("--session"))
+        #expect(command.contains("release work"))
+        #expect(!command.contains("'attach'"))
+        #expect(model.activeBorrowedZellijSelection == selection)
+        await model.shutdown()
+    }
+
+    @Test("tmux and Zellij replace one another symmetrically")
+    func presentationsAreExclusive() async throws {
+        var environment = try zellijEnvironment(sessions: ["zellij-work"])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["zellij-work"]) }
+        )
+        let tmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "zellij-work"
+        )
+
+        model.openBorrowedTmuxSession(tmux)
+        model.openBorrowedZellijSession(zellij)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == zellij
+        }
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.activeBorrowedZellijSelection == zellij)
+
+        model.openBorrowedTmuxSession(tmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(model.activeBorrowedTmuxSelection == tmux)
+        #expect(zellijStore.removedKeys.contains {
+            $0.target == .zellijSession
+        })
+        await model.shutdown()
+    }
+
+    @Test("a delayed attachment cannot replace newer tmux navigation")
+    func delayedAttachmentRespectsNewerNavigation() async throws {
+        var environment = try zellijEnvironment(sessions: ["zellij-work"])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let probeStarted = Mutex(false)
+        let probeFinished = Mutex(false)
+        let releaseProbe = DispatchSemaphore(value: 0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probeStarted.withLock { $0 = true }
+                releaseProbe.wait()
+                probeFinished.withLock { $0 = true }
+                return .available(["zellij-work"])
+            }
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "zellij-work"
+        )
+        let newerTmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+
+        model.openBorrowedZellijSession(zellij)
+        await waitUntilMainActor { probeStarted.withLock { $0 } }
+        model.openBorrowedTmuxSession(newerTmux)
+        releaseProbe.signal()
+        await waitUntilMainActor { probeFinished.withLock { $0 } }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(model.activeBorrowedTmuxSelection == newerTmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("sidebar navigation cancels delayed Zellij validation")
+    func sidebarNavigationCancelsDelayedValidation() async throws {
+        let environment = try zellijEnvironment(sessions: ["zellij-work"])
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let probeStarted = Mutex(false)
+        let probeFinished = Mutex(false)
+        let probeContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionValidationDiscovery: { _, _ in
+                probeStarted.withLock { $0 = true }
+                await withCheckedContinuation { continuation in
+                    probeContinuation.withLock { $0 = continuation }
+                }
+                probeFinished.withLock { $0 = true }
+                return .available(["zellij-work"])
+            }
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "zellij-work"
+        )
+
+        model.openBorrowedZellijSession(zellij)
+        await waitUntilMainActor { probeStarted.withLock { $0 } }
+        model.synchronizeSelection(WorkspaceSelection(selectedHostID: UUID()))
+        let continuation = probeContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        await waitUntilMainActor { probeFinished.withLock { $0 } }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("initial validation retains an actionable failure", arguments: [
+        ZellijValidationFailureCase(
+            name: "missing session",
+            result: .available([]),
+            reason: "The Zellij session is no longer running."
+        ),
+        ZellijValidationFailureCase(
+            name: "unavailable executable",
+            result: .unavailable,
+            reason: "Zellij is unavailable on this host."
+        ),
+        ZellijValidationFailureCase(
+            name: "command failure",
+            result: .failure(.commandFailed(
+                status: 255,
+                stderr: "Permission denied (publickey)."
+            )),
+            reason: "Zellij exited with status 255: Permission denied (publickey)."
+        ),
+    ])
+    func initialValidationRetainsFailure(
+        _ failure: ZellijValidationFailureCase
+    ) async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: RecordingNativeSessionSurfaceStore(),
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in failure.result }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState
+                == .disconnected(reason: failure.reason)
+        }
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        #expect(model.activeBorrowedZellijConnectionState
+            == .disconnected(reason: failure.reason))
+        await model.shutdown()
+    }
+
+    @Test("retry probes a retained session after inventory becomes unavailable")
+    func retryIgnoresCachedAvailability() async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let validations = Mutex<[ZellijDiscoveryResult]>([
+            .unavailable,
+            .available(["api"]),
+        ])
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .unavailable },
+            zellijSessionValidationDiscovery: { _, _ in
+                validations.withLock { $0.removeFirst() }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState == .disconnected(
+                reason: "Zellij is unavailable on this host."
+            )
+        }
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.snapshot.host(id: environment.host.id)?
+                .zellijAvailable == false
+        }
+
+        model.retryBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState == .connected
+        }
+
+        #expect(validations.withLock { $0.isEmpty })
+        #expect(store.requestedConfigurations.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("failed validation preserves a healthy tmux presentation")
+    func failedValidationPreservesTmux() async throws {
+        var environment = try zellijEnvironment(sessions: ["api"])
+        environment.snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "tmux-work",
+                managed: false,
+                windows: []
+            ),
+        ]
+        let zellijStore = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: zellijStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available([])
+            }
+        )
+        let tmux = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "tmux-work"
+        )
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        model.openBorrowedTmuxSession(tmux)
+        model.openBorrowedZellijSession(zellij)
+        await waitUntilMainActor { probes.withLock { $0 } == 1 }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(model.activeBorrowedTmuxSelection == tmux)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("reopening an attached session does not revalidate it")
+    func reopeningAttachedSessionDoesNotRevalidate() async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let store = RecordingNativeSessionSurfaceStore()
+        let result = Mutex<ZellijDiscoveryResult>(.available(["api"]))
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return result.withLock { $0 }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijConnectionState == .connected
+        }
+        result.withLock {
+            $0 = .failure(.commandFailed(
+                status: 1,
+                stderr: "transient inventory failure"
+            ))
+        }
+
+        model.openBorrowedZellijSession(selection)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(probes.withLock { $0 } == 1)
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(store.requestedConfigurations.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("validated remote attachment uses one frozen SSH route")
+    func attachmentUsesValidatedSSHRoute() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config",
+        ])
+        let validations = Mutex([[String]]())
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            zellijSessionValidationDiscovery: { _, arguments in
+                validations.withLock { $0.append(arguments) }
+                return .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in frozen }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor { store.lastCommand != nil }
+
+        #expect(validations.withLock { $0 } == [frozen.arguments])
+        #expect(store.lastCommand?.contains("/tmp/frozen-zellij-config") == true)
+        await model.shutdown()
+    }
+
+    @Test("attachment rejects SSH route drift after validation")
+    func attachmentRejectsSSHRouteDrift() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-zellij-config",
+        ])
+        let current = Mutex(frozen)
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                current.withLock { $0 = changed }
+                return .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                current.withLock { $0 }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState == .disconnected(
+                reason: "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+            )
+        }
+
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("endpoint changes detach the active Zellij client")
+    func endpointChangeDetaches() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@old.example.test",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let configured = CurrentValueSubject<[SSHHost], Never>([
+            SSHHost(
+                configKey: host.configKey,
+                name: host.name,
+                platform: .linux,
+                sshDestination: "dev@old.example.test"
+            ),
+        ])
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            configuredSSHHostsProvider: { configured.value }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == selection
+                && store.lastCommand != nil
+        }
+        configured.value = [
+            SSHHost(
+                configKey: host.configKey,
+                name: host.name,
+                platform: .linux,
+                sshDestination: "dev@new.example.test"
+            ),
+        ]
+        model.refreshHosts()
+
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.removedKeys.contains { $0.target == .zellijSession })
+        await model.shutdown()
+    }
+
+    @Test("new sessions remain visible through initial empty discovery")
+    func creationPublishesOptimistically() async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available([])
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+
+        model.startZellijSessionDiscovery()
+        model.createZellijSession(selection)
+        await waitUntilMainActor {
+            store.lastCommand != nil && probes.withLock { $0 } >= 2
+        }
+
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijSessions.map(\.name) == ["release"])
+        await model.shutdown()
+    }
+
+    @Test(
+        "pending creation survives transient discovery and retries",
+        arguments: [
+            ZellijPendingDiscoveryFailureCase(
+                name: "unavailable executable",
+                result: .unavailable
+            ),
+            ZellijPendingDiscoveryFailureCase(
+                name: "command failure",
+                result: .failure(.commandFailed(
+                    status: 1,
+                    stderr: "temporary inventory failure"
+                ))
+            ),
+        ]
+    )
+    func creationSurvivesTransientDiscovery(
+        _ failure: ZellijPendingDiscoveryFailureCase
+    ) async throws {
+        let environment = try zellijEnvironment(sessions: [])
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let releaseConfirmation = DispatchSemaphore(value: 0)
+        defer { releaseConfirmation.signal() }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                let attempt = probes.withLock {
+                    $0 += 1
+                    return $0
+                }
+                switch attempt {
+                case 1:
+                    return .available([])
+                case 2:
+                    return failure.result
+                default:
+                    releaseConfirmation.wait()
+                    return .available(["release", "confirmed"])
+                }
+            },
+            createdSessionDiscoveryDelays: [.zero]
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "release"
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor { probes.withLock { $0 } >= 1 }
+        model.createZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock { $0 } >= 3
+        }
+
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijSessions.map(\.name) == ["release"])
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijAvailable == true)
+
+        releaseConfirmation.signal()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.snapshot.host(id: environment.host.id)?
+                .zellijSessions.map(\.name) == ["release", "confirmed"]
+        }
+        await model.shutdown()
+    }
+
+    @Test("creation retries wait for the fleet and back off on pending hosts")
+    func creationRetriesAfterFleetCompletion() async throws {
+        let local = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS,
+            zellijAvailable: true
+        )
+        let remote = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijAvailable: true
+        )
+        let localHost = CommandHost.local
+        let remoteHost = CommandHost.ssh(SSHHostInfo(
+            user: "dev",
+            hostname: "builder",
+            port: nil
+        ))
+        let probes = Mutex([CommandHost: Int]())
+        let releaseLocal = DispatchSemaphore(value: 0)
+        let releaseRemote = DispatchSemaphore(value: 0)
+        defer {
+            releaseLocal.signal()
+            releaseRemote.signal()
+        }
+        let model = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: local.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [local, remote],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: RecordingNativeSessionSurfaceStore(),
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { host in
+                let attempt = probes.withLock {
+                    $0[host, default: 0] += 1
+                    return $0[host] ?? 0
+                }
+                if attempt == 1 {
+                    switch host {
+                    case .local:
+                        releaseLocal.wait()
+                    case .ssh:
+                        releaseRemote.wait()
+                    }
+                }
+                return .available([])
+            },
+            createdSessionDiscoveryDelays: [
+                .milliseconds(20),
+                .seconds(60),
+            ]
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: local.id,
+            name: "release"
+        )
+
+        model.createZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijConnectionState == .connected
+        }
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock {
+                $0[localHost] == 1 && $0[remoteHost] == 1
+            }
+        }
+        releaseLocal.signal()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(probes.withLock { $0[localHost] } == 1)
+        #expect(probes.withLock { $0[remoteHost] } == 1)
+
+        releaseRemote.signal()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock { $0[localHost] == 2 }
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(probes.withLock { $0[localHost] } == 2)
+        #expect(probes.withLock { $0[remoteHost] } == 1)
+        await model.shutdown()
+    }
+
+    @Test("creation retry does not cancel an overlapping fleet refresh")
+    func creationRetryPreservesFleetRefresh() async throws {
+        let local = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS,
+            zellijAvailable: true
+        )
+        let remote = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "old")],
+            zellijAvailable: true
+        )
+        let localProbes = Mutex(0)
+        let remoteProbes = Mutex(0)
+        let releaseInitialLocal = DispatchSemaphore(value: 0)
+        let releaseInitialRemote = DispatchSemaphore(value: 0)
+        let releaseRetryLocal = DispatchSemaphore(value: 0)
+        let releaseManualRemote = DispatchSemaphore(value: 0)
+        defer {
+            releaseInitialLocal.signal()
+            releaseInitialRemote.signal()
+            releaseRetryLocal.signal()
+            releaseManualRemote.signal()
+        }
+        let model = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: local.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [local, remote],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: RecordingNativeSessionSurfaceStore(),
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { host in
+                let isRemote = host.isRemote
+                let attempt = if isRemote {
+                    remoteProbes.withLock {
+                        $0 += 1
+                        return $0
+                    }
+                } else {
+                    localProbes.withLock {
+                        $0 += 1
+                        return $0
+                    }
+                }
+                if attempt == 1 {
+                    if isRemote {
+                        releaseInitialRemote.wait()
+                    } else {
+                        releaseInitialLocal.wait()
+                    }
+                } else if !isRemote, attempt == 3 {
+                    releaseRetryLocal.wait()
+                } else if isRemote, attempt == 3 {
+                    releaseManualRemote.wait()
+                }
+                if isRemote {
+                    let names = switch attempt {
+                    case 1: ["initial"]
+                    case 2: ["intermediate"]
+                    default: ["new"]
+                    }
+                    return .available(names)
+                }
+                return .available([])
+            },
+            createdSessionDiscoveryDelays: [
+                .milliseconds(100),
+                .seconds(60),
+            ]
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: local.id,
+            name: "release"
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            localProbes.withLock { $0 } == 1
+                && remoteProbes.withLock { $0 } == 1
+        }
+        releaseInitialLocal.signal()
+        releaseInitialRemote.signal()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.snapshot.host(id: remote.id)?.zellijSessions.map(\.name)
+                == ["initial"]
+        }
+        model.createZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            localProbes.withLock { $0 } == 2
+                && remoteProbes.withLock { $0 } == 2
+                && model.snapshot.host(id: remote.id)?
+                .zellijSessions.map(\.name) == ["intermediate"]
+        }
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            localProbes.withLock { $0 } == 3
+                && remoteProbes.withLock { $0 } == 2
+        }
+        model.refreshKwtInventory()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            localProbes.withLock { $0 } == 4
+                && remoteProbes.withLock { $0 } == 3
+        }
+        releaseRetryLocal.signal()
+        releaseManualRemote.signal()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.snapshot.host(id: remote.id)?.zellijSessions.map(\.name)
+                == ["new"]
+        }
+
+        #expect(model.snapshot.host(id: remote.id)?
+            .zellijSessions.map(\.name) == ["new"])
+        await model.shutdown()
+    }
+
+    @Test("remote transport loss reconnects an active Zellij session")
+    func remoteReconnect() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available(["api"])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == selection
+                && store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor {
+            probes.withLock { $0 } >= 1
+                && store.requestedConfigurations.count == 2
+        }
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        #expect(store.lastCommand?.contains("dev@builder") == true)
+        await model.shutdown()
+    }
+
+    @Test("confirmed kill suppresses reconnect in another scene")
+    func confirmedKillSuppressesPeerReconnect() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [host],
+            projects: [],
+            worktrees: []
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let reconnectStore = RecordingNativeSessionSurfaceStore()
+        let reconnectProbes = Mutex(0)
+        let reconnectProbeContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let reconnectModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: reconnectStore,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = reconnectProbes.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 2 {
+                    await withCheckedContinuation { continuation in
+                        reconnectProbeContinuation.withLock {
+                            $0 = continuation
+                        }
+                    }
+                }
+                return .available(["api"])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let kills = Mutex(0)
+        let killingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+                return .success(())
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        reconnectModel.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            reconnectStore.requestedConfigurations.count == 1
+                && !reconnectStore.surface.closeObservers.isEmpty
+        }
+        let close = try #require(
+            reconnectStore.surface.closeObservers.values.first
+        )
+        close(false, 255)
+        await waitUntilMainActor {
+            reconnectProbeContinuation.withLock { $0 != nil }
+        }
+
+        let request = try await killingModel.prepareZellijSessionKill(
+            selection
+        )
+        try await killingModel.killZellijSession(request)
+        let continuation = reconnectProbeContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(kills.withLock { $0 } == 1)
+        #expect(reconnectStore.requestedConfigurations.count == 1)
+        #expect(reconnectModel.activeBorrowedZellijSelection == nil)
+        #expect(reconnectStore.removedKeys.contains {
+            $0.target == .zellijSession
+        })
+        await reconnectModel.shutdown()
+        await killingModel.shutdown()
+    }
+
+    @Test("validation completed after a kill cannot attach")
+    func staleValidationCannotAttachAfterKill() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [host],
+            projects: [],
+            worktrees: []
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let validationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let validatingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                await withCheckedContinuation { continuation in
+                    validationContinuation.withLock { $0 = continuation }
+                }
+                return .available(["api"])
+            }
+        )
+        let killingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in .success(()) }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        validatingModel.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            validationContinuation.withLock { $0 != nil }
+        }
+        let request = try await killingModel.prepareZellijSessionKill(
+            selection
+        )
+        try await killingModel.killZellijSession(request)
+        let continuation = validationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(store.requestedConfigurations.isEmpty)
+        #expect(validatingModel.activeBorrowedZellijSelection == nil)
+        await validatingModel.shutdown()
+        await killingModel.shutdown()
+    }
+
+    @Test("failed kill restarts a matching suspended open")
+    func failedKillRestartsSuspendedOpen() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [host],
+            projects: [],
+            worktrees: []
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let validationAttempts = Mutex(0)
+        let firstValidationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let validatingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = validationAttempts.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 1 {
+                    await withCheckedContinuation { continuation in
+                        firstValidationContinuation.withLock {
+                            $0 = continuation
+                        }
+                    }
+                }
+                return .available(["api"])
+            }
+        )
+        let killingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in
+                .failure(.commandFailed(status: 1, stderr: "busy"))
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        validatingModel.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            firstValidationContinuation.withLock { $0 != nil }
+        }
+        let request = try await killingModel.prepareZellijSessionKill(
+            selection
+        )
+        await #expect(throws: ZellijCommandError.self) {
+            try await killingModel.killZellijSession(request)
+        }
+        await waitUntilMainActor {
+            validationAttempts.withLock { $0 } >= 2
+                && store.requestedConfigurations.count == 1
+        }
+        let continuation = firstValidationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+
+        #expect(validatingModel.activeBorrowedZellijSelection == selection)
+        await validatingModel.shutdown()
+        await killingModel.shutdown()
+    }
+
+    @Test("failed kill does not resume an open superseded by another session")
+    func failedKillDoesNotResumeSupersededOpen() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [
+                ZellijSessionSummary(name: "api"),
+                ZellijSessionSummary(name: "shell"),
+            ],
+            zellijAvailable: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [host],
+            projects: [],
+            worktrees: []
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let firstValidationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let apiValidationAttempts = Mutex(0)
+        let validatingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = apiValidationAttempts.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 1 {
+                    await withCheckedContinuation { continuation in
+                        firstValidationContinuation.withLock {
+                            $0 = continuation
+                        }
+                    }
+                }
+                return .available(["api", "shell"])
+            }
+        )
+        let killContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
+        let killingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api", "shell"])
+            },
+            zellijSessionKiller: { _, _, _ in
+                await withCheckedContinuation { continuation in
+                    killContinuation.withLock { $0 = continuation }
+                }
+                return .failure(.commandFailed(status: 1, stderr: "busy"))
+            }
+        )
+        let api = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        let shell = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "shell"
+        )
+
+        validatingModel.openBorrowedZellijSession(api)
+        await waitUntilMainActor {
+            firstValidationContinuation.withLock { $0 != nil }
+        }
+        let request = try await killingModel.prepareZellijSessionKill(api)
+        let killTask = Task {
+            try await killingModel.killZellijSession(request)
+        }
+        await waitUntilMainActor {
+            killCoordinator.isPending(.init(
+                hostID: host.id,
+                sessionName: api.name
+            ))
+        }
+        validatingModel.openBorrowedZellijSession(shell)
+        await waitUntilMainActor {
+            validatingModel.activeBorrowedZellijSelection == shell
+                && killContinuation.withLock { $0 != nil }
+        }
+        let releaseKill = killContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        releaseKill?.resume()
+        await #expect(throws: ZellijCommandError.self) {
+            try await killTask.value
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(validatingModel.activeBorrowedZellijSelection == shell)
+        let continuation = firstValidationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        await validatingModel.shutdown()
+        await killingModel.shutdown()
+    }
+
+    @Test("failed kill does not resume an open after host route drift")
+    func failedKillDoesNotResumeOpenAfterHostDrift() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let configuredHost = Mutex(SSHHost(
+            configKey: host.configKey,
+            name: host.name,
+            platform: .linux,
+            sshDestination: host.sshDestination ?? ""
+        ))
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let validations = Mutex(0)
+        let model = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                validations.withLock { $0 += 1 }
+                return .available(["api"])
+            },
+            configuredSSHHostsProvider: {
+                [configuredHost.withLock { $0 }]
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        let operation = try #require(killCoordinator.begin(key: .init(
+            hostID: host.id,
+            sessionName: selection.name
+        )))
+
+        model.openBorrowedZellijSession(selection)
+        configuredHost.withLock {
+            $0.sshDestination = "dev@other.example.test"
+        }
+        model.refreshHosts()
+        killCoordinator.finish(operation, outcome: .failed)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(validations.withLock { $0 } == 0)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("successful kill rejects stale discovery in another scene")
+    func successfulKillRejectsPeerDiscovery() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [host],
+            projects: [],
+            worktrees: []
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let probeCount = Mutex(0)
+        let firstProbeStarted = Mutex(false)
+        let releaseFirstProbe = DispatchSemaphore(value: 0)
+        let inventoryModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                let attempt = probeCount.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 1 {
+                    firstProbeStarted.withLock { $0 = true }
+                    releaseFirstProbe.wait()
+                    return .available(["api"])
+                }
+                return .available([])
+            }
+        )
+        let killingModel = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: UUID(),
+            snapshot: snapshot,
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in .success(()) }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        inventoryModel.startZellijSessionDiscovery()
+        await waitUntilMainActor { firstProbeStarted.withLock { $0 } }
+        let request = try await killingModel.prepareZellijSessionKill(
+            selection
+        )
+        try await killingModel.killZellijSession(request)
+
+        #expect(inventoryModel.snapshot.host(id: host.id)?
+            .zellijSessions.isEmpty == true)
+
+        releaseFirstProbe.signal()
+        await waitUntilMainActor {
+            probeCount.withLock { $0 } >= 2
+                && inventoryModel.snapshot.host(id: host.id)?
+                .zellijSessions.isEmpty == true
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(probeCount.withLock { $0 } >= 2)
+        #expect(inventoryModel.snapshot.host(id: host.id)?
+            .zellijSessions.isEmpty == true)
+        await inventoryModel.shutdown()
+        await killingModel.shutdown()
+    }
+
+    @Test("reconnect rejects SSH route drift before probing")
+    func reconnectRejectsSSHRouteDrift() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-zellij-config",
+        ])
+        let current = Mutex(frozen)
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            zellijSessionValidationDiscovery: { _, _ in .available(["api"]) },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                current.withLock { $0 }
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        current.withLock { $0 = changed }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState == .disconnected(
+                reason: "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+            )
+        }
+
+        #expect(store.requestedConfigurations.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("successful SSH recovery resumes Zellij reconnect")
+    func sshRecoveryResumesReconnect() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let discoveries = Mutex<[ZellijDiscoveryResult]>([
+            .available(["api"]),
+            .failure(.commandFailed(
+                status: 255,
+                stderr: "Permission denied (publickey,password)."
+            )),
+            .available(["api"]),
+        ])
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                discoveries.withLock { $0.removeFirst() }
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor {
+            model.sessionConnectionRecoveryRequest?.hostID == host.id
+        }
+        let recoveryRequest = try #require(
+            model.sessionConnectionRecoveryRequest
+        )
+
+        model.resumeSessionReconnectAfterSSHRecovery(recoveryRequest)
+
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 2
+                && model.activeBorrowedZellijConnectionState == .connected
+        }
+        #expect(model.sessionConnectionRecoveryRequest == nil)
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        await model.shutdown()
+    }
+
+    @Test("failed remote creation disappears when reconnect confirms absence")
+    func failedRemoteCreationDisappears() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available([])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor { probes.withLock { $0 } >= 1 }
+        let initialProbeCount = probes.withLock { $0 }
+        model.createZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock { $0 } >= initialProbeCount + 2
+                && model.snapshot.host(id: host.id)?
+                .zellijSessions.isEmpty == true
+        }
+
+        #expect(model.snapshot.host(id: host.id)?.zellijSessions.isEmpty == true)
+        await model.shutdown()
+    }
+
+    @Test("an immediate creation transport exit keeps its frozen SSH route")
+    func immediateCreationExitKeepsSSHRoute() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-zellij-config",
+        ])
+        let store = RecordingNativeSessionSurfaceStore(
+            closeOnRegistrationCode: 255
+        )
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in frozen },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.createZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock { $0 } >= 1
+                && store.requestedConfigurations.count == 2
+        }
+
+        #expect(store.lastCommand?.contains("/tmp/frozen-zellij-config") == true)
+        await model.shutdown()
+    }
+
+    @Test(
+        "terminal reconnect failure retires pending creation",
+        arguments: [
+            ZellijTerminalReconnectFailureCase(
+                name: "unavailable executable",
+                result: .unavailable,
+                reason: "Zellij is no longer available on this host."
+            ),
+            ZellijTerminalReconnectFailureCase(
+                name: "non-retryable command failure",
+                result: .failure(.commandFailed(
+                    status: 1,
+                    stderr: "invalid session state"
+                )),
+                reason: "Zellij exited with status 1: invalid session state"
+            ),
+        ]
+    )
+    func terminalReconnectFailureRetiresPendingCreation(
+        _ failure: ZellijTerminalReconnectFailureCase
+    ) async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                let attempt = probes.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 1 ? failure.result : .available([])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.createZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijConnectionState
+                == .disconnected(reason: failure.reason)
+        }
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            probes.withLock { $0 } >= 2
+        }
+
+        #expect(model.snapshot.host(id: host.id)?.zellijSessions.isEmpty == true)
+        await model.shutdown()
+    }
+
+    @Test("kill revalidates the live session and exact host")
+    func killRevalidates() async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let probes = Mutex(0)
+        let kills = Mutex([(String, CommandHost)]())
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available(["api"])
+            },
+            zellijSessionKiller: { name, host, _ in
+                kills.withLock { $0.append((name, host)) }
+                return .success(())
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        let request = try await model.prepareZellijSessionKill(selection)
+        try await model.killZellijSession(request)
+
+        #expect(probes.withLock { $0 } == 2)
+        #expect(kills.withLock { $0.count } == 1)
+        #expect(kills.withLock { $0.first?.0 } == "api")
+        #expect(kills.withLock { $0.first?.1 } == .local)
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijSessions.isEmpty == true)
+        await model.shutdown()
+    }
+
+    @Test("kill uses the confirmed SSH route for validation and mutation")
+    func killUsesFrozenSSHRoute() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-config",
+        ])
+        let validations = Mutex([[String]]())
+        let killedWith = Mutex<[String]?>(nil)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionValidationDiscovery: { _, arguments in
+                validations.withLock { $0.append(arguments) }
+                return .available(["api"])
+            },
+            zellijSessionKiller: { _, _, arguments in
+                killedWith.withLock { $0 = arguments }
+                return .success(())
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in frozen }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        let request = try await model.prepareZellijSessionKill(selection)
+        try await model.killZellijSession(request)
+
+        #expect(validations.withLock { $0 } == [
+            frozen.arguments,
+            frozen.arguments,
+        ])
+        #expect(killedWith.withLock { $0 } == frozen.arguments)
+        await model.shutdown()
+    }
+
+    @Test("kill rejects SSH route drift after confirmation")
+    func killRejectsSSHRouteDrift() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-config",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-config",
+        ])
+        let current = Mutex(frozen)
+        let kills = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+                return .success(())
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                current.withLock { $0 }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        let request = try await model.prepareZellijSessionKill(selection)
+        current.withLock { $0 = changed }
+
+        await #expect(throws: ZellijSessionPresentationError.hostChanged(
+            "api"
+        )) {
+            try await model.killZellijSession(request)
+        }
+        #expect(kills.withLock { $0 } == 0)
+        await model.shutdown()
+    }
+
+    @Test("kill rejects SSH route drift during final discovery")
+    func killRejectsSSHRouteDriftDuringFinalDiscovery() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-config",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-config",
+        ])
+        let current = Mutex(frozen)
+        let validations = Mutex(0)
+        let kills = Mutex(0)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = validations.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if attempt == 2 {
+                    try? await Task.sleep(for: .milliseconds(10))
+                    current.withLock { $0 = changed }
+                }
+                return .available(["api"])
+            },
+            zellijSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+                return .success(())
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                current.withLock { $0 }
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        let request = try await model.prepareZellijSessionKill(selection)
+
+        await #expect(throws: ZellijSessionPresentationError.hostChanged(
+            "api"
+        )) {
+            try await model.killZellijSession(request)
+        }
+        #expect(validations.withLock { $0 } == 2)
+        #expect(kills.withLock { $0 } == 0)
+        await model.shutdown()
+    }
+
+    private func zellijEnvironment(
+        sessions: [String]
+    ) throws -> (database: WorkspaceDatabase, host: HostSummary, snapshot: WorkspaceSnapshot) {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "local",
+            name: "This Mac",
+            kind: .selfHost,
+            platform: .macOS,
+            zellijSessions: sessions.map(ZellijSessionSummary.init(name:)),
+            zellijAvailable: true
+        )
+        return (
+            database,
+            host,
+            WorkspaceSnapshot(hosts: [host], projects: [], worktrees: [])
+        )
+    }
+}

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -37,6 +37,15 @@ struct ZellijTerminalReconnectFailureCase:
     var testDescription: String { name }
 }
 
+struct ZellijKillValidationFailureCase:
+    Sendable, CustomTestStringConvertible {
+    var name: String
+    var result: ZellijDiscoveryResult
+    var expectsUnavailable: Bool
+
+    var testDescription: String { name }
+}
+
 @Suite("Workspace Zellij support", .serialized)
 @MainActor
 struct WorkspaceZellijTests {
@@ -305,8 +314,8 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
-    @Test("sidebar navigation cancels delayed Zellij validation")
-    func sidebarNavigationCancelsDelayedValidation() async throws {
+    @Test("same-host sidebar navigation cancels delayed Zellij validation")
+    func sameHostSidebarNavigationCancelsDelayedValidation() async throws {
         let environment = try zellijEnvironment(sessions: ["zellij-work"])
         let zellijStore = RecordingNativeSessionSurfaceStore()
         let probeStarted = Mutex(false)
@@ -334,7 +343,10 @@ struct WorkspaceZellijTests {
 
         model.openBorrowedZellijSession(zellij)
         await waitUntilMainActor { probeStarted.withLock { $0 } }
-        model.synchronizeSelection(WorkspaceSelection(selectedHostID: UUID()))
+        model.cancelPendingZellijPresentation()
+        model.synchronizeSelection(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
         let continuation = probeContinuation.withLock {
             let continuation = $0
             $0 = nil
@@ -346,6 +358,62 @@ struct WorkspaceZellijTests {
 
         #expect(model.activeBorrowedZellijSelection == nil)
         #expect(zellijStore.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("runner timeout retries an active Zellij reconnect")
+    func runnerTimeoutRetriesReconnect() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let results = Mutex<[ZellijDiscoveryResult]>([
+            .available(["api"]),
+            .failure(.commandFailed(
+                status: AccountCommandRunner.timedOutStatus,
+                stderr: "SSH command timed out."
+            )),
+            .available(["api"]),
+        ])
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host], projects: [], worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in
+                results.withLock { $0.removeFirst() }
+            },
+            tmuxReconnectIntervals: [.zero, .zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 2
+        }
+
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(results.withLock { $0.isEmpty })
         await model.shutdown()
     }
 
@@ -1940,6 +2008,118 @@ struct WorkspaceZellijTests {
         #expect(kills.withLock { $0.first?.1 } == .local)
         #expect(model.snapshot.host(id: environment.host.id)?
             .zellijSessions.isEmpty == true)
+        await model.shutdown()
+    }
+
+    @Test(
+        "kill preparation preserves validation failures",
+        arguments: [
+            ZellijKillValidationFailureCase(
+                name: "unavailable executable",
+                result: .unavailable,
+                expectsUnavailable: true
+            ),
+            ZellijKillValidationFailureCase(
+                name: "command failure",
+                result: .failure(.commandFailed(
+                    status: 23,
+                    stderr: "probe failed"
+                )),
+                expectsUnavailable: false
+            ),
+        ]
+    )
+    func killPreparationPreservesValidationFailure(
+        _ failure: ZellijKillValidationFailureCase
+    ) async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            zellijSessionValidationDiscovery: { _, _ in failure.result }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+
+        do {
+            _ = try await model.prepareZellijSessionKill(selection)
+            Issue.record("Expected kill preparation to fail")
+        } catch {
+            if failure.expectsUnavailable {
+                #expect(error as? ZellijSessionPresentationError == .unavailable)
+            } else {
+                #expect(error as? ZellijCommandError == .commandFailed(
+                    status: 23,
+                    stderr: "probe failed"
+                ))
+            }
+        }
+        await model.shutdown()
+    }
+
+    @Test(
+        "final kill validation preserves failures",
+        arguments: [
+            ZellijKillValidationFailureCase(
+                name: "unavailable executable",
+                result: .unavailable,
+                expectsUnavailable: true
+            ),
+            ZellijKillValidationFailureCase(
+                name: "command failure",
+                result: .failure(.commandFailed(
+                    status: 23,
+                    stderr: "probe failed"
+                )),
+                expectsUnavailable: false
+            ),
+        ]
+    )
+    func finalKillValidationPreservesFailure(
+        _ failure: ZellijKillValidationFailureCase
+    ) async throws {
+        let environment = try zellijEnvironment(sessions: ["api"])
+        let attempts = Mutex(0)
+        let kills = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            zellijSessionValidationDiscovery: { _, _ in
+                let attempt = attempts.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 1 ? .available(["api"]) : failure.result
+            },
+            zellijSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+                return .success(())
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: environment.host.id,
+            name: "api"
+        )
+        let request = try await model.prepareZellijSessionKill(selection)
+
+        do {
+            try await model.killZellijSession(request)
+            Issue.record("Expected final kill validation to fail")
+        } catch {
+            if failure.expectsUnavailable {
+                #expect(error as? ZellijSessionPresentationError == .unavailable)
+            } else {
+                #expect(error as? ZellijCommandError == .commandFailed(
+                    status: 23,
+                    stderr: "probe failed"
+                ))
+            }
+        }
+        #expect(kills.withLock { $0 } == 0)
         await model.shutdown()
     }
 

--- a/Tests/App/ZellijInventoryClientTests.swift
+++ b/Tests/App/ZellijInventoryClientTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import GhosthubTransport
+import GhosthubWorkspace
+import GhosthubZellij
+import Synchronization
+import Testing
+@testable import GhosthubApp
+
+private struct CapturedZellijCommand: Equatable, Sendable {
+    var executable: String
+    var command: String
+}
+
+private final class ZellijCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands = [CapturedZellijCommand]()
+
+    func append(_ command: CapturedZellijCommand) {
+        lock.withLock { commands.append(command) }
+    }
+
+    var snapshot: [CapturedZellijCommand] {
+        lock.withLock { commands }
+    }
+}
+
+@Suite("Zellij inventory client")
+struct ZellijInventoryClientTests {
+    @Test("local discovery resolves Zellij and excludes exited sessions")
+    func localDiscovery() {
+        let commands = ZellijCommandRecorder()
+        let client = ZellijInventoryClient(
+            commandRunner: commandRunner(capturing: commands),
+            connectionArgumentsProvider: { _ in [] }
+        )
+
+        #expect(client.discover(on: .local) == .available(["api"]))
+        let captured = commands.snapshot
+        #expect(captured.count == 2)
+        #expect(captured[0].executable == "/bin/account-shell")
+        #expect(captured[0].command.contains("command -v zellij"))
+        #expect(captured[1].command.contains(
+            "'/opt/homebrew/bin/zellij' 'list-sessions' '--no-formatting'"
+        ))
+    }
+
+    @Test("remote discovery samples SSH routing once")
+    func remoteDiscovery() {
+        let commands = ZellijCommandRecorder()
+        let routeSamples = Mutex(0)
+        let host = SSHHostInfo(
+            user: "dev",
+            hostname: "build.example",
+            port: 2222
+        )
+        let client = ZellijInventoryClient(
+            commandRunner: commandRunner(capturing: commands),
+            connectionArgumentsProvider: { suppliedHost in
+                #expect(suppliedHost == host)
+                return routeSamples.withLock { samples in
+                    samples += 1
+                    return samples == 1
+                        ? ["-F", "/tmp/ghosthub ssh config"]
+                        : ["-F", "/tmp/changed ssh config"]
+                }
+            }
+        )
+
+        #expect(client.discover(on: .ssh(host)) == .available(["api"]))
+        let captured = commands.snapshot
+        #expect(routeSamples.withLock { $0 } == 1)
+        #expect(captured.count == 2)
+        #expect(captured.allSatisfy { $0.command.contains("/usr/bin/ssh") })
+        #expect(captured.allSatisfy {
+            $0.command.contains("/tmp/ghosthub ssh config")
+        })
+        #expect(captured.allSatisfy {
+            $0.command.contains("dev@build.example")
+        })
+    }
+
+    @Test("missing Zellij is a silent optional capability")
+    func missingExecutable() {
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                AccountCommandOutput(
+                    status: 127,
+                    stdout: "",
+                    stderr: "zellij: command not found"
+                )
+            }
+        )
+        let client = ZellijInventoryClient(
+            commandRunner: runner,
+            connectionArgumentsProvider: { _ in [] }
+        )
+
+        #expect(client.discover(on: .local) == .unavailable)
+    }
+
+    @Test("Windows hosts are unavailable without starting a process")
+    func windowsUnavailable() {
+        let calls = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                calls.withLock { $0 += 1 }
+                return AccountCommandOutput(status: 0, stdout: "", stderr: "")
+            }
+        )
+        let client = ZellijInventoryClient(
+            commandRunner: runner,
+            connectionArgumentsProvider: { _ in [] }
+        )
+        let host = SSHHostInfo(
+            user: nil,
+            hostname: "windows.example",
+            port: nil,
+            platform: .windows
+        )
+
+        #expect(client.discover(on: .ssh(host)) == .unavailable)
+        #expect(calls.withLock { $0 } == 0)
+    }
+
+    private func commandRunner(
+        capturing commands: ZellijCommandRecorder
+    ) -> AccountCommandRunner {
+        AccountCommandRunner(
+            processRunner: { executable, arguments, _, _ in
+                let command = arguments.last ?? ""
+                commands.append(CapturedZellijCommand(
+                    executable: executable,
+                    command: command
+                ))
+                if command.contains("command -v zellij") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_ZELLIJ_PATH\n/opt/homebrew/bin/zellij\n",
+                        stderr: ""
+                    )
+                }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: """
+                    shell startup output
+                    GHOSTHUB_ZELLIJ_SESSIONS
+                    api [Created 4m 3s ago]
+                    archived [Created 2d 1h ago] (EXITED - attach to resurrect)
+
+                    """,
+                    stderr: ""
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+    }
+}

--- a/Tests/TestSupport/WorkspaceModelFixtures.swift
+++ b/Tests/TestSupport/WorkspaceModelFixtures.swift
@@ -133,6 +133,8 @@ public extension HostSummary {
         tmuxSessions: [TmuxSessionSummary] = [],
         herdrSessions: [HerdrSessionSummary] = [],
         herdrAvailable: Bool = false,
+        zellijSessions: [ZellijSessionSummary] = [],
+        zellijAvailable: Bool = false,
         decodedConnectionState: HostConnectionState? = nil,
         transientOverride: HostConnectionState? = nil,
         operationAvailability:
@@ -155,6 +157,8 @@ public extension HostSummary {
             tmuxSessions: tmuxSessions,
             herdrSessions: herdrSessions,
             herdrAvailable: herdrAvailable,
+            zellijSessions: zellijSessions,
+            zellijAvailable: zellijAvailable,
             decodedConnectionState:
             decodedConnectionState,
             transientOverride: transientOverride,

--- a/Tests/UI/CommandPaletteModelTests.swift
+++ b/Tests/UI/CommandPaletteModelTests.swift
@@ -720,6 +720,40 @@ struct CommandPaletteModelTests {
         })
     }
 
+    @Test("active Zellij sessions expose create, open, and kill commands")
+    func zellijSessionCommands() {
+        let host = HostSummary.fixture(
+            name: "Build Box",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let commands = makeCommandPaletteCommands(
+            snapshot: .fixture(hosts: [host]),
+            selection: WorkspaceSelection(selectedHostID: host.id)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        #expect(commands.contains {
+            $0.action == .newZellijSession(host.id)
+        })
+        #expect(commands.contains {
+            $0.action == .openZellijSession(selection)
+        })
+        #expect(commands.contains {
+            $0.action == .killZellijSession(selection)
+        })
+        #expect(CommandPaletteModel.filteredCommands(
+            commands,
+            query: "zellij api build"
+        ).count == 2)
+    }
+
     @Test("Windows hosts do not offer POSIX project registration")
     func windowsHostsHideAddProject() {
         let host = HostSummary.fixture(

--- a/Tests/UI/KeyboardNavigationModelTests.swift
+++ b/Tests/UI/KeyboardNavigationModelTests.swift
@@ -61,6 +61,10 @@ struct KeyboardNavigationModelTests {
                     .init(name: "running-a", isDefault: false, state: .running),
                     .init(name: "stopped", isDefault: false, state: .stopped),
                     .init(name: "running-z", isDefault: false, state: .running),
+                ],
+                zellijSessions: [
+                    .init(name: "zellij-a"),
+                    .init(name: "zellij-z"),
                 ]
             )], projects: [], worktrees: [],
             directoryWorkspaces: [directoryOne, directoryTwo]
@@ -91,6 +95,12 @@ struct KeyboardNavigationModelTests {
         #expect(KeyboardNavigationModel.siblingTargets(
             for: .herdrSession(hostID: hostID, name: "stopped"), in: context
         ).isEmpty)
+        #expect(KeyboardNavigationModel.siblingTargets(
+            for: .zellijSession(hostID: hostID, name: "zellij-a"), in: context
+        ) == [
+            .zellijSession(hostID: hostID, name: "zellij-a"),
+            .zellijSession(hostID: hostID, name: "zellij-z"),
+        ])
     }
 
     @Test("single, missing, and non-session targets pass through")

--- a/Tests/UI/NewZellijSessionSheetTests.swift
+++ b/Tests/UI/NewZellijSessionSheetTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import GhosthubUI
+
+@Suite("New Zellij session naming")
+struct NewZellijSessionSheetTests {
+    @Test(
+        "valid names follow Zellij's path-safe session boundary",
+        arguments: ["api", "release work", "déploiement"]
+    )
+    func validNames(_ name: String) {
+        #expect(ZellijSessionName.isValid(name))
+    }
+
+    @Test(
+        "invalid names are rejected before launch",
+        arguments: ["", "   ", ".", "..", "team/api", "api\nworker"]
+    )
+    func invalidNames(_ name: String) {
+        #expect(!ZellijSessionName.isValid(name))
+    }
+}

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -133,6 +133,32 @@ struct SidebarToggleStabilityTests {
         #expect(second.columnVisibility == .all)
     }
 
+    @Test("command palette opens only in its targeted window")
+    func commandPaletteOpensOnlyInTargetedWindow() {
+        let firstTarget = SidebarToggleTarget()
+        let secondTarget = SidebarToggleTarget()
+        let first = StabilityTestEnvironment(
+            sidebarToggleTarget: firstTarget
+        )
+        let second = StabilityTestEnvironment(
+            sidebarToggleTarget: secondTarget
+        )
+        defer {
+            first.close()
+            second.close()
+        }
+
+        NotificationCenter.default.post(
+            name: .ghosthubCommandPalette,
+            object: firstTarget
+        )
+        first.settle()
+        second.settle()
+
+        #expect(first.isCommandPalettePresented)
+        #expect(!second.isCommandPalettePresented)
+    }
+
     @Test("right side panel toggle preserves main column view identity")
     func rightSidePanelTogglePreservesMainColumn() {
         let env = SidePanelStabilityTestEnvironment()
@@ -205,6 +231,10 @@ private final class StabilityTestEnvironment {
 
     var columnVisibility: NavigationSplitViewVisibility {
         model.columnVisibility
+    }
+
+    var isCommandPalettePresented: Bool {
+        model.isCommandPalettePresented
     }
 
     var terminalResizeDeferrals: [Bool] {
@@ -338,6 +368,7 @@ private final class StabilityTestModel: ObservableObject {
     @Published var selection: WorkspaceSelection
     @Published var activeSession: WorkspaceTmuxSessionSelection?
     @Published var columnVisibility: NavigationSplitViewVisibility = .all
+    @Published var isCommandPalettePresented = false
     private(set) var terminalResizeDeferrals: [Bool] = []
 
     init(
@@ -385,7 +416,8 @@ private struct StabilityTestHarness: View {
             sidebarToggleTarget: sidebarToggleTarget,
             settingsStore: settingsStore,
             selection: $model.selection,
-            columnVisibility: $model.columnVisibility
+            columnVisibility: $model.columnVisibility,
+            isCommandPalettePresented: $model.isCommandPalettePresented
         )
         .defaultAppStorage(defaults)
         .environment(\.controlActiveState, .key)

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -85,6 +85,19 @@ struct TmuxSessionPresentationLifecycleTests {
         #expect(!didDetach)
     }
 
+    @Test("command palette navigation deactivates every session backend")
+    func commandPaletteNavigationDeactivatesEverySessionBackend() {
+        var deactivated: [String] = []
+
+        RootView.deactivateSessionsForNavigation(
+            hideTmux: { deactivated.append("tmux") },
+            deactivateHerdr: { deactivated.append("herdr") },
+            deactivateZellij: { deactivated.append("zellij") }
+        )
+
+        #expect(deactivated == ["tmux", "herdr", "zellij"])
+    }
+
     @Test("validated Herdr activation closes the tmux presentation it replaced")
     func herdrActivationClosesReplacedTmuxAfterValidation() async throws {
         let hostID = UUID()
@@ -126,6 +139,25 @@ struct TmuxSessionPresentationLifecycleTests {
             )
         }
         #expect(closedTmuxSessions == [tmux])
+    }
+
+    @Test("Zellij activation delegates peer takeover to the scene model")
+    func zellijActivationDelegatesPeerTakeover() {
+        let session = WorkspaceZellijSessionSelection(
+            hostID: UUID(),
+            name: "api"
+        )
+        var events: [String] = []
+
+        RootView.startZellijSessionActivation(
+            session,
+            open: {
+                #expect($0 == session)
+                events.append("open-zellij")
+            }
+        )
+
+        #expect(events == ["open-zellij"])
     }
 
     @Test(
@@ -239,7 +271,8 @@ struct TmuxSessionPresentationLifecycleTests {
             action: .delete
         )
         let firstContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
-        let controller = HerdrLifecyclePreparationController()
+        let controller =
+            SessionPreparationController<HerdrSessionLifecycleRequest>()
         var prepared: [HerdrSessionLifecycleRequest] = []
         var cancelled: [HerdrSessionLifecycleRequest] = []
         var failures: [String] = []
@@ -291,6 +324,95 @@ struct TmuxSessionPresentationLifecycleTests {
         #expect(prepared == [second])
         #expect(cancelled == [first])
         #expect(failures.isEmpty)
+    }
+
+    @Test("newer Zellij kill preparation supersedes and releases older authority")
+    func zellijKillPreparationSupersedesOlderRequest() async {
+        let host = HostSummary.fixture()
+        let first = ZellijSessionKillRequest(
+            authorityID: UUID(),
+            session: .init(hostID: host.id, name: "first"),
+            confirmedHost: host
+        )
+        let second = ZellijSessionKillRequest(
+            authorityID: UUID(),
+            session: .init(hostID: host.id, name: "second"),
+            confirmedHost: host
+        )
+        let firstContinuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
+        let controller =
+            SessionPreparationController<ZellijSessionKillRequest>()
+        var prepared: [ZellijSessionKillRequest] = []
+        var cancelled: [ZellijSessionKillRequest] = []
+        var failures: [String] = []
+
+        controller.start(
+            prepare: {
+                await withCheckedContinuation { continuation in
+                    firstContinuation.withLock { $0 = continuation }
+                }
+                return first
+            },
+            cancelPrepared: { cancelled.append($0) },
+            onPrepared: { prepared.append($0) },
+            onFailure: { failures.append($0.localizedDescription) }
+        )
+        for _ in 0 ..< 1_000 {
+            if firstContinuation.withLock({ $0 != nil }) {
+                break
+            }
+            await Task.yield()
+        }
+
+        controller.start(
+            prepare: { second },
+            cancelPrepared: { cancelled.append($0) },
+            onPrepared: { prepared.append($0) },
+            onFailure: { failures.append($0.localizedDescription) }
+        )
+        for _ in 0 ..< 1_000 {
+            if prepared == [second] {
+                break
+            }
+            await Task.yield()
+        }
+
+        let continuation = firstContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        for _ in 0 ..< 1_000 {
+            if cancelled == [first] {
+                break
+            }
+            await Task.yield()
+        }
+
+        #expect(prepared == [second])
+        #expect(cancelled == [first])
+        #expect(failures.isEmpty)
+    }
+
+    @Test("displacing a Zellij kill confirmation releases its authority")
+    func displacedZellijKillConfirmationReleasesAuthority() {
+        let host = HostSummary.fixture()
+        let request = ZellijSessionKillRequest(
+            authorityID: UUID(),
+            session: .init(hostID: host.id, name: "api"),
+            confirmedHost: host
+        )
+        var alert: WorkspaceAlert? = .zellijKillConfirmation(request)
+        var cancelled: [ZellijSessionKillRequest] = []
+
+        RootView.cancelPreparedZellijKill(
+            workspaceAlert: &alert,
+            cancel: { cancelled.append($0) }
+        )
+
+        #expect(alert == nil)
+        #expect(cancelled == [request])
     }
 
     @Test("Root presents only the active Herdr backend")
@@ -376,6 +498,60 @@ struct TmuxSessionPresentationLifecycleTests {
 
         #expect(model.closedSessions == [model.activeSession])
         withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("peer takeover navigation preserves Herdr during validation")
+    func peerTakeoverNavigationPreservesHerdr() {
+        let model = HerdrRoutePresentationModel()
+        let hostingView = hostView(
+            HerdrRoutePresentationHarness(
+                model: model,
+                suppressesDeactivation: true
+            ),
+            size: CGSize(width: 100, height: 100)
+        )
+
+        model.selectHostRoute()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        model.navigate(.anotherHost)
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(model.closedSessions.isEmpty)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("peer takeover navigation preserves tmux during validation")
+    func peerTakeoverNavigationPreservesTmux() {
+        let model = TmuxRoutePresentationModel()
+        let hostingView = hostView(
+            TmuxRoutePresentationHarness(model: model),
+            size: CGSize(width: 100, height: 100)
+        )
+
+        model.navigateToPeerHost()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        #expect(model.hideCount == 0)
+        withExtendedLifetime(hostingView) {}
+    }
+
+    @Test("pinned console preserves peer takeover navigation suppression")
+    func pinnedConsolePreservesPeerTakeoverNavigationSuppression() {
+        let targetHostID = UUID()
+        let pending = WorkspaceSelection(selectedHostID: targetHostID)
+        let selection = WorkspaceSelection(
+            selectedHostID: targetHostID,
+            consoleBindingMode: .pinHost,
+            pinnedConsoleHostID: UUID()
+        )
+
+        #expect(RootView.isPeerTakeoverNavigation(
+            selection,
+            pending: pending
+        ))
     }
 
     @Test("Root refuses contradictory native presentations")
@@ -1357,15 +1533,60 @@ private final class HerdrRoutePresentationModel: ObservableObject {
 
 private struct HerdrRoutePresentationHarness: View {
     @ObservedObject var model: HerdrRoutePresentationModel
+    var suppressesDeactivation = false
 
     var body: some View {
         Color.clear.modifier(
             HerdrSessionPresentationLifecycleModifier(
                 selection: model.selection,
                 activeSession: model.activeSession,
+                suppressesDeactivation: suppressesDeactivation,
                 deactivate: { session in
                     model.recordClosedSession(session)
                 }
+            )
+        )
+    }
+}
+
+@MainActor
+private final class TmuxRoutePresentationModel: ObservableObject {
+    @Published var selection: WorkspaceSelection
+    let baseline: WorkspaceSelection
+    let activeSession: WorkspaceTmuxSessionSelection
+    private(set) var hideCount = 0
+    private let peerHostID = UUID()
+
+    init() {
+        let hostID = UUID()
+        baseline = WorkspaceSelection(selectedHostID: hostID)
+        selection = baseline
+        activeSession = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "editor"
+        )
+    }
+
+    func navigateToPeerHost() {
+        selection = WorkspaceSelection(selectedHostID: peerHostID)
+    }
+
+    func recordHide() {
+        hideCount += 1
+    }
+}
+
+private struct TmuxRoutePresentationHarness: View {
+    @ObservedObject var model: TmuxRoutePresentationModel
+
+    var body: some View {
+        Color.clear.modifier(
+            TmuxSessionPresentationLifecycleModifier(
+                selection: model.selection,
+                selectionBaseline: model.baseline,
+                activeSession: model.activeSession,
+                suppressesHide: true,
+                hide: model.recordHide
             )
         )
     }

--- a/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
+++ b/Tests/UI/TmuxSessionPresentationLifecycleTests.swift
@@ -455,6 +455,49 @@ struct TmuxSessionPresentationLifecycleTests {
         ) == nil)
     }
 
+    @Test("Root forwards the active Zellij reconnect action")
+    func rootForwardsZellijReconnect() {
+        var host = HostSummary.fixture()
+        host.zellijAvailable = true
+        host.zellijSessions = [ZellijSessionSummary(name: "api")]
+        let zellij = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        var selection = WorkspaceSelection(selectedHostID: host.id)
+        var reconnectAction: (() -> Void)?
+        var reconnectCount = 0
+        let hostingView = hostView(
+            RootView(
+                display: WorkspaceDisplayState(
+                    snapshot: .fixture(hosts: [host]),
+                    activeZellijSession: zellij
+                ),
+                content: ContentBuilders(
+                    zellijSessionContentBuilder: { _, _, _, actions in
+                        reconnectAction = actions.reconnectNow
+                        return AnyView(ActiveHerdrPresentationMarker())
+                    }
+                ),
+                handlers: InteractionHandlers(
+                    reconnectActiveZellijSessionNow: {
+                        reconnectCount += 1
+                    }
+                ),
+                selection: Binding(
+                    get: { selection },
+                    set: { selection = $0 }
+                )
+            ),
+            size: CGSize(width: 960, height: 640)
+        )
+
+        reconnectAction?()
+
+        #expect(reconnectCount == 1)
+        withExtendedLifetime(hostingView) {}
+    }
+
     @Test("Herdr survives selection collapse to its host route")
     func herdrSurvivesHostRouteSelectionCollapse() {
         let model = HerdrRoutePresentationModel()

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -228,6 +228,47 @@ struct WorkspaceSidebarModelTests {
         #expect(!herdr.isEmpty)
     }
 
+    @Test("Zellij sessions have an independent group and ordering")
+    func zellijSessionRowsAndOrdering() {
+        let hostID = UUID()
+        let sessions = ["alpha", "beta", "gamma"]
+        let host = HostSummary.fixture(
+            id: hostID,
+            zellijSessions: sessions.reversed().map(
+                ZellijSessionSummary.init(name:)
+            ),
+            zellijAvailable: true
+        )
+        let ids = sessions.map {
+            WorkspaceSidebarModel.zellijSessionOrderID(
+                hostID: hostID,
+                name: $0
+            )
+        }
+        var order = WorkspaceSidebarOrder()
+        let didMove = order.move(ids[0], to: ids[2], within: ids)
+        #expect(didMove)
+
+        let section = WorkspaceSidebarModel.sections(
+            in: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionOrderRawValue: order.rawValue
+        )[0]
+
+        #expect(section.zellijSessionRows.map(\.title)
+            == ["beta", "gamma", "alpha"])
+        #expect(section.zellijSessionRows[0].target == .zellijSession(
+            hostID: hostID,
+            name: "beta"
+        ))
+        #expect(section.zellijSessionRows[0].icon == .zellijSession)
+        #expect(section.zellijSessionRows[0].subtitle == "Zellij session")
+        #expect(section.visibleGroups == [.zellijSessions])
+    }
+
     @Test("sidebar hierarchy advances one compact indent per level")
     func hierarchyIndentAdvancesByLevel() {
         let host = WorkspaceSidebarHierarchy.indent(level: 0)

--- a/Tests/UI/WorkspaceSidebarViewTests.swift
+++ b/Tests/UI/WorkspaceSidebarViewTests.swift
@@ -10,10 +10,12 @@ struct WorkspaceSidebarViewTests {
     func sectionActionsTargetExactHost() throws {
         let host = HostSummary.fixture(
             id: UUID(),
-            herdrAvailable: true
+            herdrAvailable: true,
+            zellijAvailable: true
         )
         var tmuxHosts: [UUID] = []
         var herdrHosts: [UUID] = []
+        var zellijHosts: [UUID] = []
         var projectHosts: [UUID] = []
         let action = { section in
             WorkspaceSidebarSectionActionModel.action(
@@ -21,15 +23,18 @@ struct WorkspaceSidebarViewTests {
                 host: host,
                 onNewTmuxSession: { tmuxHosts.append($0.id) },
                 onNewHerdrSession: { herdrHosts.append($0.id) },
+                onNewZellijSession: { zellijHosts.append($0.id) },
                 onAddProject: { projectHosts.append($0.id) }
             )
         }
 
         try #require(action(.tmuxSessions)).perform()
         try #require(action(.herdrSessions)).perform()
+        try #require(action(.zellijSessions)).perform()
         try #require(action(.projects)).perform()
         #expect(tmuxHosts == [host.id])
         #expect(herdrHosts == [host.id])
+        #expect(zellijHosts == [host.id])
         #expect(projectHosts == [host.id])
     }
 
@@ -63,6 +68,7 @@ struct WorkspaceSidebarViewTests {
             host: unavailableHost,
             onNewTmuxSession: { _ in },
             onNewHerdrSession: { _ in },
+            onNewZellijSession: { _ in },
             onAddProject: { _ in }
         ) == nil)
     }
@@ -86,6 +92,7 @@ struct WorkspaceSidebarViewTests {
             host: host,
             onNewTmuxSession: { _ in },
             onNewHerdrSession: { _ in },
+            onNewZellijSession: { _ in },
             onAddProject: { _ in }
         ) == nil)
     }

--- a/Tests/Zellij/ZellijAttachmentInfoTests.swift
+++ b/Tests/Zellij/ZellijAttachmentInfoTests.swift
@@ -1,0 +1,96 @@
+import GhosthubTransport
+import Testing
+@testable import GhosthubZellij
+
+@Suite("Native Zellij attachment")
+struct ZellijAttachmentInfoTests {
+    @Test("local attachment removes inherited Zellij identity")
+    func localAttachment() throws {
+        let command = try ZellijAttachmentInfo(
+            sessionName: "release work",
+            host: .local
+        ).attachCommand(zellijPath: "/opt/homebrew/bin/zellij")
+
+        #expect(command.contains("unset ZELLIJ ZELLIJ_PANE_ID ZELLIJ_SESSION_NAME"))
+        #expect(command.contains("attach"))
+        #expect(command.contains("release work"))
+        #expect(!command.contains("--create"))
+    }
+
+    @Test("attachment terminates options before a leading-dash name")
+    func attachmentLeadingDashName() throws {
+        let command = try ZellijAttachmentInfo(
+            sessionName: "-release",
+            host: .local
+        ).attachCommand(zellijPath: "/usr/bin/zellij")
+
+        #expect(command.contains(
+            #"'\''attach'\'' '\''--'\'' '\''-release'\''"#
+        ))
+    }
+
+    @Test("new session refuses live and resurrectable name collisions")
+    func create() throws {
+        let command = try ZellijAttachmentInfo(
+            sessionName: "new-session",
+            host: .local
+        ).attachCommand(
+            zellijPath: "/usr/local/bin/zellij",
+            launchMode: .create
+        )
+
+        #expect(command.contains("--session"))
+        #expect(command.contains("new-session"))
+        #expect(!command.contains("'attach'"))
+    }
+
+    @Test("creation joins a leading-dash name to the session option")
+    func creationLeadingDashName() throws {
+        let command = try ZellijAttachmentInfo(
+            sessionName: "-release",
+            host: .local
+        ).attachCommand(
+            zellijPath: "/usr/bin/zellij",
+            launchMode: .create
+        )
+
+        #expect(command.contains("'--session=-release'"))
+        #expect(!command.contains("'--session' '-release'"))
+    }
+
+    @Test("remote attachment allocates a PTY and uses the account shell")
+    func remoteAttachment() throws {
+        let command = try ZellijAttachmentInfo(
+            sessionName: "ops",
+            host: .ssh(SSHHostInfo(
+                user: "dev",
+                hostname: "example.test",
+                port: 2222
+            ))
+        ).attachCommand(
+            zellijPath: "/usr/bin/zellij",
+            sshConnectionArguments: ["-o", "ControlPath=/tmp/control"]
+        )
+
+        #expect(command.contains("-tt"))
+        #expect(command.contains("dev@example.test"))
+        #expect(command.contains("ControlPath=/tmp/control"))
+        #expect(command.contains("/usr/bin/zellij"))
+    }
+
+    @Test("kill targets one shell-quoted session name")
+    func killCommand() {
+        #expect(ZellijSessionLifecycle.killCommand(
+            zellijPath: "/usr/bin/zellij",
+            sessionName: "release work"
+        ) == "'/usr/bin/zellij' 'kill-session' '--' 'release work'")
+    }
+
+    @Test("kill terminates options before a leading-dash name")
+    func killLeadingDashName() {
+        #expect(ZellijSessionLifecycle.killCommand(
+            zellijPath: "/usr/bin/zellij",
+            sessionName: "-release"
+        ) == "'/usr/bin/zellij' 'kill-session' '--' '-release'")
+    }
+}

--- a/Tests/Zellij/ZellijExecutableTests.swift
+++ b/Tests/Zellij/ZellijExecutableTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import GhosthubZellij
+
+@Suite("Zellij executable discovery")
+struct ZellijExecutableTests {
+    @Test("successful output without the marker is rejected")
+    func missingMarker() {
+        #expect(
+            ZellijExecutable.parse(
+                status: 0,
+                stdout: "/usr/bin/zellij\n",
+                stderr: ""
+            ) == .failure(.missingMarker)
+        )
+    }
+}

--- a/Tests/Zellij/ZellijSessionListTests.swift
+++ b/Tests/Zellij/ZellijSessionListTests.swift
@@ -1,0 +1,83 @@
+import Testing
+@testable import GhosthubZellij
+
+@Suite("Zellij session inventory")
+struct ZellijSessionListTests {
+    @Test("unformatted output becomes active session names")
+    func parsesNames() {
+        #expect(
+            ZellijSessionList.parse(
+                status: 0,
+                stdout: """
+                Last login: Mon Aug 10 08:30:00 on ttys001
+                GHOSTHUB_ZELLIJ_SESSIONS
+                api [Created 2m 3s ago]
+                release work [Created 1h 4m ago] (current)
+                old work [Created 3d 1h ago] (EXITED - attach to resurrect)
+
+                """,
+                stderr: ""
+            ) == .available(["api", "release work"])
+        )
+    }
+
+    @Test("inventory command frames Zellij output")
+    func commandFramesOutput() {
+        #expect(
+            ZellijSessionList.command(zellijPath: "/opt/Zellij Bin/zellij")
+                == "printf '\\n%s\\n' 'GHOSTHUB_ZELLIJ_SESSIONS'; "
+                + "printf '\\n%s\\n' 'GHOSTHUB_ZELLIJ_ERRORS' >&2; "
+                + "exec '/opt/Zellij Bin/zellij' 'list-sessions' "
+                + "'--no-formatting'"
+        )
+    }
+
+    @Test("missing Zellij is an unavailable optional capability")
+    func missingExecutable() {
+        #expect(
+            ZellijSessionList.parse(
+                status: 127,
+                stdout: "",
+                stderr: "zellij: command not found"
+            ) == .unavailable
+        )
+    }
+
+    @Test("a no-sessions response is an available empty inventory")
+    func emptyInventory() {
+        #expect(
+            ZellijSessionList.parse(
+                status: 1,
+                stdout: "",
+                stderr: """
+                shell startup warning
+                GHOSTHUB_ZELLIJ_ERRORS
+                No active zellij sessions found.
+
+                """
+            ) == .available([])
+        )
+    }
+
+    @Test("unrecognized output remains a visible inventory failure")
+    func malformedInventory() {
+        #expect(
+            ZellijSessionList.parse(
+                status: 0,
+                stdout: "login banner\nGHOSTHUB_ZELLIJ_SESSIONS\nunexpected output\n",
+                stderr: ""
+            ) == .failure(.malformedInventory(line: "unexpected output"))
+        )
+    }
+
+    @Test("successful output without the inventory marker is rejected")
+    func missingMarker() {
+        #expect(
+            ZellijSessionList.parse(
+                status: 0,
+                stdout: "api [Created 2m 3s ago]\n",
+                stderr: ""
+            ) == .failure(.missingMarker)
+        )
+    }
+}

--- a/Tests/test_demo_scripts.py
+++ b/Tests/test_demo_scripts.py
@@ -308,6 +308,84 @@ def test_demo_herdr_requires_staged_scratch_ownership(tmp_path: Path) -> None:
     assert result.stdout == ""
     assert "demo scratch is not staged" in result.stderr
 
+
+def run_zellij_until_render(
+    fixture: Path,
+    arguments: list[str],
+    *,
+    env: dict[str, str],
+) -> tuple[str, str]:
+    process = subprocess.Popen(
+        [str(fixture), *arguments],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=0.2)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        stdout, stderr = process.communicate(timeout=1)
+    return stdout, stderr
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "scratch_variable", "render_prefix", "kill_name"),
+    [
+        (
+            "bin/zellij",
+            "GHOSTHUB_DEMO_SCRATCH",
+            "Zellij demo session",
+            "-release",
+        ),
+        (
+            "remote/zellij",
+            "GHOSTHUB_DEMO_REMOTE_SCRATCH",
+            "Remote Zellij demo session",
+            "gpu-console",
+        ),
+    ],
+)
+def test_demo_zellij_accepts_hardened_session_arguments(
+    tmp_path: Path,
+    fixture_name: str,
+    scratch_variable: str,
+    render_prefix: str,
+    kill_name: str,
+) -> None:
+    scratch = tmp_path / "zellij"
+    scratch.mkdir(mode=0o700)
+    (scratch / ".ghosthub-demo-scratch").touch()
+    fixture = DEMO / fixture_name
+    env = {**os.environ, scratch_variable: str(scratch)}
+
+    attached, attach_error = run_zellij_until_render(
+        fixture,
+        ["attach", "--", "-release"],
+        env=env,
+    )
+    created, create_error = run_zellij_until_render(
+        fixture,
+        ["--session=-new-release"],
+        env=env,
+    )
+    killed = subprocess.run(
+        [str(fixture), "kill-session", "--", kill_name],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert f"{render_prefix}: -release" in attached, attach_error
+    assert f"{render_prefix}: -new-release" in created, create_error
+    assert killed.returncode == 0, killed.stderr
+    assert (scratch / f"zellij-killed-{kill_name}").is_file()
+
 @pytest.mark.parametrize(
     ("launcher_shell", "launcher_zdotdir"),
     [

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,20 +7,21 @@ the [Threat Model](threat-model.md).
 
 ## Mental Model
 
-- **Host:** a machine that runs tmux and optionally Herdr sessions. The local
+- **Host:** a machine that runs tmux and optionally Herdr or Zellij sessions. The local
   Mac is the default host. Remote hosts are reachable over SSH, commonly
   through a tailnet.
 - **Project:** a git repository reported by kwt on a host.
 - **Worktree:** a kwt workspace with an exact tmux session name.
 - **Directory workspace:** one kwt-registered plain directory with an exact
   tmux session name and no Git children.
-- **Session:** an ordinary tmux session or running/stopped Herdr session on a host.
+- **Session:** an ordinary tmux session, running/stopped Herdr session, or
+  active Zellij session on a host.
 
 The sidebar is a host-wide session navigator. Its **Projects** group shows
 repository hierarchies followed by flat registered-directory rows. It also
-shows directly discovered tmux sessions and running or stopped Herdr sessions
-on each host, including sessions that were not created by Ghosthub or kwt. The
-three inventories are independent; kwt worktrees and directory workspaces
+shows directly discovered tmux sessions, running or stopped Herdr sessions,
+and active Zellij sessions on each host, including sessions that were not
+created by Ghosthub or kwt. The four inventories are independent; kwt worktrees and directory workspaces
 remain tmux-backed. Users may hide matching standalone tmux sessions
 from navigation with case-sensitive wildcard patterns; discovery retains the
 complete inventory so a kwt-owned session confirmed by current discovery is
@@ -28,7 +29,7 @@ indicated on its worktree or directory row. Cached sessions do not remain live
 while a host is unreachable. Kwt-owned sessions are hidden from the separate tmux session
 group by default, with a Worktrees setting that exposes those duplicate
 entries.
-Tmux and Herdr sessions are each presented through their ordinary native
+Tmux, Herdr, and Zellij sessions are each presented through their ordinary native
 whole-session client. The selected backend alone owns and renders its internal
 layout, and each scene presents at most one such client.
 
@@ -59,8 +60,8 @@ into native UI.
 
 The workspace `WindowGroup` is data-backed. Each scene continuously captures a
 small logical descriptor containing stable host and project keys, the durable
-kwt worktree generation or registered directory path, and either exact tmux
-session/protected-socket identity or exact Herdr session identity. Its window UUID exists only for native scene
+kwt worktree generation or registered directory path, and an exact tmux
+session/protected-socket, Herdr session, or Zellij session identity. Its window UUID exists only for native scene
 adoption; runtime model UUIDs and worktree paths are never persisted as host,
 project, or worktree identity. A worktree without a canonical generation
 degrades to project-only navigation and does not persist its worktree-owned
@@ -102,8 +103,9 @@ refreshes. Explicit user navigation cancels pending restoration so a stale
 scene can never take the window back.
 Herdr restoration requires a completed fresh Herdr probe for the restored host
 and the exact running name; cached pre-refresh rows never authorize attachment.
-A captured scene contains one tmux descriptor, one Herdr descriptor, or neither,
-never both.
+Zellij restoration has the same fresh-inventory requirement for the exact
+active name. A captured scene contains one tmux, Herdr, or Zellij descriptor,
+or none, never more than one.
 A scene captured without an active native presentation restores its navigation
 without opening or creating the selected worktree or directory session; the
 user explicitly selects the workspace to attach again.
@@ -120,8 +122,8 @@ the final workspace window leaves Ghosthub running, matching ordinary macOS
 terminal behavior; Cmd-Q remains the explicit app-termination path. Ghosthub
 confirms app termination by default, and users can disable that confirmation in
 **Settings -> Terminal**. Closing presentations or quitting never terminates a
-tmux or Herdr session: both detach clients. Kill Session remains a separate
-confirmed tmux action. Herdr exposes separate Create, Stop, Restart, and Delete
+tmux, Herdr, or Zellij session: all detach clients. Kill Session remains a
+separate confirmed tmux or Zellij action. Herdr exposes separate Create, Stop, Restart, and Delete
 actions; Stop and Delete require confirmation and are never implied by
 navigation or closing.
 
@@ -135,7 +137,7 @@ The Swift app owns native presentation and terminal rendering:
 - libghostty surface lifecycle, input, resize, and rendering.
 - Workspace/session selection and presentation state.
 - Local GRDB persistence for app-owned state.
-- SSH host settings and native tmux/Herdr client presentation.
+- SSH host settings and native tmux/Herdr/Zellij client presentation.
 
 Swift should stay focused on native app behavior and terminal hosting. Shared
 pure domain models belong in `Sources/Workspace`; external workspace state is
@@ -395,9 +397,9 @@ the environment of an existing session or running pane.
 
 ## Startup and Onboarding
 
-Ghosthub starts independent kwt, tmux, and Herdr inventories before deciding
-which empty state to show. Herdr is additive and never blocks the workspace;
-missing Herdr is silent. Existing users go directly to their host-wide session
+Ghosthub starts independent kwt, tmux, Herdr, and Zellij inventories before deciding
+which empty state to show. Herdr and Zellij are additive and never block the workspace;
+missing installations are silent. Existing users go directly to their host-wide session
 sidebar;
 there is no repository-intake interstitial and no first-launch modal.
 
@@ -421,6 +423,7 @@ repositories.
 | `Sources/Transport/` | Shared local/SSH routing, quoting, and command execution primitives |
 | `Sources/Tmux/` | Native tmux discovery and attachment command model |
 | `Sources/Herdr/` | Native Herdr discovery and attachment command model |
+| `Sources/Zellij/` | Native Zellij discovery and attachment command model |
 | `Sources/Workspace/` | Pure workspace, host, project, worktree, and session models |
 | `Sources/Persistence/` | GRDB repositories for app-local state |
 | `tools/` | Python bootstrap and packaging automation |
@@ -434,7 +437,7 @@ remain visible, and explicit reloads publish a user-visible result.
 
 ## Session Attachment
 
-Each scene owns one native presentation slot shared by tmux and Herdr.
+Each scene owns one native presentation slot shared by tmux, Herdr, and Zellij.
 Selecting either backend disposes the other client before opening the new one.
 Herdr discovery and attachment are supported on the local Mac and configured
 remote POSIX hosts, not experimental Windows/psmux hosts. Ghosthub shows
@@ -453,6 +456,35 @@ state, and Herdr record immediately before execution. Herdr exposes no stable
 session-generation identifier, so same-name/same-socket replacement cannot
 receive tmux-strength identity protection; this race is documented rather than
 hidden behind a false guarantee.
+
+Zellij discovery and attachment are supported on the local Mac and configured
+remote POSIX hosts. Ghosthub lists only active sessions, filtering Zellij's
+exited/resurrectable entries. Ordinary open and restoration use attach-only;
+remote restoration samples and rechecks one SSH connection snapshot, then
+passes that frozen route to the client presentation. If the route changes,
+restoration is canceled without attaching.
+New Zellij Session uses `--session`, which refuses active and resurrectable
+name collisions while Zellij creates and presents the new session. Ghosthub
+does not expose resurrection or delete exited sessions and does not manage
+tabs, panes, layouts, themes, plugins, configuration, updates, or processes
+inside a session. Zellij provides no atomic active-only attachment, so a
+session that exits between Ghosthub's active-state probe and `zellij attach`
+may be resurrected by Zellij; Ghosthub does not pass `--force-run-commands`.
+
+Closing a Zellij presentation only detaches. Kill Session is a separate
+confirmed action that revalidates the exact name and current host immediately
+before `kill-session`. A shared kill fence cancels matching reconnects and
+detaches matching presentations across workspace scenes before the command,
+preventing an already-launched Ghosthub client from undoing an intentional
+kill. The successful event also invalidates in-flight Zellij discovery, removes
+the killed row from every scene's cached inventory, and starts fresh discovery.
+Per-session kill revisions prevent validation begun before the kill from
+attaching afterward. A failed kill releases the fence and revalidates an
+eligible detached presentation or matching pending open or restoration before
+resuming it, while preserving its navigation and route checks. Zellij exposes
+no stable session-generation identifier, so a same-name replacement between
+that final check and the command remains an accepted race rather than receiving
+tmux's stronger identity guarantee.
 
 Kwt workspaces and otherwise-unbound host sessions use the same native tmux
 client. Ghosthub never projects tmux windows or panes into a Swift split tree.
@@ -597,6 +629,15 @@ Herdr's JSON session list is independently authoritative for running and
 stopped Herdr sessions. Exit 127 means optional capability absence and emits no diagnostic;
 malformed output or another failure produces only a host-scoped warning and
 never changes tmux reachability, kwt availability, or blocking workspace state.
+Zellij's unformatted session list is independently authoritative for active
+Zellij sessions. Exited entries are excluded. Missing Zellij is silent, while
+malformed output or another failure produces only a host-scoped warning.
+Tmux, Herdr, and Zellij fleet sweeps accumulate their host results and publish
+the completed runtime inventory once. Session-only publication uses the
+runtime overlay, which cannot reconcile kwt projects or worktrees and cannot
+normalize their paths. The full overlay remains reserved for authoritative kwt
+changes. Application activation starts neither inventory discovery nor process
+sampling; explicit refresh and lifecycle reconciliation own those costs.
 
 Ghosthub local persistence stores app-owned state:
 
@@ -612,6 +653,6 @@ current schema, bootstrap paths, fixtures, and tests directly.
 ## Direction
 
 Ghosthub should remain a native terminal client and session switcher: one
-sidebar for tmux and Herdr fleets across a user's Macs, Linux hosts, and tailnet.
+sidebar for tmux, Herdr, and Zellij fleets across a user's Macs, Linux hosts, and tailnet.
 The native app owns discovery, native client presentation, and SSH reconnect
-supervision. It does not reconstruct tmux or Herdr terminal state in Swift.
+supervision. It does not reconstruct tmux, Herdr, or Zellij terminal state in Swift.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -632,12 +632,13 @@ never changes tmux reachability, kwt availability, or blocking workspace state.
 Zellij's unformatted session list is independently authoritative for active
 Zellij sessions. Exited entries are excluded. Missing Zellij is silent, while
 malformed output or another failure produces only a host-scoped warning.
-Tmux, Herdr, and Zellij fleet sweeps accumulate their host results and publish
-the completed runtime inventory once. Session-only publication uses the
-runtime overlay, which cannot reconcile kwt projects or worktrees and cannot
-normalize their paths. The full overlay remains reserved for authoritative kwt
-changes. Application activation starts neither inventory discovery nor process
-sampling; explicit refresh and lifecycle reconciliation own those costs.
+Zellij fleet sweeps accumulate their host results and publish the completed
+runtime inventory once. Tmux and Herdr publish host-scoped runtime results as
+hosts complete. Session-only publication uses the runtime overlay, which cannot
+reconcile kwt projects or worktrees and cannot normalize their paths. The full
+overlay remains reserved for authoritative kwt changes. Application activation
+starts neither inventory discovery nor process sampling; explicit refresh and
+lifecycle reconciliation own those costs.
 
 Ghosthub local persistence stores app-owned state:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,18 +5,18 @@ description: Internal engineering guide for Ghosthub
 
 # Ghosthub
 
-Ghosthub is a native macOS terminal for local and remote tmux and Herdr
-fleets. It gives equal status to ordinary tmux sessions, running Herdr
-sessions, and tmux sessions bound to managed git worktrees, all presented
-through libghostty terminal surfaces.
+Ghosthub is a native macOS terminal for all local and remote multiplexer
+fleets. Today it gives equal status to ordinary tmux sessions, Herdr sessions,
+and Zellij sessions, plus tmux sessions bound to managed git worktrees. All are
+presented through libghostty terminal surfaces.
 
 Ghosthub is alpha software. These are internal engineering docs for Kenn
 engineers and approved contributors building, operating, and releasing it.
 
 ## What Ghosthub Is
 
-- A native terminal and control plane for local and remote tmux and Herdr
-  sessions.
+- A native terminal and control plane for all supported local and remote
+  multiplexers: today, tmux, Herdr, and Zellij.
 - A native Swift app built around embedded libghostty terminal surfaces.
 - A manager for optional worktree-bound sessions and their lifecycle through
   kwt, including branch and GitHub pull-request imports.
@@ -35,7 +35,7 @@ Ghosthub.app
   ├─ SwiftUI/AppKit workspace shell
   ├─ libghostty terminal surfaces
   ├─ local app persistence
-  ├─ native tmux and Herdr clients with SSH reconnect
+  ├─ native tmux, Herdr, and Zellij clients with SSH reconnect
   ├─ bundled kwt for local worktree state
   └─ managed architecture-matched kwt and host tmux over SSH
 ```

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -6,8 +6,8 @@ configuration and launcher-terminal environment.
 
 ## Product Boundary
 
-Ghosthub is a native session switcher for tmux and Herdr fleets across the
-local Mac and configured SSH hosts. There are three independent inventory
+Ghosthub is a native session switcher for tmux, Herdr, and Zellij fleets across the
+local Mac and configured SSH hosts. There are four independent inventory
 sources:
 
 - **kwt workspaces:** projects, worktrees, and registered plain directories
@@ -17,9 +17,12 @@ sources:
   list-sessions` discovery on the host.
 - **Herdr sessions:** running and stopped sessions returned by `herdr session list --json`
   on the local Mac and remote POSIX hosts.
+- **Zellij sessions:** active sessions returned by `zellij list-sessions
+  --no-formatting` on the local Mac and remote POSIX hosts. Exited,
+  resurrectable sessions are filtered out.
 
 The two tmux-backed sources open through the same ordinary tmux client in one
-libghostty surface. Herdr opens through its ordinary whole-session client. A
+libghostty surface. Herdr and Zellij open through their ordinary whole-session clients. A
 session created by Middleman is visible when it exists on the host tmux server,
 but Ghosthub does not consult Middleman to identify, create, attach, mutate, or
 destroy it.
@@ -29,8 +32,8 @@ New Tmux Session for a host. This is not a separate managed-session type: the
 result immediately joins the same direct tmux inventory and has the same
 detach-only presentation lifecycle as every other session.
 
-Herdr is optional. Exit 127 during its capability or inventory probe is silent
-and does not affect host usability. Invalid output and real command failures
+Herdr and Zellij are optional. Exit 127 during either capability or inventory
+probe is silent and does not affect host usability. Invalid output and real command failures
 produce only a host-scoped warning; they never change tmux reachability, kwt
 availability, cached project inventory, or the workspace's blocking state.
 
@@ -116,7 +119,7 @@ remote-client mode.
 Herdr owns workspaces, tabs, panes, layout, history, key bindings, terminal
 state, and the processes inside each session. Ghosthub owns discovery,
 whole-session lifecycle requests, and the disposable client presentation. Each
-scene may present either one tmux client or one Herdr client, never both.
+scene may present one tmux, Herdr, or Zellij client, never more than one.
 Navigating away, pressing Cmd-W, closing a window, or quitting closes only the
 client. Ghosthub never reconstructs or otherwise controls Herdr themes,
 workspaces, tabs, panes, agents, plugins, installation, updates, configuration,
@@ -191,6 +194,50 @@ Live validation and automated fixtures must isolate Herdr with
 `XDG_CONFIG_HOME`. `HERDR_CONFIG_PATH` alone is insufficient because it does
 not relocate all session state.
 
+## Native Zellij Attachment
+
+Ghosthub resolves `zellij` in the host account's login environment and opens an
+active session with `zellij attach <exact-name>`. **New Zellij Session** uses
+`zellij --session <exact-name>`, which creates and presents a new session while
+refusing both active and resurrectable name collisions. Local sessions use
+libghostty's normal macOS login-shell path. Remote sessions use an ordinary
+OpenSSH PTY with keepalives and the remote account login environment.
+
+Zellij owns tabs, panes, layout, history, key bindings, terminal state,
+configuration, plugins, and every process inside the session. Ghosthub owns
+active-session discovery and the disposable client presentation. It does not
+offer pane actions, an explicit resurrection workflow, or deletion of
+resurrection data. Zellij does not expose an atomic active-only attachment:
+Ghosthub validates the exact name as active first, but if the session exits
+before `zellij attach` resolves it, Zellij may resurrect its saved layout.
+Ghosthub never passes `--force-run-commands`; this narrow upstream race is
+accepted rather than represented as a false attach-only guarantee. Discovery
+and attachment remove inherited `ZELLIJ`, `ZELLIJ_PANE_ID`, and
+`ZELLIJ_SESSION_NAME` values so launching Ghosthub from inside Zellij cannot
+redirect the new client into the enclosing session.
+
+Navigating away, pressing Cmd-W, closing a window, or quitting closes only the
+client. A clean detach stays detached until the user reconnects. A remote SSH
+transport failure probes the exact active session before launching a
+replacement client and stops recovery if the session disappears, Zellij is no
+longer available, or the failure requires connection review.
+
+**Kill Session** is the only destructive Zellij lifecycle action. Ghosthub
+confirms the host and name, establishes a shared same-session kill fence, then
+repeats active-session discovery against the current endpoint immediately
+before `zellij kill-session <exact-name>`. The fence cancels matching reconnect
+attempts and detaches matching presentations in every scene before the command,
+so neither a reconnect nor an already-launched client can immediately resurrect
+a deliberately killed session. Successful kills invalidate in-flight Zellij
+discovery, remove the row from every scene, and begin a fresh inventory probe.
+A per-session kill revision also rejects attachment validation that began
+before the kill. A failed kill releases the fence and revalidates an eligible
+detached presentation or matching pending open or restoration before resuming
+it, while preserving its navigation and route checks. Zellij does not expose a
+stable session-generation identifier, so a same-name replacement between that
+final check and the kill command cannot receive tmux's replacement-identity
+guarantee. Closing or disconnecting never implies a kill.
+
 ## Relaunch Restoration
 
 Quitting Ghosthub or installing an update only drops disposable clients. When
@@ -231,6 +278,12 @@ the descriptor's exact host reports that exact name as running. A missing or
 stopped session remains pending and never substitutes another name. Because
 Herdr's attach command can restart a server that stops after the final probe,
 Ghosthub accepts only that narrow probe-to-launch race.
+An ordinary Zellij session restores only after a completed fresh Zellij probe
+on the exact host reports the exact name as active. Remote restoration then
+validates that session against one SSH connection snapshot, rechecks the route,
+and reuses the snapshot for attachment; route drift cancels restoration. It
+never creates a missing session intentionally, but the same unavoidable Zellij
+probe-to-attach resurrection race applies.
 Offline or otherwise unavailable targets remain pending and retry when normal
 inventory refreshes publish new state. Navigating the window elsewhere cancels
 the pending target. If a scene was captured without an active native
@@ -376,7 +429,7 @@ attach-only client. Confirmed absence ends a default-socket or protected-socket
 presentation only when that exact session had already been established; an
 unconfirmed interrupted kwt establishment may rerun its one-shot creation path.
 A reachable non-transport client failure is presented as unable to attach
-rather than retried indefinitely. A clean tmux or Herdr detach does not start
+rather than retried indefinitely. A clean tmux, Herdr, or Zellij detach does not start
 recovery. Herdr recovery shares only the supervisor policy: each attempt uses
 its own exact Herdr session probe, stops when Herdr is unavailable or the name
 is absent, and never creates a terminal surface for an unsuccessful probe.
@@ -409,7 +462,7 @@ build 22523 or newer. Older ConPTY builds preserve keyboard input but consume
 psmux mouse-reporting sequences; supporting them would require the separate
 psmux `ssh -T` wrapper and is not part of this experiment.
 
-Tmux and Herdr servers remain alive on the remote host while the network is
+Tmux, Herdr, and Zellij servers remain alive on the remote host while the network is
 unavailable. After connectivity returns, the client reattaches to the same
 exact session and its backend renders authoritative state. Copy-mode and
 programs on configured remote
@@ -425,8 +478,9 @@ unsafe unbracketed text can reach the PTY.
 ## Inventory and Startup
 
 At startup Ghosthub loads kwt project/worktree inventory, tmux session
-inventory, and optional Herdr inventory for every supported resolvable host.
-Herdr is not probed on experimental Windows hosts. The initial content view
+inventory, and optional Herdr and Zellij inventories for every supported
+resolvable host. Herdr and Zellij are not probed on experimental Windows
+hosts. The initial content view
 remains in an
 explicit loading state until kwt returns, so the empty onboarding state never
 flashes before existing workspaces are known. That loaded empty state is

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -6,7 +6,7 @@ description: Security boundaries and trust assumptions for Ghosthub
 # Threat Model
 
 This document defines the security claims Ghosthub makes and the assumptions
-used to classify security findings. Ghosthub is a native terminal and tmux/Herdr
+used to classify security findings. Ghosthub is a native terminal and tmux/Herdr/Zellij
 control plane for one user across machines that user administers. It is not a
 sandbox or a hardened client for attaching to hostile terminal servers.
 
@@ -19,7 +19,7 @@ Ghosthub aims to protect:
 - terminal input and session metadata while they cross the network
 - the session lifecycle boundary: ordinary presentation only attaches or
   detaches; creation and termination require separate, explicit user actions,
-  with confirmation before tmux Kill and Herdr Stop/Delete
+  with confirmation before tmux or Zellij Kill and Herdr Stop/Delete
 - app-owned settings and persistence from unintended cross-host or
   cross-worktree mutation
 - application-update integrity, rooted in the reviewed Sparkle Ed25519 key,
@@ -27,7 +27,7 @@ Ghosthub aims to protect:
 
 The main security goals are to use the system SSH trust and encryption model,
 avoid sending local data to a remote pane except through an intentional
-terminal interaction, and keep tmux and Herdr presentation non-destructive
+terminal interaction, and keep tmux, Herdr, and Zellij presentation non-destructive
 outside explicit whole-session lifecycle requests.
 
 Herdr does not expose a stable session-generation identifier. Ghosthub
@@ -36,6 +36,11 @@ but does not claim that this prevents a same-name/same-socket replacement race.
 Stop can terminate every process in a session; Delete can permanently remove
 saved shape. Both actions require confirmation, and Delete is never offered for
 the default session.
+
+Zellij likewise does not expose a stable session-generation identifier.
+Ghosthub revalidates the selected host and active name before a confirmed
+kill, but does not claim protection from replacement in the remaining
+check-to-command race.
 
 ## Trust Boundaries
 
@@ -51,8 +56,9 @@ trusting a launcher-controlled local `PATH`.
 ### Configured SSH hosts
 
 Every remote host added to Ghosthub is a **trusted peer** administered by the
-user. This trust includes the host operating system, its SSH service, the tmux
-server and socket, and processes running in panes Ghosthub attaches to. SSH
+user. This trust includes the host operating system, its SSH service, the
+multiplexer servers and sockets, and processes running in panes Ghosthub
+attaches to. SSH
 host authentication and transport confidentiality are delegated to the user's
 OpenSSH configuration and host-key policy.
 

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -248,6 +248,22 @@ static BOOL DemoPalettePostcondition(NSString *kind,
   return NO;
 }
 
+static void DemoWaitForPalettePostcondition(
+    NSString *kind, NSWindow *paletteSheet, NSUInteger attemptsRemaining,
+    void (^completion)(BOOL)) {
+  BOOL matched = DemoPalettePostcondition(kind, paletteSheet);
+  if (matched || attemptsRemaining == 0) {
+    completion(matched);
+    return;
+  }
+  dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC),
+      dispatch_get_main_queue(), ^{
+        DemoWaitForPalettePostcondition(
+            kind, paletteSheet, attemptsRemaining - 1, completion);
+      });
+}
+
 static NSWindow *DemoRootWindow(void) {
   NSWindow *window = DemoControlledWindow;
   if (window == nil || !window.isVisible) {
@@ -550,12 +566,8 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                                     message:@"command palette lost its window"];
                           return;
                         }
-                        dispatch_after(
-                            dispatch_time(
-                                DISPATCH_TIME_NOW, 750 * NSEC_PER_MSEC),
-                            dispatch_get_main_queue(), ^{
-                              BOOL matched = DemoPalettePostcondition(
-                                  expectKind, paletteSheet);
+                        DemoWaitForPalettePostcondition(
+                            expectKind, paletteSheet, 50, ^(BOOL matched) {
                               [self acknowledge:requestID
                                         success:matched
                                         message:matched

--- a/website/demo/bin/zellij
+++ b/website/demo/bin/zellij
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Faux Zellij inventory for the isolated website screenshot environment.
+set -euo pipefail
+
+scratch="${GHOSTHUB_DEMO_SCRATCH:?GHOSTHUB_DEMO_SCRATCH is not set}"
+if [[ ! -f "$scratch/.ghosthub-demo-scratch" ]]; then
+  echo "faux zellij: demo scratch is not staged" >&2
+  exit 64
+fi
+
+if [[ "${1:-}" == "list-sessions" && "${2:-}" == "--no-formatting" \
+  && "$#" -eq 2 ]]; then
+  found=""
+  for name in release-shell docs-preview; do
+    if [[ ! -f "$scratch/zellij-killed-$name" ]]; then
+      printf '%s [Created 18m 7s ago]\n' "$name"
+      found=1
+    fi
+  done
+  printf 'archived-layout [Created 2d 3h ago] (EXITED - attach to resurrect)\n'
+  [[ -n "$found" ]] && exit 0
+  echo "No active zellij sessions found." >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "attach" && "${2:-}" == "--" \
+  && -n "${3:-}" && "$#" -eq 3 ]]; then
+  name="$3"
+  if [[ -f "$scratch/zellij-killed-$name" ]]; then
+    echo "faux zellij: session is not active" >&2
+    exit 1
+  fi
+  printf '\033[2J\033[HZellij demo session: %s\n\n' "$name"
+  printf 'Tabs, panes, and layout remain owned by Zellij.\n'
+  while true; do sleep 3600; done
+fi
+
+if [[ "${1:-}" == --session=* && "$#" -eq 1 ]]; then
+  name="${1#--session=}"
+  [[ -n "$name" ]] || exit 64
+  if [[ "$name" == "release-shell" || "$name" == "docs-preview" \
+    || "$name" == "archived-layout" \
+    || -f "$scratch/zellij-killed-$name" ]]; then
+    echo "faux zellij: session name already exists" >&2
+    exit 1
+  fi
+  printf '\033[2J\033[HZellij demo session: %s\n\n' "$name"
+  while true; do sleep 3600; done
+fi
+
+if [[ "${1:-}" == "kill-session" && "${2:-}" == "--" \
+  && -n "${3:-}" && "$#" -eq 3 ]]; then
+  touch "$scratch/zellij-killed-$3"
+  exit 0
+fi
+
+echo "faux zellij: unsupported command" >&2
+exit 64

--- a/website/demo/home/zprofile
+++ b/website/demo/home/zprofile
@@ -1,5 +1,5 @@
 # Copied to $SCRATCH/home/.zprofile by stage.sh. The demo app's login shells
-# source this, which routes Herdr to the fixture, kwt to its staged helper,
+# source this, which routes Herdr and Zellij to fixtures, kwt to its staged helper,
 # and tmux to the demo socket dir.
 if [ -n "${GHOSTHUB_DEMO_ROOT:-}" ]; then
   export PATH="$GHOSTHUB_DEMO_ROOT/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"

--- a/website/demo/remote/Dockerfile
+++ b/website/demo/remote/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update \
   && useradd -m -s /bin/bash demo
 
 COPY entry.sh /usr/local/bin/entry.sh
-RUN chmod +x /usr/local/bin/entry.sh
+COPY zellij /usr/local/bin/zellij
+RUN chmod +x /usr/local/bin/entry.sh /usr/local/bin/zellij
 
 EXPOSE 22
 CMD ["/usr/local/bin/entry.sh"]

--- a/website/demo/remote/zellij
+++ b/website/demo/remote/zellij
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Faux Zellij inventory for the isolated remote screenshot host.
+set -euo pipefail
+
+scratch="${GHOSTHUB_DEMO_REMOTE_SCRATCH:-/tmp}"
+
+if [[ "${1:-}" == "list-sessions" && "${2:-}" == "--no-formatting" \
+  && "$#" -eq 2 ]]; then
+  [[ -f "$scratch/zellij-killed-gpu-console" ]] \
+    || printf 'gpu-console [Created 42m 8s ago]\n'
+  printf 'old-benchmark [Created 4d 2h ago] (EXITED - attach to resurrect)\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "attach" && "${2:-}" == "--" \
+  && -n "${3:-}" && "$#" -eq 3 ]]; then
+  name="$3"
+  [[ -f "$scratch/zellij-killed-$name" ]] && exit 1
+  printf 'Remote Zellij demo session: %s\n' "$name"
+  while true; do sleep 3600; done
+fi
+
+if [[ "${1:-}" == --session=* && "$#" -eq 1 ]]; then
+  name="${1#--session=}"
+  [[ -n "$name" ]] || exit 64
+  [[ "$name" == "gpu-console" || "$name" == "old-benchmark" \
+    || -f "$scratch/zellij-killed-$name" ]] && exit 1
+  printf 'Remote Zellij demo session: %s\n' "$name"
+  while true; do sleep 3600; done
+fi
+
+if [[ "${1:-}" == "kill-session" && "${2:-}" == "--" \
+  && "${3:-}" == "gpu-console" && "$#" -eq 3 ]]; then
+  touch "$scratch/zellij-killed-gpu-console"
+  exit 0
+fi
+
+exit 64

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -253,14 +253,19 @@ capture_state hero.png
 echo "==> guide: ordinary worktree session"
 palette "add-session-filters"
 sleep 4
-# Select the running default Herdr row so its discoverable lifecycle menu
-# affordance remains visible while the palette names the available actions.
-# AppKit uses a bottom-left coordinate origin for the fixed demo window.
-demo_input click "120,578"
+# The hero capture collapses the local Zellij group to keep its terminal
+# content prominent. Reopen it, attach to a synthetic Zellij session, and
+# leave Tmux and Herdr visible as peer groups while the palette names the
+# available Zellij actions. AppKit uses a bottom-left coordinate origin.
+demo_input click "32,489"
+palette "docs-preview"
 sleep 2
-palette "Herdr" false
+palette "Zellij" false
 capture_state guide-sessions.png
 demo_input escape
+# Restore the compact disclosure state used by the later fixed-size captures.
+demo_input click "32,489"
+sleep 0.5
 
 echo "==> guide: remote host settings"
 palette "Open Hosts Settings" true sheet
@@ -349,43 +354,14 @@ if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
 fi
 
 prepare_command_tab() {
-  local query="$1" create="${2:-true}" select="${3:-palette}"
+  local query="$1" create="${2:-true}"
   if [[ "$create" == "true" ]]; then
     demo_input new-tab
     sleep 2
   fi
   demo_input frame "110,145,1500,820"
   sleep 1
-  if [[ "$select" == "row" ]]; then
-    case "$query" in
-      fix-reconnect-backoff)
-        demo_input click "32,310"
-        sleep 0.5
-        demo_input click "32,268"
-        sleep 0.5
-        demo_input click "80,202"
-        ;;
-      add-session-filters)
-        demo_input click "32,228"
-        sleep 0.5
-        demo_input click "32,185"
-        sleep 0.5
-        demo_input click "80,115"
-        ;;
-      docbank-export) demo_input click "80,613" ;;
-      release-watch) demo_input click "80,569" ;;
-      scratch) demo_input click "80,525" ;;
-      test-matrix) demo_input click "80,481" ;;
-      *)
-        echo "error: no fixed demo tab row for $query" >&2
-        return 1
-        ;;
-    esac
-  elif [[ "$select" == "press" ]]; then
-    demo_input press "$query"
-  else
-    palette "$query"
-  fi
+  palette "$query"
   sleep 3
   demo_input expect-window-title "$query"
   demo_input hide-sidebar
@@ -394,19 +370,14 @@ prepare_command_tab() {
 echo "==> guide: six-tab tmux workspace"
 demo_input new-window
 sleep 2
-if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" != "1" ]]; then
-  # The Overview captures leave Projects expanded. Collapse it so the first
-  # tab starts from the same sidebar state as the focused tabs-only workflow.
-  demo_input frame "110,145,1500,820"
-  demo_input click "32,310"
-  sleep 0.5
-fi
-prepare_command_tab "fix-reconnect-backoff" false row
-prepare_command_tab "add-session-filters" true row
-prepare_command_tab "scratch" true row
-prepare_command_tab "docbank-export" true row
-prepare_command_tab "release-watch" true row
-prepare_command_tab "test-matrix" true row
+# Palette commands are scoped to the controlled workspace, so tab selection
+# stays independent of every command-center window already on screen.
+prepare_command_tab "fix-reconnect-backoff" false
+prepare_command_tab "add-session-filters"
+prepare_command_tab "scratch"
+prepare_command_tab "docbank-export"
+prepare_command_tab "release-watch"
+prepare_command_tab "test-matrix"
 capture_state guide-native-tabs.png exact
 
 if [[ "${GHOSTHUB_DEMO_TABS_ONLY:-}" == "1" ]]; then

--- a/website/docs/content/getting-started.md
+++ b/website/docs/content/getting-started.md
@@ -1,5 +1,5 @@
 ---
-description: Install Ghosthub and attach to a local tmux or Herdr session.
+description: Install Ghosthub and attach to a local tmux, Herdr, or Zellij session.
 icon: lucide/rocket
 ---
 
@@ -13,18 +13,21 @@ Ghosthub currently requires:
 - macOS 26 (Tahoe) or newer
 - tmux 3.2 or newer for tmux sessions
 - Herdr 0.8.0 or newer for Herdr sessions
+- Zellij 0.44 or newer for Zellij sessions
 
 The Cmd-D and Cmd-Shift-D pane shortcuts require tmux 3.4 or newer or Herdr
 0.8.0 or newer on the attached session. With older versions, use your normal
 multiplexer split keys.
 
-Use either multiplexer or both. When the Herdr CLI is available on the local
+Use any supported multiplexer independently or together. When the Herdr CLI is available on the local
 Mac or a remote POSIX host, Ghosthub discovers its running and stopped sessions.
-Experimental Windows hosts do not support Herdr.
+When Zellij is available, Ghosthub discovers its active sessions and excludes
+exited/resurrectable entries. Experimental Windows hosts support neither Herdr
+nor Zellij.
 
-Ghosthub and Herdr are complementary, not competing choices. Keep using tmux
-and tmux-backed worktrees wherever they fit, run Herdr wherever it fits, and
-open both kinds of session from the same Ghosthub host sidebar.
+Ghosthub is a home for all supported multiplexers, not a competing session
+format. Keep using tmux and tmux-backed worktrees wherever they fit, and run
+Herdr or Zellij wherever each fits from the same Ghosthub host sidebar.
 
 Native Windows hosts are experimental and have additional requirements. See
 [Remote Hosts](remote-hosts.md#experimental-windows-hosts).
@@ -55,14 +58,21 @@ Verify it with:
 tmux -V
 ```
 
+Install Zellij locally when you want Zellij sessions:
+
+```sh
+brew install zellij
+```
+
 ## Open an existing session
 
 1. Launch Ghosthub.
 2. Expand your Mac under **Hosts** in the sidebar.
-3. Select an existing entry under **Tmux Sessions** or **Herdr Sessions**.
+3. Select an existing entry under **Tmux Sessions**, **Herdr Sessions**, or
+   **Zellij Sessions**.
 
 Ghosthub attaches the ordinary whole-session client for that backend. Existing
-tmux windows and panes or Herdr workspaces, tabs, and panes stay under their
+tmux windows and panes, Herdr workspaces, or Zellij tabs and panes stay under their
 backend's control. Closing the presentation detaches without stopping the
 server.
 
@@ -70,7 +80,7 @@ server.
 
 1. Expand your Mac in the sidebar.
 2. Select the **+** beside **Tmux Sessions** or, when available, **Herdr
-   Sessions**.
+   Sessions** or **Zellij Sessions**.
 3. Enter a session name and create it.
 
 The session is not tied to a Git repository. Close the Ghosthub window or tab
@@ -89,4 +99,4 @@ restart their saved shape later.
 !!! note "Worktrees are optional"
 
     You do not need kwt, a Git repository, or a worktree to use Ghosthub as a
-    local and remote tmux or Herdr session switcher.
+    local and remote tmux, Herdr, or Zellij session switcher.

--- a/website/docs/content/index.md
+++ b/website/docs/content/index.md
@@ -5,10 +5,10 @@ icon: lucide/book-open
 
 # Ghosthub documentation
 
-Ghosthub is a native macOS terminal for local and remote tmux and Herdr
-sessions. It can attach to either multiplexer without Git setup. When you want
-project context, it can also create and manage tmux sessions bound to Git
-worktrees.
+Ghosthub is the native macOS terminal for all your multiplexers. Today it
+supports local and remote tmux, Herdr, and Zellij sessions. Any supported
+multiplexer works without Git setup; when you want project context, Ghosthub
+can also create and manage tmux sessions bound to Git worktrees.
 
 These docs explain how to operate Ghosthub. For a shorter, visual introduction,
 start with the [five-minute Overview](https://ghosthub.ai/overview/).
@@ -19,24 +19,27 @@ start with the [five-minute Overview](https://ghosthub.ai/overview/).
 | --- | --- |
 | Install Ghosthub and open a first session | [Getting Started](/docs/getting-started/) |
 | See what changed in each release | [Changelog](/docs/changelog/) |
-| Attach to tmux or Herdr, or manage a session | [Sessions](/docs/sessions/) |
+| Attach to tmux, Herdr, or Zellij, or manage a session | [Sessions](/docs/sessions/) |
 | Connect a Mac, Linux, or experimental Windows host | [Remote Hosts](/docs/remote-hosts/) |
 | Register a Git repository or create a worktree | [Projects and Worktrees](/docs/projects-worktrees/) |
 | Use windows, tabs, the sidebar, or the Command Palette | [Windows and Navigation](/docs/windows-navigation/) |
 | Change fonts, colors, shell behavior, or tmux themes | [Terminal Configuration](/docs/terminal-configuration/) |
 | Find an application shortcut | [Keyboard Shortcuts](/docs/keyboard-shortcuts/) |
 | Understand anonymous usage reporting and stored data | [Privacy](/docs/privacy/) |
-| Diagnose a connection, tmux, Herdr, or worktree problem | [Troubleshooting](/docs/troubleshooting/) |
+| Diagnose a connection, multiplexer, or worktree problem | [Troubleshooting](/docs/troubleshooting/) |
 
 ## The important mental model
 
-Ghosthub is a client and presentation layer for multiplexers, not a replacement
-for them. Tmux and Herdr can run side by side on the same hosts: using Herdr
-through Ghosthub does not replace Ghosthub, and it does not disable Ghosthub's
-tmux sessions or tmux-backed worktrees.
+Ghosthub is a client and presentation layer for all multiplexers, not a
+replacement for them. Every supported backend is a first-class peer and can
+run beside the others on the same hosts. The model is intentionally open to
+future backends, including the [terminal multiplexer Superlogical is
+building](https://www.superlogical.com/) once it has a public integration
+surface.
 
 - **Hosts** are the local Mac or machines reached over SSH.
-- **Sessions** are ordinary tmux sessions or running/stopped Herdr sessions on a host.
+- **Sessions** are ordinary tmux sessions, running/stopped Herdr sessions, or
+  active Zellij sessions on a host.
   They do not need a Git repository.
 - **Projects** are Git repositories registered with
   [kwt](https://kwt.sh) on a particular host.
@@ -47,10 +50,11 @@ Tmux continues to own its windows, panes, layout, history, and processes. Herdr
 continues to own its workspaces, tabs, panes, history, key bindings, and
 processes. Closing a Ghosthub presentation detaches from a session; it does not
 end the backend session. Ghosthub offers separate whole-session lifecycle
-actions for both multiplexers while leaving their internal models intact.
+actions while leaving each multiplexer's internal model intact. Zellij owns
+its tabs, panes, layout, history, plugins, and processes.
 
 Ghosthub uses an ordinary local or SSH client for every attachment. It does not
-use tmux control mode, Herdr's remote transport, or reconstruct either
+use tmux control mode, Herdr's remote transport, or reconstruct any
 multiplexer's terminal state in Swift.
 
 ## Human and machine-readable pages

--- a/website/docs/content/keyboard-shortcuts.md
+++ b/website/docs/content/keyboard-shortcuts.md
@@ -57,7 +57,7 @@ include Settings (++cmd+comma++), New Window (++cmd+n++), New Tab (++cmd+t++),
 Close (++cmd+w++), Close Window (++shift+cmd+w++), Quit (++cmd+q++), and the
 usual Edit shortcuts. The Keyboard pane lists them for reference.
 
-Closing a presentation, window, or the app detaches from tmux or Herdr. It does
+Closing a presentation, window, or the app detaches from tmux, Herdr, or Zellij. It does
 not end the session.
 
 ## Edit a shortcut

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -5,9 +5,10 @@ icon: lucide/server
 
 # Remote hosts
 
-Ghosthub can discover tmux plus running and stopped Herdr sessions on remote
-macOS and Linux machines over SSH. Herdr is optional; native Windows hosts
-using psmux are experimental and do not support it.
+Ghosthub can discover tmux, running and stopped Herdr sessions, and active
+Zellij sessions on remote macOS and Linux machines over SSH. Herdr and Zellij
+are optional; native Windows hosts using psmux are experimental and do not
+support them.
 
 ## Before you add a host
 
@@ -15,6 +16,7 @@ A macOS or Linux host needs:
 
 - a working OpenSSH server
 - tmux 3.2 or newer
+- Herdr 0.8 or Zellij 0.44 when you want those session backends
 - a destination that your Mac's OpenSSH configuration can resolve
 
 Ghosthub checks the remote multiplexer version when attaching. Cmd-D and
@@ -36,6 +38,11 @@ its running and stopped sessions under **Herdr Sessions**. It still uses Ghosthu
 trust, authentication, pooling, and reconnect path rather than Herdr's remote
 transport.
 
+If Zellij is installed, Ghosthub adds its active sessions under **Zellij
+Sessions** and filters out exited/resurrectable entries. Attachments still use
+Ghosthub's ordinary OpenSSH transport rather than a backend-specific remote
+mode.
+
 ## exe.dev hosts
 
 Ghosthub can discover running exe.dev VMs as SSH hosts without adding each VM
@@ -48,7 +55,7 @@ manually. Create and manage VMs through [exe.dev](https://exe.dev/docs), then:
    authentication prompt.
 
 Running VMs appear with the rest of the host fleet. Ghosthub uses each VM's
-exe.dev-provided SSH destination for ordinary tmux, optional Herdr, and optional
+exe.dev-provided SSH destination for ordinary tmux, optional Herdr or Zellij, and optional
 kwt discovery.
 
 Leaving **Tags** empty discovers every VM on the account. With tags entered,
@@ -67,7 +74,7 @@ regard to case, and are managed in exe.dev.
 4. Select **Test Connection**.
 
 An unreachable host does not block discovery or use of the rest of the fleet.
-An expanded, reachable host with no projects, tmux sessions, or Herdr sessions
+An expanded, reachable host with no projects, tmux sessions, Herdr sessions, or Zellij sessions
 says so in the sidebar.
 
 ## Host-key trust
@@ -91,14 +98,14 @@ challenge requires one.
 
 If a host shows a caution icon, select it to review trust, authenticate, or
 retry. A successful ordinary host-inventory authentication refreshes inventory;
-it does not open a tmux or Herdr session by itself.
+it does not open a tmux, Herdr, or Zellij session by itself.
 
 ## Automatic reconnect
 
 If an active SSH connection drops, Ghosthub shows **Connection interrupted**
 and retries automatically, with no more than 30 seconds between attempts.
 Choose **Reconnect Now** to try immediately. When the connection returns,
-Ghosthub reattaches to the same exact tmux or Herdr session; the server-side
+Ghosthub reattaches to the same exact tmux, Herdr, or active Zellij session; the server-side
 processes were never moved into Ghosthub.
 
 If SSH needs authentication or host-key review, the presentation changes to

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -1,27 +1,28 @@
 ---
-description: Attach to tmux and Herdr sessions, reconnect safely, and manage whole-session lifecycle.
+description: Attach to tmux, Herdr, and Zellij sessions, reconnect safely, and manage whole-session lifecycle.
 icon: lucide/square-terminal
 ---
 
 # Sessions
 
-Ghosthub keeps three host inventories independent. Standalone tmux sessions
+Ghosthub keeps four host inventories independent. Standalone tmux sessions
 appear under **Tmux Sessions**, running and stopped Herdr sessions appear under **Herdr
-Sessions**, and tmux-backed kwt worktrees and registered directories appear
-under **Projects**, in that order. Registered directories are flat rows after
-the repository hierarchies. A missing Herdr installation is normal: Ghosthub
-simply omits its group without showing a warning.
+Sessions**, active Zellij sessions appear under **Zellij Sessions**, and
+tmux-backed kwt worktrees and registered directories appear under **Projects**,
+in that order. Registered directories are flat rows after the repository
+hierarchies. Missing Herdr or Zellij installations are normal: Ghosthub simply
+omits those groups without showing a warning.
 
-You do not choose Herdr *instead of* Ghosthub. Herdr owns a session's internal
-workspace, tabs, panes, history, key bindings, and processes;
-Ghosthub discovers that session and presents its ordinary client beside your
-tmux sessions and tmux-backed worktrees. Both multiplexers can be active on the
-same host fleet.
+Ghosthub treats every supported multiplexer as a first-class peer. It discovers
+each backend independently and presents its ordinary client beside the others;
+tmux, Herdr, and Zellij can all be active on the same host fleet. Each continues
+to own its own windows or tabs, panes, layout, history, key bindings, plugins,
+and processes.
 
 ## Create a standalone session
 
 1. Expand the target host.
-2. Select the **+** beside **Tmux Sessions** or **Herdr Sessions**.
+2. Select the **+** beside **Tmux Sessions**, **Herdr Sessions**, or **Zellij Sessions**.
 3. Enter a session name.
 
 A new tmux session remains usable from the `tmux` CLI and other tmux clients.
@@ -31,9 +32,13 @@ appear only when the host's `herdr session list --json` capability is
 available. A name already present in either running or stopped state is
 rejected; restart a stopped session instead.
 
+A new Zellij session uses Zellij's new-session path and remains an ordinary
+Zellij session. Active and resurrectable names are both rejected. Ghosthub
+lists only active sessions and does not expose resurrection as a workflow.
+
 ## Attach and detach
 
-Select a running tmux or Herdr session in the sidebar, or search for it in the Command
+Select a running tmux, Herdr, or Zellij session in the sidebar, or search for it in the Command
 Palette with ++shift+cmd+p++. Ghosthub opens an ordinary local or SSH client
 for the selected backend. Herdr receives the complete terminal and continues
 to own its workspaces, tabs, panes, history, and key bindings.
@@ -41,20 +46,31 @@ to own its workspaces, tabs, panes, history, and key bindings.
 Switching to another host, worktree, or session hides an opened tmux terminal
 without detaching it. Each workspace keeps every tmux session you explicitly
 open connected, and returning to one reuses the same terminal and client.
-Switching away from Herdr detaches its presentation; the Herdr server and its
-processes continue running.
+Switching away from Herdr or Zellij detaches its presentation; the server and
+its processes continue running.
+
+Zellij does not provide an atomic active-only attach command. Ghosthub checks
+that a selected session is active before attaching and does not offer
+resurrection, but Zellij may resurrect its saved layout if the session exits in
+the brief interval before the client command resolves it. Ghosthub does not
+request automatic execution of resurrected commands.
 
 Press ++cmd+w++ to detach only the active presentation. Closing a workspace
 tab or window detaches every presentation it owns, and quitting Ghosthub
 detaches them all. None of these actions ends a tmux session or stops a Herdr
-server. A normal Herdr detach offers **Reconnect** and does not retry
-automatically.
+or Zellij server. A normal Herdr or Zellij detach offers **Reconnect** and does
+not retry automatically.
 
 On a remote host, a dropped SSH transport enters automatic recovery. Ghosthub
 probes the same exact session before each replacement client. Retry stops when
 the session disappears, Herdr becomes unavailable, or the client reports a
 non-transport failure. **Reconnect Now** skips the current delay; host-key or
 authentication problems open the existing connection review flow.
+
+When Ghosthub restores a remote Zellij presentation after relaunch, it validates
+the active session using one frozen SSH route and rechecks that route before
+attaching. If the SSH configuration changed during validation, restoration
+stops instead of attaching to another endpoint.
 
 ## Activity indicators
 
@@ -94,7 +110,7 @@ Ghosthub confirms the host and exact tmux session before it sends
 `kill-session`. Ending a session terminates all of its windows, panes, and
 processes and cannot be undone.
 
-Ghosthub cancels the operation if the host connection changes, or if the
+For tmux, Ghosthub cancels the operation if the host connection changes, or if the
 original session disappears and another session appears under the same name.
 If the command fails, the active attachment remains open.
 
@@ -112,6 +128,18 @@ Herdr lifecycle is whole-session only:
 These actions are also in the Command Palette. Ghosthub suppresses reconnect
 across every open scene while an intentional stop runs, so another window does
 not silently resurrect the session.
+
+An active Zellij row offers **Kill Session…**. Ghosthub confirms the host and
+name, rechecks that exact active session immediately before the command, and
+then asks Zellij to kill it. While the kill is running, Ghosthub detaches that
+session and suppresses same-session reconnects in every open scene so neither
+an existing client nor an automatic reconnect can undo the intentional kill.
+Successful kills also remove the row from every open scene and refresh Zellij
+inventory. If the kill fails, an eligible detached presentation or matching
+pending open or restoration is rechecked before it resumes. Zellij does not
+provide tmux-style stable session identity, so a same-name replacement between
+the final check and command is an accepted race. Ghosthub never offers
+resurrection or deletes exited Zellij sessions.
 
 !!! warning "Killing a session is different from removing a worktree"
 
@@ -150,3 +178,6 @@ whole-session create, stop, restart, and delete, plus the explicit Split Right
 and Split Down requests against a connected Herdr 0.8.0-or-newer session. Herdr
 selects the focused pane and continues to own themes, workspaces, tabs, panes,
 agents, plugins, configuration, updates, and internal process behavior.
+For Zellij, Ghosthub manages only active-session create, attach, and confirmed
+kill. Zellij continues to own tabs, panes, layouts, themes, plugins,
+configuration, updates, resurrection data, and process behavior.

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose common Ghosthub installation, SSH, tmux, Herdr, and worktree problems.
+description: Diagnose common Ghosthub installation, SSH, multiplexer, and worktree problems.
 icon: lucide/life-buoy
 ---
 
@@ -29,7 +29,7 @@ tmux -V
 tmux list-sessions
 ```
 
-An expanded host with no discovered tmux or Herdr sessions or projects reports
+An expanded host with no discovered tmux, Herdr, or Zellij sessions or projects reports
 that it is empty. Project inventory is separate from SSH reachability, so a
 reachable host can also show a separate kwt diagnostic.
 

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -5,18 +5,19 @@ icon: lucide/panels-top-left
 
 # Windows and navigation
 
-Each Ghosthub workspace can show a tmux or Herdr presentation. It can keep
+Each Ghosthub workspace can show a tmux, Herdr, or Zellij presentation. It can keep
 multiple tmux presentations connected while showing one at a time; Herdr owns
 the complete internal workspace shown by its client. Native macOS tabs group
-complete Ghosthub workspaces and do not replace either multiplexer's internal
+complete Ghosthub workspaces and do not replace any multiplexer's internal
 windows, tabs, or panes.
 
 ## Use the sidebar
 
-The sidebar shows standalone tmux sessions, running and stopped Herdr sessions, projects,
+The sidebar shows standalone tmux sessions, running and stopped Herdr sessions,
+active Zellij sessions, projects,
 and worktrees under each host. Select an item to attach. Moving among tmux
 targets hides the previous terminal without detaching its local or SSH client;
-moving away from Herdr detaches only its presentation and leaves its server
+moving away from Herdr or Zellij detaches only its presentation and leaves its server
 running. Stopped Herdr rows are dimmed and labeled **Stopped**. Expand a host
 to see its current inventory and connection diagnostics.
 
@@ -27,7 +28,7 @@ the full window while preserving its session attachment.
 
 Press ++shift+cmd+p++ and type to search:
 
-- hosts, projects, worktrees, and standalone tmux or Herdr sessions
+- hosts, projects, worktrees, and standalone tmux, Herdr, or Zellij sessions
 - settings pages
 - session lifecycle commands
 - appearance and theme commands
@@ -39,7 +40,7 @@ Press Return to perform the selected action.
 - ++cmd+t++ opens a workspace tab in the current window.
 - ++cmd+n++ opens a separate workspace window.
 
-Each can attach to a different local or remote tmux or Herdr session. Use the macOS
+Each can attach to a different local or remote tmux, Herdr, or Zellij session. Use the macOS
 **Window** menu to move a tab into its own window or merge windows into a native
 tab group.
 
@@ -48,8 +49,8 @@ tab group.
 ++cmd+w++ closes and detaches only the active session presentation. Other
 sessions opened in that workspace remain connected. ++shift+cmd+w++ closes the
 containing workspace window and detaches every presentation it owns. Neither
-action ends a tmux session or stops a Herdr server. Use the separately confirmed
-**Kill Session…** or **Stop Session…** action when termination is intentional.
+action ends a tmux session or stops a Herdr or Zellij server. Use the separately
+confirmed **Kill Session…** or **Stop Session…** action when termination is intentional.
 
 Closing the final workspace leaves Ghosthub running. Use ++cmd+q++ to quit.
 Quit confirmation is enabled by default and can be changed under
@@ -58,7 +59,8 @@ Quit confirmation is enabled by default and can be changed under
 ## Restore workspaces after launch or update
 
 Ghosthub asks macOS to restore native windows and tabs. It reconnects each
-saved presentation only when it can confirm the exact tmux or running Herdr
+saved presentation only when it can confirm the exact tmux, running Herdr, or
+active Zellij
 session. Offline SSH hosts continue retrying as inventory refreshes.
 
 During an update relaunch, Ghosthub recreates saved windows if macOS does not
@@ -68,7 +70,7 @@ you are ready to attach.
 
 ## Rearrange navigation
 
-Drag worktrees within a project, or reorder standalone tmux and Herdr sessions
+Drag worktrees within a project, or reorder standalone tmux, Herdr, and Zellij sessions
 within their host groups. The insertion line previews the destination. Ghosthub
-remembers this display order without changing anything in Git, kwt, tmux, or
-Herdr.
+remembers this display order without changing anything in Git, kwt, tmux,
+Herdr, or Zellij.

--- a/website/docs/llms.txt
+++ b/website/docs/llms.txt
@@ -1,6 +1,6 @@
 # Ghosthub
 
-> Ghosthub is a multiplexer-native macOS terminal for local and remote tmux and Herdr sessions, with optional Git worktree management.
+> Ghosthub is the multiplexer-native macOS terminal for all your multiplexers. Today it supports local and remote tmux, Herdr, and Zellij sessions, with optional Git worktree management.
 
 Ghosthub is alpha software. The Overview is a short visual tour; the Docs links below are comprehensive task-oriented references. Markdown versions are canonical for machine readers.
 
@@ -9,14 +9,14 @@ Ghosthub is alpha software. The Overview is a short visual tour; the Docs links 
 - [Documentation overview](https://ghosthub.ai/docs.md): Mental model and documentation map
 - [Getting started](https://ghosthub.ai/docs/getting-started.md): Requirements, installation, and first session
 - [Changelog](https://ghosthub.ai/docs/changelog.md): User-facing changes in each Ghosthub release
-- [Sessions](https://ghosthub.ai/docs/sessions.md): Create, attach, detach, and manage tmux and Herdr sessions
+- [Sessions](https://ghosthub.ai/docs/sessions.md): Create, attach, detach, and manage tmux, Herdr, and Zellij sessions
 - [Remote hosts](https://ghosthub.ai/docs/remote-hosts.md): SSH and exe.dev setup, trust, authentication, reconnect, and supported hosts
 - [Projects and worktrees](https://ghosthub.ai/docs/projects-worktrees.md): Register repositories and manage branch- or pull-request-backed worktrees
 - [Windows and navigation](https://ghosthub.ai/docs/windows-navigation.md): Sidebar, Command Palette, windows, tabs, and restoration
 - [Terminal configuration](https://ghosthub.ai/docs/terminal-configuration.md): Ghosthub-owned libghostty configuration and tmux themes
 - [Keyboard shortcuts](https://ghosthub.ai/docs/keyboard-shortcuts.md): Application, workspace, tmux, and Herdr pane-splitting shortcuts
 - [Privacy](https://ghosthub.ai/docs/privacy.md): Anonymous usage data and local state
-- [Troubleshooting](https://ghosthub.ai/docs/troubleshooting.md): Common local, SSH, tmux, Herdr, and worktree problems
+- [Troubleshooting](https://ghosthub.ai/docs/troubleshooting.md): Common local, SSH, multiplexer, and worktree problems
 
 ## Other
 

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -7,9 +7,9 @@ interface Feature {
 
 const features: Feature[] = [
   {
-    title: 'Tmux and Herdr, together',
-    body: 'Create or attach to sessions on your Mac, over SSH, or on exe.dev VMs. '
-      + 'Each multiplexer keeps ownership of its own session world.',
+    title: 'All multiplexers',
+    body: 'Bring tmux, Herdr, and Zellij sessions into one fleet across your Mac, SSH, '
+      + 'and exe.dev. Each multiplexer keeps ownership of its own session world.',
     icon: 'M4 5h24v22H4Z M4 13h24 M16 13v14',
   },
   {

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -7,8 +7,8 @@ import ZoomableImage from './ZoomableImage.astro';
 import hero from '../assets/hero.png';
 
 const heroAlt =
-  'Ghosthub main window with local and remote tmux sessions, Herdr sessions, '
-  + 'and tmux-backed worktrees in the sidebar';
+  'Ghosthub main window with local and remote tmux, Herdr, and Zellij sessions '
+  + 'alongside tmux-backed worktrees';
 ---
 
 <section class="hero">
@@ -17,11 +17,11 @@ const heroAlt =
       <AppIcon prefix="gh-ic-hero" />
       <span class="wordmark">Ghosthub</span>
     </p>
-    <h1>A multiplexer-native power terminal for your fleet</h1>
+    <h1>All your multiplexers. One native terminal.</h1>
     <p class="sub">
-      Create or attach to tmux and Herdr sessions on your Mac or over SSH. Run
-      both side by side with tmux-backed worktrees, keepalives, and automatic
-      reconnect in one native terminal.
+      Ghosthub is multiplexer-native across your Mac and SSH hosts. Create or
+      attach to tmux, Herdr, and Zellij sessions with optional tmux-backed
+      worktrees, keepalives, and automatic reconnect.
     </p>
     <div class="install-action">
       <InstallCommand>

--- a/website/src/components/OverviewCTA.astro
+++ b/website/src/components/OverviewCTA.astro
@@ -4,7 +4,7 @@
       <p class="eyebrow">Five-minute overview</p>
       <h2>See how the pieces fit together</h2>
       <p>
-        Tour tmux and Herdr sessions, resilient SSH, optional worktrees, and
+        Tour an all-multiplexer fleet, resilient SSH, optional worktrees, and
         native macOS command centers.
       </p>
     </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,10 +4,10 @@ import OverviewCTA from '../components/OverviewCTA.astro';
 import Hero from '../components/Hero.astro';
 import SiteLayout from '../layouts/SiteLayout.astro';
 
-const title = 'Ghosthub: a multiplexer-native power terminal for your fleet';
+const title = 'Ghosthub: all your multiplexers in one native terminal';
 const description =
-  'Ghosthub is a free and open source macOS terminal for local and SSH tmux and '
-  + 'Herdr sessions, with Git worktree management, keepalives, and automatic reconnect.';
+  'Ghosthub is a free and open source, multiplexer-native macOS terminal. Bring tmux, '
+  + 'Herdr, and Zellij sessions into one local and SSH fleet.';
 ---
 
 <SiteLayout title={title} description={description} path="/">

--- a/website/src/pages/overview.astro
+++ b/website/src/pages/overview.astro
@@ -14,14 +14,14 @@ import { RELEASES_URL } from '../config';
 
 const title = 'Ghosthub overview';
 const description =
-  'A visual overview of Ghosthub across tmux and Herdr sessions, SSH hosts, '
-  + 'Git worktrees, native tabs and windows, and terminal configuration.';
+  'A visual overview of Ghosthub as the native terminal for all your multiplexers, '
+  + 'across SSH hosts, Git worktrees, native tabs, and windows.';
 
 const imageWidths = [640, 960, 1280, 1600];
 const imageSizes = '(max-width: 900px) calc(100vw - 3rem), 900px';
 const imageAlt = {
   sessions:
-    'Ghosthub workspace showing Tmux Sessions, Herdr Sessions, Projects, and a remote host in the sidebar',
+    'Ghosthub workspace showing Tmux, Herdr, and Zellij sessions for local and remote hosts',
   hosts: 'Ghosthub Hosts settings with a configured remote GPU host',
   worktree:
     'Ghosthub new worktree sheet listing available local and remote branches',
@@ -41,16 +41,20 @@ const imageAlt = {
       <p class="eyebrow">Five-minute overview</p>
       <h1>Meet Ghosthub</h1>
       <p class="lead">
-        Ghosthub is a native macOS terminal for local and remote multiplexer
-        fleets. It brings tmux sessions, Herdr sessions, and optional
-        tmux-backed worktrees into one sidebar without replacing the tools that
-        own them.
+        Ghosthub is the native macOS terminal for all your multiplexers. Today,
+        it brings tmux, Herdr, and Zellij sessions, plus optional tmux-backed
+        worktrees, into one local and remote fleet without replacing the tools
+        that own them.
       </p>
       <p>
-        Use tmux and Herdr together on the same hosts. Ghosthub handles
-        discovery, presentation, SSH keepalives, and reconnect while each
-        multiplexer keeps its own panes, layout, history, key bindings, and
-        processes.
+        Ghosthub handles discovery, presentation, SSH keepalives, and reconnect
+        while every multiplexer keeps its own panes, layout, history, key
+        bindings, and processes.
+      </p>
+      <p>
+        That backend-open model is ready for the multiplexers still to come,
+        including the <a href="https://www.superlogical.com/">terminal multiplexer
+        Superlogical is building</a>, once they publish an integration surface.
       </p>
       <p class="docs-callout">
         Ready for setup and operating details? Visit the <a href="/docs/">Docs</a>.
@@ -64,7 +68,7 @@ const imageAlt = {
       <div class="requirements" aria-label="Requirements">
         <span>Apple Silicon</span>
         <span>macOS 26+</span>
-        <span>tmux 3.2+ and/or Herdr 0.8+</span>
+        <span>tmux 3.2+, Herdr 0.8+, and/or Zellij 0.44+</span>
       </div>
       <InstallCommand />
     </div>
@@ -86,10 +90,10 @@ const imageAlt = {
         <div>
           <h2>Your session fleet in one place</h2>
           <p>
-            Tmux and Herdr sessions appear side by side for every supported
-            host. Open either with its ordinary client, create new sessions
-            where the backend is available, and keep tmux-backed project work
-            visible in the same hierarchy.
+            Every supported multiplexer appears as a first-class peer for each
+            host. Open tmux, Herdr, or Zellij with its ordinary client, create
+            sessions wherever that backend is available, and keep tmux-backed
+            project work visible in the same hierarchy.
           </p>
           <p>
             Ghosthub detaches when you close a presentation. Explicit lifecycle
@@ -144,7 +148,7 @@ const imageAlt = {
           <p>
             Register a repository to create tmux-backed worktrees from branches
             or GitHub pull requests. Git is optional for standalone tmux and
-            Herdr sessions.
+            Herdr or Zellij sessions.
           </p>
           <p><a href="/docs/projects-worktrees/">Explore projects and worktrees</a>.</p>
         </div>
@@ -192,7 +196,7 @@ const imageAlt = {
         <div>
           <h2>Build your command center</h2>
           <p>
-            Use independent macOS windows and tabs for different tmux or Herdr
+            Use independent macOS windows and tabs for different tmux, Herdr, or Zellij
             sessions, then hide each sidebar when the terminal should fill the
             frame.
           </p>
@@ -264,9 +268,9 @@ const imageAlt = {
       <p class="eyebrow">That’s it</p>
       <h2>Bring the tools you already use</h2>
       <p>
-        Ghosthub works with tmux and Herdr rather than asking you to replace
-        them. Your sessions remain ordinary backend sessions, available from
-        their own clients even when Ghosthub is closed.
+        Ghosthub is a home for all multiplexers rather than a replacement for
+        one. Your tmux, Herdr, and Zellij sessions remain ordinary backend
+        sessions, available from their own clients even when Ghosthub is closed.
       </p>
       <a data-download href={RELEASES_URL}>Download Ghosthub <span aria-hidden="true">&rarr;</span></a>
     </div>


### PR DESCRIPTION
Ghosthub should organize every multiplexer in one local and remote fleet instead of treating tmux and Herdr as a fixed pair, without bringing fleet-sized work back into activation or session refresh.

- Adds Zellij 0.44+ discovery, create, attach, reconnect, sibling navigation, and confirmed kill on local macOS and remote POSIX hosts; missing installs stay silent, Windows remains unsupported, and exited or resurrectable sessions remain outside Ghosthub.
- Batches each Zellij fleet sweep into one runtime-only publication, so session discovery and lifecycle reconciliation cannot replay KWT projects, worktrees, or path normalization.
- Keeps each backend authoritative for panes, tabs, layout, and history, and freezes SSH authority for validation, restoration, and destructive actions so stale navigation, kill races, and host-route drift fail closed.
- Reframes the product as “all multiplexers,” names tmux, Herdr, and Zellij as today’s supported backends, and points toward Superlogical’s forthcoming multiplexer without promising an unreleased integration.
- Refreshes the complete deterministic website screenshot set with synthetic local and remote Zellij sessions.

A final-base Time Profiler activation capture contained no Zellij discovery, inventory overlay, KWT reconciliation, path normalization, `lstat`, or process sampling. All 1,497 Swift tests pass in stable non-parallel mode; essential workflows, warnings-as-errors, build, formatting, 50 bootstrap tests, and 141 Python tests also pass.