### PR TITLE
Filter exe.dev discovery by VM tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ test, and documentation-only changes are omitted.
 
 ## [Unreleased]
 
+### Added
+
+- exe.dev accounts can limit discovery to VMs carrying specific exe.dev tags,
+  so a fleet of dozens of VMs shows only the ones you work in.
+
 ## [0.7.0] - 2026-08-09
 
 ### Added

--- a/Sources/App/ExeVMInventory.swift
+++ b/Sources/App/ExeVMInventory.swift
@@ -163,17 +163,17 @@ struct ExeConfiguredHost: Equatable, Sendable {
 }
 
 private struct ExeAccountHostCache {
-    var sshDestination: String
+    var identity: ExeAccountIdentity
     var hosts: [ExeConfiguredHost]
 }
 
 private struct ExeVMInventoryRefreshState {
     var id: UUID
-    var accountDestinations: [String: String]
+    var accountIdentities: [String: ExeAccountIdentity]
     var accountNames: [String: String]
-    var persistedAccountDestinations: [String: String]
+    var persistedAccountIdentities: [String: ExeAccountIdentity]
     var persistedAccountNames: [String: String]
-    var visibleAccountDestinations: [String: String]
+    var visibleAccountIdentities: [String: ExeAccountIdentity]
     var visibleAccountNames: [String: String]
     var previousHostsByAccount: [String: ExeAccountHostCache]
     var previousStatuses: [String: ExeAccountStatus]
@@ -225,13 +225,13 @@ final class ExeVMInventoryStore: ObservableObject {
     ) -> UUID {
         let enabled = ExeAccountSanitizer.discoverableAccounts(accounts)
             .filter(\.isEnabled)
-        var enabledDestinations: [String: String] = [:]
+        var enabledIdentities: [String: ExeAccountIdentity] = [:]
         var enabledNames: [String: String] = [:]
         for account in enabled {
-            enabledDestinations[account.configKey] = account.sshDestination
+            enabledIdentities[account.configKey] = ExeAccountIdentity(account)
             enabledNames[account.configKey] = account.name
         }
-        let persistedDestinations = Self.enabledDestinations(
+        let persistedIdentities = Self.enabledIdentities(
             in: ExeAccountSanitizer.discoverableAccounts(persistedAccounts)
         )
         let persistedNames = Self.enabledAccountNames(
@@ -251,8 +251,8 @@ final class ExeVMInventoryStore: ObservableObject {
         let previousStatuses = statusesByAccount
         let refreshID = UUID()
         hostsByAccount = hostsByAccount.filter {
-            enabledDestinations[$0.key] == $0.value.sshDestination
-                || persistedDestinations[$0.key] == $0.value.sshDestination
+            enabledIdentities[$0.key] == $0.value.identity
+                || persistedIdentities[$0.key] == $0.value.identity
         }
         for (configKey, name) in enabledNames {
             guard var cache = hostsByAccount[configKey] else { continue }
@@ -261,26 +261,26 @@ final class ExeVMInventoryStore: ObservableObject {
             }
             hostsByAccount[configKey] = cache
         }
-        let retainedKeys = Set(enabledDestinations.keys)
-            .union(persistedDestinations.keys)
+        let retainedKeys = Set(enabledIdentities.keys)
+            .union(persistedIdentities.keys)
         statusesByAccount = statusesByAccount.filter { configKey, _ in
             retainedKeys.contains(configKey)
         }
-        var visibleDestinations = persistedDestinations
+        var visibleIdentities = persistedIdentities
         var visibleNames = persistedNames
-        for (configKey, destination) in enabledDestinations {
-            visibleDestinations[configKey] = destination
+        for (configKey, identity) in enabledIdentities {
+            visibleIdentities[configKey] = identity
         }
         for (configKey, name) in enabledNames {
             visibleNames[configKey] = name
         }
         refreshState = ExeVMInventoryRefreshState(
             id: refreshID,
-            accountDestinations: enabledDestinations,
+            accountIdentities: enabledIdentities,
             accountNames: enabledNames,
-            persistedAccountDestinations: persistedDestinations,
+            persistedAccountIdentities: persistedIdentities,
             persistedAccountNames: persistedNames,
-            visibleAccountDestinations: visibleDestinations,
+            visibleAccountIdentities: visibleIdentities,
             visibleAccountNames: visibleNames,
             previousHostsByAccount: previousHostsByAccount,
             previousStatuses: previousStatuses
@@ -333,8 +333,8 @@ final class ExeVMInventoryStore: ObservableObject {
                           self.refreshState?.id == refreshID
                     else { return }
                     guard let state = self.refreshState,
-                          state.accountDestinations[account.configKey]
-                          == account.sshDestination
+                          state.accountIdentities[account.configKey]
+                          == ExeAccountIdentity(account)
                     else { continue }
                     let accountName = state.accountNames[account.configKey]
                         ?? account.name
@@ -392,50 +392,51 @@ final class ExeVMInventoryStore: ObservableObject {
         guard let state = refreshState,
               state.id == refreshID
         else { return }
-        let previousAccounts = state.accountDestinations.map {
+        let previousAccounts = state.accountIdentities.map { configKey, identity in
             ExeAccount(
-                configKey: $0.key,
-                name: state.accountNames[$0.key] ?? $0.key,
-                sshDestination: $0.value
+                configKey: configKey,
+                name: state.accountNames[configKey] ?? configKey,
+                sshDestination: identity.sshDestination,
+                tagFilter: identity.tagFilter
             )
         }
         let resolvedAccounts = ExeAccountSanitizer.accountsForPersistence(
             currentAccounts,
             previous: previousAccounts
         )
-        let currentDestinations = Self.enabledDestinations(
+        let currentIdentities = Self.enabledIdentities(
             in: resolvedAccounts
         )
-        let retainedDestinations = state.accountDestinations.filter {
-            currentDestinations[$0.key] == $0.value
+        let retainedIdentities = state.accountIdentities.filter {
+            currentIdentities[$0.key] == $0.value
         }
         var retainedNames = state.accountNames.filter {
-            retainedDestinations[$0.key] != nil
+            retainedIdentities[$0.key] != nil
         }
         for (configKey, name) in Self.enabledAccountNames(
             in: resolvedAccounts
-        ) where retainedDestinations[configKey] != nil {
+        ) where retainedIdentities[configKey] != nil {
             retainedNames[configKey] = name
         }
-        var visibleDestinations = state.persistedAccountDestinations
-        for (configKey, destination) in retainedDestinations {
-            visibleDestinations[configKey] = destination
+        var visibleIdentities = state.persistedAccountIdentities
+        for (configKey, identity) in retainedIdentities {
+            visibleIdentities[configKey] = identity
         }
         var visibleNames = state.persistedAccountNames.filter {
-            visibleDestinations[$0.key] != nil
+            visibleIdentities[$0.key] != nil
         }
         for (configKey, name) in retainedNames {
             visibleNames[configKey] = name
         }
-        refreshState?.visibleAccountDestinations = visibleDestinations
+        refreshState?.visibleAccountIdentities = visibleIdentities
         refreshState?.visibleAccountNames = visibleNames
         publishInventory()
     }
 
-    private static func enabledDestinations(
+    private static func enabledIdentities(
         in accounts: [ExeAccount]
-    ) -> [String: String] {
-        var destinations: [String: String] = [:]
+    ) -> [String: ExeAccountIdentity] {
+        var identities: [String: ExeAccountIdentity] = [:]
         for account in accounts where account.isEnabled {
             let configKey = account.configKey.trimmingCharacters(
                 in: .whitespacesAndNewlines
@@ -445,11 +446,14 @@ final class ExeVMInventoryStore: ObservableObject {
             )
             guard !configKey.isEmpty,
                   !destination.isEmpty,
-                  destinations[configKey] == nil
+                  identities[configKey] == nil
             else { continue }
-            destinations[configKey] = destination
+            identities[configKey] = ExeAccountIdentity(
+                sshDestination: destination,
+                tagFilter: account.tagFilter
+            )
         }
-        return destinations
+        return identities
     }
 
     private static func enabledAccountNames(
@@ -484,16 +488,16 @@ final class ExeVMInventoryStore: ObservableObject {
 
         for account in retainedAccounts {
             let configKey = account.configKey
-            let destination = account.sshDestination
-            let currentMatches = state.accountDestinations[configKey]
-                == destination
+            let identity = ExeAccountIdentity(account)
+            let currentMatches = state.accountIdentities[configKey]
+                == identity
             let cache: ExeAccountHostCache? = if currentMatches,
                                                  let current = hostsByAccount[configKey],
-                                                 current.sshDestination == destination {
+                                                 current.identity == identity {
                 current
             } else if let previous = state
                 .previousHostsByAccount[configKey],
-                previous.sshDestination == destination {
+                previous.identity == identity {
                 previous
             } else {
                 nil
@@ -526,17 +530,17 @@ final class ExeVMInventoryStore: ObservableObject {
         repeat {
             needsInventoryPublish = false
             if let state = refreshState {
-                hosts = state.visibleAccountDestinations.keys.sorted().flatMap {
+                hosts = state.visibleAccountIdentities.keys.sorted().flatMap {
                     configKey -> [ExeConfiguredHost] in
-                    guard let destination = state
-                        .visibleAccountDestinations[configKey]
+                    guard let identity = state
+                        .visibleAccountIdentities[configKey]
                     else { return [] }
                     let cache: ExeAccountHostCache? = if hostsByAccount[
                         configKey
-                    ]?.sshDestination == destination {
+                    ]?.identity == identity {
                         hostsByAccount[configKey]
                     } else if state.previousHostsByAccount[configKey]?
-                        .sshDestination == destination {
+                        .identity == identity {
                         state.previousHostsByAccount[configKey]
                     } else {
                         nil
@@ -550,9 +554,9 @@ final class ExeVMInventoryStore: ObservableObject {
                     return visibleHosts
                 }
                 var visibleStatuses: [String: ExeAccountStatus] = [:]
-                for (configKey, destination) in state
-                    .visibleAccountDestinations {
-                    if state.accountDestinations[configKey] == destination,
+                for (configKey, identity) in state
+                    .visibleAccountIdentities {
+                    if state.accountIdentities[configKey] == identity,
                        let status = statusesByAccount[configKey] {
                         visibleStatuses[configKey] = status
                     } else if let status = state.previousStatuses[configKey] {
@@ -575,9 +579,10 @@ final class ExeVMInventoryStore: ObservableObject {
         for account: ExeAccount,
         accountName: String
     ) {
-        let running = vms.filter(\.isRunning)
+        let matching = vms.filter(account.discovers)
+        let running = matching.filter(\.isRunning)
         hostsByAccount[account.configKey] = ExeAccountHostCache(
-            sshDestination: account.sshDestination,
+            identity: ExeAccountIdentity(account),
             hosts: running.map {
                 Self.configuredHost(
                     $0,
@@ -587,8 +592,9 @@ final class ExeVMInventoryStore: ObservableObject {
             }
         )
         statusesByAccount[account.configKey] = .loaded(
-            totalVMs: vms.count,
-            runningVMs: running.count
+            totalVMs: matching.count,
+            runningVMs: running.count,
+            identity: ExeAccountIdentity(account)
         )
     }
 

--- a/Sources/Settings/ExeAccount.swift
+++ b/Sources/Settings/ExeAccount.swift
@@ -4,26 +4,109 @@ public struct ExeAccount: Codable, Equatable, Sendable, Identifiable {
     public var configKey: String
     public var name: String
     public var sshDestination: String
+    /// Comma- or space-separated exe.dev tags. Empty discovers every VM.
+    public var tagFilter: String
     public var isEnabled: Bool
 
     public var id: String { configKey }
+
+    private enum CodingKeys: String, CodingKey {
+        case configKey, name, sshDestination, tagFilter, isEnabled
+    }
 
     public init(
         configKey: String,
         name: String,
         sshDestination: String,
+        tagFilter: String = "",
         isEnabled: Bool = true
     ) {
         self.configKey = configKey
         self.name = name
         self.sshDestination = sshDestination
+        self.tagFilter = tagFilter
         self.isEnabled = isEnabled
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        configKey = try container.decode(String.self, forKey: .configKey)
+        name = try container.decode(String.self, forKey: .name)
+        sshDestination = try container.decode(
+            String.self,
+            forKey: .sshDestination
+        )
+        tagFilter = try container.decodeIfPresent(
+            String.self,
+            forKey: .tagFilter
+        ) ?? ""
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+    }
+
+    /// Whether this account discovers `vm`, given its tag filter.
+    public func discovers(_ vm: ExeVMRecord) -> Bool {
+        ExeTagFilter.matches(vm.tags, filter: tagFilter)
+    }
+}
+
+public enum ExeTagFilter {
+    /// Splits user-entered filter text into distinct tags.
+    public static func tags(in text: String) -> [String] {
+        var seen = Set<String>()
+        return text.split { $0 == "," || $0.isWhitespace }
+            .map(String.init)
+            .filter { seen.insert($0.lowercased()).inserted }
+    }
+
+    public static func normalized(_ text: String) -> String {
+        tags(in: text).joined(separator: ", ")
+    }
+
+    /// Canonical form for asking whether two filters select the same VMs.
+    /// Order, case, and duplicates do not change the answer.
+    public static func key(_ text: String) -> String {
+        tags(in: text).map { $0.lowercased() }.sorted().joined(separator: ",")
+    }
+
+    public static func matches(_ tags: [String], filter: String) -> Bool {
+        let wanted = Set(self.tags(in: filter).map { $0.lowercased() })
+        guard !wanted.isEmpty else { return true }
+        return tags.contains { wanted.contains($0.lowercased()) }
+    }
+}
+
+/// Everything about an account that changes which VMs it discovers.
+public struct ExeAccountIdentity: Equatable, Sendable {
+    public var sshDestination: String
+    public var tagFilter: String
+
+    public init(sshDestination: String, tagFilter: String = "") {
+        self.sshDestination = sshDestination.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        self.tagFilter = ExeTagFilter.normalized(tagFilter)
+    }
+
+    public init(_ account: ExeAccount) {
+        self.init(
+            sshDestination: account.sshDestination,
+            tagFilter: account.tagFilter
+        )
+    }
+
+    /// Identities that discover the same VMs are equal, so reordering or
+    /// recasing tags neither reports a change nor discards cached inventory.
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.sshDestination == rhs.sshDestination
+            && ExeTagFilter.key(lhs.tagFilter) == ExeTagFilter.key(rhs.tagFilter)
     }
 }
 
 public enum ExeAccountStatus: Equatable, Sendable {
     case loading
-    case loaded(totalVMs: Int, runningVMs: Int)
+    /// `identity` is what discovery actually ran with, which a settings draft
+    /// may have moved on from since.
+    case loaded(totalVMs: Int, runningVMs: Int, identity: ExeAccountIdentity)
     case failed(String)
 }
 
@@ -34,11 +117,12 @@ public struct ExeVMRecord: Decodable, Equatable, Sendable {
     public var region: String?
     public var regionDisplayName: String?
     public var httpsURL: String?
+    public var tags: [String]
 
     private enum CodingKeys: String, CodingKey {
         case vmName = "vm_name"
         case sshDestination = "ssh_dest"
-        case status, region
+        case status, region, tags
         case regionDisplayName = "region_display"
         case httpsURL = "https_url"
     }
@@ -49,7 +133,8 @@ public struct ExeVMRecord: Decodable, Equatable, Sendable {
         status: String,
         region: String? = nil,
         regionDisplayName: String? = nil,
-        httpsURL: String? = nil
+        httpsURL: String? = nil,
+        tags: [String] = []
     ) {
         self.vmName = vmName
         self.sshDestination = sshDestination
@@ -57,6 +142,28 @@ public struct ExeVMRecord: Decodable, Equatable, Sendable {
         self.region = region
         self.regionDisplayName = regionDisplayName
         self.httpsURL = httpsURL
+        self.tags = tags
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        vmName = try container.decode(String.self, forKey: .vmName)
+        sshDestination = try container.decode(
+            String.self,
+            forKey: .sshDestination
+        )
+        status = try container.decode(String.self, forKey: .status)
+        region = try container.decodeIfPresent(String.self, forKey: .region)
+        regionDisplayName = try container.decodeIfPresent(
+            String.self,
+            forKey: .regionDisplayName
+        )
+        httpsURL = try container.decodeIfPresent(
+            String.self,
+            forKey: .httpsURL
+        )
+        tags = try container.decodeIfPresent([String].self, forKey: .tags)
+            ?? []
     }
 
     public var isRunning: Bool {
@@ -96,6 +203,7 @@ public enum ExeAccountSanitizer {
                 configKey: configKey,
                 name: name,
                 sshDestination: destination,
+                tagFilter: ExeTagFilter.normalized(account.tagFilter),
                 isEnabled: account.isEnabled
             )
         }
@@ -179,6 +287,7 @@ public enum ExeAccountSanitizer {
                 configKey: configKey,
                 name: name,
                 sshDestination: destination,
+                tagFilter: ExeTagFilter.normalized(draft.tagFilter),
                 isEnabled: draft.isEnabled
             ))
         }

--- a/Sources/UI/ExeAccountsSettingsView.swift
+++ b/Sources/UI/ExeAccountsSettingsView.swift
@@ -308,6 +308,20 @@ struct ExeAccountsSettingsView: View {
             .font(.system(size: 11))
             .foregroundStyle(.secondary)
 
+            accountField(
+                "Tags",
+                placeholder: "All VMs",
+                text: binding.tagFilter
+            )
+
+            Text(
+                "Leave Tags empty to discover every VM. Otherwise Ghosthub"
+                    + " discovers only VMs carrying at least one of these"
+                    + " exe.dev tags, such as dev, prod."
+            )
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+
             accountStatus(account)
         }
         .padding(12)
@@ -375,11 +389,13 @@ struct ExeAccountsSettingsView: View {
                     Text("Discovering VMs…")
                 }
                 .font(.system(size: 12))
-            case let .loaded(totalVMs, runningVMs):
-                Text(
-                    "\(runningVMs) running of \(totalVMs) VM"
-                        + (totalVMs == 1 ? "" : "s")
-                )
+            case let .loaded(totalVMs, runningVMs, identity):
+                Text(Self.loadedSummary(
+                    totalVMs: totalVMs,
+                    runningVMs: runningVMs,
+                    discovered: identity,
+                    draft: ExeAccountIdentity(account)
+                ))
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
             case let .failed(message):
@@ -390,6 +406,36 @@ struct ExeAccountsSettingsView: View {
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// Counts describe the identity discovery ran with, so an edited draft
+    /// must not relabel them. It reports the pending edit instead.
+    static func loadedSummary(
+        totalVMs: Int,
+        runningVMs: Int,
+        discovered: ExeAccountIdentity,
+        draft: ExeAccountIdentity
+    ) -> String {
+        guard discovered == draft else {
+            let subject = if discovered.sshDestination != draft.sshDestination,
+                             ExeTagFilter.key(discovered.tagFilter)
+                             != ExeTagFilter.key(draft.tagFilter) {
+                "Destination and tags"
+            } else if discovered.sshDestination != draft.sshDestination {
+                "Destination"
+            } else {
+                "Tags"
+            }
+            return "\(subject) changed. Select Connect and Discover VMs to"
+                + " apply."
+        }
+        let tags = ExeTagFilter.tags(in: discovered.tagFilter)
+        let noun = "VM" + (totalVMs == 1 ? "" : "s")
+        guard !tags.isEmpty else {
+            return "\(runningVMs) running of \(totalVMs) \(noun)"
+        }
+        return "\(runningVMs) running of \(totalVMs) \(noun) tagged "
+            + tags.joined(separator: " or ")
     }
 
     private func errorText(_ message: String) -> some View {

--- a/Tests/App/ExeVMInventoryTests.swift
+++ b/Tests/App/ExeVMInventoryTests.swift
@@ -21,7 +21,7 @@ struct ExeVMInventoryTests {
                 """
                 local login-shell output
                 \(startMarker)
-                {"vms":[{"vm_name":"build","ssh_dest":"vm+build@exe.dev","ssh_host":"build.exe.xyz","status":"running","region":"lon","region_display":"London, UK","https_url":"https://build.exe.xyz"}]}
+                {"vms":[{"vm_name":"build","ssh_dest":"vm+build@exe.dev","ssh_host":"build.exe.xyz","status":"running","region":"lon","region_display":"London, UK","https_url":"https://build.exe.xyz","tags":["dev"]}]}
                 \(endMarker)
                 trailing output
                 """,
@@ -43,6 +43,7 @@ struct ExeVMInventoryTests {
         #expect(vm.vmName == "build")
         #expect(vm.sshDestination == "vm+build@exe.dev")
         #expect(vm.regionDisplayName == "London, UK")
+        #expect(vm.tags == ["dev"])
         #expect(vm.isRunning)
     }
 
@@ -100,7 +101,10 @@ struct ExeVMInventoryTests {
             for await statuses in store.$statuses.values {
                 if statuses["personal"] == .loaded(
                     totalVMs: 1,
-                    runningVMs: 1
+                    runningVMs: 1,
+                    identity: ExeAccountIdentity(
+                        sshDestination: "old.exe.dev"
+                    )
                 ) {
                     return
                 }
@@ -154,7 +158,10 @@ struct ExeVMInventoryTests {
             for await statuses in store.$statuses.values {
                 if statuses["personal"] == .loaded(
                     totalVMs: 1,
-                    runningVMs: 1
+                    runningVMs: 1,
+                    identity: ExeAccountIdentity(
+                        sshDestination: "old.exe.dev"
+                    )
                 ) {
                     return
                 }
@@ -204,14 +211,20 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 1)
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "new.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(newRefreshID, currentAccounts: [])
         #expect(store.hosts.count == 1)
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "new.exe.dev"
+            )
         ))
     }
 
@@ -275,7 +288,10 @@ struct ExeVMInventoryTests {
         #expect(restored.metadata.accountName == "Personal")
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "old.exe.dev"
+            )
         ))
 
         let movedAgain = ExeAccount(
@@ -358,7 +374,10 @@ struct ExeVMInventoryTests {
             == "vm+build@exe.dev")
         #expect(store.statuses[account.configKey] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "exe.dev"
+            )
         ))
     }
 
@@ -394,7 +413,10 @@ struct ExeVMInventoryTests {
             guard cancellations.load() == 0,
                   statuses["personal"] == .loaded(
                       totalVMs: 1,
-                      runningVMs: 1
+                      runningVMs: 1,
+                      identity: ExeAccountIdentity(
+                          sshDestination: "personal.exe.dev"
+                      )
                   ),
                   let refreshID
             else { return }
@@ -438,7 +460,10 @@ struct ExeVMInventoryTests {
             )
             #expect(store.statuses["personal"] == .loaded(
                 totalVMs: 1,
-                runningVMs: 1
+                runningVMs: 1,
+                identity: ExeAccountIdentity(
+                    sshDestination: "personal.exe.dev"
+                )
             ))
             #expect(store.statuses["work"] == nil)
         }
@@ -570,11 +595,17 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 2)
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "personal.exe.dev"
+            )
         ))
         #expect(store.statuses["work"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "work.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(
@@ -608,7 +639,10 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 2)
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "personal.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(
@@ -625,7 +659,10 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 2)
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "personal.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(
@@ -643,7 +680,10 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 2)
         #expect(store.statuses["work"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "work.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(
@@ -660,7 +700,10 @@ struct ExeVMInventoryTests {
         #expect(store.hosts.count == 2)
         #expect(store.statuses["work"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "work.exe.dev"
+            )
         ))
 
         store.invalidateRefresh(refreshID, currentAccounts: [])
@@ -743,11 +786,169 @@ struct ExeVMInventoryTests {
         })?.metadata.accountName == "Work")
         #expect(store.statuses["personal"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "personal.exe.dev"
+            )
         ))
         #expect(store.statuses["work"] == .loaded(
             totalVMs: 1,
-            runningVMs: 1
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "work.exe.dev"
+            )
         ))
+    }
+
+    @MainActor
+    @Test("tag filters scope discovered VMs and reported counts")
+    func tagFilterScopesDiscoveredVMs() {
+        let store = ExeVMInventoryStore(client: ExeVMClient { _, _, _ in
+            (255, "", "Unexpected query")
+        })
+        let account = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "Dev"
+        )
+
+        store.refresh(
+            accounts: [account],
+            persistedAccounts: [account],
+            prefetchedVMs: [account.configKey: [
+                ExeVMRecord(
+                    vmName: "kelp-dev",
+                    sshDestination: "kelp-dev.exe.xyz",
+                    status: "running",
+                    tags: ["dev"]
+                ),
+                ExeVMRecord(
+                    vmName: "kelp-dev-stopped",
+                    sshDestination: "kelp-dev-stopped.exe.xyz",
+                    status: "stopped",
+                    tags: ["dev"]
+                ),
+                ExeVMRecord(
+                    vmName: "kelp-prod",
+                    sshDestination: "kelp-prod.exe.xyz",
+                    status: "running",
+                    tags: ["prod"]
+                ),
+                ExeVMRecord(
+                    vmName: "scratchme",
+                    sshDestination: "scratchme.exe.xyz",
+                    status: "running"
+                ),
+            ]]
+        )
+
+        #expect(store.hosts.map(\.sshHost.name) == ["kelp-dev"])
+        #expect(store.statuses["personal"] == .loaded(
+            totalVMs: 2,
+            runningVMs: 1,
+            identity: ExeAccountIdentity(
+                sshDestination: "exe.dev", tagFilter: "Dev"
+            )
+        ))
+    }
+
+    @MainActor
+    @Test("reordering tags keeps cached hosts and the discovered filter")
+    func reorderingTagsKeepsCachedHosts() {
+        let store = ExeVMInventoryStore(client: ExeVMClient { _, _, _ in
+            (255, "", "Unexpected query")
+        })
+        let account = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "dev, prod"
+        )
+        let reordered = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "PROD,dev"
+        )
+        store.refresh(
+            accounts: [account],
+            persistedAccounts: [account],
+            prefetchedVMs: [account.configKey: [ExeVMRecord(
+                vmName: "kelp-dev",
+                sshDestination: "kelp-dev.exe.xyz",
+                status: "running",
+                tags: ["dev"]
+            )]]
+        )
+        let refreshID = store.refresh(
+            accounts: [reordered],
+            persistedAccounts: [account]
+        )
+        store.invalidateRefresh(refreshID, currentAccounts: [reordered])
+
+        // Cache survives: an equivalent filter is not a new identity. The
+        // status is left alone here because that second refresh is in flight.
+        #expect(store.hosts.map(\.sshHost.name) == ["kelp-dev"])
+        store.cancelRefresh(refreshID, retaining: [reordered])
+        #expect(store.hosts.map(\.sshHost.name) == ["kelp-dev"])
+    }
+
+    @MainActor
+    @Test("changing only the tag filter invalidates cached hosts")
+    func changingTagFilterInvalidatesCachedHosts() async {
+        let client = ExeVMClient { _, startMarker, endMarker in
+            (
+                0,
+                """
+                \(startMarker)
+                {"vms":[{"vm_name":"kelp-dev","ssh_dest":"kelp-dev.exe.xyz","status":"running","tags":["dev"]},{"vm_name":"kelp-prod","ssh_dest":"kelp-prod.exe.xyz","status":"running","tags":["prod"]}]}
+                \(endMarker)
+                """,
+                ""
+            )
+        }
+        let store = ExeVMInventoryStore(client: client)
+        let devAccount = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "dev"
+        )
+        let prodAccount = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "prod"
+        )
+        var loaded = Task { @MainActor in
+            for await hosts in store.$hosts.values
+                where hosts.first?.sshHost.name == "kelp-dev" {
+                return
+            }
+        }
+        store.refresh(accounts: [devAccount])
+        await loaded.value
+
+        loaded = Task { @MainActor in
+            for await hosts in store.$hosts.values
+                where hosts.first?.sshHost.name == "kelp-prod" {
+                return
+            }
+        }
+        let prodRefreshID = store.refresh(
+            accounts: [prodAccount],
+            persistedAccounts: [devAccount]
+        )
+        await loaded.value
+
+        store.invalidateRefresh(
+            prodRefreshID,
+            currentAccounts: [devAccount]
+        )
+        #expect(store.hosts.map(\.sshHost.name) == ["kelp-dev"])
+
+        store.cancelRefresh(prodRefreshID, retaining: [devAccount])
+        #expect(store.hosts.map(\.sshHost.name) == ["kelp-dev"])
     }
 }

--- a/Tests/Settings/ExeAccountTests.swift
+++ b/Tests/Settings/ExeAccountTests.swift
@@ -74,6 +74,66 @@ struct ExeAccountTests {
         ]) == ["exe.dev"])
     }
 
+    @Test("tag filters normalize to a canonical, deduplicated list")
+    func normalizesTagFilters() {
+        #expect(ExeTagFilter.tags(in: "  dev,,prod dev  ,DEV ")
+            == ["dev", "prod"])
+        #expect(ExeTagFilter.normalized(" prod ,dev") == "prod, dev")
+        #expect(ExeTagFilter.normalized("   ").isEmpty)
+
+        let stored = ExeAccountSanitizer.storedAccounts([
+            ExeAccount(
+                configKey: "personal",
+                name: "Personal",
+                sshDestination: "exe.dev",
+                tagFilter: " dev,  prod dev "
+            ),
+        ])
+
+        #expect(stored.first?.tagFilter == "dev, prod")
+        #expect(ExeAccountSanitizer.accountsForPersistence(
+            [ExeAccount(
+                configKey: "personal",
+                name: "Personal",
+                sshDestination: "exe.dev",
+                tagFilter: "dev,,prod"
+            )],
+            previous: []
+        ).first?.tagFilter == "dev, prod")
+    }
+
+    @Test(
+        "accounts discover VMs carrying any filtered tag",
+        arguments: [
+            ("", ["prod"], true),
+            ("", [], true),
+            ("dev", ["dev"], true),
+            ("dev", ["DEV"], true),
+            ("dev, prod", ["prod", "lax"], true),
+            ("dev", ["prod"], false),
+            ("dev", [], false),
+        ]
+    )
+    func discoversTaggedVMs(
+        tagFilter: String,
+        vmTags: [String],
+        discovers: Bool
+    ) {
+        let account = ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: tagFilter
+        )
+
+        #expect(account.discovers(ExeVMRecord(
+            vmName: "kelp-prod",
+            sshDestination: "kelp-prod.exe.xyz",
+            status: "running",
+            tags: vmTags
+        )) == discovers)
+    }
+
     @Test("persistence reconciles invalid accounts independently")
     func reconcilesPersistenceByAccount() {
         let personal = ExeAccount(

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -205,6 +205,32 @@ final class SettingsStoreTests {
     }
 
     @Test
+    func exeAccountsStoredBeforeTagFiltersStillLoad() {
+        let legacy = Data("""
+        [{"configKey":"personal","name":"Personal","sshDestination":"exe.dev","isEnabled":true}]
+        """.utf8)
+        defaults.set(legacy, forKey: "ghosthub.settings.hosts.exeAccounts")
+
+        #expect(makeSUT().exeAccounts == [ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev"
+        )])
+    }
+
+    @Test
+    func exeAccountTagFiltersSurviveAReload() {
+        makeSUT().setExeAccounts([ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "dev, prod"
+        )])
+
+        #expect(makeSUT().exeAccounts.first?.tagFilter == "dev, prod")
+    }
+
+    @Test
     func testLoadingHiddenTmuxSessionPatternsFromAppConfig() throws {
         try writeAppConfig(toml: """
         [tmux]

--- a/Tests/UI/ExeAccountsSettingsTests.swift
+++ b/Tests/UI/ExeAccountsSettingsTests.swift
@@ -77,7 +77,68 @@ struct ExeAccountsSettingsTests {
             name: "Personal",
             sshDestination: "other.exe.dev"
         )]))
+        #expect(!operation.matches(operation, accounts: [ExeAccount(
+            configKey: "personal",
+            name: "Personal",
+            sshDestination: "exe.dev",
+            tagFilter: "dev"
+        )]))
         #expect(!operation.matches(nil, accounts: [account]))
+    }
+
+    @Test("discovery counts name the tags they were scoped to")
+    func discoveryCountsNameScopedTags() {
+        #expect(ExeAccountsSettingsView.loadedSummary(
+            totalVMs: 4,
+            runningVMs: 3,
+            discovered: ExeAccountIdentity(sshDestination: "exe.dev"),
+            draft: ExeAccountIdentity(sshDestination: "exe.dev")
+        ) == "3 running of 4 VMs")
+        #expect(ExeAccountsSettingsView.loadedSummary(
+            totalVMs: 1,
+            runningVMs: 1,
+            discovered: ExeAccountIdentity(
+                sshDestination: "exe.dev",
+                tagFilter: "dev, prod"
+            ),
+            draft: ExeAccountIdentity(
+                sshDestination: " exe.dev ",
+                tagFilter: "PROD,dev"
+            )
+        ) == "1 running of 1 VM tagged dev or prod")
+    }
+
+    @Test(
+        "counts are never labeled with an identity discovery did not use",
+        arguments: [
+            ("exe.dev", "dev", "exe.dev", "prod", "Tags"),
+            ("exe.dev", "dev", "exe.dev", "", "Tags"),
+            ("exe.dev", "", "exe.dev", "dev", "Tags"),
+            ("exe.dev", "dev", "exe.dev", "dev, prod", "Tags"),
+            ("exe.dev", "", "other.exe.dev", "", "Destination"),
+            ("exe.dev", "dev", "other.exe.dev", "dev", "Destination"),
+            ("exe.dev", "dev", "other.exe.dev", "prod", "Destination and tags"),
+        ]
+    )
+    func editedAccountsDoNotRelabelStaleCounts(
+        discoveredDestination: String,
+        discoveredTags: String,
+        draftDestination: String,
+        draftTags: String,
+        subject: String
+    ) {
+        #expect(ExeAccountsSettingsView.loadedSummary(
+            totalVMs: 1,
+            runningVMs: 1,
+            discovered: ExeAccountIdentity(
+                sshDestination: discoveredDestination,
+                tagFilter: discoveredTags
+            ),
+            draft: ExeAccountIdentity(
+                sshDestination: draftDestination,
+                tagFilter: draftTags
+            )
+        ) == "\(subject) changed. Select Connect and Discover VMs to apply.")
     }
 
     @MainActor

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -320,7 +320,10 @@ An enabled exe.dev account is a host-inventory provider, not a terminal
 backend. Ghosthub invokes the account's configured OpenSSH destination with
 `ls --json`, then treats each running VM as an ordinary Linux SSH host using
 the response's exact `ssh_dest`; it never synthesizes a VM hostname or SSH
-username. Enabled accounts must use unique OpenSSH destinations; multiple
+username. An account may carry a tag filter, in which case only VMs whose
+`tags` include at least one filtered tag are discovered at all; the filter is
+part of the account's discovery identity, so changing it invalidates that
+account's cached VM list exactly as changing its destination does. Enabled accounts must use unique OpenSSH destinations; multiple
 accounts therefore use distinct Host aliases. The account display name is
 provider presentation metadata and never contributes to stable host identity.
 The dynamic VM list is not copied into manual host settings. A

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -43,12 +43,18 @@ manually. Create and manage VMs through [exe.dev](https://exe.dev/docs), then:
 
 1. Open **Settings → Integrations**.
 2. Add an exe.dev account. The default SSH destination is `exe.dev`.
-3. Select **Connect and Discover VMs** and complete any OpenSSH trust or
+3. Optionally enter **Tags** to narrow discovery, such as `dev` or `dev, prod`.
+4. Select **Connect and Discover VMs** and complete any OpenSSH trust or
    authentication prompt.
 
 Running VMs appear with the rest of the host fleet. Ghosthub uses each VM's
 exe.dev-provided SSH destination for ordinary tmux, optional Herdr, and optional
 kwt discovery.
+
+Leaving **Tags** empty discovers every VM on the account. With tags entered,
+Ghosthub discovers only VMs carrying at least one of them, and the account's
+status line reports the counts it was scoped to. Tags are matched without
+regard to case, and are managed in exe.dev.
 
 ![Ghosthub Integrations settings showing a connected exe.dev account and discovered VM status](assets/guide-exe-dev.png)
 


### PR DESCRIPTION
Thanks for Ghosthub. I was stoked to see that you added exe.dev support. I make use of a lot of tags to keep dev vms separate from vms that are hosting something. I thought it would be great to make use of those tags. That way I can keep the web hosts out of the list. I added a simple filter.

<img width="1065" height="770" alt="image" src="https://github.com/user-attachments/assets/0cd5cf37-9996-48c1-abf0-ffcb93c1c998" />

Another way, would be to do something like right click "hide this host" but a filter seemed simpler. 

If you'd rather have your own agent do this prompt got me there with Claude.

```
Read how the exe.dev integration works, then extend it so an account can
discover only VMs carrying specific tags.

Discovery runs `ssh exe.dev ls --json`. The response is `{"vms": [...]}`, where
each VM looks like this (fields trimmed to the ones that matter):

  {"vm_name": "kelp-prod", "ssh_dest": "kelp-prod.exe.xyz", "status": "running",
   "region": "lax", "region_display": "Los Angeles, USA",
   "https_url": "https://kelp-prod.exe.xyz", "tags": ["prod"]}

`tags` is absent entirely on untagged VMs. In my fleet: `kelp-prod` is tagged
prod, `kelp-dev` is tagged dev, and `scratchme` has no tags.

Requirements:
- Per-account filter, editable in Settings → Integrations, empty means "every
  VM" (today's behavior).
- A VM matches if it carries any one of the filtered tags. Matching is
  case-insensitive.
- The account's status line should make it obvious the filter is in effect.

Watch out for these, they are easy to get wrong:
- Accounts already persisted in UserDefaults must survive the schema change.
- The filter changes which VMs an account resolves to, so think about what that
  means for the cached-inventory and settings-draft state machine in
  ExeVMInventory.swift — particularly the cancel and invalidate paths.

Follow AGENTS.md: tests in the same change, `make format`, and the build and
test gates before you call it done. Commit, but don't open a PR.
```