### PR TITLE
Add local WSL Herdr sessions and lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,9 +181,13 @@ ordinary attach-only client; named creation consumes one non-retryable
 discovery. Stopped Herdr rows expose Restart, named stopped rows additionally
 expose confirmed Delete, and running rows expose confirmed Stop. Those
 destructive actions freshly revalidate the WSL runtime, executable, state, and
-configuration paths before mutation; stopping a session first closes its
-matching client presentations. Tmux continues to expose separate detach and
-confirmed Kill Session controls rather than sharing Herdr lifecycle semantics.
+configuration paths, then recheck the runtime at the mutation boundary. A
+per-session in-flight guard serializes ordinary-client launch against Stop and
+Delete, disables duplicate actions, and remains active through fresh inventory
+publication or a classified operation failure; stopping a session first closes
+its matching client presentations. Tmux continues to expose separate detach
+and confirmed Kill Session controls rather than sharing Herdr lifecycle
+semantics.
 The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,12 +182,15 @@ discovery. Stopped Herdr rows expose Restart, named stopped rows additionally
 expose confirmed Delete, and running rows expose confirmed Stop. Those
 destructive actions freshly revalidate the WSL runtime, executable, state, and
 configuration paths, then recheck the runtime at the mutation boundary. A
-per-session in-flight guard serializes ordinary-client launch against Stop and
-Delete, disables duplicate actions, and remains active through fresh inventory
-publication or a classified operation failure; stopping a session first closes
-its matching client presentations. Tmux continues to expose separate detach
-and confirmed Kill Session controls rather than sharing Herdr lifecycle
-semantics.
+per-session in-flight guard disables duplicate actions and remains active
+through fresh inventory publication or a classified operation failure. A
+workspace operation fence serializes complete attachment, retained-client
+retry, creation or restart, and lifecycle operations through worker and
+inventory publication. Constructive and lifecycle snapshots each advance the
+inventory generation, preventing older full snapshots from overwriting their
+result. Stopping a session first closes its matching client presentations.
+Tmux continues to expose separate detach and confirmed Kill Session controls
+rather than sharing Herdr lifecycle semantics.
 The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ timeouts. Returning focus to a window refreshes a ready WSL inventory, matching
 the Swift app's activation-driven discovery without retrying disconnected or
 failed hosts in a loop. Later refreshes reuse the admitted host capability so
 they perform ordinary inventory reads instead of repeating tmux admission. The
-same refresh resolves optional Herdr through the WSL account environment,
+same refresh resolves optional Herdr through WSL's POSIX login profile,
 scrubs inherited Herdr routing variables, and publishes running and stopped
 sessions separately from tmux. Missing Herdr is silent; a broken Herdr probe is
 scoped to that capability and never makes the WSL tmux host unavailable. Tmux

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,10 @@ ordinary attach-only client; named creation consumes one non-retryable
 discovery. Stopped Herdr rows expose Restart, named stopped rows additionally
 expose confirmed Delete, and running rows expose confirmed Stop. Those
 destructive actions freshly revalidate the WSL runtime, executable, state, and
-configuration paths, then recheck the runtime at the mutation boundary. A
+configuration paths, including whether Herdr currently identifies the record
+as its default session, then recheck the runtime at the mutation boundary.
+User-authored creation names use the restricted creation grammar; Restart
+preserves authoritative names from inventory unchanged. A
 per-session in-flight guard disables duplicate actions and remains active
 through fresh inventory publication or a classified operation failure. A
 workspace operation fence serializes complete attachment, retained-client

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,12 @@ while refresh remains host-scoped. Refresh keeps the last usable rows visible
 until replacement inventory publishes. A running Herdr row opens through its
 ordinary attach-only client; named creation consumes one non-retryable
 `herdr --session` launch authority with the same inherited-environment scrub as
-discovery.
+discovery. Stopped Herdr rows expose Restart, named stopped rows additionally
+expose confirmed Delete, and running rows expose confirmed Stop. Those
+destructive actions freshly revalidate the WSL runtime, executable, state, and
+configuration paths before mutation; stopping a session first closes its
+matching client presentations. Tmux continues to expose separate detach and
+confirmed Kill Session controls rather than sharing Herdr lifecycle semantics.
 The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,13 @@ they perform ordinary inventory reads instead of repeating tmux admission. The
 same refresh resolves optional Herdr through the WSL account environment,
 scrubs inherited Herdr routing variables, and publishes running and stopped
 sessions separately from tmux. Missing Herdr is silent; a broken Herdr probe is
-scoped to that capability and never makes the WSL tmux host unavailable.
+scoped to that capability and never makes the WSL tmux host unavailable. Tmux
+and Herdr creation controls live beside their respective inventory headings,
+while refresh remains host-scoped. Refresh keeps the last usable rows visible
+until replacement inventory publishes. A running Herdr row opens through its
+ordinary attach-only client; named creation consumes one non-retryable
+`herdr --session` launch authority with the same inherited-environment scrub as
+discovery.
 The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,8 +150,9 @@ consumed through kwt's machine-readable CLI surfaces.
 ### Windows and Linux Rust applications
 
 The first Rust product slice is a native Windows GPUI application attaching to
-tmux inside WSL2. Linux remains a compile-and-contract target until a native
-Linux product slice is authorized. Neither replaces the macOS SwiftUI
+tmux and discovering optional Herdr sessions inside WSL2. Linux remains a
+compile-and-contract target until a native Linux product slice is authorized.
+Neither replaces the macOS SwiftUI
 application or embeds a Rust runtime into it. Cross-platform parity is enforced
 through the repository-root contracts corpus rather than a shared process, FFI
 domain model, or live database.
@@ -167,7 +168,11 @@ for cold start; later attempts have 30 seconds, in addition to per-command
 timeouts. Returning focus to a window refreshes a ready WSL inventory, matching
 the Swift app's activation-driven discovery without retrying disconnected or
 failed hosts in a loop. Later refreshes reuse the admitted host capability so
-they perform ordinary inventory reads instead of repeating tmux admission.
+they perform ordinary inventory reads instead of repeating tmux admission. The
+same refresh resolves optional Herdr through the WSL account environment,
+scrubs inherited Herdr routing variables, and publishes running and stopped
+sessions separately from tmux. Missing Herdr is silent; a broken Herdr probe is
+scoped to that capability and never makes the WSL tmux host unavailable.
 The ready host also exposes explicit bare-session creation. Rust consumes one
 non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -238,13 +238,22 @@ Other executable, permission, transport, and malformed-output failures remain a
 Herdr-scoped diagnostic and do not change tmux readiness or cached tmux rows.
 
 The inventory preserves both running and stopped sessions and publishes them in
-a separate compact Herdr group under the WSL host. The Herdr executable and
-inventory are captured inside the same before/after WSL runtime check as tmux,
-so a distro restart cannot combine evidence from different runtime instances.
-The first incremental slice exposes this optional inventory. Ordinary-client
-attachment, retained presentation switching, and explicit lifecycle actions
-must reuse the shipped exact-name and environment-scrubbing rules; they may not
-reinterpret Herdr as a tmux-compatible server or use Herdr's remote mode.
+a separate compact Herdr group under the WSL host. Tmux and Herdr each own the
+creation action beside their group header; the host row owns refresh, not
+session creation. A refresh marks the host as connecting without discarding
+either cached group, so navigation remains stable while replacement inventory
+is in flight.
+
+The Herdr executable and inventory are captured inside the same before/after
+WSL runtime check as tmux, so a distro restart cannot combine evidence from
+different runtime instances. Opening a running row uses
+`herdr session attach <exact-name>`. Creating a named session consumes one
+non-cloneable launch authority for `herdr --session <exact-name>` and never
+replays it after failure. Both paths launch an ordinary ConPTY client through
+direct argv after removing all inherited Herdr routing variables. Retained
+presentation switching and explicit Stop, Restart, and Delete actions remain
+later work and must reuse the shipped exact-name rules; Rust does not reinterpret
+Herdr as a tmux-compatible server or use Herdr's remote mode.
 
 ### Terminal ownership
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1,17 +1,18 @@
 # Windows and Linux Rust Port
 
 This document is the maintained design for native Ghosthub applications on
-Windows and Linux. The first product slice is Windows-only and uses tmux in
-WSL2; Linux remains a compile-and-contract target until a native Linux product
-slice is authorized. The shipped macOS application remains SwiftUI/AppKit with
-libghostty. The shared product and terminal invariants remain authoritative in
+Windows and Linux. The first product slice is Windows-only, uses tmux in WSL2,
+and discovers optional Herdr sessions there; Linux remains a
+compile-and-contract target until a native Linux product slice is authorized.
+The shipped macOS application remains SwiftUI/AppKit with libghostty. The
+shared product and terminal invariants remain authoritative in
 [architecture.md](architecture.md) and
 [terminal-sessions.md](terminal-sessions.md).
 
-The port exists to deliver the same native terminal for local and remote tmux
-fleets on Windows and Linux. It is not a rewrite of the macOS application, a
-shared runtime embedded into Swift, or a reason to change macOS away from
-SwiftUI.
+The port exists to deliver the same native terminal for local and remote
+multiplexer fleets on Windows and Linux. It is not a rewrite of the macOS
+application, a shared runtime embedded into Swift, or a reason to change macOS
+away from SwiftUI.
 
 ## 1. Product and Dependency Boundary
 
@@ -224,6 +225,26 @@ Host publishes classified diagnostics rather than flattening command failures:
 Failures remain retryable where another attempt can change the result. The
 empty state names the resolved distro, binary, and default or configured socket
 environment so zero sessions cannot silently conceal where Ghosthub looked.
+
+### Optional Herdr capability in WSL
+
+Herdr is discovered as an optional capability of the resolved WSL endpoint,
+not as a second host and not as an application startup requirement. After tmux
+admission, Host resolves an exact absolute `herdr` executable through the WSL
+account login environment, removes every inherited Herdr routing variable named
+in [Terminal Sessions](terminal-sessions.md), and invokes
+`herdr session list --json` through direct argv. Exit 127 is silent absence.
+Other executable, permission, transport, and malformed-output failures remain a
+Herdr-scoped diagnostic and do not change tmux readiness or cached tmux rows.
+
+The inventory preserves both running and stopped sessions and publishes them in
+a separate compact Herdr group under the WSL host. The Herdr executable and
+inventory are captured inside the same before/after WSL runtime check as tmux,
+so a distro restart cannot combine evidence from different runtime instances.
+The first incremental slice exposes this optional inventory. Ordinary-client
+attachment, retained presentation switching, and explicit lifecycle actions
+must reuse the shipped exact-name and environment-scrubbing rules; they may not
+reinterpret Herdr as a tmux-compatible server or use Herdr's remote mode.
 
 ### Terminal ownership
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -257,10 +257,13 @@ stopped row restarts it through the one-shot launch path: the default session
 uses plain `herdr`, while a named session uses `herdr --session <exact-name>`.
 Stop and Delete require confirmation, then Host freshly revalidates the WSL
 runtime, executable, expected running or stopped state, session directory, and
-socket before invoking the direct lifecycle command. Stop first closes every
-matching client presentation; Delete is offered only for stopped non-default
-sessions. Rust does not reinterpret Herdr as a tmux-compatible server or use
-Herdr's remote mode.
+socket, followed by a final runtime check immediately before invoking the
+direct lifecycle command. A per-session in-flight guard disables duplicate
+actions and serializes client launch against Stop or Delete. Stop first closes
+every matching client presentation; Delete is offered only for stopped
+non-default sessions. The guard remains until fresh inventory publishes or a
+classified operation failure is reported. Rust does not reinterpret Herdr as a
+tmux-compatible server or use Herdr's remote mode.
 
 ### Terminal ownership
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -252,9 +252,15 @@ different runtime instances. Opening a running row uses
 non-cloneable launch authority for `herdr --session <exact-name>` and never
 replays it after failure. Both paths launch an ordinary ConPTY client through
 direct argv after removing all inherited Herdr routing variables. Retained
-presentation switching and explicit Stop, Restart, and Delete actions remain
-later work and must reuse the shipped exact-name rules; Rust does not reinterpret
-Herdr as a tmux-compatible server or use Herdr's remote mode.
+presentation switching uses the same presentation slot as tmux. Selecting a
+stopped row restarts it through the one-shot launch path: the default session
+uses plain `herdr`, while a named session uses `herdr --session <exact-name>`.
+Stop and Delete require confirmation, then Host freshly revalidates the WSL
+runtime, executable, expected running or stopped state, session directory, and
+socket before invoking the direct lifecycle command. Stop first closes every
+matching client presentation; Delete is offered only for stopped non-default
+sessions. Rust does not reinterpret Herdr as a tmux-compatible server or use
+Herdr's remote mode.
 
 ### Terminal ownership
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -255,6 +255,10 @@ direct argv after removing all inherited Herdr routing variables. Retained
 presentation switching uses the same presentation slot as tmux. Selecting a
 stopped row restarts it through the one-shot launch path: the default session
 uses plain `herdr`, while a named session uses `herdr --session <exact-name>`.
+Creation accepts Ghosthub's restricted user-authored name type; Restart carries
+the authoritative discovered name unchanged, so an existing session is not
+made unmanageable by newer creation rules. The captured default-session role
+is part of restart and lifecycle validation alongside state and paths.
 Stop and Delete require confirmation, then Host freshly revalidates the WSL
 runtime, executable, expected running or stopped state, session directory, and
 socket, followed by a final runtime check immediately before invoking the

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -259,11 +259,16 @@ Stop and Delete require confirmation, then Host freshly revalidates the WSL
 runtime, executable, expected running or stopped state, session directory, and
 socket, followed by a final runtime check immediately before invoking the
 direct lifecycle command. A per-session in-flight guard disables duplicate
-actions and serializes client launch against Stop or Delete. Stop first closes
-every matching client presentation; Delete is offered only for stopped
-non-default sessions. The guard remains until fresh inventory publishes or a
-classified operation failure is reported. Rust does not reinterpret Herdr as a
-tmux-compatible server or use Herdr's remote mode.
+actions. A workspace operation fence serializes attach, retained-client retry,
+create or restart, and lifecycle mutation from fresh discovery through worker
+publication or failure, so Stop and Delete cannot be followed by an older
+launch completing. Stop first closes every matching client presentation;
+Delete is offered only for stopped non-default sessions. The guard remains
+until fresh inventory publishes or a classified operation failure is reported.
+Every constructive or lifecycle publication advances the inventory generation
+and cancels an older refresh, so an earlier full snapshot cannot overwrite the
+result. Rust does not reinterpret Herdr as a tmux-compatible server or use
+Herdr's remote mode.
 
 ### Terminal ownership
 

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -230,8 +230,9 @@ environment so zero sessions cannot silently conceal where Ghosthub looked.
 
 Herdr is discovered as an optional capability of the resolved WSL endpoint,
 not as a second host and not as an application startup requirement. After tmux
-admission, Host resolves an exact absolute `herdr` executable through the WSL
-account login environment, removes every inherited Herdr routing variable named
+admission, Host resolves an exact absolute `herdr` executable through WSL's
+POSIX login profile (`/bin/sh -lc` with a fixed Ghosthub-owned probe), removes
+every inherited Herdr routing variable named
 in [Terminal Sessions](terminal-sessions.md), and invokes
 `herdr session list --json` through direct argv. Exit 127 is silent absence.
 Other executable, permission, transport, and malformed-output failures remain a

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-test-contracts = "test -p ghosthub-contracts -p ghosthub-config -p ghosthub-host -p ghosthub-session -p ghosthub-architecture"
+test-contracts = "test -p ghosthub-contracts -p ghosthub-config -p ghosthub-host -p ghosthub-session -p ghosthub-architecture --features ghosthub-host/test-support"
 test-psmux-live = "test -p ghosthub-session --test psmux_live -- --ignored --nocapture"
 test-wsl-host-live = "test -p ghosthub-host --test wsl_live -- --ignored --nocapture"
 test-wsl-terminal-live = "test --locked -p ghosthub-terminal --test wsl_live -- --ignored --nocapture --test-threads=1"

--- a/rust/host/Cargo.toml
+++ b/rust/host/Cargo.toml
@@ -17,6 +17,8 @@ test-support = []
 ghosthub-model.workspace = true
 ghosthub-session.workspace = true
 getrandom.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
@@ -33,8 +35,6 @@ windows-sys = { version = "=0.61.2", features = [
 
 [dev-dependencies]
 ghosthub-contracts.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/rust/host/src/herdr.rs
+++ b/rust/host/src/herdr.rs
@@ -3,13 +3,6 @@ use session::{HerdrSessionRecord, HerdrSessionState};
 
 pub(crate) const PATH_MARKER: &str = "GHOSTHUB_HERDR_PATH";
 
-pub(crate) const ACCOUNT_LOGIN_HANDOFF: &str = concat!(
-    "ghosthub_account_shell=$(/usr/bin/getent passwd \"$(/usr/bin/id -u)\" ",
-    "| /usr/bin/cut -d: -f7); ",
-    "[ -n \"$ghosthub_account_shell\" ] && [ -x \"$ghosthub_account_shell\" ] || exit 127; ",
-    "exec \"$ghosthub_account_shell\" -lc \"$1\""
-);
-
 pub(crate) const RESOLVE_SCRIPT: &str = concat!(
     "unset HERDR_ENV HERDR_SESSION HERDR_SOCKET_PATH HERDR_CLIENT_SOCKET_PATH ",
     "HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_BIN_PATH ",

--- a/rust/host/src/herdr.rs
+++ b/rust/host/src/herdr.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use session::{HerdrSessionRecord, HerdrSessionState};
+use session::{HerdrLifecycleAction, HerdrSessionRecord, HerdrSessionState};
 
 pub(crate) const PATH_MARKER: &str = "GHOSTHUB_HERDR_PATH";
 
@@ -65,25 +65,67 @@ pub(crate) fn parse_inventory(bytes: &[u8]) -> Result<Vec<HerdrSessionRecord>, S
     Ok(envelope
         .sessions
         .into_iter()
-        .map(|session| {
-            HerdrSessionRecord::new(
-                session.name,
-                session.is_default,
-                if session.running {
-                    HerdrSessionState::Running
-                } else {
-                    HerdrSessionState::Stopped
-                },
-                session.directory,
-                session.socket,
-            )
-        })
+        .map(Session::into_record)
         .collect())
+}
+
+pub(crate) fn parse_lifecycle(
+    action: HerdrLifecycleAction,
+    bytes: &[u8],
+) -> Result<HerdrSessionRecord, String> {
+    let envelope: LifecycleEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| "Herdr returned malformed lifecycle JSON".to_owned())?;
+    if let Some(error) = envelope.error {
+        return Err(error.message);
+    }
+    let completed = match action {
+        HerdrLifecycleAction::Stop => envelope.stopped,
+        HerdrLifecycleAction::Delete => envelope.deleted,
+    };
+    if completed != Some(true) {
+        return Err(format!(
+            "Herdr did not confirm that session {} completed",
+            action.command()
+        ));
+    }
+    envelope
+        .session
+        .map(Session::into_record)
+        .ok_or_else(|| "Herdr lifecycle response omitted the session record".to_owned())
+}
+
+pub(crate) fn lifecycle_error(bytes: &[u8], stderr: &[u8]) -> String {
+    serde_json::from_slice::<LifecycleEnvelope>(bytes)
+        .ok()
+        .and_then(|envelope| envelope.error)
+        .map(|error| error.message)
+        .filter(|message| !message.trim().is_empty())
+        .unwrap_or_else(|| {
+            let message = String::from_utf8_lossy(stderr).trim().to_owned();
+            if message.is_empty() {
+                "Herdr lifecycle command failed".to_owned()
+            } else {
+                message
+            }
+        })
 }
 
 #[derive(Deserialize)]
 struct SessionEnvelope {
     sessions: Vec<Session>,
+}
+
+#[derive(Deserialize)]
+struct LifecycleEnvelope {
+    session: Option<Session>,
+    stopped: Option<bool>,
+    deleted: Option<bool>,
+    error: Option<LifecycleCommandError>,
+}
+
+#[derive(Deserialize)]
+struct LifecycleCommandError {
+    message: String,
 }
 
 #[derive(Deserialize)]
@@ -96,6 +138,22 @@ struct Session {
     directory: String,
     #[serde(rename = "socket_path")]
     socket: String,
+}
+
+impl Session {
+    fn into_record(self) -> HerdrSessionRecord {
+        HerdrSessionRecord::new(
+            self.name,
+            self.is_default,
+            if self.running {
+                HerdrSessionState::Running
+            } else {
+                HerdrSessionState::Stopped
+            },
+            self.directory,
+            self.socket,
+        )
+    }
 }
 
 #[cfg(test)]
@@ -134,5 +192,18 @@ mod tests {
         assert_eq!(sessions[1].state(), HerdrSessionState::Stopped);
         assert_eq!(sessions[1].session_directory(), "/tmp/review");
         assert_eq!(sessions[1].socket_path(), "/tmp/review/herdr.sock");
+    }
+
+    #[test]
+    fn lifecycle_requires_the_action_confirmation_and_record() {
+        let stopped = parse_lifecycle(
+            HerdrLifecycleAction::Stop,
+            br#"{"session":{"name":"review","default":false,"running":false,"session_dir":"/tmp/review","socket_path":"/tmp/review/herdr.sock"},"stopped":true}"#,
+        )
+        .expect("confirmed stop");
+
+        assert_eq!(stopped.name(), "review");
+        assert_eq!(stopped.state(), HerdrSessionState::Stopped);
+        assert!(parse_lifecycle(HerdrLifecycleAction::Delete, br#"{"deleted":false}"#).is_err());
     }
 }

--- a/rust/host/src/herdr.rs
+++ b/rust/host/src/herdr.rs
@@ -1,0 +1,145 @@
+use serde::Deserialize;
+use session::{HerdrSessionRecord, HerdrSessionState};
+
+pub(crate) const PATH_MARKER: &str = "GHOSTHUB_HERDR_PATH";
+
+pub(crate) const ACCOUNT_LOGIN_HANDOFF: &str = concat!(
+    "ghosthub_account_shell=$(/usr/bin/getent passwd \"$(/usr/bin/id -u)\" ",
+    "| /usr/bin/cut -d: -f7); ",
+    "[ -n \"$ghosthub_account_shell\" ] && [ -x \"$ghosthub_account_shell\" ] || exit 127; ",
+    "exec \"$ghosthub_account_shell\" -lc \"$1\""
+);
+
+pub(crate) const RESOLVE_SCRIPT: &str = concat!(
+    "unset HERDR_ENV HERDR_SESSION HERDR_SOCKET_PATH HERDR_CLIENT_SOCKET_PATH ",
+    "HERDR_PANE_ID HERDR_TAB_ID HERDR_WORKSPACE_ID HERDR_BIN_PATH ",
+    "HERDR_ACTIVE_WORKSPACE_ID HERDR_ACTIVE_TAB_ID HERDR_ACTIVE_PANE_ID ",
+    "HERDR_ACTIVE_PANE_CWD; ",
+    "ghosthub_herdr_path=$(command -v herdr) || exit 127; ",
+    "[ -n \"$ghosthub_herdr_path\" ] || exit 127; ",
+    "case \"$ghosthub_herdr_path\" in /*) ;; *) exit 127 ;; esac; ",
+    "[ -x \"$ghosthub_herdr_path\" ] || exit 127; ",
+    "printf '%s\\n%s\\n' 'GHOSTHUB_HERDR_PATH' \"$ghosthub_herdr_path\""
+);
+
+pub(crate) const CONTROL_VARIABLES: [&str; 12] = [
+    "HERDR_ENV",
+    "HERDR_SESSION",
+    "HERDR_SOCKET_PATH",
+    "HERDR_CLIENT_SOCKET_PATH",
+    "HERDR_PANE_ID",
+    "HERDR_TAB_ID",
+    "HERDR_WORKSPACE_ID",
+    "HERDR_BIN_PATH",
+    "HERDR_ACTIVE_WORKSPACE_ID",
+    "HERDR_ACTIVE_TAB_ID",
+    "HERDR_ACTIVE_PANE_ID",
+    "HERDR_ACTIVE_PANE_CWD",
+];
+
+pub(crate) enum ExecutableProbe {
+    Available(String),
+    Unavailable,
+}
+
+pub(crate) fn parse_executable(status: i32, stdout: &[u8]) -> Result<ExecutableProbe, String> {
+    if status == 127 {
+        return Ok(ExecutableProbe::Unavailable);
+    }
+    if status != 0 {
+        return Err(format!(
+            "Herdr executable probe exited with status {status}"
+        ));
+    }
+    let stdout = std::str::from_utf8(stdout)
+        .map_err(|_| "Herdr executable probe output is not UTF-8".to_owned())?;
+    let mut lines = stdout.lines();
+    let mut resolved = None;
+    while let Some(line) = lines.next() {
+        if line == PATH_MARKER {
+            resolved = lines.next();
+        }
+    }
+    let Some(path) = resolved.map(str::trim).filter(|path| path.starts_with('/')) else {
+        return Ok(ExecutableProbe::Unavailable);
+    };
+    Ok(ExecutableProbe::Available(path.to_owned()))
+}
+
+pub(crate) fn parse_inventory(bytes: &[u8]) -> Result<Vec<HerdrSessionRecord>, String> {
+    let envelope: SessionEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| "Herdr returned malformed session inventory JSON".to_owned())?;
+    Ok(envelope
+        .sessions
+        .into_iter()
+        .map(|session| {
+            HerdrSessionRecord::new(
+                session.name,
+                session.is_default,
+                if session.running {
+                    HerdrSessionState::Running
+                } else {
+                    HerdrSessionState::Stopped
+                },
+                session.directory,
+                session.socket,
+            )
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct SessionEnvelope {
+    sessions: Vec<Session>,
+}
+
+#[derive(Deserialize)]
+struct Session {
+    name: String,
+    #[serde(rename = "default")]
+    is_default: bool,
+    running: bool,
+    #[serde(rename = "session_dir")]
+    directory: String,
+    #[serde(rename = "socket_path")]
+    socket: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executable_probe_uses_the_last_marker_and_requires_an_absolute_path() {
+        assert!(matches!(
+            parse_executable(0, b"banner\nGHOSTHUB_HERDR_PATH\n/usr/local/bin/herdr\n"),
+            Ok(ExecutableProbe::Available(path)) if path == "/usr/local/bin/herdr"
+        ));
+        assert!(matches!(
+            parse_executable(0, b"GHOSTHUB_HERDR_PATH\nrelative/herdr\n"),
+            Ok(ExecutableProbe::Unavailable)
+        ));
+        assert!(matches!(
+            parse_executable(127, b""),
+            Ok(ExecutableProbe::Unavailable)
+        ));
+    }
+
+    #[test]
+    fn inventory_preserves_running_stopped_and_location_fields() {
+        let sessions = parse_inventory(
+            br#"{"sessions":[
+                {"name":"default","default":true,"running":true,"session_dir":"/tmp/default","socket_path":"/tmp/default/herdr.sock"},
+                {"name":"review","default":false,"running":false,"session_dir":"/tmp/review","socket_path":"/tmp/review/herdr.sock","future":"ignored"}
+            ]}"#,
+        )
+        .expect("valid Herdr inventory");
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].state(), HerdrSessionState::Running);
+        assert!(sessions[0].is_default());
+        assert_eq!(sessions[1].state(), HerdrSessionState::Stopped);
+        assert_eq!(sessions[1].session_directory(), "/tmp/review");
+        assert_eq!(sessions[1].socket_path(), "/tmp/review/herdr.sock");
+    }
+}

--- a/rust/host/src/lib.rs
+++ b/rust/host/src/lib.rs
@@ -12,13 +12,15 @@ use std::time::{Duration, Instant};
 pub use model::DiagnosticKind as HostErrorKind;
 
 mod command_process;
+mod herdr;
 #[cfg(windows)]
 mod windows_system;
 mod wsl;
 
 pub use wsl::{
-    AdmissionAttacher, AttachTerm, HostError, HostSnapshot, LiveSessionTarget, SystemWslPresence,
-    WslConfig, WslEndpoint, WslExecutable, WslHost, WslPresence, WslRuntimeIdentity,
+    AdmissionAttacher, AttachTerm, HerdrInventory, HostError, HostSnapshot, LiveSessionTarget,
+    SystemWslPresence, WslConfig, WslEndpoint, WslExecutable, WslHost, WslPresence,
+    WslRuntimeIdentity,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -9,9 +9,9 @@ use std::time::{Duration, Instant};
 use model::DiagnosticKind;
 use session::{
     AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform, HerdrAttachPlan,
-    HerdrLaunchOnce, HerdrLifecycleAction, HerdrSessionName, HerdrSessionRecord, HerdrSessionState,
-    IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary,
-    resolve_tmux_binary,
+    HerdrLaunchOnce, HerdrLaunchTarget, HerdrLifecycleAction, HerdrSessionRecord,
+    HerdrSessionState, IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName,
+    VerifiedTmuxBinary, resolve_tmux_binary,
 };
 
 use crate::herdr::{self, ExecutableProbe};
@@ -621,7 +621,7 @@ impl<R: CommandRunner> WslHost<R> {
         &self,
         endpoint: &WslEndpoint,
         executable: &str,
-        name: HerdrSessionName,
+        name: HerdrLaunchTarget,
         is_default: bool,
     ) -> HerdrLaunchOnce {
         let mut args = pinned_prefix(endpoint);
@@ -637,10 +637,10 @@ impl<R: CommandRunner> WslHost<R> {
 
     /// Revalidate and execute one confirmed destructive Herdr lifecycle action.
     ///
-    /// The current runtime, executable, state, and configuration paths are
-    /// captured immediately before mutation. Herdr does not expose a stable
-    /// generation identity, so same-name/same-path replacement remains an
-    /// accepted backend limitation.
+    /// The current runtime, executable, default role, state, and configuration
+    /// paths are captured immediately before mutation. Herdr does not expose a
+    /// stable generation identity, so replacement that preserves all of those
+    /// fields remains an accepted backend limitation.
     ///
     /// # Errors
     ///
@@ -659,12 +659,6 @@ impl<R: CommandRunner> WslHost<R> {
             return Err(HostError::new(
                 DiagnosticKind::Transport,
                 "WSL changed before the Herdr lifecycle action",
-            ));
-        }
-        if action == HerdrLifecycleAction::Delete && confirmed.is_default() {
-            return Err(HostError::new(
-                DiagnosticKind::UnsupportedEnvironment,
-                "Herdr's default session cannot be deleted",
             ));
         }
         let (executable, sessions) = match self.discover_herdr(endpoint, cancellation) {
@@ -689,27 +683,7 @@ impl<R: CommandRunner> WslHost<R> {
                     format!("Herdr session {} no longer exists", confirmed.name()),
                 )
             })?;
-        if current.state() != action.expected_state() {
-            let expected = match action.expected_state() {
-                HerdrSessionState::Running => "running",
-                HerdrSessionState::Stopped => "stopped",
-            };
-            return Err(HostError::new(
-                DiagnosticKind::Transport,
-                format!("Herdr session {} is no longer {expected}", confirmed.name()),
-            ));
-        }
-        if current.session_directory() != confirmed.session_directory()
-            || current.socket_path() != confirmed.socket_path()
-        {
-            return Err(HostError::new(
-                DiagnosticKind::Transport,
-                format!(
-                    "Herdr session {} moved to a different configuration",
-                    confirmed.name()
-                ),
-            ));
-        }
+        validate_herdr_lifecycle_target(confirmed, current, action)?;
 
         self.require_runtime(endpoint, expected_runtime, cancellation)?;
 
@@ -2229,6 +2203,50 @@ impl<R: CommandRunner> WslHost<R> {
     }
 }
 
+fn validate_herdr_lifecycle_target(
+    confirmed: &HerdrSessionRecord,
+    current: &HerdrSessionRecord,
+    action: HerdrLifecycleAction,
+) -> Result<(), HostError> {
+    if action == HerdrLifecycleAction::Delete && current.is_default() {
+        return Err(HostError::new(
+            DiagnosticKind::UnsupportedEnvironment,
+            "Herdr's current default session cannot be deleted",
+        ));
+    }
+    if current.is_default() != confirmed.is_default() {
+        return Err(HostError::new(
+            DiagnosticKind::Transport,
+            format!(
+                "Herdr session {} changed its default role",
+                confirmed.name()
+            ),
+        ));
+    }
+    if current.state() != action.expected_state() {
+        let expected = match action.expected_state() {
+            HerdrSessionState::Running => "running",
+            HerdrSessionState::Stopped => "stopped",
+        };
+        return Err(HostError::new(
+            DiagnosticKind::Transport,
+            format!("Herdr session {} is no longer {expected}", confirmed.name()),
+        ));
+    }
+    if current.session_directory() != confirmed.session_directory()
+        || current.socket_path() != confirmed.socket_path()
+    {
+        return Err(HostError::new(
+            DiagnosticKind::Transport,
+            format!(
+                "Herdr session {} moved to a different configuration",
+                confirmed.name()
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn admission_matches(
     verified_endpoint: &WslEndpoint,
     verified_runtime: &WslRuntimeIdentity,
@@ -2928,7 +2946,9 @@ mod tests {
         let plan = host.herdr_launch_once(
             &endpoint,
             "/home/test/.local/bin/herdr",
-            HerdrSessionName::parse("review.fix_1").expect("valid name"),
+            HerdrLaunchTarget::created(
+                session::HerdrSessionName::parse("review.fix_1").expect("valid name"),
+            ),
             false,
         );
         let (program, args, target) = plan.into_parts();

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -9,10 +9,11 @@ use std::time::{Duration, Instant};
 use model::DiagnosticKind;
 use session::{
     AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform,
-    IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary,
-    resolve_tmux_binary,
+    HerdrSessionRecord, IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName,
+    VerifiedTmuxBinary, resolve_tmux_binary,
 };
 
+use crate::herdr::{self, ExecutableProbe};
 use crate::{CancellationToken, CommandOutput, CommandRunner};
 
 const DEFAULT_TMUX: &str = "/usr/bin/tmux";
@@ -170,6 +171,48 @@ pub struct HostSnapshot {
     endpoint: WslEndpoint,
     runtime: WslRuntimeIdentity,
     sessions: Vec<DiscoveredSession>,
+    herdr: Box<HerdrInventory>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HerdrInventory {
+    Unavailable,
+    Available {
+        executable: String,
+        sessions: Vec<HerdrSessionRecord>,
+    },
+    Failed(HostError),
+}
+
+impl HerdrInventory {
+    #[must_use]
+    pub const fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+
+    #[must_use]
+    pub fn executable(&self) -> Option<&str> {
+        match self {
+            Self::Available { executable, .. } => Some(executable),
+            Self::Unavailable | Self::Failed(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub fn sessions(&self) -> &[HerdrSessionRecord] {
+        match self {
+            Self::Available { sessions, .. } => sessions,
+            Self::Unavailable | Self::Failed(_) => &[],
+        }
+    }
+
+    #[must_use]
+    pub const fn diagnostic(&self) -> Option<&HostError> {
+        match self {
+            Self::Failed(error) => Some(error),
+            Self::Unavailable | Self::Available { .. } => None,
+        }
+    }
 }
 
 /// Fresh, non-persistable authority to kill one exact live tmux session.
@@ -242,7 +285,23 @@ impl HostSnapshot {
                 init_start_ticks,
             },
             sessions,
+            herdr: Box::new(HerdrInventory::Unavailable),
         }
+    }
+
+    #[cfg(feature = "test-support")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_fixture_with_herdr(
+        distro: impl Into<String>,
+        kernel_boot_id: impl Into<String>,
+        init_start_ticks: u64,
+        sessions: Vec<DiscoveredSession>,
+        herdr: HerdrInventory,
+    ) -> Self {
+        let mut snapshot = Self::test_fixture(distro, kernel_boot_id, init_start_ticks, sessions);
+        snapshot.herdr = Box::new(herdr);
+        snapshot
     }
 
     #[must_use]
@@ -258,6 +317,11 @@ impl HostSnapshot {
     #[must_use]
     pub fn sessions(&self) -> &[DiscoveredSession] {
         &self.sessions
+    }
+
+    #[must_use]
+    pub fn herdr(&self) -> &HerdrInventory {
+        self.herdr.as_ref()
     }
 }
 
@@ -457,12 +521,14 @@ impl<R: CommandRunner> WslHost<R> {
         for _attempt in 0..DISCOVERY_ATTEMPTS {
             self.verify_tmux(&endpoint, &runtime, attacher, cancellation)?;
             let sessions = self.discover_sessions(&endpoint, cancellation)?;
+            let herdr = self.discover_herdr(&endpoint, cancellation);
             let observed_runtime = self.resolve_runtime(&endpoint, cancellation)?;
             if runtime == observed_runtime {
                 return Ok(HostSnapshot {
                     endpoint,
                     runtime,
                     sessions,
+                    herdr: Box::new(herdr),
                 });
             }
             runtime = observed_runtime;
@@ -609,6 +675,7 @@ impl<R: CommandRunner> WslHost<R> {
         &self,
         endpoint: &WslEndpoint,
         runtime: &WslRuntimeIdentity,
+        herdr: &HerdrInventory,
         cancellation: &CancellationToken,
     ) -> Result<HostSnapshot, HostError> {
         let sessions = self.discover_sessions(endpoint, cancellation)?;
@@ -623,6 +690,7 @@ impl<R: CommandRunner> WslHost<R> {
             endpoint: endpoint.clone(),
             runtime: observed_runtime,
             sessions,
+            herdr: Box::new(herdr.clone()),
         })
     }
 
@@ -837,6 +905,87 @@ impl<R: CommandRunner> WslHost<R> {
             ));
         }
         parse_inventory(&output.stdout)
+    }
+
+    fn discover_herdr(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+    ) -> HerdrInventory {
+        match self.resolve_herdr_executable(endpoint, cancellation) {
+            Ok(ExecutableProbe::Available(executable)) => {
+                self.list_herdr_sessions(endpoint, cancellation, executable)
+            }
+            Ok(ExecutableProbe::Unavailable) => HerdrInventory::Unavailable,
+            Err(error) => HerdrInventory::Failed(error),
+        }
+    }
+
+    fn resolve_herdr_executable(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+    ) -> Result<ExecutableProbe, HostError> {
+        let mut args = pinned_prefix(endpoint);
+        args.extend(
+            [
+                "/bin/sh",
+                "-c",
+                herdr::ACCOUNT_LOGIN_HANDOFF,
+                "ghosthub-herdr-resolve",
+                herdr::RESOLVE_SCRIPT,
+            ]
+            .into_iter()
+            .map(OsString::from),
+        );
+        let output = self.run(&args, cancellation)?;
+        if output.status != 0 && output.status != 127 {
+            return Err(classify_command_failure(
+                output.status,
+                &output.stderr,
+                "resolve Herdr executable",
+            ));
+        }
+        herdr::parse_executable(output.status, &output.stdout)
+            .map_err(|detail| HostError::new(DiagnosticKind::MalformedOutput, detail))
+    }
+
+    fn list_herdr_sessions(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+        executable: String,
+    ) -> HerdrInventory {
+        let mut args = pinned_prefix(endpoint);
+        append_herdr_environment(&mut args);
+        args.extend(
+            [executable.as_str(), "session", "list", "--json"]
+                .into_iter()
+                .map(OsString::from),
+        );
+        let output = match self.run(&args, cancellation) {
+            Ok(output) => output,
+            Err(error) => return HerdrInventory::Failed(error),
+        };
+        if output.status == 127 {
+            return HerdrInventory::Unavailable;
+        }
+        if output.status != 0 {
+            return HerdrInventory::Failed(classify_command_failure(
+                output.status,
+                &output.stderr,
+                "list Herdr sessions",
+            ));
+        }
+        match herdr::parse_inventory(&output.stdout) {
+            Ok(sessions) => HerdrInventory::Available {
+                executable,
+                sessions,
+            },
+            Err(detail) => {
+                HerdrInventory::Failed(HostError::new(DiagnosticKind::MalformedOutput, detail))
+            }
+        }
     }
 
     fn run_tmux_command(
@@ -2126,6 +2275,14 @@ fn append_tmux_environment(
         args.push(OsString::from(format!("TMUX_TMPDIR={path}")));
     }
     args.extend(environment.iter().map(OsString::from));
+}
+
+fn append_herdr_environment(args: &mut Vec<OsString>) {
+    args.push(OsString::from("/usr/bin/env"));
+    for variable in herdr::CONTROL_VARIABLES {
+        args.push(OsString::from("-u"));
+        args.push(OsString::from(variable));
+    }
 }
 
 fn settle_uncertain_cleanup(

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -171,6 +171,7 @@ impl WslRuntimeIdentity {
 pub struct HostSnapshot {
     endpoint: WslEndpoint,
     runtime: WslRuntimeIdentity,
+    creation_term: AttachTerm,
     sessions: Vec<DiscoveredSession>,
     herdr: Box<HerdrInventory>,
 }
@@ -285,6 +286,7 @@ impl HostSnapshot {
                 kernel_boot_id: kernel_boot_id.into(),
                 init_start_ticks,
             },
+            creation_term: AttachTerm::Xterm256Color,
             sessions,
             herdr: Box::new(HerdrInventory::Unavailable),
         }
@@ -305,6 +307,14 @@ impl HostSnapshot {
         snapshot
     }
 
+    #[cfg(feature = "test-support")]
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn test_fixture_with_creation_term(mut self, term: AttachTerm) -> Self {
+        self.creation_term = term;
+        self
+    }
+
     #[must_use]
     pub const fn endpoint(&self) -> &WslEndpoint {
         &self.endpoint
@@ -313,6 +323,11 @@ impl HostSnapshot {
     #[must_use]
     pub const fn runtime(&self) -> &WslRuntimeIdentity {
         &self.runtime
+    }
+
+    #[must_use]
+    pub const fn creation_term(&self) -> AttachTerm {
+        self.creation_term
     }
 
     #[must_use]
@@ -545,7 +560,7 @@ impl<R: CommandRunner> WslHost<R> {
         let endpoint = self.resolve_endpoint(cancellation)?;
         let mut runtime = self.resolve_runtime(&endpoint, cancellation)?;
         for _attempt in 0..DISCOVERY_ATTEMPTS {
-            self.verify_tmux(&endpoint, &runtime, attacher, cancellation)?;
+            let creation_term = self.verify_tmux(&endpoint, &runtime, attacher, cancellation)?;
             let sessions = self.discover_sessions(&endpoint, cancellation)?;
             let herdr = self.discover_herdr(&endpoint, cancellation);
             let observed_runtime = self.resolve_runtime(&endpoint, cancellation)?;
@@ -553,6 +568,7 @@ impl<R: CommandRunner> WslHost<R> {
                 return Ok(HostSnapshot {
                     endpoint,
                     runtime,
+                    creation_term,
                     sessions,
                     herdr: Box::new(herdr),
                 });
@@ -648,10 +664,11 @@ impl<R: CommandRunner> WslHost<R> {
         executable: &str,
         name: HerdrLaunchTarget,
         is_default: bool,
+        term: AttachTerm,
     ) -> HerdrLaunchOnce {
         let mut args = pinned_prefix(endpoint);
         append_herdr_environment(&mut args);
-        args.push(OsString::from("TERM=xterm-256color"));
+        args.push(OsString::from(term.environment()));
         args.push(OsString::from(executable));
         if !is_default {
             args.push(OsString::from("--session"));
@@ -675,6 +692,7 @@ impl<R: CommandRunner> WslHost<R> {
         &self,
         endpoint: &WslEndpoint,
         expected_runtime: &WslRuntimeIdentity,
+        expected_executable: &str,
         confirmed: &HerdrSessionRecord,
         action: HerdrLifecycleAction,
         cancellation: &CancellationToken,
@@ -699,6 +717,12 @@ impl<R: CommandRunner> WslHost<R> {
             }
             HerdrInventory::Failed(error) => return Err(error),
         };
+        if executable != expected_executable {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "the Herdr executable changed after lifecycle confirmation",
+            ));
+        }
         let current = sessions
             .iter()
             .find(|session| session.name() == confirmed.name())
@@ -830,6 +854,7 @@ impl<R: CommandRunner> WslHost<R> {
         &self,
         endpoint: &WslEndpoint,
         runtime: &WslRuntimeIdentity,
+        creation_term: AttachTerm,
         herdr: &HerdrInventory,
         cancellation: &CancellationToken,
     ) -> Result<HostSnapshot, HostError> {
@@ -844,6 +869,7 @@ impl<R: CommandRunner> WslHost<R> {
         Ok(HostSnapshot {
             endpoint: endpoint.clone(),
             runtime: observed_runtime,
+            creation_term,
             sessions,
             herdr: Box::new(herdr.clone()),
         })
@@ -1165,17 +1191,18 @@ impl<R: CommandRunner> WslHost<R> {
         runtime: &WslRuntimeIdentity,
         attacher: &A,
         cancellation: &CancellationToken,
-    ) -> Result<(), HostError> {
-        if self
+    ) -> Result<AttachTerm, HostError> {
+        if let Some(term) = self
             .verified_tmux
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
-            .is_some_and(|verified| {
+            .filter(|verified| {
                 admission_matches(&verified.endpoint, &verified.runtime, endpoint, runtime)
             })
+            .map(|verified| verified.creation_term)
         {
-            return Ok(());
+            return Ok(term);
         }
 
         let sequence = ADMISSION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
@@ -1731,7 +1758,7 @@ impl<R: CommandRunner> WslHost<R> {
             creation_term,
             _binary: verified,
         });
-        Ok(())
+        Ok(creation_term)
     }
 
     fn create_admission_tmpdir(
@@ -2849,6 +2876,7 @@ mod tests {
                 kernel_boot_id: "boot".to_owned(),
                 init_start_ticks: 1,
             },
+            creation_term: AttachTerm::Xterm256Color,
             sessions: Vec::new(),
             herdr: Box::new(HerdrInventory::Available {
                 executable: "/usr/bin/herdr".to_owned(),
@@ -3028,6 +3056,7 @@ mod tests {
                 session::HerdrSessionName::parse("review.fix_1").expect("valid name"),
             ),
             false,
+            AttachTerm::Xterm256Color,
         );
         let (program, args, target) = plan.into_parts();
 
@@ -3042,6 +3071,7 @@ mod tests {
             args.windows(2)
                 .any(|pair| pair == ["-u", "HERDR_ACTIVE_PANE_CWD"])
         );
+        assert!(args.iter().any(|arg| arg == "TERM=xterm-256color"));
         assert_eq!(
             args.iter()
                 .rev()
@@ -3055,5 +3085,18 @@ mod tests {
                 OsStr::new("review.fix_1"),
             ]
         );
+
+        let baseline = host.herdr_launch_once(
+            &endpoint,
+            "/home/test/.local/bin/herdr",
+            HerdrLaunchTarget::created(
+                session::HerdrSessionName::parse("baseline").expect("valid name"),
+            ),
+            false,
+            AttachTerm::Xterm,
+        );
+        let (_, baseline_args, _) = baseline.into_parts();
+        assert!(baseline_args.iter().any(|arg| arg == "TERM=xterm"));
+        assert!(!baseline_args.iter().any(|arg| arg == "TERM=xterm-256color"));
     }
 }

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -2841,16 +2841,20 @@ mod tests {
             "/tmp/other",
             "/tmp/other.sock",
         );
-        let snapshot = HostSnapshot::test_fixture_with_herdr(
-            "Ubuntu",
-            "boot",
-            1,
-            Vec::new(),
-            HerdrInventory::Available {
+        let snapshot = HostSnapshot {
+            endpoint: WslEndpoint {
+                distro: "Ubuntu".to_owned(),
+            },
+            runtime: WslRuntimeIdentity {
+                kernel_boot_id: "boot".to_owned(),
+                init_start_ticks: 1,
+            },
+            sessions: Vec::new(),
+            herdr: Box::new(HerdrInventory::Available {
                 executable: "/usr/bin/herdr".to_owned(),
                 sessions: vec![running, other.clone()],
-            },
-        );
+            }),
+        };
         let stopped = HerdrSessionRecord::new(
             "work",
             false,

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -690,13 +690,14 @@ impl<R: CommandRunner> WslHost<R> {
     /// record no longer matches the confirmation, or Herdr rejects the action.
     pub fn mutate_herdr_session(
         &self,
-        endpoint: &WslEndpoint,
-        expected_runtime: &WslRuntimeIdentity,
+        expected_host: (&WslEndpoint, &WslRuntimeIdentity),
         expected_executable: &str,
         confirmed: &HerdrSessionRecord,
         action: HerdrLifecycleAction,
         cancellation: &CancellationToken,
+        before_mutation: impl FnOnce(),
     ) -> Result<HerdrSessionRecord, HostError> {
+        let (endpoint, expected_runtime) = expected_host;
         let runtime = self.resolve_runtime(endpoint, cancellation)?;
         if &runtime != expected_runtime {
             return Err(HostError::new(
@@ -735,6 +736,7 @@ impl<R: CommandRunner> WslHost<R> {
         validate_herdr_lifecycle_target(confirmed, current, action)?;
 
         self.require_runtime(endpoint, expected_runtime, cancellation)?;
+        before_mutation();
 
         let mut args = pinned_prefix(endpoint);
         append_herdr_environment(&mut args);

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -965,15 +965,9 @@ impl<R: CommandRunner> WslHost<R> {
     ) -> Result<ExecutableProbe, HostError> {
         let mut args = pinned_prefix(endpoint);
         args.extend(
-            [
-                "/bin/sh",
-                "-c",
-                herdr::ACCOUNT_LOGIN_HANDOFF,
-                "ghosthub-herdr-resolve",
-                herdr::RESOLVE_SCRIPT,
-            ]
-            .into_iter()
-            .map(OsString::from),
+            ["/bin/sh", "-lc", herdr::RESOLVE_SCRIPT]
+                .into_iter()
+                .map(OsString::from),
         );
         let output = self.run(&args, cancellation)?;
         if output.status != 0 && output.status != 127 {

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -9,8 +9,9 @@ use std::time::{Duration, Instant};
 use model::DiagnosticKind;
 use session::{
     AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform, HerdrAttachPlan,
-    HerdrLaunchOnce, HerdrSessionName, HerdrSessionRecord, IDENTITY_MISMATCH_MARKER,
-    ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary, resolve_tmux_binary,
+    HerdrLaunchOnce, HerdrLifecycleAction, HerdrSessionName, HerdrSessionRecord, HerdrSessionState,
+    IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary,
+    resolve_tmux_binary,
 };
 
 use crate::herdr::{self, ExecutableProbe};
@@ -621,13 +622,129 @@ impl<R: CommandRunner> WslHost<R> {
         endpoint: &WslEndpoint,
         executable: &str,
         name: HerdrSessionName,
+        is_default: bool,
     ) -> HerdrLaunchOnce {
         let mut args = pinned_prefix(endpoint);
         append_herdr_environment(&mut args);
         args.push(OsString::from("TERM=xterm-256color"));
-        args.extend([executable, "--session"].into_iter().map(OsString::from));
-        args.push(OsString::from(name.as_str()));
+        args.push(OsString::from(executable));
+        if !is_default {
+            args.push(OsString::from("--session"));
+            args.push(OsString::from(name.as_str()));
+        }
         HerdrLaunchOnce::launch_or_attach(self.wsl_executable.as_os_str(), args, name)
+    }
+
+    /// Revalidate and execute one confirmed destructive Herdr lifecycle action.
+    ///
+    /// The current runtime, executable, state, and configuration paths are
+    /// captured immediately before mutation. Herdr does not expose a stable
+    /// generation identity, so same-name/same-path replacement remains an
+    /// accepted backend limitation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified error when the endpoint changed, the current
+    /// record no longer matches the confirmation, or Herdr rejects the action.
+    pub fn mutate_herdr_session(
+        &self,
+        endpoint: &WslEndpoint,
+        expected_runtime: &WslRuntimeIdentity,
+        confirmed: &HerdrSessionRecord,
+        action: HerdrLifecycleAction,
+        cancellation: &CancellationToken,
+    ) -> Result<HerdrSessionRecord, HostError> {
+        let runtime = self.resolve_runtime(endpoint, cancellation)?;
+        if &runtime != expected_runtime {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "WSL changed before the Herdr lifecycle action",
+            ));
+        }
+        if action == HerdrLifecycleAction::Delete && confirmed.is_default() {
+            return Err(HostError::new(
+                DiagnosticKind::UnsupportedEnvironment,
+                "Herdr's default session cannot be deleted",
+            ));
+        }
+        let (executable, sessions) = match self.discover_herdr(endpoint, cancellation) {
+            HerdrInventory::Available {
+                executable,
+                sessions,
+            } => (executable, sessions),
+            HerdrInventory::Unavailable => {
+                return Err(HostError::new(
+                    DiagnosticKind::ExecutableNotFound,
+                    "Herdr is unavailable on this host",
+                ));
+            }
+            HerdrInventory::Failed(error) => return Err(error),
+        };
+        let current = sessions
+            .iter()
+            .find(|session| session.name() == confirmed.name())
+            .ok_or_else(|| {
+                HostError::new(
+                    DiagnosticKind::Transport,
+                    format!("Herdr session {} no longer exists", confirmed.name()),
+                )
+            })?;
+        if current.state() != action.expected_state() {
+            let expected = match action.expected_state() {
+                HerdrSessionState::Running => "running",
+                HerdrSessionState::Stopped => "stopped",
+            };
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                format!("Herdr session {} is no longer {expected}", confirmed.name()),
+            ));
+        }
+        if current.session_directory() != confirmed.session_directory()
+            || current.socket_path() != confirmed.socket_path()
+        {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                format!(
+                    "Herdr session {} moved to a different configuration",
+                    confirmed.name()
+                ),
+            ));
+        }
+
+        let mut args = pinned_prefix(endpoint);
+        append_herdr_environment(&mut args);
+        args.extend(
+            [
+                executable.as_str(),
+                "session",
+                action.command(),
+                confirmed.name(),
+                "--json",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        );
+        let output = self.run(&args, cancellation)?;
+        if output.status != 0 {
+            return Err(HostError::new(
+                if output.status == 127 {
+                    DiagnosticKind::ExecutableNotFound
+                } else {
+                    DiagnosticKind::Transport
+                },
+                herdr::lifecycle_error(&output.stdout, &output.stderr),
+            ));
+        }
+        let record = herdr::parse_lifecycle(action, &output.stdout)
+            .map_err(|detail| HostError::new(DiagnosticKind::MalformedOutput, detail))?;
+        let observed_runtime = self.resolve_runtime(endpoint, cancellation)?;
+        if &observed_runtime != expected_runtime {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "WSL changed during the Herdr lifecycle action",
+            ));
+        }
+        Ok(record)
     }
 
     /// Build one atomic local create-or-attach client for an already verified
@@ -2810,6 +2927,7 @@ mod tests {
             &endpoint,
             "/home/test/.local/bin/herdr",
             HerdrSessionName::parse("review.fix_1").expect("valid name"),
+            false,
         );
         let (program, args, target) = plan.into_parts();
 

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -364,6 +364,7 @@ impl HostSnapshot {
         }
         let index = sessions.iter().position(|session| {
             session.name() == confirmed.name()
+                && session.state() == confirmed.state()
                 && session.is_default() == confirmed.is_default()
                 && session.session_directory() == confirmed.session_directory()
                 && session.socket_path() == confirmed.socket_path()
@@ -3025,6 +3026,16 @@ mod tests {
         );
         assert!(
             snapshot("/usr/bin/herdr", replacement)
+                .with_herdr_lifecycle(
+                    HerdrLifecycleAction::Stop,
+                    "/usr/bin/herdr",
+                    &confirmed,
+                    stopped.clone(),
+                )
+                .is_none()
+        );
+        assert!(
+            snapshot("/usr/bin/herdr", stopped.clone())
                 .with_herdr_lifecycle(
                     HerdrLifecycleAction::Stop,
                     "/usr/bin/herdr",

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -348,15 +348,26 @@ impl HostSnapshot {
     pub fn with_herdr_lifecycle(
         mut self,
         action: HerdrLifecycleAction,
+        expected_executable: &str,
         confirmed: &HerdrSessionRecord,
         record: HerdrSessionRecord,
     ) -> Option<Self> {
-        let HerdrInventory::Available { sessions, .. } = self.herdr.as_mut() else {
+        let HerdrInventory::Available {
+            executable,
+            sessions,
+        } = self.herdr.as_mut()
+        else {
             return None;
         };
-        let index = sessions
-            .iter()
-            .position(|session| session.name() == confirmed.name())?;
+        if executable != expected_executable {
+            return None;
+        }
+        let index = sessions.iter().position(|session| {
+            session.name() == confirmed.name()
+                && session.is_default() == confirmed.is_default()
+                && session.session_directory() == confirmed.session_directory()
+                && session.socket_path() == confirmed.socket_path()
+        })?;
         match action {
             HerdrLifecycleAction::Stop => sessions[index] = record,
             HerdrLifecycleAction::Delete => {
@@ -2927,7 +2938,7 @@ mod tests {
             sessions: Vec::new(),
             herdr: Box::new(HerdrInventory::Available {
                 executable: "/usr/bin/herdr".to_owned(),
-                sessions: vec![running, other.clone()],
+                sessions: vec![running.clone(), other.clone()],
             }),
         };
         let stopped = HerdrSessionRecord::new(
@@ -2939,7 +2950,12 @@ mod tests {
         );
 
         let stopped_snapshot = snapshot
-            .with_herdr_lifecycle(HerdrLifecycleAction::Stop, &stopped, stopped.clone())
+            .with_herdr_lifecycle(
+                HerdrLifecycleAction::Stop,
+                "/usr/bin/herdr",
+                &running,
+                stopped.clone(),
+            )
             .expect("stop response applies");
         assert_eq!(
             stopped_snapshot.herdr().sessions(),
@@ -2947,10 +2963,76 @@ mod tests {
         );
 
         let deleted_snapshot = stopped_snapshot
-            .with_herdr_lifecycle(HerdrLifecycleAction::Delete, &other, other.clone())
+            .with_herdr_lifecycle(
+                HerdrLifecycleAction::Delete,
+                "/usr/bin/herdr",
+                &other,
+                other.clone(),
+            )
             .expect("delete response applies");
         assert_eq!(deleted_snapshot.herdr().sessions().len(), 1);
         assert_eq!(deleted_snapshot.herdr().sessions()[0].name(), "work");
+    }
+
+    #[test]
+    fn lifecycle_publication_rejects_changed_inventory_identity() {
+        let confirmed = HerdrSessionRecord::new(
+            "work",
+            false,
+            HerdrSessionState::Running,
+            "/tmp/work",
+            "/tmp/work.sock",
+        );
+        let stopped = HerdrSessionRecord::new(
+            "work",
+            false,
+            HerdrSessionState::Stopped,
+            "/tmp/work",
+            "/tmp/work.sock",
+        );
+        let snapshot = |executable: &str, session: HerdrSessionRecord| HostSnapshot {
+            endpoint: WslEndpoint {
+                distro: "Ubuntu".to_owned(),
+            },
+            runtime: WslRuntimeIdentity {
+                kernel_boot_id: "boot".to_owned(),
+                init_start_ticks: 1,
+            },
+            creation_term: AttachTerm::Xterm256Color,
+            sessions: Vec::new(),
+            herdr: Box::new(HerdrInventory::Available {
+                executable: executable.to_owned(),
+                sessions: vec![session],
+            }),
+        };
+        let replacement = HerdrSessionRecord::new(
+            "work",
+            false,
+            HerdrSessionState::Running,
+            "/tmp/replacement",
+            "/tmp/replacement.sock",
+        );
+
+        assert!(
+            snapshot("/opt/herdr-v2", confirmed.clone())
+                .with_herdr_lifecycle(
+                    HerdrLifecycleAction::Stop,
+                    "/usr/bin/herdr",
+                    &confirmed,
+                    stopped.clone(),
+                )
+                .is_none()
+        );
+        assert!(
+            snapshot("/usr/bin/herdr", replacement)
+                .with_herdr_lifecycle(
+                    HerdrLifecycleAction::Stop,
+                    "/usr/bin/herdr",
+                    &confirmed,
+                    stopped,
+                )
+                .is_none()
+        );
     }
 
     #[test]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -324,6 +324,31 @@ impl HostSnapshot {
     pub fn herdr(&self) -> &HerdrInventory {
         self.herdr.as_ref()
     }
+
+    /// Apply one authoritative Herdr lifecycle response to this snapshot.
+    ///
+    /// Returns `None` when the snapshot does not contain the session inventory
+    /// that authorized the operation.
+    #[must_use]
+    pub fn with_herdr_lifecycle(
+        mut self,
+        action: HerdrLifecycleAction,
+        record: HerdrSessionRecord,
+    ) -> Option<Self> {
+        let HerdrInventory::Available { sessions, .. } = self.herdr.as_mut() else {
+            return None;
+        };
+        let index = sessions
+            .iter()
+            .position(|session| session.name() == record.name())?;
+        match action {
+            HerdrLifecycleAction::Stop => sessions[index] = record,
+            HerdrLifecycleAction::Delete => {
+                sessions.remove(index);
+            }
+        }
+        Some(self)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2799,6 +2824,55 @@ mod tests {
     use std::io;
 
     use super::*;
+
+    #[test]
+    fn authoritative_herdr_lifecycle_updates_only_the_target_session() {
+        let running = HerdrSessionRecord::new(
+            "work",
+            false,
+            HerdrSessionState::Running,
+            "/tmp/work",
+            "/tmp/work.sock",
+        );
+        let other = HerdrSessionRecord::new(
+            "other",
+            false,
+            HerdrSessionState::Running,
+            "/tmp/other",
+            "/tmp/other.sock",
+        );
+        let snapshot = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot",
+            1,
+            Vec::new(),
+            HerdrInventory::Available {
+                executable: "/usr/bin/herdr".to_owned(),
+                sessions: vec![running, other.clone()],
+            },
+        );
+        let stopped = HerdrSessionRecord::new(
+            "work",
+            false,
+            HerdrSessionState::Stopped,
+            "/tmp/work",
+            "/tmp/work.sock",
+        );
+
+        let stopped_snapshot = snapshot
+            .with_herdr_lifecycle(HerdrLifecycleAction::Stop, stopped.clone())
+            .expect("stop response applies");
+        assert_eq!(
+            stopped_snapshot.herdr().sessions(),
+            &[stopped, other.clone()]
+        );
+
+        let deleted_snapshot = stopped_snapshot
+            .with_herdr_lifecycle(HerdrLifecycleAction::Delete, other)
+            .expect("delete response applies");
+        assert_eq!(deleted_snapshot.herdr().sessions().len(), 1);
+        assert_eq!(deleted_snapshot.herdr().sessions()[0].name(), "work");
+    }
 
     #[test]
     fn missing_system_wsl_is_not_an_error() {

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -711,6 +711,8 @@ impl<R: CommandRunner> WslHost<R> {
             ));
         }
 
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
+
         let mut args = pinned_prefix(endpoint);
         append_herdr_environment(&mut args);
         args.extend(

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -348,6 +348,7 @@ impl HostSnapshot {
     pub fn with_herdr_lifecycle(
         mut self,
         action: HerdrLifecycleAction,
+        confirmed: &HerdrSessionRecord,
         record: HerdrSessionRecord,
     ) -> Option<Self> {
         let HerdrInventory::Available { sessions, .. } = self.herdr.as_mut() else {
@@ -355,7 +356,7 @@ impl HostSnapshot {
         };
         let index = sessions
             .iter()
-            .position(|session| session.name() == record.name())?;
+            .position(|session| session.name() == confirmed.name())?;
         match action {
             HerdrLifecycleAction::Stop => sessions[index] = record,
             HerdrLifecycleAction::Delete => {
@@ -698,13 +699,74 @@ impl<R: CommandRunner> WslHost<R> {
         before_mutation: impl FnOnce(),
     ) -> Result<HerdrSessionRecord, HostError> {
         let (endpoint, expected_runtime) = expected_host;
-        let runtime = self.resolve_runtime(endpoint, cancellation)?;
-        if &runtime != expected_runtime {
+        self.validate_current_herdr_lifecycle_target(
+            endpoint,
+            expected_runtime,
+            expected_executable,
+            confirmed,
+            action,
+            cancellation,
+        )?;
+
+        before_mutation();
+
+        self.validate_current_herdr_lifecycle_target(
+            endpoint,
+            expected_runtime,
+            expected_executable,
+            confirmed,
+            action,
+            cancellation,
+        )?;
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
+
+        let mut args = pinned_prefix(endpoint);
+        append_herdr_environment(&mut args);
+        args.extend(
+            [
+                expected_executable,
+                "session",
+                action.command(),
+                confirmed.name(),
+                "--json",
+            ]
+            .into_iter()
+            .map(OsString::from),
+        );
+        let output = self.run(&args, cancellation)?;
+        if output.status != 0 {
             return Err(HostError::new(
-                DiagnosticKind::Transport,
-                "WSL changed before the Herdr lifecycle action",
+                if output.status == 127 {
+                    DiagnosticKind::ExecutableNotFound
+                } else {
+                    DiagnosticKind::Transport
+                },
+                herdr::lifecycle_error(&output.stdout, &output.stderr),
             ));
         }
+        let record = herdr::parse_lifecycle(action, &output.stdout)
+            .map_err(|detail| HostError::new(DiagnosticKind::MalformedOutput, detail))?;
+        validate_herdr_lifecycle_response(confirmed, &record, action)?;
+        let observed_runtime = self.resolve_runtime(endpoint, cancellation)?;
+        if &observed_runtime != expected_runtime {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "WSL changed during the Herdr lifecycle action",
+            ));
+        }
+        Ok(record)
+    }
+
+    fn validate_current_herdr_lifecycle_target(
+        &self,
+        endpoint: &WslEndpoint,
+        expected_runtime: &WslRuntimeIdentity,
+        expected_executable: &str,
+        confirmed: &HerdrSessionRecord,
+        action: HerdrLifecycleAction,
+        cancellation: &CancellationToken,
+    ) -> Result<(), HostError> {
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
         let (executable, sessions) = match self.discover_herdr(endpoint, cancellation) {
             HerdrInventory::Available {
                 executable,
@@ -733,45 +795,7 @@ impl<R: CommandRunner> WslHost<R> {
                     format!("Herdr session {} no longer exists", confirmed.name()),
                 )
             })?;
-        validate_herdr_lifecycle_target(confirmed, current, action)?;
-
-        self.require_runtime(endpoint, expected_runtime, cancellation)?;
-        before_mutation();
-
-        let mut args = pinned_prefix(endpoint);
-        append_herdr_environment(&mut args);
-        args.extend(
-            [
-                executable.as_str(),
-                "session",
-                action.command(),
-                confirmed.name(),
-                "--json",
-            ]
-            .into_iter()
-            .map(OsString::from),
-        );
-        let output = self.run(&args, cancellation)?;
-        if output.status != 0 {
-            return Err(HostError::new(
-                if output.status == 127 {
-                    DiagnosticKind::ExecutableNotFound
-                } else {
-                    DiagnosticKind::Transport
-                },
-                herdr::lifecycle_error(&output.stdout, &output.stderr),
-            ));
-        }
-        let record = herdr::parse_lifecycle(action, &output.stdout)
-            .map_err(|detail| HostError::new(DiagnosticKind::MalformedOutput, detail))?;
-        let observed_runtime = self.resolve_runtime(endpoint, cancellation)?;
-        if &observed_runtime != expected_runtime {
-            return Err(HostError::new(
-                DiagnosticKind::Transport,
-                "WSL changed during the Herdr lifecycle action",
-            ));
-        }
-        Ok(record)
+        validate_herdr_lifecycle_target(confirmed, current, action)
     }
 
     /// Build one atomic local create-or-attach client for an already verified
@@ -2301,6 +2325,27 @@ fn validate_herdr_lifecycle_target(
     Ok(())
 }
 
+fn validate_herdr_lifecycle_response(
+    confirmed: &HerdrSessionRecord,
+    response: &HerdrSessionRecord,
+    action: HerdrLifecycleAction,
+) -> Result<(), HostError> {
+    let same_identity = response.name() == confirmed.name()
+        && response.is_default() == confirmed.is_default()
+        && response.session_directory() == confirmed.session_directory()
+        && response.socket_path() == confirmed.socket_path();
+    if !same_identity || response.state() != HerdrSessionState::Stopped {
+        return Err(HostError::new(
+            DiagnosticKind::MalformedOutput,
+            format!(
+                "Herdr returned an inconsistent session record after {}",
+                action.command()
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn admission_matches(
     verified_endpoint: &WslEndpoint,
     verified_runtime: &WslRuntimeIdentity,
@@ -2894,7 +2939,7 @@ mod tests {
         );
 
         let stopped_snapshot = snapshot
-            .with_herdr_lifecycle(HerdrLifecycleAction::Stop, stopped.clone())
+            .with_herdr_lifecycle(HerdrLifecycleAction::Stop, &stopped, stopped.clone())
             .expect("stop response applies");
         assert_eq!(
             stopped_snapshot.herdr().sessions(),
@@ -2902,7 +2947,7 @@ mod tests {
         );
 
         let deleted_snapshot = stopped_snapshot
-            .with_herdr_lifecycle(HerdrLifecycleAction::Delete, other)
+            .with_herdr_lifecycle(HerdrLifecycleAction::Delete, &other, other.clone())
             .expect("delete response applies");
         assert_eq!(deleted_snapshot.herdr().sessions().len(), 1);
         assert_eq!(deleted_snapshot.herdr().sessions()[0].name(), "work");

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -8,9 +8,9 @@ use std::time::{Duration, Instant};
 
 use model::DiagnosticKind;
 use session::{
-    AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform,
-    HerdrSessionRecord, IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName,
-    VerifiedTmuxBinary, resolve_tmux_binary,
+    AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform, HerdrAttachPlan,
+    HerdrLaunchOnce, HerdrSessionName, HerdrSessionRecord, IDENTITY_MISMATCH_MARKER,
+    ProbeObservation, SessionIdentity, SessionName, VerifiedTmuxBinary, resolve_tmux_binary,
 };
 
 use crate::herdr::{self, ExecutableProbe};
@@ -591,6 +591,43 @@ impl<R: CommandRunner> WslHost<R> {
             session.name(),
             session.identity().clone(),
         )
+    }
+
+    /// Build an attach-only plan for one exact running Herdr session.
+    #[must_use]
+    pub fn herdr_attach_plan(
+        &self,
+        endpoint: &WslEndpoint,
+        executable: &str,
+        session: &HerdrSessionRecord,
+        term: AttachTerm,
+    ) -> HerdrAttachPlan {
+        let mut args = pinned_prefix(endpoint);
+        append_herdr_environment(&mut args);
+        args.push(OsString::from(term.environment()));
+        args.extend(
+            [executable, "session", "attach", session.name()]
+                .into_iter()
+                .map(OsString::from),
+        );
+        HerdrAttachPlan::attach_only(self.wsl_executable.as_os_str(), args)
+    }
+
+    /// Build one Herdr launch-or-attach client. The returned authority is
+    /// consumed by the terminal launcher and cannot be retried.
+    #[must_use]
+    pub fn herdr_launch_once(
+        &self,
+        endpoint: &WslEndpoint,
+        executable: &str,
+        name: HerdrSessionName,
+    ) -> HerdrLaunchOnce {
+        let mut args = pinned_prefix(endpoint);
+        append_herdr_environment(&mut args);
+        args.push(OsString::from("TERM=xterm-256color"));
+        args.extend([executable, "--session"].into_iter().map(OsString::from));
+        args.push(OsString::from(name.as_str()));
+        HerdrLaunchOnce::launch_or_attach(self.wsl_executable.as_os_str(), args, name)
     }
 
     /// Build one atomic local create-or-attach client for an already verified
@@ -2762,5 +2799,49 @@ mod tests {
             .collect::<Vec<_>>()
         );
         assert!(marker.starts_with("__ghc_") && marker.ends_with("__"));
+    }
+
+    #[test]
+    fn herdr_launch_is_one_scrubbed_argv_only_client_command() {
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu Work").expect("valid config"),
+            crate::StdCommandRunner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let endpoint = WslEndpoint {
+            distro: "Ubuntu Work".to_owned(),
+        };
+        let plan = host.herdr_launch_once(
+            &endpoint,
+            "/home/test/.local/bin/herdr",
+            HerdrSessionName::parse("review.fix_1").expect("valid name"),
+        );
+        let (program, args, target) = plan.into_parts();
+
+        assert_eq!(program, r"C:\Windows\System32\wsl.exe");
+        assert_eq!(target.as_str(), "review.fix_1");
+        assert_eq!(
+            args.first().and_then(|value| value.to_str()),
+            Some("--distribution")
+        );
+        assert!(args.windows(2).any(|pair| pair == ["-u", "HERDR_ENV"]));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["-u", "HERDR_ACTIVE_PANE_CWD"])
+        );
+        assert_eq!(
+            args.iter()
+                .rev()
+                .take(3)
+                .rev()
+                .map(OsString::as_os_str)
+                .collect::<Vec<_>>(),
+            [
+                OsStr::new("/home/test/.local/bin/herdr"),
+                OsStr::new("--session"),
+                OsStr::new("review.fix_1"),
+            ]
+        );
     }
 }

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -941,6 +941,22 @@ fn herdr_inventory_is_additive_and_scrubs_control_environment() {
     assert_eq!(sessions.len(), 2);
     assert_eq!(sessions[0].state(), HerdrSessionState::Running);
     assert_eq!(sessions[1].state(), HerdrSessionState::Stopped);
+    let resolve_call = host
+        .runner()
+        .all_calls()
+        .into_iter()
+        .find(|(_, args)| {
+            args.last()
+                .is_some_and(|argument| argument.to_string_lossy().contains("command -v herdr"))
+        })
+        .expect("Herdr executable resolution call");
+    assert!(
+        resolve_call
+            .1
+            .windows(2)
+            .any(|arguments| arguments == ["/bin/sh", "-lc"]),
+        "WSL capability resolution must load the POSIX login profile"
+    );
     let list_call = host
         .runner()
         .all_calls()

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1058,18 +1058,20 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         "/tmp/herdr/review",
         "/tmp/herdr/review/herdr.sock",
     );
+    let validation_completed = AtomicBool::new(false);
 
     let stopped = host
         .mutate_herdr_session(
-            &endpoint,
-            &runtime,
+            (&endpoint, &runtime),
             "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
+            || validation_completed.store(true, Ordering::Release),
         )
         .expect("confirmed stop");
 
+    assert!(validation_completed.load(Ordering::Acquire));
     assert_eq!(stopped.state(), HerdrSessionState::Stopped);
     let action = host
         .runner()
@@ -1114,20 +1116,22 @@ fn herdr_lifecycle_rejects_an_executable_changed_after_confirmation() {
         "/tmp/herdr/review",
         "/tmp/herdr/review/herdr.sock",
     );
+    let validation_completed = AtomicBool::new(false);
 
     let error = host
         .mutate_herdr_session(
-            identity.endpoint(),
-            identity.runtime(),
+            (identity.endpoint(), identity.runtime()),
             "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
+            || validation_completed.store(true, Ordering::Release),
         )
         .expect_err("changed executable invalidates confirmation");
 
     assert_eq!(error.kind(), HostErrorKind::Transport);
     assert!(error.to_string().contains("executable changed"));
+    assert!(!validation_completed.load(Ordering::Acquire));
     assert!(
         !host
             .runner()
@@ -1171,12 +1175,12 @@ fn herdr_lifecycle_rechecks_runtime_after_discovery_before_mutation() {
 
     let error = host
         .mutate_herdr_session(
-            identity.endpoint(),
-            identity.runtime(),
+            (identity.endpoint(), identity.runtime()),
             "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
+            || {},
         )
         .expect_err("a restarted distro must block mutation");
 
@@ -1221,12 +1225,12 @@ fn herdr_delete_rejects_a_session_that_became_the_default() {
 
     let error = host
         .mutate_herdr_session(
-            identity.endpoint(),
-            identity.runtime(),
+            (identity.endpoint(), identity.runtime()),
             "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Delete,
             &CancellationToken::new(),
+            || {},
         )
         .expect_err("the current default session must never be deleted");
 
@@ -1271,12 +1275,12 @@ fn herdr_stop_rejects_a_changed_default_role() {
 
     let error = host
         .mutate_herdr_session(
-            identity.endpoint(),
-            identity.runtime(),
+            (identity.endpoint(), identity.runtime()),
             "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
+            || {},
         )
         .expect_err("a changed default role invalidates confirmation");
 

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1025,8 +1025,15 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         instance_output(),
         instance_output(),
         instance_output(),
+        instance_output(),
     ]);
     runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":false,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
         output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
         output(
             0,
@@ -1086,6 +1093,62 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         OsString::from("review"),
         OsString::from("--json"),
     ]));
+}
+
+#[test]
+fn herdr_lifecycle_rejects_an_inconsistent_response_record() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        instance_output(),
+        instance_output(),
+    ]);
+    let inventory = output(
+        0,
+        r#"{"sessions":[{"name":"review","default":false,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+        "",
+    );
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        inventory.clone(),
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        inventory,
+        output(
+            0,
+            r#"{"session":{"name":"other","default":false,"running":false,"session_dir":"/tmp/herdr/other","socket_path":"/tmp/herdr/other/herdr.sock"},"stopped":true}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Running,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let error = host
+        .mutate_herdr_session(
+            (identity.endpoint(), identity.runtime()),
+            "/opt/herdr/bin/herdr",
+            &confirmed,
+            HerdrLifecycleAction::Stop,
+            &CancellationToken::new(),
+            || {},
+        )
+        .expect_err("a mismatched response must not be published");
+
+    assert_eq!(error.kind(), HostErrorKind::MalformedOutput);
+    assert!(error.to_string().contains("inconsistent session record"));
 }
 
 #[test]

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -13,7 +13,9 @@ use host::{
 };
 use serde::Deserialize;
 use session::ExecutablePlatform;
-use session::{AdmissionPlan, HerdrSessionState, SessionName};
+use session::{
+    AdmissionPlan, HerdrLifecycleAction, HerdrSessionRecord, HerdrSessionState, SessionName,
+};
 
 #[derive(Clone, Copy, Debug)]
 struct AdmissionStatusFailure {
@@ -472,6 +474,9 @@ fn is_herdr_call(args: &[OsString]) -> bool {
     }) || args
         .windows(3)
         .any(|arguments| arguments == ["session", "list", "--json"])
+        || args
+            .windows(2)
+            .any(|arguments| arguments == ["session", "stop"] || arguments == ["session", "delete"])
 }
 
 #[allow(
@@ -1012,6 +1017,68 @@ fn malformed_herdr_inventory_does_not_hide_tmux_sessions() {
     assert!(
         matches!(snapshot.herdr(), HerdrInventory::Failed(error) if error.kind() == HostErrorKind::MalformedOutput)
     );
+}
+
+#[test]
+fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
+    let runner = RecordingRunner::new(vec![instance_output(), instance_output()]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":false,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+        output(
+            0,
+            r#"{"session":{"name":"review","default":false,"running":false,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"},"stopped":true}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let endpoint = identity.endpoint().clone();
+    let runtime = identity.runtime().clone();
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Running,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let stopped = host
+        .mutate_herdr_session(
+            &endpoint,
+            &runtime,
+            &confirmed,
+            HerdrLifecycleAction::Stop,
+            &CancellationToken::new(),
+        )
+        .expect("confirmed stop");
+
+    assert_eq!(stopped.state(), HerdrSessionState::Stopped);
+    let action = host
+        .runner()
+        .all_calls()
+        .into_iter()
+        .find(|(_, args)| args.windows(2).any(|pair| pair == ["session", "stop"]))
+        .expect("Herdr stop call");
+    assert!(action.1.windows(2).any(|pair| pair == ["-u", "HERDR_ENV"]));
+    assert!(action.1.ends_with(&[
+        OsString::from("session"),
+        OsString::from("stop"),
+        OsString::from("review"),
+        OsString::from("--json"),
+    ]));
 }
 
 #[test]

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1021,7 +1021,11 @@ fn malformed_herdr_inventory_does_not_hide_tmux_sessions() {
 
 #[test]
 fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
-    let runner = RecordingRunner::new(vec![instance_output(), instance_output()]);
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        instance_output(),
+        instance_output(),
+    ]);
     runner.set_herdr_outputs(vec![
         output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
         output(
@@ -1079,6 +1083,58 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         OsString::from("review"),
         OsString::from("--json"),
     ]));
+}
+
+#[test]
+fn herdr_lifecycle_rechecks_runtime_after_discovery_before_mutation() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        instance_output_with("91d83b4d-2b1a-47b7-bd2d-5d5bb698bdf7", 200),
+    ]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":false,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Running,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let error = host
+        .mutate_herdr_session(
+            identity.endpoint(),
+            identity.runtime(),
+            &confirmed,
+            HerdrLifecycleAction::Stop,
+            &CancellationToken::new(),
+        )
+        .expect_err("a restarted distro must block mutation");
+
+    assert_eq!(error.kind(), HostErrorKind::Transport);
+    assert!(
+        !host
+            .runner()
+            .all_calls()
+            .iter()
+            .any(|(_, args)| { args.windows(2).any(|pair| pair == ["session", "stop"]) })
+    );
 }
 
 #[test]

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1063,6 +1063,7 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         .mutate_herdr_session(
             &endpoint,
             &runtime,
+            "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
@@ -1083,6 +1084,57 @@ fn herdr_stop_revalidates_state_and_paths_before_direct_mutation() {
         OsString::from("review"),
         OsString::from("--json"),
     ]));
+}
+
+#[test]
+fn herdr_lifecycle_rejects_an_executable_changed_after_confirmation() {
+    let runner = RecordingRunner::new(vec![instance_output()]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr-v2/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":false,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Running,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let error = host
+        .mutate_herdr_session(
+            identity.endpoint(),
+            identity.runtime(),
+            "/opt/herdr/bin/herdr",
+            &confirmed,
+            HerdrLifecycleAction::Stop,
+            &CancellationToken::new(),
+        )
+        .expect_err("changed executable invalidates confirmation");
+
+    assert_eq!(error.kind(), HostErrorKind::Transport);
+    assert!(error.to_string().contains("executable changed"));
+    assert!(
+        !host
+            .runner()
+            .all_calls()
+            .iter()
+            .any(|(_, args)| args.windows(2).any(|pair| pair == ["session", "stop"]))
+    );
 }
 
 #[test]
@@ -1121,6 +1173,7 @@ fn herdr_lifecycle_rechecks_runtime_after_discovery_before_mutation() {
         .mutate_herdr_session(
             identity.endpoint(),
             identity.runtime(),
+            "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),
@@ -1170,6 +1223,7 @@ fn herdr_delete_rejects_a_session_that_became_the_default() {
         .mutate_herdr_session(
             identity.endpoint(),
             identity.runtime(),
+            "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Delete,
             &CancellationToken::new(),
@@ -1219,6 +1273,7 @@ fn herdr_stop_rejects_a_changed_default_role() {
         .mutate_herdr_session(
             identity.endpoint(),
             identity.runtime(),
+            "/opt/herdr/bin/herdr",
             &confirmed,
             HerdrLifecycleAction::Stop,
             &CancellationToken::new(),

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -1138,6 +1138,104 @@ fn herdr_lifecycle_rechecks_runtime_after_discovery_before_mutation() {
 }
 
 #[test]
+fn herdr_delete_rejects_a_session_that_became_the_default() {
+    let runner = RecordingRunner::new(vec![instance_output()]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":true,"running":false,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Stopped,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let error = host
+        .mutate_herdr_session(
+            identity.endpoint(),
+            identity.runtime(),
+            &confirmed,
+            HerdrLifecycleAction::Delete,
+            &CancellationToken::new(),
+        )
+        .expect_err("the current default session must never be deleted");
+
+    assert_eq!(error.kind(), HostErrorKind::UnsupportedEnvironment);
+    assert!(
+        !host
+            .runner()
+            .all_calls()
+            .iter()
+            .any(|(_, args)| { args.windows(2).any(|pair| pair == ["session", "delete"]) })
+    );
+}
+
+#[test]
+fn herdr_stop_rejects_a_changed_default_role() {
+    let runner = RecordingRunner::new(vec![instance_output()]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"review","default":true,"running":true,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let identity = host::HostSnapshot::test_fixture(
+        "Ubuntu",
+        "65c18272-9676-4d59-9f67-ff4556cd1601",
+        987_654,
+        Vec::new(),
+    );
+    let confirmed = HerdrSessionRecord::new(
+        "review",
+        false,
+        HerdrSessionState::Running,
+        "/tmp/herdr/review",
+        "/tmp/herdr/review/herdr.sock",
+    );
+
+    let error = host
+        .mutate_herdr_session(
+            identity.endpoint(),
+            identity.runtime(),
+            &confirmed,
+            HerdrLifecycleAction::Stop,
+            &CancellationToken::new(),
+        )
+        .expect_err("a changed default role invalidates confirmation");
+
+    assert_eq!(error.kind(), HostErrorKind::Transport);
+    assert!(
+        !host
+            .runner()
+            .all_calls()
+            .iter()
+            .any(|(_, args)| { args.windows(2).any(|pair| pair == ["session", "stop"]) })
+    );
+}
+
+#[test]
 #[allow(
     clippy::too_many_lines,
     reason = "the admission transcript assertions stay together for safety auditing"

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -8,12 +8,12 @@ use std::sync::{Arc, Mutex};
 
 use contracts::{Manifest, PlatformTag};
 use host::{
-    AdmissionAttacher, AttachTerm, CancellationToken, CommandOutput, CommandRunner, HostErrorKind,
-    WslConfig, WslExecutable, WslHost,
+    AdmissionAttacher, AttachTerm, CancellationToken, CommandOutput, CommandRunner, HerdrInventory,
+    HostErrorKind, WslConfig, WslExecutable, WslHost,
 };
 use serde::Deserialize;
 use session::ExecutablePlatform;
-use session::{AdmissionPlan, SessionName};
+use session::{AdmissionPlan, HerdrSessionState, SessionName};
 
 #[derive(Clone, Copy, Debug)]
 struct AdmissionStatusFailure {
@@ -39,6 +39,7 @@ struct RecordingRunner {
     namespaces_are_isolated: bool,
     exact_targets_are_strict: bool,
     admission_directory: Mutex<AdmissionDirectoryState>,
+    herdr_outputs: Mutex<VecDeque<CommandOutput>>,
 }
 
 #[derive(Debug, Default)]
@@ -75,6 +76,7 @@ impl RecordingRunner {
             namespaces_are_isolated: true,
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
+            herdr_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -95,6 +97,7 @@ impl RecordingRunner {
             namespaces_are_isolated: true,
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
+            herdr_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -119,6 +122,7 @@ impl RecordingRunner {
             namespaces_are_isolated: true,
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
+            herdr_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -147,6 +151,7 @@ impl RecordingRunner {
             namespaces_are_isolated: true,
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
+            herdr_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -167,6 +172,7 @@ impl RecordingRunner {
             namespaces_are_isolated: false,
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
+            herdr_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -210,13 +216,17 @@ impl RecordingRunner {
             .lock()
             .expect("calls lock")
             .iter()
-            .filter(|(_, args)| !is_admission_call(args))
+            .filter(|(_, args)| !is_admission_call(args) && !is_herdr_call(args))
             .cloned()
             .collect()
     }
 
     fn all_calls(&self) -> Vec<(OsString, Vec<OsString>)> {
         self.calls.lock().expect("calls lock").clone()
+    }
+
+    fn set_herdr_outputs(&self, outputs: Vec<CommandOutput>) {
+        *self.herdr_outputs.lock().expect("Herdr outputs lock") = outputs.into();
     }
 
     fn all_timeouts(&self) -> Vec<std::time::Duration> {
@@ -318,6 +328,14 @@ impl CommandRunner for RecordingRunner {
             .expect("calls lock")
             .push((program.to_owned(), args.to_vec()));
         self.timeouts.lock().expect("timeouts lock").push(timeout);
+        if is_herdr_call(args) {
+            return Ok(self
+                .herdr_outputs
+                .lock()
+                .expect("Herdr outputs lock")
+                .pop_front()
+                .unwrap_or_else(|| output(127, "", "herdr: not found")));
+        }
         if self
             .admission_failure
             .is_some_and(|failed| admission_command(args).is_some_and(|command| command == failed))
@@ -444,6 +462,16 @@ fn is_admission_call(args: &[OsString]) -> bool {
             argument.starts_with("ghv-") || argument.starts_with("/tmp/ghosthub-tmux-probe.")
         })
     }) || args.last().is_some_and(|argument| argument == "-V")
+}
+
+fn is_herdr_call(args: &[OsString]) -> bool {
+    args.iter().any(|argument| {
+        argument
+            .to_str()
+            .is_some_and(|argument| argument.contains("GHOSTHUB_HERDR_PATH"))
+    }) || args
+        .windows(3)
+        .any(|arguments| arguments == ["session", "list", "--json"])
 }
 
 #[allow(
@@ -878,6 +906,96 @@ fn discovers_identity_in_one_tmux_crossing() {
     assert_eq!(session.identity().created_at(), 1_700_000_000);
     assert_eq!(session.attached_clients(), 1);
     assert_eq!(host.runner().calls().len(), 3);
+}
+
+#[test]
+fn herdr_inventory_is_additive_and_scrubs_control_environment() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t1\t4\twork\n", ""),
+        instance_output(),
+    ]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(
+            0,
+            r#"{"sessions":[{"name":"default","default":true,"running":true,"session_dir":"/tmp/herdr/default","socket_path":"/tmp/herdr/default/herdr.sock"},{"name":"review","default":false,"running":false,"session_dir":"/tmp/herdr/review","socket_path":"/tmp/herdr/review/herdr.sock"}]}"#,
+            "",
+        ),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+
+    let snapshot = discover(&host).expect("tmux discovery remains authoritative");
+
+    let HerdrInventory::Available {
+        executable,
+        sessions,
+    } = snapshot.herdr()
+    else {
+        panic!("Herdr is available");
+    };
+    assert_eq!(executable, "/opt/herdr/bin/herdr");
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].state(), HerdrSessionState::Running);
+    assert_eq!(sessions[1].state(), HerdrSessionState::Stopped);
+    let list_call = host
+        .runner()
+        .all_calls()
+        .into_iter()
+        .find(|(_, args)| {
+            args.windows(3)
+                .any(|arguments| arguments == ["session", "list", "--json"])
+        })
+        .expect("Herdr list call");
+    assert!(
+        list_call
+            .1
+            .iter()
+            .any(|argument| argument == "/opt/herdr/bin/herdr")
+    );
+    for variable in [
+        "HERDR_ENV",
+        "HERDR_SESSION",
+        "HERDR_SOCKET_PATH",
+        "HERDR_CLIENT_SOCKET_PATH",
+        "HERDR_PANE_ID",
+        "HERDR_TAB_ID",
+        "HERDR_WORKSPACE_ID",
+        "HERDR_BIN_PATH",
+        "HERDR_ACTIVE_WORKSPACE_ID",
+        "HERDR_ACTIVE_TAB_ID",
+        "HERDR_ACTIVE_PANE_ID",
+        "HERDR_ACTIVE_PANE_CWD",
+    ] {
+        assert!(list_call.1.windows(2).any(|pair| pair == ["-u", variable]));
+    }
+}
+
+#[test]
+fn malformed_herdr_inventory_does_not_hide_tmux_sessions() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t1\t4\twork\n", ""),
+        instance_output(),
+    ]);
+    runner.set_herdr_outputs(vec![
+        output(0, "GHOSTHUB_HERDR_PATH\n/opt/herdr/bin/herdr\n", ""),
+        output(0, "not-json", ""),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+
+    let snapshot = discover(&host).expect("Herdr failure is host-capability scoped");
+
+    assert_eq!(snapshot.sessions()[0].name(), "work");
+    assert!(
+        matches!(snapshot.herdr(), HerdrInventory::Failed(error) if error.kind() == HostErrorKind::MalformedOutput)
+    );
 }
 
 #[test]

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -103,6 +103,65 @@ pub struct DiscoveredSession {
     attached_clients: u32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HerdrSessionState {
+    Running,
+    Stopped,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrSessionRecord {
+    name: String,
+    is_default: bool,
+    state: HerdrSessionState,
+    session_directory: String,
+    socket_path: String,
+}
+
+impl HerdrSessionRecord {
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        is_default: bool,
+        state: HerdrSessionState,
+        session_directory: impl Into<String>,
+        socket_path: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            is_default,
+            state,
+            session_directory: session_directory.into(),
+            socket_path: socket_path.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub const fn is_default(&self) -> bool {
+        self.is_default
+    }
+
+    #[must_use]
+    pub const fn state(&self) -> HerdrSessionState {
+        self.state
+    }
+
+    #[must_use]
+    pub fn session_directory(&self) -> &str {
+        &self.session_directory
+    }
+
+    #[must_use]
+    pub fn socket_path(&self) -> &str {
+        &self.socket_path
+    }
+}
+
 impl DiscoveredSession {
     #[must_use]
     pub fn new(name: impl Into<String>, identity: SessionIdentity, attached_clients: u32) -> Self {

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -160,6 +160,30 @@ pub enum HerdrSessionState {
     Stopped,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HerdrLifecycleAction {
+    Stop,
+    Delete,
+}
+
+impl HerdrLifecycleAction {
+    #[must_use]
+    pub const fn command(self) -> &'static str {
+        match self {
+            Self::Stop => "stop",
+            Self::Delete => "delete",
+        }
+    }
+
+    #[must_use]
+    pub const fn expected_state(self) -> HerdrSessionState {
+        match self {
+            Self::Stop => HerdrSessionState::Running,
+            Self::Delete => HerdrSessionState::Stopped,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HerdrSessionRecord {
     name: String,

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -193,6 +193,42 @@ pub struct HerdrSessionRecord {
     socket_path: String,
 }
 
+/// Exact name carried by a one-shot Herdr launch authority.
+///
+/// User-authored names can enter only through [`HerdrSessionName`], while
+/// names read from Herdr inventory are preserved without applying creation
+/// restrictions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrLaunchTarget(HerdrLaunchTargetSource);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum HerdrLaunchTargetSource {
+    Created(HerdrSessionName),
+    Discovered(String),
+}
+
+impl HerdrLaunchTarget {
+    #[must_use]
+    pub const fn created(name: HerdrSessionName) -> Self {
+        Self(HerdrLaunchTargetSource::Created(name))
+    }
+
+    #[must_use]
+    pub fn discovered(record: &HerdrSessionRecord) -> Self {
+        Self(HerdrLaunchTargetSource::Discovered(
+            record.name().to_owned(),
+        ))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match &self.0 {
+            HerdrLaunchTargetSource::Created(name) => name.as_str(),
+            HerdrLaunchTargetSource::Discovered(name) => name,
+        }
+    }
+}
+
 impl HerdrSessionRecord {
     #[must_use]
     pub fn new(
@@ -284,7 +320,7 @@ pub struct HerdrAttachPlan {
 pub struct HerdrLaunchOnce {
     program: OsString,
     args: Vec<OsString>,
-    target_name: HerdrSessionName,
+    target_name: HerdrLaunchTarget,
 }
 
 impl HerdrAttachPlan {
@@ -312,7 +348,7 @@ impl HerdrLaunchOnce {
     pub fn launch_or_attach(
         program: impl Into<OsString>,
         args: Vec<OsString>,
-        target_name: HerdrSessionName,
+        target_name: HerdrLaunchTarget,
     ) -> Self {
         Self {
             program: program.into(),
@@ -322,7 +358,7 @@ impl HerdrLaunchOnce {
     }
 
     #[must_use]
-    pub fn into_parts(self) -> (OsString, Vec<OsString>, HerdrSessionName) {
+    pub fn into_parts(self) -> (OsString, Vec<OsString>, HerdrLaunchTarget) {
         (self.program, self.args, self.target_name)
     }
 }
@@ -667,8 +703,8 @@ fn parse_revision(output: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CreateOnce, HerdrLaunchOnce, HerdrSessionName, HerdrSessionNameError, SessionName,
-        SessionNameError,
+        CreateOnce, HerdrLaunchOnce, HerdrLaunchTarget, HerdrSessionName, HerdrSessionNameError,
+        HerdrSessionRecord, HerdrSessionState, SessionName, SessionNameError,
     };
     use static_assertions::assert_not_impl_any;
 
@@ -698,6 +734,23 @@ mod tests {
         assert_eq!(
             HerdrSessionName::parse(&"x".repeat(65)),
             Err(HerdrSessionNameError::TooLong)
+        );
+    }
+
+    #[test]
+    fn discovered_herdr_names_bypass_creation_only_restrictions() {
+        let record = HerdrSessionRecord::new(
+            "review session",
+            false,
+            HerdrSessionState::Stopped,
+            "/tmp/herdr/review session",
+            "/tmp/herdr/review session/herdr.sock",
+        );
+
+        assert!(HerdrSessionName::parse(record.name()).is_err());
+        assert_eq!(
+            HerdrLaunchTarget::discovered(&record).as_str(),
+            record.name()
         );
     }
 

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -103,6 +103,57 @@ pub struct DiscoveredSession {
     attached_clients: u32,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrSessionName(String);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HerdrSessionNameError {
+    Empty,
+    TooLong,
+    ForbiddenCharacter,
+}
+
+impl HerdrSessionName {
+    /// Normalize and validate a user-supplied Herdr session name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the name contains 1-64 ASCII letters, digits,
+    /// periods, underscores, or hyphens and is not `.` or `..`.
+    pub fn parse(value: &str) -> Result<Self, HerdrSessionNameError> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(HerdrSessionNameError::Empty);
+        }
+        if value.len() > 64 {
+            return Err(HerdrSessionNameError::TooLong);
+        }
+        if matches!(value, "." | "..")
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        {
+            return Err(HerdrSessionNameError::ForbiddenCharacter);
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for HerdrSessionNameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("Name the Herdr session."),
+            Self::TooLong | Self::ForbiddenCharacter => formatter
+                .write_str("Use 1-64 ASCII letters, numbers, periods, underscores, or hyphens."),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HerdrSessionState {
     Running,
@@ -194,6 +245,62 @@ pub struct AttachPlan {
     args: Vec<OsString>,
     target_name: String,
     identity: SessionIdentity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrAttachPlan {
+    program: OsString,
+    args: Vec<OsString>,
+}
+
+/// One Herdr launch-or-attach action. This constructive authority is consumed
+/// by the terminal launcher and is intentionally neither cloneable nor
+/// serializable.
+#[derive(Debug, Eq, PartialEq)]
+pub struct HerdrLaunchOnce {
+    program: OsString,
+    args: Vec<OsString>,
+    target_name: HerdrSessionName,
+}
+
+impl HerdrAttachPlan {
+    #[must_use]
+    pub fn attach_only(program: impl Into<OsString>, args: Vec<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            args,
+        }
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &OsStr {
+        &self.program
+    }
+
+    #[must_use]
+    pub fn args(&self) -> &[OsString] {
+        &self.args
+    }
+}
+
+impl HerdrLaunchOnce {
+    #[must_use]
+    pub fn launch_or_attach(
+        program: impl Into<OsString>,
+        args: Vec<OsString>,
+        target_name: HerdrSessionName,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            target_name,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (OsString, Vec<OsString>, HerdrSessionName) {
+        (self.program, self.args, self.target_name)
+    }
 }
 
 /// One atomic local create-or-attach launch. The authority is intentionally
@@ -535,10 +642,40 @@ fn parse_revision(output: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CreateOnce, SessionName, SessionNameError};
+    use super::{
+        CreateOnce, HerdrLaunchOnce, HerdrSessionName, HerdrSessionNameError, SessionName,
+        SessionNameError,
+    };
     use static_assertions::assert_not_impl_any;
 
     assert_not_impl_any!(CreateOnce: Clone, serde::Serialize);
+    assert_not_impl_any!(HerdrLaunchOnce: Clone, serde::Serialize);
+
+    #[test]
+    fn herdr_session_names_match_the_shipped_creation_contract() {
+        assert_eq!(
+            HerdrSessionName::parse("  review.fix_1  ")
+                .expect("valid name")
+                .as_str(),
+            "review.fix_1"
+        );
+        assert_eq!(
+            HerdrSessionName::parse(" "),
+            Err(HerdrSessionNameError::Empty)
+        );
+        assert_eq!(
+            HerdrSessionName::parse("."),
+            Err(HerdrSessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            HerdrSessionName::parse("has space"),
+            Err(HerdrSessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            HerdrSessionName::parse(&"x".repeat(65)),
+            Err(HerdrSessionNameError::TooLong)
+        );
+    }
 
     #[test]
     fn session_names_match_the_shipped_creation_contract() {

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -11,7 +11,9 @@ use crossbeam_channel::{
 };
 use input::{EncodedInput, KeyInput, MouseAction, MouseInput, encode_input, encode_mouse};
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
-use session::{AdmissionPlan, AttachPlan, CreateOnce, SessionIdentity};
+use session::{
+    AdmissionPlan, AttachPlan, CreateOnce, HerdrAttachPlan, HerdrLaunchOnce, SessionIdentity,
+};
 use surface::{GridSize, PixelSize, SurfaceStore};
 
 use crate::windows_job::RelayJob;
@@ -270,6 +272,60 @@ impl TerminalWorker {
         Self::launch(
             plan.program(),
             plan.args(),
+            None,
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+        )
+    }
+
+    /// Spawn an attach-only Herdr client with UI-derived initial dimensions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PTY, child process, or relay containment
+    /// cannot be established.
+    pub fn attach_herdr_with_metadata(
+        plan: &HerdrAttachPlan,
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+    ) -> Result<Self, WorkerError> {
+        Self::launch(
+            plan.program(),
+            plan.args(),
+            None,
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+        )
+    }
+
+    /// Consume one Herdr launch-or-attach authority and spawn its ordinary
+    /// client inside a native pseudoterminal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PTY, child process, or relay containment
+    /// cannot be established. The consumed authority is never returned.
+    pub fn launch_herdr_with_metadata(
+        plan: HerdrLaunchOnce,
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+    ) -> Result<Self, WorkerError> {
+        let (program, args, _target_name) = plan.into_parts();
+        Self::launch(
+            &program,
+            &args,
             None,
             size,
             resize_sequence,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -2549,6 +2549,7 @@ impl RootView {
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let running = session.state() == HerdrSessionState::Running;
+        let lifecycle_action = session.lifecycle_action();
         let selection = SessionSelection::herdr(host.id(), host.endpoint(), session.name());
         let active = active_session_selection(content).as_ref() == Some(&selection);
         let actions = herdr_row_actions(session);
@@ -2565,8 +2566,11 @@ impl RootView {
             .pl(px(14.0))
             .pr_2()
             .bg(rgb(if active { 0x18_3f_68 } else { 0x0f_1116 }))
-            .cursor_pointer()
-            .hover(|style| style.bg(rgb(0x1c_2028)))
+            .when(lifecycle_action.is_none(), |element| {
+                element
+                    .cursor_pointer()
+                    .hover(|style| style.bg(rgb(0x1c_2028)))
+            })
             .child(
                 div()
                     .w(px(18.0))
@@ -2584,10 +2588,24 @@ impl RootView {
                     .text_color(rgb(if running { 0xc4_c9_d2 } else { 0x7f_8794 }))
                     .child(session.name().to_owned()),
             )
+            .when_some(lifecycle_action, |element, action| {
+                element.child(
+                    div()
+                        .flex_none()
+                        .text_xs()
+                        .text_color(rgb(0x8f_96_a3))
+                        .child(match action {
+                            workspace::HerdrLifecycleAction::Stop => "Stopping…",
+                            workspace::HerdrLifecycleAction::Delete => "Deleting…",
+                        }),
+                )
+            })
             .children(actions.into_iter().map(|action| {
                 Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
             }));
-        row = if running {
+        row = if lifecycle_action.is_some() {
+            row
+        } else if running {
             row.on_click(cx.listener(move |this, _, window, cx| {
                 this.select_session(&selection, window, cx);
             }))
@@ -3061,6 +3079,9 @@ fn herdr_lifecycle_copy(
 }
 
 fn herdr_row_actions(session: &workspace::HerdrSessionItem) -> Vec<HerdrRowAction> {
+    if session.lifecycle_action().is_some() {
+        return Vec::new();
+    }
     match session.state() {
         HerdrSessionState::Running => vec![HerdrRowAction::Stop],
         HerdrSessionState::Stopped if session.is_default() => vec![HerdrRowAction::Restart],

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -2555,10 +2555,19 @@ impl RootView {
             .and_then(workspace::HerdrSessionItem::lifecycle_action);
         let selection = session.selection.clone();
         let active = session.active;
-        let actions = session
-            .inventory
-            .as_ref()
-            .map_or_else(Vec::new, herdr_row_actions);
+        let actions = if session.access.can_mutate() {
+            session
+                .inventory
+                .as_ref()
+                .map_or_else(Vec::new, herdr_row_actions)
+        } else {
+            Vec::new()
+        };
+        let row_is_actionable = if running {
+            session.access.can_open()
+        } else {
+            session.access.can_mutate()
+        };
         let mut row = div()
             .id((
                 gpui::ElementId::named_usize("herdr-session-host", host_index),
@@ -2572,7 +2581,7 @@ impl RootView {
             .pl(px(14.0))
             .pr_2()
             .bg(rgb(if active { 0x18_3f_68 } else { 0x0f_1116 }))
-            .when(lifecycle_action.is_none(), |element| {
+            .when(lifecycle_action.is_none() && row_is_actionable, |element| {
                 element
                     .cursor_pointer()
                     .hover(|style| style.bg(rgb(0x1c_2028)))
@@ -2623,14 +2632,16 @@ impl RootView {
         }));
         row = if lifecycle_action.is_some() {
             row
-        } else if running {
+        } else if running && session.access.can_open() {
             row.on_click(cx.listener(move |this, _, window, cx| {
                 this.select_session(&selection, window, cx);
             }))
-        } else {
+        } else if session.access.can_mutate() {
             row.on_click(cx.listener(move |this, _, window, cx| {
                 this.restart_herdr_session(&selection, window, cx);
             }))
+        } else {
+            row
         };
         row.into_any_element()
     }
@@ -3056,7 +3067,25 @@ struct TreeHerdrSession {
     selection: SessionSelection,
     inventory: Option<workspace::HerdrSessionItem>,
     active: bool,
+    access: HerdrRowAccess,
     show_endpoint: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HerdrRowAccess {
+    Cached,
+    OpenOnly,
+    Mutable,
+}
+
+impl HerdrRowAccess {
+    const fn can_open(self) -> bool {
+        !matches!(self, Self::Cached)
+    }
+
+    const fn can_mutate(self) -> bool {
+        matches!(self, Self::Mutable)
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -3273,6 +3302,7 @@ fn tree_herdr_sessions(
             selection: SessionSelection::herdr(host.id(), host.endpoint(), inventory.name()),
             inventory: Some(inventory.clone()),
             active: false,
+            access: HerdrRowAccess::Cached,
             show_endpoint: false,
         })
         .collect::<Vec<_>>();
@@ -3291,12 +3321,25 @@ fn tree_herdr_sessions(
                 selection: selection.clone(),
                 inventory: None,
                 active: false,
+                access: HerdrRowAccess::Cached,
                 show_endpoint: selection.endpoint() != host.endpoint(),
             });
         }
     }
+    let host_accepts_actions = !matches!(
+        host.connection(),
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    );
     for session in &mut sessions {
         session.active = active.as_ref() == Some(&session.selection);
+        let retained = retained.contains(&session.selection);
+        session.access = if session.inventory.is_some() && host_accepts_actions {
+            HerdrRowAccess::Mutable
+        } else if session.active || retained {
+            HerdrRowAccess::OpenOnly
+        } else {
+            HerdrRowAccess::Cached
+        };
     }
     sessions
 }
@@ -4332,9 +4375,36 @@ mod tests {
         assert_eq!(rows[0].selection.session(), "retained");
         assert!(rows[0].show_endpoint);
         assert!(rows[0].inventory.is_none());
+        assert!(rows[0].access.can_open());
+        assert!(!rows[0].access.can_mutate());
         assert_eq!(rows[1].selection.session(), "active");
         assert!(rows[1].active);
         assert!(rows[1].inventory.is_none());
+        assert!(rows[1].access.can_open());
+        assert!(!rows[1].access.can_mutate());
+    }
+
+    #[test]
+    fn unavailable_cached_herdr_sessions_are_visible_but_not_actionable() {
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Unavailable,
+            Vec::new(),
+            None,
+        )
+        .with_herdr_sessions(vec![HerdrSessionItem::new(
+            "cached",
+            false,
+            HerdrSessionState::Stopped,
+        )]);
+
+        let rows = tree_herdr_sessions(&host, &WorkspaceContent::Shell, &[]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].selection.session(), "cached");
+        assert!(!rows[0].access.can_open());
+        assert!(!rows[0].access.can_mutate());
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -881,6 +881,54 @@ impl RootView {
         cx.notify();
     }
 
+    fn restart_herdr_session(
+        &mut self,
+        selection: &SessionSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match self.workspace.restart_herdr_session(selection) {
+            Ok(()) => {
+                self.diagnostic = None;
+                self.observed_presentation_id = None;
+                self.clear_terminal_input();
+                self.paint_cache.clear();
+                self.resize_for_window(window);
+            }
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
+    fn request_herdr_lifecycle(
+        &mut self,
+        selection: &SessionSelection,
+        action: workspace::HerdrLifecycleAction,
+        cx: &mut Context<Self>,
+    ) {
+        match self.workspace.request_herdr_lifecycle(selection, action) {
+            Ok(()) => self.diagnostic = None,
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        cx.notify();
+    }
+
+    fn cancel_herdr_lifecycle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.workspace.cancel_herdr_lifecycle();
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
+    fn confirm_herdr_lifecycle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.workspace.confirm_herdr_lifecycle() {
+            Ok(()) => self.diagnostic = None,
+            Err(error) => self.diagnostic = Some(error.to_string()),
+        }
+        window.focus(&self.focus);
+        cx.notify();
+    }
+
     fn sync_terminal_scope(&mut self) -> bool {
         let snapshot = self.workspace.snapshot();
         let presentation_id = terminal_presentation_id(snapshot.content());
@@ -1928,6 +1976,114 @@ impl RootView {
         Some(self.session_kill_overlay(&confirmation, cx))
     }
 
+    fn herdr_lifecycle_overlay(
+        &self,
+        confirmation: &workspace::HerdrLifecycleConfirmation,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let (verb, title, description) = herdr_lifecycle_copy(confirmation);
+        div()
+            .absolute()
+            .inset_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(rgba(0x00_00_00_80))
+            .child(
+                div()
+                    .id("herdr-lifecycle-dialog")
+                    .track_focus(&self.kill_focus)
+                    .w(px(460.0))
+                    .flex()
+                    .flex_col()
+                    .rounded_lg()
+                    .border_1()
+                    .border_color(rgb(0x36_3c48))
+                    .bg(rgb(0x18_1b22))
+                    .shadow_lg()
+                    .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                        if event.keystroke.key.eq_ignore_ascii_case("escape") && !event.is_held {
+                            this.cancel_herdr_lifecycle(window, cx);
+                            cx.stop_propagation();
+                        }
+                    }))
+                    .child(
+                        div()
+                            .px_4()
+                            .py_3()
+                            .border_b_1()
+                            .border_color(rgb(0x2a_2f39))
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(rgb(0xe0_e4eb))
+                            .child(title),
+                    )
+                    .child(
+                        div()
+                            .px_4()
+                            .py_4()
+                            .text_sm()
+                            .text_color(rgb(0xb6_bcc7))
+                            .child(description),
+                    )
+                    .child(
+                        div()
+                            .px_4()
+                            .py_3()
+                            .border_t_1()
+                            .border_color(rgb(0x2a_2f39))
+                            .flex()
+                            .items_center()
+                            .justify_end()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .id("cancel-herdr-lifecycle")
+                                    .px_3()
+                                    .py_1()
+                                    .rounded_sm()
+                                    .cursor_pointer()
+                                    .text_sm()
+                                    .text_color(rgb(0xb6_bcc7))
+                                    .hover(|style| style.bg(rgb(0x29_2e38)))
+                                    .child("Cancel")
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.cancel_herdr_lifecycle(window, cx);
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .id("confirm-herdr-lifecycle")
+                                    .px_3()
+                                    .py_1()
+                                    .rounded_sm()
+                                    .cursor_pointer()
+                                    .bg(rgb(0xa9_3038))
+                                    .hover(|style| style.bg(rgb(0xc1_3b43)))
+                                    .text_sm()
+                                    .text_color(rgb(0xff_f6f6))
+                                    .child(verb)
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.confirm_herdr_lifecycle(window, cx);
+                                    })),
+                            ),
+                    ),
+            )
+            .into_any_element()
+    }
+
+    fn pending_herdr_lifecycle_overlay(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        let confirmation = self.workspace.herdr_lifecycle_confirmation()?;
+        if !self.kill_focus.is_focused(window) {
+            window.focus(&self.kill_focus);
+        }
+        Some(self.herdr_lifecycle_overlay(&confirmation, cx))
+    }
+
     fn synchronize_render_state(&mut self, snapshot: &workspace::WorkspaceSnapshot) {
         self.observed_revision = snapshot.revision();
         if !matches!(snapshot.content(), WorkspaceContent::Terminal { .. }) {
@@ -2101,13 +2257,11 @@ impl RootView {
         }
 
         let sessions = tree_sessions(host, content, retained);
-        if host.connection() == HostConnectionState::Ready || !sessions.is_empty() {
+        let groups = session_group_visibility(host);
+        if groups.tmux {
             host_tree = host_tree.child(Self::session_tree(host_index, host, &sessions, cx));
         }
-        if host.herdr_available()
-            || !host.herdr_sessions().is_empty()
-            || host.herdr_diagnostic().is_some()
-        {
+        if groups.herdr {
             host_tree = host_tree.child(Self::herdr_tree(host_index, host, content, cx));
         }
         host_tree.into_any_element()
@@ -2397,6 +2551,7 @@ impl RootView {
         let running = session.state() == HerdrSessionState::Running;
         let selection = SessionSelection::herdr(host.id(), host.endpoint(), session.name());
         let active = active_session_selection(content).as_ref() == Some(&selection);
+        let actions = herdr_row_actions(session);
         let mut row = div()
             .id((
                 gpui::ElementId::named_usize("herdr-session-host", host_index),
@@ -2410,9 +2565,8 @@ impl RootView {
             .pl(px(14.0))
             .pr_2()
             .bg(rgb(if active { 0x18_3f_68 } else { 0x0f_1116 }))
-            .when(running, |row| {
-                row.cursor_pointer().hover(|style| style.bg(rgb(0x1c_2028)))
-            })
+            .cursor_pointer()
+            .hover(|style| style.bg(rgb(0x1c_2028)))
             .child(
                 div()
                     .w(px(18.0))
@@ -2430,19 +2584,65 @@ impl RootView {
                     .text_color(rgb(if running { 0xc4_c9_d2 } else { 0x7f_8794 }))
                     .child(session.name().to_owned()),
             )
-            .child(
-                div()
-                    .flex_none()
-                    .text_xs()
-                    .text_color(rgb(0x73_7a87))
-                    .child(if running { "running" } else { "stopped" }),
-            );
-        if running {
-            row = row.on_click(cx.listener(move |this, _, window, cx| {
-                this.select_session(&selection, window, cx);
+            .children(actions.into_iter().map(|action| {
+                Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
             }));
-        }
+        row = if running {
+            row.on_click(cx.listener(move |this, _, window, cx| {
+                this.select_session(&selection, window, cx);
+            }))
+        } else {
+            row.on_click(cx.listener(move |this, _, window, cx| {
+                this.restart_herdr_session(&selection, window, cx);
+            }))
+        };
         row.into_any_element()
+    }
+
+    fn herdr_row_action(
+        host_index: usize,
+        index: usize,
+        selection: SessionSelection,
+        action: HerdrRowAction,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let (label, color) = match action {
+            HerdrRowAction::Stop => ("Stop", 0xc7_7378),
+            HerdrRowAction::Restart => ("Restart", 0x79_aee3),
+            HerdrRowAction::Delete => ("Delete", 0xc7_7378),
+        };
+        div()
+            .id((
+                gpui::ElementId::named_usize("herdr-action-host", host_index),
+                format!("{index}-{label}"),
+            ))
+            .flex_none()
+            .px_1()
+            .py_1()
+            .rounded_sm()
+            .text_xs()
+            .text_color(rgb(color))
+            .hover(|style| style.bg(rgb(0x25_2a34)))
+            .child(label)
+            .on_click(cx.listener(move |this, _, window, cx| {
+                match action {
+                    HerdrRowAction::Stop => this.request_herdr_lifecycle(
+                        &selection,
+                        workspace::HerdrLifecycleAction::Stop,
+                        cx,
+                    ),
+                    HerdrRowAction::Restart => {
+                        this.restart_herdr_session(&selection, window, cx);
+                    }
+                    HerdrRowAction::Delete => this.request_herdr_lifecycle(
+                        &selection,
+                        workspace::HerdrLifecycleAction::Delete,
+                        cx,
+                    ),
+                }
+                cx.stop_propagation();
+            }))
+            .into_any_element()
     }
 
     fn host_status_row(
@@ -2821,6 +3021,62 @@ struct HostTreeStatus {
     action: &'static str,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SessionGroupVisibility {
+    tmux: bool,
+    herdr: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HerdrRowAction {
+    Stop,
+    Restart,
+    Delete,
+}
+
+fn herdr_lifecycle_copy(
+    confirmation: &workspace::HerdrLifecycleConfirmation,
+) -> (&'static str, String, &'static str) {
+    let selection = confirmation.selection();
+    match confirmation.action() {
+        workspace::HerdrLifecycleAction::Stop => (
+            "Stop Session",
+            format!(
+                "Stop “{}” on {}?",
+                selection.session(),
+                selection.endpoint()
+            ),
+            "This terminates every process in the session while preserving its saved workspace layout.",
+        ),
+        workspace::HerdrLifecycleAction::Delete => (
+            "Delete Session",
+            format!(
+                "Delete “{}” on {}?",
+                selection.session(),
+                selection.endpoint()
+            ),
+            "This permanently removes the stopped session and its saved workspace layout.",
+        ),
+    }
+}
+
+fn herdr_row_actions(session: &workspace::HerdrSessionItem) -> Vec<HerdrRowAction> {
+    match session.state() {
+        HerdrSessionState::Running => vec![HerdrRowAction::Stop],
+        HerdrSessionState::Stopped if session.is_default() => vec![HerdrRowAction::Restart],
+        HerdrSessionState::Stopped => vec![HerdrRowAction::Restart, HerdrRowAction::Delete],
+    }
+}
+
+fn session_group_visibility(host: &HostItem) -> SessionGroupVisibility {
+    SessionGroupVisibility {
+        tmux: true,
+        herdr: host.herdr_available()
+            || !host.herdr_sessions().is_empty()
+            || host.herdr_diagnostic().is_some(),
+    }
+}
+
 fn host_tree_status(host: &HostItem) -> Option<HostTreeStatus> {
     match host.connection() {
         HostConnectionState::Connecting | HostConnectionState::Ready => None,
@@ -3069,6 +3325,7 @@ impl Render for RootView {
         let content = self.content_element(&snapshot, cx);
         let creation_overlay = self.new_session_overlay(&snapshot, window, cx);
         let kill_overlay = self.pending_session_kill_overlay(window, cx);
+        let herdr_lifecycle_overlay = self.pending_herdr_lifecycle_overlay(window, cx);
         let mut root = div()
             .flex()
             .flex_col()
@@ -3081,7 +3338,8 @@ impl Render for RootView {
             .child(self.title_bar(title, cx))
             .child(div().flex_1().min_h_0().w_full().child(content))
             .children(creation_overlay)
-            .children(kill_overlay);
+            .children(kill_overlay)
+            .children(herdr_lifecycle_overlay);
 
         if let Some(notice) = snapshot.notice() {
             root = root.child(
@@ -3714,24 +3972,26 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::{
-        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, INPUT_BUFFER_FULL_DIAGNOSTIC,
+        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, HerdrRowAction, INPUT_BUFFER_FULL_DIAGNOSTIC,
         INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, NewSessionDraft, NewSessionKind,
         PendingUiInput, QueuedUiInput, TerminalKeyIdentity, TerminalKeyboard, TerminalPointer,
         TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch,
         active_session_selection, application_navigation_width, canonical_terminal_key_with,
         clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, host_tree_status, input_queue_has_capacity,
-        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
-        named_key, new_session_validation, normalize_cell_width, queued_input_matches_presentation,
-        retained_key_event_with, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
-        transitioned_presentation, tree_sessions, workspace_window_title,
+        coalesce_last_resize, coalesce_last_wheel, herdr_row_actions, host_tree_status,
+        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
+        kill_confirmation_title, named_key, new_session_validation, normalize_cell_width,
+        queued_input_matches_presentation, retained_key_event_with, session_group_visibility,
+        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
+        workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
-        HostConnectionState, HostItem, KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton,
-        MouseInput, NamedKey, SessionItem, SessionSelection, WorkspaceContent, WorkspaceSnapshot,
+        HerdrSessionItem, HerdrSessionState, HostConnectionState, HostItem, KeyEvent, KeyInput,
+        Modifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionItem, SessionSelection,
+        WorkspaceContent, WorkspaceSnapshot,
     };
 
     #[test]
@@ -3944,6 +4204,21 @@ mod tests {
         );
 
         assert_eq!(host_tree_status(&host), None);
+        assert!(session_group_visibility(&host).tmux);
+    }
+
+    #[test]
+    fn herdr_rows_expose_state_appropriate_lifecycle_actions() {
+        let running = HerdrSessionItem::new("running", false, HerdrSessionState::Running);
+        let default = HerdrSessionItem::new("default", true, HerdrSessionState::Stopped);
+        let stopped = HerdrSessionItem::new("review", false, HerdrSessionState::Stopped);
+
+        assert_eq!(herdr_row_actions(&running), vec![HerdrRowAction::Stop]);
+        assert_eq!(herdr_row_actions(&default), vec![HerdrRowAction::Restart]);
+        assert_eq!(
+            herdr_row_actions(&stopped),
+            vec![HerdrRowAction::Restart, HerdrRowAction::Delete]
+        );
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -69,10 +69,7 @@ pub fn empty_inventory_text(host: &HostItem) -> String {
     let namespace = host
         .socket_directory()
         .unwrap_or("the default tmux socket namespace");
-    format!(
-        "No tmux server is running in {} using {namespace}. Use + beside the host to create one, or review WSL host settings.",
-        host.endpoint()
-    )
+    format!("No tmux sessions in {} using {namespace}.", host.endpoint())
 }
 
 #[must_use]
@@ -2094,37 +2091,13 @@ impl RootView {
                 .flex_col()
                 .child(Self::host_header(host_index, host, is_selected, cx));
 
-        match host.connection() {
-            HostConnectionState::Connecting => {
-                if host.sessions().is_empty() && host.herdr_sessions().is_empty() {
-                    host_tree = host_tree.child(Self::host_status_row(
-                        host_index,
-                        "Refreshing sessions…".to_owned(),
-                        "Cancel",
-                        true,
-                        cx,
-                    ));
-                }
-            }
-            HostConnectionState::Unavailable => {
-                let message = host.diagnostic().map_or_else(
-                    || "Host unavailable".to_owned(),
-                    |diagnostic| diagnostic.message().to_owned(),
-                );
-                host_tree = host_tree.child(Self::host_status_row(
-                    host_index, message, "Retry", false, cx,
-                ));
-            }
-            HostConnectionState::Disconnected => {
-                host_tree = host_tree.child(Self::host_status_row(
-                    host_index,
-                    "Host disconnected".to_owned(),
-                    "Connect",
-                    false,
-                    cx,
-                ));
-            }
-            HostConnectionState::Ready => {}
+        if let Some(status) = host_tree_status(host) {
+            host_tree = host_tree.child(Self::host_status_row(
+                host_index,
+                status.message,
+                status.action,
+                cx,
+            ));
         }
 
         let sessions = tree_sessions(host, content, retained);
@@ -2201,6 +2174,23 @@ impl RootView {
                     .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
                     .child("↻")
                     .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+            );
+        } else if host.connection() == HostConnectionState::Connecting {
+            host_header = host_header.child(
+                div()
+                    .id(("cancel-host-refresh", host_index))
+                    .flex_none()
+                    .size(px(24.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .text_sm()
+                    .text_color(rgb(0x8f_96_a3))
+                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                    .child("×")
+                    .on_click(cx.listener(|this, _, _, cx| this.cancel_refresh(cx))),
             );
         }
         host_header.into_any_element()
@@ -2459,14 +2449,8 @@ impl RootView {
         host_index: usize,
         message: String,
         action: &'static str,
-        cancel: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let action_id = if cancel {
-            "cancel-host-refresh"
-        } else {
-            "retry-host-refresh"
-        };
         div()
             .mx_2()
             .mb_1()
@@ -2477,20 +2461,14 @@ impl RootView {
             .child(div().text_xs().text_color(rgb(0x9b_a2ae)).child(message))
             .child(
                 div()
-                    .id((action_id, host_index))
+                    .id(("retry-host-refresh", host_index))
                     .mt_1()
                     .cursor_pointer()
                     .text_xs()
                     .text_color(rgb(0x79_aee3))
                     .hover(|style| style.text_color(rgb(0xb6_d8_f8)))
                     .child(action)
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        if cancel {
-                            this.cancel_refresh(cx);
-                        } else {
-                            this.refresh(cx);
-                        }
-                    })),
+                    .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
             )
             .into_any_element()
     }
@@ -2655,7 +2633,7 @@ impl RootView {
     fn host_landing_element(host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
         if host.connection() == HostConnectionState::Ready {
             return centered(if host.sessions().is_empty() {
-                "Use + beside WSL to create a tmux session."
+                "No tmux sessions."
             } else {
                 "Choose a session to open its terminal."
             });
@@ -2769,13 +2747,7 @@ impl RootView {
                 "Select an existing session. Ghosthub attaches as an ordinary tmux client.",
             ));
         if sessions.is_empty() {
-            let empty = host.map_or_else(
-                || {
-                    "No tmux server is running in this distro. Use + beside WSL to create one."
-                        .to_owned()
-                },
-                empty_inventory_text,
-            );
+            let empty = host.map_or_else(|| "No tmux sessions.".to_owned(), empty_inventory_text);
             list = list.child(div().p_4().rounded_md().bg(rgb(0x1a_1d24)).child(empty));
         }
         for (index, session) in sessions.iter().enumerate() {
@@ -2841,6 +2813,29 @@ struct TreeSession {
     selection: SessionSelection,
     state: TreeSessionState,
     show_endpoint: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct HostTreeStatus {
+    message: String,
+    action: &'static str,
+}
+
+fn host_tree_status(host: &HostItem) -> Option<HostTreeStatus> {
+    match host.connection() {
+        HostConnectionState::Connecting | HostConnectionState::Ready => None,
+        HostConnectionState::Unavailable => Some(HostTreeStatus {
+            message: host.diagnostic().map_or_else(
+                || "Host unavailable".to_owned(),
+                |diagnostic| diagnostic.message().to_owned(),
+            ),
+            action: "Retry",
+        }),
+        HostConnectionState::Disconnected => Some(HostTreeStatus {
+            message: "Host disconnected".to_owned(),
+            action: "Connect",
+        }),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3725,7 +3720,7 @@ mod tests {
         TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch,
         active_session_selection, application_navigation_width, canonical_terminal_key_with,
         clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity,
+        coalesce_last_resize, coalesce_last_wheel, host_tree_status, input_queue_has_capacity,
         is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
         named_key, new_session_validation, normalize_cell_width, queued_input_matches_presentation,
         retained_key_event_with, terminal_cell_at_with_offset, terminal_key_input,
@@ -3936,6 +3931,19 @@ mod tests {
             assert!(rows[1].state.is_active());
             assert!(rows[1].state.can_open());
         }
+    }
+
+    #[test]
+    fn focus_refresh_does_not_insert_a_transient_navigation_status_row() {
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Connecting,
+            Vec::new(),
+            None,
+        );
+
+        assert_eq!(host_tree_status(&host), None);
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -309,7 +309,14 @@ pub struct RootView {
 struct NewSessionDraft {
     host_id: String,
     endpoint: String,
+    kind: NewSessionKind,
     name: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NewSessionKind {
+    Tmux,
+    Herdr,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -713,12 +720,14 @@ impl RootView {
         &mut self,
         host_id: &str,
         endpoint: &str,
+        kind: NewSessionKind,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.new_session = Some(NewSessionDraft {
             host_id: host_id.to_owned(),
             endpoint: endpoint.to_owned(),
+            kind,
             name: String::new(),
         });
         self.diagnostic = None;
@@ -745,10 +754,17 @@ impl RootView {
             cx.notify();
             return;
         }
-        match self
-            .workspace
-            .create_session(&draft.host_id, &draft.endpoint, &draft.name)
-        {
+        let result = match draft.kind {
+            NewSessionKind::Tmux => {
+                self.workspace
+                    .create_session(&draft.host_id, &draft.endpoint, &draft.name)
+            }
+            NewSessionKind::Herdr => {
+                self.workspace
+                    .create_herdr_session(&draft.host_id, &draft.endpoint, &draft.name)
+            }
+        };
+        match result {
             Ok(()) => {
                 self.new_session = None;
                 self.diagnostic = None;
@@ -1786,7 +1802,10 @@ impl RootView {
                                 .text_sm()
                                 .font_weight(FontWeight::SEMIBOLD)
                                 .text_color(rgb(0xe0_e4eb))
-                                .child("New tmux session"),
+                                .child(match draft.kind {
+                                    NewSessionKind::Tmux => "New tmux session",
+                                    NewSessionKind::Herdr => "New Herdr session",
+                                }),
                         )
                         .child(Self::new_session_name_input(draft, focused, cx))
                         .children(validation.map(|message| {
@@ -2077,13 +2096,15 @@ impl RootView {
 
         match host.connection() {
             HostConnectionState::Connecting => {
-                host_tree = host_tree.child(Self::host_status_row(
-                    host_index,
-                    "Refreshing sessions…".to_owned(),
-                    "Cancel",
-                    true,
-                    cx,
-                ));
+                if host.sessions().is_empty() && host.herdr_sessions().is_empty() {
+                    host_tree = host_tree.child(Self::host_status_row(
+                        host_index,
+                        "Refreshing sessions…".to_owned(),
+                        "Cancel",
+                        true,
+                        cx,
+                    ));
+                }
             }
             HostConnectionState::Unavailable => {
                 let message = host.diagnostic().map_or_else(
@@ -2108,13 +2129,13 @@ impl RootView {
 
         let sessions = tree_sessions(host, content, retained);
         if host.connection() == HostConnectionState::Ready || !sessions.is_empty() {
-            host_tree = host_tree.child(Self::session_tree(host_index, &sessions, cx));
+            host_tree = host_tree.child(Self::session_tree(host_index, host, &sessions, cx));
         }
         if host.herdr_available()
             || !host.herdr_sessions().is_empty()
             || host.herdr_diagnostic().is_some()
         {
-            host_tree = host_tree.child(Self::herdr_tree(host_index, host, cx));
+            host_tree = host_tree.child(Self::herdr_tree(host_index, host, content, cx));
         }
         host_tree.into_any_element()
     }
@@ -2165,49 +2186,29 @@ impl RootView {
                     .child(host.name().to_owned()),
             );
         if host.connection() == HostConnectionState::Ready {
-            let host_id = host.id().to_owned();
-            let endpoint = host.endpoint().to_owned();
-            host_header = host_header
-                .child(
-                    div()
-                        .id(("create-session-host", host_index))
-                        .flex_none()
-                        .size(px(24.0))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .text_sm()
-                        .text_color(rgb(0x8f_96_a3))
-                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
-                        .child("+")
-                        .on_click(cx.listener(move |this, _, window, cx| {
-                            this.open_new_session(&host_id, &endpoint, window, cx);
-                        })),
-                )
-                .child(
-                    div()
-                        .id(("refresh-host", host_index))
-                        .flex_none()
-                        .size(px(24.0))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .text_xs()
-                        .text_color(rgb(0x8f_96_a3))
-                        .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
-                        .child("↻")
-                        .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
-                );
+            host_header = host_header.child(
+                div()
+                    .id(("refresh-host", host_index))
+                    .flex_none()
+                    .size(px(24.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .text_xs()
+                    .text_color(rgb(0x8f_96_a3))
+                    .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                    .child("↻")
+                    .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+            );
         }
         host_header.into_any_element()
     }
 
     fn session_tree(
         host_index: usize,
+        host: &HostItem,
         sessions: &[TreeSession],
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
@@ -2217,17 +2218,46 @@ impl RootView {
             .border_color(rgb(0x25_2932))
             .flex()
             .flex_col()
-            .child(
-                div()
+            .child({
+                let mut header = div()
                     .h(px(24.0))
                     .flex()
                     .items_center()
                     .pl(px(17.0))
+                    .pr_1()
                     .text_xs()
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(0x73_7a87))
-                    .child("TMUX SESSIONS"),
-            );
+                    .child(div().flex_1().child("TMUX SESSIONS"));
+                if host.connection() == HostConnectionState::Ready {
+                    let host_id = host.id().to_owned();
+                    let endpoint = host.endpoint().to_owned();
+                    header = header.child(
+                        div()
+                            .id(("create-tmux-session", host_index))
+                            .size(px(22.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded_sm()
+                            .cursor_pointer()
+                            .text_sm()
+                            .text_color(rgb(0x8f_96_a3))
+                            .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                            .child("+")
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.open_new_session(
+                                    &host_id,
+                                    &endpoint,
+                                    NewSessionKind::Tmux,
+                                    window,
+                                    cx,
+                                );
+                            })),
+                    );
+                }
+                header
+            });
         if sessions.is_empty() {
             tree = tree.child(
                 div()
@@ -2251,24 +2281,58 @@ impl RootView {
         tree.into_any_element()
     }
 
-    fn herdr_tree(host_index: usize, host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
+    fn herdr_tree(
+        host_index: usize,
+        host: &HostItem,
+        content: &WorkspaceContent,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let host_id = host.id().to_owned();
+        let endpoint = host.endpoint().to_owned();
         let mut tree = div()
             .ml(px(18.0))
             .border_l_1()
             .border_color(rgb(0x25_2932))
             .flex()
             .flex_col()
-            .child(
-                div()
+            .child({
+                let mut header = div()
                     .h(px(24.0))
                     .flex()
                     .items_center()
                     .pl(px(17.0))
+                    .pr_1()
                     .text_xs()
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(0x73_7a87))
-                    .child("HERDR SESSIONS"),
-            );
+                    .child(div().flex_1().child("HERDR SESSIONS"));
+                if host.connection() == HostConnectionState::Ready && host.herdr_available() {
+                    header = header.child(
+                        div()
+                            .id(("create-herdr-session", host_index))
+                            .size(px(22.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded_sm()
+                            .cursor_pointer()
+                            .text_sm()
+                            .text_color(rgb(0x8f_96_a3))
+                            .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
+                            .child("+")
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.open_new_session(
+                                    &host_id,
+                                    &endpoint,
+                                    NewSessionKind::Herdr,
+                                    window,
+                                    cx,
+                                );
+                            })),
+                    );
+                }
+                header
+            });
         if let Some(diagnostic) = host.herdr_diagnostic() {
             tree = tree.child(Self::herdr_diagnostic_row(
                 host_index,
@@ -2288,7 +2352,9 @@ impl RootView {
             );
         }
         for (index, session) in host.herdr_sessions().iter().enumerate() {
-            tree = tree.child(Self::herdr_session_row(host_index, index, session));
+            tree = tree.child(Self::herdr_session_row(
+                host_index, index, host, session, content, cx,
+            ));
         }
         tree.into_any_element()
     }
@@ -2333,10 +2399,15 @@ impl RootView {
     fn herdr_session_row(
         host_index: usize,
         index: usize,
+        host: &HostItem,
         session: &workspace::HerdrSessionItem,
+        content: &WorkspaceContent,
+        cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let running = session.state() == HerdrSessionState::Running;
-        div()
+        let selection = SessionSelection::herdr(host.id(), host.endpoint(), session.name());
+        let active = active_session_selection(content).as_ref() == Some(&selection);
+        let mut row = div()
             .id((
                 gpui::ElementId::named_usize("herdr-session-host", host_index),
                 index.to_string(),
@@ -2348,6 +2419,10 @@ impl RootView {
             .gap_1()
             .pl(px(14.0))
             .pr_2()
+            .bg(rgb(if active { 0x18_3f_68 } else { 0x0f_1116 }))
+            .when(running, |row| {
+                row.cursor_pointer().hover(|style| style.bg(rgb(0x1c_2028)))
+            })
             .child(
                 div()
                     .w(px(18.0))
@@ -2371,8 +2446,13 @@ impl RootView {
                     .text_xs()
                     .text_color(rgb(0x73_7a87))
                     .child(if running { "running" } else { "stopped" }),
-            )
-            .into_any_element()
+            );
+        if running {
+            row = row.on_click(cx.listener(move |this, _, window, cx| {
+                this.select_session(&selection, window, cx);
+            }));
+        }
+        row.into_any_element()
     }
 
     fn host_status_row(
@@ -2796,13 +2876,18 @@ fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelecti
             host_id,
             endpoint,
             session,
+            kind,
         }
         | WorkspaceContent::Terminal {
             host_id,
             endpoint,
             session,
+            kind,
             ..
-        } => Some(SessionSelection::new(host_id, endpoint, session)),
+        } => Some(match kind {
+            workspace::SessionKind::Tmux => SessionSelection::new(host_id, endpoint, session),
+            workspace::SessionKind::Herdr => SessionSelection::herdr(host_id, endpoint, session),
+        }),
         WorkspaceContent::Shell
         | WorkspaceContent::Loading
         | WorkspaceContent::Ready { .. }
@@ -2816,9 +2901,9 @@ fn tree_sessions(
     retained: &[SessionSelection],
 ) -> Vec<TreeSession> {
     let active = active_session_selection(content);
-    let active_for_host = active
-        .as_ref()
-        .filter(|active| active.host_id() == host.id());
+    let active_for_host = active.as_ref().filter(|active| {
+        active.host_id() == host.id() && active.kind() == workspace::SessionKind::Tmux
+    });
 
     let mut selections = host
         .sessions()
@@ -2832,7 +2917,9 @@ fn tree_sessions(
         .collect::<Vec<_>>();
     for selection in retained
         .iter()
-        .filter(|selection| selection.host_id() == host.id())
+        .filter(|selection| {
+            selection.host_id() == host.id() && selection.kind() == workspace::SessionKind::Tmux
+        })
         .chain(active_for_host)
     {
         if !selections
@@ -3115,13 +3202,36 @@ fn new_session_validation(
     if draft.name.trim().is_empty() {
         return None;
     }
-    let Ok(name) = SessionName::parse(&draft.name) else {
-        return Some("Use 1–100 characters without #, periods, colons, or line breaks.".to_owned());
-    };
-    host.sessions()
-        .iter()
-        .any(|session| session.name() == name.as_str())
-        .then(|| "A session with this name already exists on this host.".to_owned())
+    match draft.kind {
+        NewSessionKind::Tmux => {
+            let Ok(name) = SessionName::parse(&draft.name) else {
+                return Some(
+                    "Use 1–100 characters without #, periods, colons, or line breaks.".to_owned(),
+                );
+            };
+            host.sessions()
+                .iter()
+                .any(|session| session.name() == name.as_str())
+                .then(|| "A tmux session with this name already exists on this host.".to_owned())
+        }
+        NewSessionKind::Herdr => {
+            if !host.herdr_available() {
+                return Some("Herdr is not available on this host.".to_owned());
+            }
+            let Ok(name) = workspace::HerdrSessionName::parse(&draft.name) else {
+                return Some(
+                    "Use 1–64 ASCII letters, numbers, periods, underscores, or hyphens.".to_owned(),
+                );
+            };
+            host.herdr_sessions()
+                .iter()
+                .any(|session| session.name() == name.as_str())
+                .then(|| {
+                    "A Herdr session with this name already exists on this host. Restart it instead."
+                        .to_owned()
+                })
+        }
+    }
 }
 
 fn window_control(
@@ -3610,17 +3720,17 @@ mod tests {
 
     use super::{
         APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, INPUT_BUFFER_FULL_DIAGNOSTIC,
-        INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, NewSessionDraft, PendingUiInput,
-        QueuedUiInput, TerminalKeyIdentity, TerminalKeyboard, TerminalPointer, TerminalResize,
-        UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, active_session_selection,
-        application_navigation_width, canonical_terminal_key_with, clear_terminal_input_state,
-        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, input_queue_has_capacity, is_toggle_sidebar_shortcut,
-        kill_confirmation_description, kill_confirmation_title, named_key, new_session_validation,
-        normalize_cell_width, queued_input_matches_presentation, retained_key_event_with,
-        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
-        workspace_window_title,
+        INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, NewSessionDraft, NewSessionKind,
+        PendingUiInput, QueuedUiInput, TerminalKeyIdentity, TerminalKeyboard, TerminalPointer,
+        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch,
+        active_session_selection, application_navigation_width, canonical_terminal_key_with,
+        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
+        coalesce_last_resize, coalesce_last_wheel, input_queue_has_capacity,
+        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
+        named_key, new_session_validation, normalize_cell_width, queued_input_matches_presentation,
+        retained_key_event_with, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
+        transitioned_presentation, tree_sessions, workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -3644,6 +3754,7 @@ mod tests {
         let mut draft = NewSessionDraft {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
+            kind: NewSessionKind::Tmux,
             name: String::new(),
         };
 
@@ -3661,7 +3772,7 @@ mod tests {
         draft.name = "existing".to_owned();
         assert_eq!(
             new_session_validation(&snapshot, &draft).as_deref(),
-            Some("A session with this name already exists on this host.")
+            Some("A tmux session with this name already exists on this host.")
         );
         draft.name = "  release work  ".to_owned();
         assert_eq!(new_session_validation(&snapshot, &draft), None);
@@ -3725,6 +3836,7 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "work".to_owned(),
+            kind: workspace::SessionKind::Tmux,
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };
@@ -3732,6 +3844,13 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "other".to_owned(),
+            kind: workspace::SessionKind::Tmux,
+        };
+        let herdr = WorkspaceContent::Attaching {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            session: "agent".to_owned(),
+            kind: workspace::SessionKind::Herdr,
         };
 
         assert_eq!(
@@ -3741,6 +3860,10 @@ mod tests {
         assert_eq!(
             active_session_selection(&attaching),
             Some(SessionSelection::new("wsl", "Ubuntu", "other"))
+        );
+        assert_eq!(
+            active_session_selection(&herdr),
+            Some(SessionSelection::herdr("wsl", "Ubuntu", "agent"))
         );
         assert_eq!(active_session_selection(&WorkspaceContent::Shell), None);
     }
@@ -3752,6 +3875,7 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
+            kind: workspace::SessionKind::Tmux,
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };
@@ -3759,6 +3883,7 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
+            kind: workspace::SessionKind::Tmux,
         };
 
         assert_eq!(
@@ -3779,6 +3904,7 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
+            kind: workspace::SessionKind::Tmux,
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };
@@ -3833,6 +3959,7 @@ mod tests {
             host_id: "wsl".to_owned(),
             endpoint: "Ubuntu".to_owned(),
             session: "demo".to_owned(),
+            kind: workspace::SessionKind::Tmux,
             presentation_id: 1,
             surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
         };

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -2257,12 +2257,13 @@ impl RootView {
         }
 
         let sessions = tree_sessions(host, content, retained);
-        let groups = session_group_visibility(host);
+        let herdr_sessions = tree_herdr_sessions(host, content, retained);
+        let groups = session_group_visibility(host, &herdr_sessions);
         if groups.tmux {
             host_tree = host_tree.child(Self::session_tree(host_index, host, &sessions, cx));
         }
         if groups.herdr {
-            host_tree = host_tree.child(Self::herdr_tree(host_index, host, content, cx));
+            host_tree = host_tree.child(Self::herdr_tree(host_index, host, &herdr_sessions, cx));
         }
         host_tree.into_any_element()
     }
@@ -2428,7 +2429,7 @@ impl RootView {
     fn herdr_tree(
         host_index: usize,
         host: &HostItem,
-        content: &WorkspaceContent,
+        sessions: &[TreeHerdrSession],
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let host_id = host.id().to_owned();
@@ -2483,7 +2484,7 @@ impl RootView {
                 diagnostic.message().to_owned(),
                 cx,
             ));
-        } else if host.herdr_sessions().is_empty() {
+        } else if sessions.is_empty() {
             tree = tree.child(
                 div()
                     .h(px(SESSION_ROW_HEIGHT))
@@ -2495,10 +2496,8 @@ impl RootView {
                     .child("No sessions"),
             );
         }
-        for (index, session) in host.herdr_sessions().iter().enumerate() {
-            tree = tree.child(Self::herdr_session_row(
-                host_index, index, host, session, content, cx,
-            ));
+        for (index, session) in sessions.iter().enumerate() {
+            tree = tree.child(Self::herdr_session_row(host_index, index, session, cx));
         }
         tree.into_any_element()
     }
@@ -2543,16 +2542,23 @@ impl RootView {
     fn herdr_session_row(
         host_index: usize,
         index: usize,
-        host: &HostItem,
-        session: &workspace::HerdrSessionItem,
-        content: &WorkspaceContent,
+        session: &TreeHerdrSession,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let running = session.state() == HerdrSessionState::Running;
-        let lifecycle_action = session.lifecycle_action();
-        let selection = SessionSelection::herdr(host.id(), host.endpoint(), session.name());
-        let active = active_session_selection(content).as_ref() == Some(&selection);
-        let actions = herdr_row_actions(session);
+        let running = session
+            .inventory
+            .as_ref()
+            .is_none_or(|inventory| inventory.state() == HerdrSessionState::Running);
+        let lifecycle_action = session
+            .inventory
+            .as_ref()
+            .and_then(workspace::HerdrSessionItem::lifecycle_action);
+        let selection = session.selection.clone();
+        let active = session.active;
+        let actions = session
+            .inventory
+            .as_ref()
+            .map_or_else(Vec::new, herdr_row_actions);
         let mut row = div()
             .id((
                 gpui::ElementId::named_usize("herdr-session-host", host_index),
@@ -2586,7 +2592,7 @@ impl RootView {
                     .truncate()
                     .text_sm()
                     .text_color(rgb(if running { 0xc4_c9_d2 } else { 0x7f_8794 }))
-                    .child(session.name().to_owned()),
+                    .child(selection.session().to_owned()),
             )
             .when_some(lifecycle_action, |element, action| {
                 element.child(
@@ -2599,10 +2605,19 @@ impl RootView {
                             workspace::HerdrLifecycleAction::Delete => "Deleting…",
                         }),
                 )
-            })
-            .children(actions.into_iter().map(|action| {
-                Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
-            }));
+            });
+        if session.show_endpoint {
+            row = row.child(
+                div()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(0x73_7a87))
+                    .child(format!("· {}", selection.endpoint())),
+            );
+        }
+        row = row.children(actions.into_iter().map(|action| {
+            Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
+        }));
         row = if lifecycle_action.is_some() {
             row
         } else if running {
@@ -3033,6 +3048,14 @@ struct TreeSession {
     show_endpoint: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreeHerdrSession {
+    selection: SessionSelection,
+    inventory: Option<workspace::HerdrSessionItem>,
+    active: bool,
+    show_endpoint: bool,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 struct HostTreeStatus {
     message: String,
@@ -3089,11 +3112,14 @@ fn herdr_row_actions(session: &workspace::HerdrSessionItem) -> Vec<HerdrRowActio
     }
 }
 
-fn session_group_visibility(host: &HostItem) -> SessionGroupVisibility {
+fn session_group_visibility(
+    host: &HostItem,
+    herdr_sessions: &[TreeHerdrSession],
+) -> SessionGroupVisibility {
     SessionGroupVisibility {
         tmux: true,
         herdr: host.herdr_available()
-            || !host.herdr_sessions().is_empty()
+            || !herdr_sessions.is_empty()
             || host.herdr_diagnostic().is_some(),
     }
 }
@@ -3226,6 +3252,50 @@ fn tree_sessions(
             }
         })
         .collect()
+}
+
+fn tree_herdr_sessions(
+    host: &HostItem,
+    content: &WorkspaceContent,
+    retained: &[SessionSelection],
+) -> Vec<TreeHerdrSession> {
+    let active = active_session_selection(content);
+    let active_for_host = active.as_ref().filter(|selection| {
+        selection.host_id() == host.id() && selection.kind() == workspace::SessionKind::Herdr
+    });
+    let mut sessions = host
+        .herdr_sessions()
+        .iter()
+        .map(|inventory| TreeHerdrSession {
+            selection: SessionSelection::herdr(host.id(), host.endpoint(), inventory.name()),
+            inventory: Some(inventory.clone()),
+            active: false,
+            show_endpoint: false,
+        })
+        .collect::<Vec<_>>();
+    for selection in retained
+        .iter()
+        .filter(|selection| {
+            selection.host_id() == host.id() && selection.kind() == workspace::SessionKind::Herdr
+        })
+        .chain(active_for_host)
+    {
+        if !sessions
+            .iter()
+            .any(|candidate| candidate.selection == *selection)
+        {
+            sessions.push(TreeHerdrSession {
+                selection: selection.clone(),
+                inventory: None,
+                active: false,
+                show_endpoint: selection.endpoint() != host.endpoint(),
+            });
+        }
+    }
+    for session in &mut sessions {
+        session.active = active.as_ref() == Some(&session.selection);
+    }
+    sessions
 }
 
 fn kill_confirmation_title(selection: &SessionSelection) -> String {
@@ -4004,8 +4074,8 @@ mod tests {
         kill_confirmation_title, named_key, new_session_validation, normalize_cell_width,
         queued_input_matches_presentation, retained_key_event_with, session_group_visibility,
         terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_sessions,
-        workspace_window_title,
+        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_herdr_sessions,
+        tree_sessions, workspace_window_title,
     };
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
@@ -4225,7 +4295,43 @@ mod tests {
         );
 
         assert_eq!(host_tree_status(&host), None);
-        assert!(session_group_visibility(&host).tmux);
+        assert!(session_group_visibility(&host, &[]).tmux);
+    }
+
+    #[test]
+    fn retained_and_active_herdr_sessions_survive_unavailable_inventory() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let active = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            session: "active".to_owned(),
+            kind: workspace::SessionKind::Herdr,
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Unavailable,
+            Vec::new(),
+            None,
+        );
+        let retained = vec![SessionSelection::herdr(
+            "wsl",
+            "Ubuntu-Previous",
+            "retained",
+        )];
+
+        let rows = tree_herdr_sessions(&host, &active, &retained);
+
+        assert_eq!(rows.len(), 2);
+        assert!(session_group_visibility(&host, &rows).herdr);
+        assert_eq!(rows[0].selection.session(), "retained");
+        assert!(rows[0].show_endpoint);
+        assert!(rows[0].inventory.is_none());
+        assert_eq!(rows[1].selection.session(), "active");
+        assert!(rows[1].active);
+        assert!(rows[1].inventory.is_none());
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -18,7 +18,7 @@ use gpui::{
 use model::PortStatus;
 use surface::{CellStyle, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
 use workspace::{
-    HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput,
+    HerdrSessionState, HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput,
     Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionName,
     SessionSelection, Workspace, WorkspaceContent, WorkspaceEvent,
 };
@@ -2110,6 +2110,12 @@ impl RootView {
         if host.connection() == HostConnectionState::Ready || !sessions.is_empty() {
             host_tree = host_tree.child(Self::session_tree(host_index, &sessions, cx));
         }
+        if host.herdr_available()
+            || !host.herdr_sessions().is_empty()
+            || host.herdr_diagnostic().is_some()
+        {
+            host_tree = host_tree.child(Self::herdr_tree(host_index, host, cx));
+        }
         host_tree.into_any_element()
     }
 
@@ -2243,6 +2249,130 @@ impl RootView {
             ));
         }
         tree.into_any_element()
+    }
+
+    fn herdr_tree(host_index: usize, host: &HostItem, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let mut tree = div()
+            .ml(px(18.0))
+            .border_l_1()
+            .border_color(rgb(0x25_2932))
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .h(px(24.0))
+                    .flex()
+                    .items_center()
+                    .pl(px(17.0))
+                    .text_xs()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(rgb(0x73_7a87))
+                    .child("HERDR SESSIONS"),
+            );
+        if let Some(diagnostic) = host.herdr_diagnostic() {
+            tree = tree.child(Self::herdr_diagnostic_row(
+                host_index,
+                diagnostic.message().to_owned(),
+                cx,
+            ));
+        } else if host.herdr_sessions().is_empty() {
+            tree = tree.child(
+                div()
+                    .h(px(SESSION_ROW_HEIGHT))
+                    .flex()
+                    .items_center()
+                    .pl(px(31.0))
+                    .text_xs()
+                    .text_color(rgb(0x73_7a87))
+                    .child("No sessions"),
+            );
+        }
+        for (index, session) in host.herdr_sessions().iter().enumerate() {
+            tree = tree.child(Self::herdr_session_row(host_index, index, session));
+        }
+        tree.into_any_element()
+    }
+
+    fn herdr_diagnostic_row(
+        host_index: usize,
+        message: String,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .mx_2()
+            .mb_1()
+            .px_2()
+            .py_1()
+            .rounded_sm()
+            .bg(rgb(0x16_1920))
+            .flex()
+            .items_center()
+            .gap_2()
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .truncate()
+                    .text_xs()
+                    .text_color(rgb(0x9b_a2ae))
+                    .child(message),
+            )
+            .child(
+                div()
+                    .id(("retry-herdr", host_index))
+                    .flex_none()
+                    .cursor_pointer()
+                    .text_xs()
+                    .text_color(rgb(0x79_aee3))
+                    .child("Retry")
+                    .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+            )
+            .into_any_element()
+    }
+
+    fn herdr_session_row(
+        host_index: usize,
+        index: usize,
+        session: &workspace::HerdrSessionItem,
+    ) -> gpui::AnyElement {
+        let running = session.state() == HerdrSessionState::Running;
+        div()
+            .id((
+                gpui::ElementId::named_usize("herdr-session-host", host_index),
+                index.to_string(),
+            ))
+            .mr_1()
+            .h(px(SESSION_ROW_HEIGHT))
+            .flex()
+            .items_center()
+            .gap_1()
+            .pl(px(14.0))
+            .pr_2()
+            .child(
+                div()
+                    .w(px(18.0))
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(if running { 0x79_c9_a3 } else { 0x68_6f7a }))
+                    .child(if running { ">_" } else { "○" }),
+            )
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .truncate()
+                    .text_sm()
+                    .text_color(rgb(if running { 0xc4_c9_d2 } else { 0x7f_8794 }))
+                    .child(session.name().to_owned()),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .text_xs()
+                    .text_color(rgb(0x73_7a87))
+                    .child(if running { "running" } else { "stopped" }),
+            )
+            .into_any_element()
     }
 
     fn host_status_row(

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -2615,6 +2615,9 @@ impl RootView {
                     .child(format!("· {}", selection.endpoint())),
             );
         }
+        if active {
+            row = row.child(Self::tree_detach_action(cx));
+        }
         row = row.children(actions.into_iter().map(|action| {
             Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
         }));

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -2451,7 +2451,10 @@ impl RootView {
                     .font_weight(FontWeight::SEMIBOLD)
                     .text_color(rgb(0x73_7a87))
                     .child(div().flex_1().child("HERDR SESSIONS"));
-                if host.connection() == HostConnectionState::Ready && host.herdr_available() {
+                if host.connection() == HostConnectionState::Ready
+                    && host.herdr_available()
+                    && host.herdr_diagnostic().is_none()
+                {
                     header = header.child(
                         div()
                             .id(("create-herdr-session", host_index))
@@ -2549,10 +2552,8 @@ impl RootView {
             .inventory
             .as_ref()
             .is_none_or(|inventory| inventory.state() == HerdrSessionState::Running);
-        let lifecycle_action = session
-            .inventory
-            .as_ref()
-            .and_then(workspace::HerdrSessionItem::lifecycle_action);
+        let operation_label = session.inventory.as_ref().and_then(herdr_operation_label);
+        let operation_pending = operation_label.is_some();
         let selection = session.selection.clone();
         let active = session.active;
         let actions = if session.access.can_mutate() {
@@ -2581,7 +2582,7 @@ impl RootView {
             .pl(px(14.0))
             .pr_2()
             .bg(rgb(if active { 0x18_3f_68 } else { 0x0f_1116 }))
-            .when(lifecycle_action.is_none() && row_is_actionable, |element| {
+            .when(!operation_pending && row_is_actionable, |element| {
                 element
                     .cursor_pointer()
                     .hover(|style| style.bg(rgb(0x1c_2028)))
@@ -2603,16 +2604,13 @@ impl RootView {
                     .text_color(rgb(if running { 0xc4_c9_d2 } else { 0x7f_8794 }))
                     .child(selection.session().to_owned()),
             )
-            .when_some(lifecycle_action, |element, action| {
+            .when_some(operation_label, |element, label| {
                 element.child(
                     div()
                         .flex_none()
                         .text_xs()
                         .text_color(rgb(0x8f_96_a3))
-                        .child(match action {
-                            workspace::HerdrLifecycleAction::Stop => "Stopping…",
-                            workspace::HerdrLifecycleAction::Delete => "Deleting…",
-                        }),
+                        .child(label),
                 )
             });
         if session.show_endpoint {
@@ -2630,7 +2628,7 @@ impl RootView {
         row = row.children(actions.into_iter().map(|action| {
             Self::herdr_row_action(host_index, index, selection.clone(), action, cx)
         }));
-        row = if lifecycle_action.is_some() {
+        row = if operation_pending {
             row
         } else if running && session.access.can_open() {
             row.on_click(cx.listener(move |this, _, window, cx| {
@@ -3134,13 +3132,22 @@ fn herdr_lifecycle_copy(
 }
 
 fn herdr_row_actions(session: &workspace::HerdrSessionItem) -> Vec<HerdrRowAction> {
-    if session.lifecycle_action().is_some() {
+    if session.lifecycle_action().is_some() || session.launch_pending() {
         return Vec::new();
     }
     match session.state() {
         HerdrSessionState::Running => vec![HerdrRowAction::Stop],
         HerdrSessionState::Stopped if session.is_default() => vec![HerdrRowAction::Restart],
         HerdrSessionState::Stopped => vec![HerdrRowAction::Restart, HerdrRowAction::Delete],
+    }
+}
+
+fn herdr_operation_label(session: &workspace::HerdrSessionItem) -> Option<&'static str> {
+    match session.lifecycle_action() {
+        Some(workspace::HerdrLifecycleAction::Stop) => Some("Stopping…"),
+        Some(workspace::HerdrLifecycleAction::Delete) => Some("Deleting…"),
+        None if session.launch_pending() => Some("Starting…"),
+        None => None,
     }
 }
 
@@ -3329,7 +3336,7 @@ fn tree_herdr_sessions(
     let host_accepts_actions = !matches!(
         host.connection(),
         HostConnectionState::Disconnected | HostConnectionState::Unavailable
-    );
+    ) && host.herdr_diagnostic().is_none();
     for session in &mut sessions {
         session.active = active.as_ref() == Some(&session.selection);
         let retained = retained.contains(&session.selection);
@@ -3605,7 +3612,7 @@ fn new_session_validation(
                 .then(|| "A tmux session with this name already exists on this host.".to_owned())
         }
         NewSessionKind::Herdr => {
-            if !host.herdr_available() {
+            if !host.herdr_available() || host.herdr_diagnostic().is_some() {
                 return Some("Herdr is not available on this host.".to_owned());
             }
             let Ok(name) = workspace::HerdrSessionName::parse(&draft.name) else {
@@ -4109,26 +4116,27 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::{
-        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, HerdrRowAction, INPUT_BUFFER_FULL_DIAGNOSTIC,
-        INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey, NewSessionDraft, NewSessionKind,
-        PendingUiInput, QueuedUiInput, TerminalKeyIdentity, TerminalKeyboard, TerminalPointer,
-        TerminalResize, UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch,
-        active_session_selection, application_navigation_width, canonical_terminal_key_with,
-        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, herdr_row_actions, host_tree_status,
-        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
-        kill_confirmation_title, named_key, new_session_validation, normalize_cell_width,
-        queued_input_matches_presentation, retained_key_event_with, session_group_visibility,
-        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
-        terminal_line_height, terminal_wheel_steps, transitioned_presentation, tree_herdr_sessions,
-        tree_sessions, workspace_window_title,
+        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, HerdrRowAccess, HerdrRowAction,
+        INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC, InputRefusal, LayoutKey,
+        NewSessionDraft, NewSessionKind, PendingUiInput, QueuedUiInput, TerminalKeyIdentity,
+        TerminalKeyboard, TerminalPointer, TerminalResize, UI_INPUT_BYTE_CAPACITY,
+        UI_INPUT_CAPACITY, WheelBatch, active_session_selection, application_navigation_width,
+        canonical_terminal_key_with, clear_terminal_input_state, clears_after_input_delivery,
+        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
+        herdr_row_actions, host_tree_status, input_queue_has_capacity, is_toggle_sidebar_shortcut,
+        kill_confirmation_description, kill_confirmation_title, named_key, new_session_validation,
+        normalize_cell_width, queued_input_matches_presentation, retained_key_event_with,
+        session_group_visibility, terminal_cell_at_with_offset, terminal_key_input,
+        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
+        transitioned_presentation, tree_herdr_sessions, tree_sessions, workspace_window_title,
     };
+    use model::DiagnosticKind;
     use std::sync::Arc;
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
-        HerdrSessionItem, HerdrSessionState, HostConnectionState, HostItem, KeyEvent, KeyInput,
-        Modifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionItem, SessionSelection,
-        WorkspaceContent, WorkspaceSnapshot,
+        HerdrSessionItem, HerdrSessionState, HostConnectionState, HostDiagnostic, HostItem,
+        KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionItem,
+        SessionSelection, WorkspaceContent, WorkspaceSnapshot,
     };
 
     #[test]
@@ -4403,6 +4411,27 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].selection.session(), "cached");
+        assert!(!rows[0].access.can_open());
+        assert!(!rows[0].access.can_mutate());
+    }
+
+    #[test]
+    fn failed_current_herdr_inventory_exposes_cached_rows_only() {
+        let host = HostItem::wsl("Ubuntu", None, HostConnectionState::Ready, Vec::new(), None)
+            .with_herdr_sessions(vec![HerdrSessionItem::new(
+                "cached",
+                false,
+                HerdrSessionState::Running,
+            )])
+            .with_herdr_diagnostic(HostDiagnostic::new(
+                DiagnosticKind::MalformedOutput,
+                "invalid Herdr inventory",
+            ));
+
+        let rows = tree_herdr_sessions(&host, &WorkspaceContent::Shell, &[]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].access, HerdrRowAccess::Cached);
         assert!(!rows[0].access.can_open());
         assert!(!rows[0].access.can_mutate());
     }

--- a/rust/ui/tests/root_view.rs
+++ b/rust/ui/tests/root_view.rs
@@ -34,10 +34,9 @@ fn empty_inventory_copy_names_the_socket_namespace() {
         None,
     );
 
-    assert_eq!(
-        empty_inventory_text(&host),
-        "No tmux server is running in Ubuntu using /run/user/1000/tmux. Use + beside the host to create one, or review WSL host settings."
-    );
+    let copy = empty_inventory_text(&host);
+    assert!(copy.contains("Ubuntu"));
+    assert!(copy.contains("/run/user/1000/tmux"));
 }
 
 #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -13,6 +13,7 @@ use host::{
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
+use session::HerdrLaunchTarget;
 pub use session::{
     HerdrLifecycleAction, HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName,
     SessionNameError,
@@ -849,7 +850,7 @@ struct HerdrCreateRequest {
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
     executable: String,
-    name: HerdrSessionName,
+    name: HerdrLaunchTarget,
     precondition: HerdrLaunchPrecondition,
 }
 
@@ -1196,12 +1197,8 @@ impl<T> RetainedPresentations<T> {
                 refreshed_session_name(&presentation.key, snapshot, socket_directory)
                 && name != presentation.attachment.request.name
             {
-                presentation.selection = SessionSelection::new(
-                    &presentation.key.host_id,
-                    presentation.key.endpoint.clone(),
-                    name,
-                );
                 presentation.attachment.request.name = name.to_owned();
+                presentation.selection = presentation.attachment.request.selection();
                 changed = true;
             }
         }
@@ -1210,12 +1207,8 @@ impl<T> RetainedPresentations<T> {
                 refreshed_session_name(&presentation.key, snapshot, socket_directory)
                 && name != presentation.attachment.request.name
             {
-                presentation.selection = SessionSelection::new(
-                    &presentation.key.host_id,
-                    presentation.key.endpoint.clone(),
-                    name,
-                );
                 presentation.attachment.request.name = name.to_owned();
+                presentation.selection = presentation.attachment.request.selection();
                 changed = true;
             }
         }
@@ -3800,7 +3793,7 @@ fn capture_herdr_create_request(
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
             executable: executable.clone(),
-            name,
+            name: HerdrLaunchTarget::created(name),
             precondition: HerdrLaunchPrecondition::Absent,
         })
     })
@@ -3843,8 +3836,7 @@ fn capture_herdr_restart_request(
         if record.state() != HerdrSessionState::Stopped {
             return Err(WorkspaceError::new("Herdr session is already running"));
         }
-        let name = HerdrSessionName::parse(record.name())
-            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        let name = HerdrLaunchTarget::discovered(&record);
         Ok(HerdrCreateRequest {
             host_id: selection.host_id().to_owned(),
             host: context.host.clone(),
@@ -4255,6 +4247,7 @@ fn create_herdr_fresh(
                 .iter()
                 .find(|session| {
                     session.name() == request.name.as_str()
+                        && session.is_default() == request.precondition.is_default()
                         && session.state() == HerdrSessionState::Running
                 })
                 .cloned()
@@ -4284,6 +4277,7 @@ fn validate_herdr_launch_precondition(
         }
         (HerdrLaunchPrecondition::Stopped(expected), Some(current))
             if current.state() == HerdrSessionState::Stopped
+                && current.is_default() == expected.is_default()
                 && current.session_directory() == expected.session_directory()
                 && current.socket_path() == expected.socket_path() => {}
         (HerdrLaunchPrecondition::Stopped(_), Some(current))
@@ -6469,6 +6463,53 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn inventory_rename_preserves_a_retained_herdr_selection() {
+        let original_snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = herdr_attach_request_fixture(&original_snapshot, "original");
+        let key = request.presentation_key();
+        let mut retained = RetainedPresentations::new();
+        retained.insert(RetainedPresentation {
+            key: key.clone(),
+            selection: request.selection(),
+            attachment: ActiveAttachment {
+                request,
+                term: AttachTerm::Xterm256Color,
+                generation: 1,
+                fallback: None,
+            },
+            worker: (),
+            presentation_id: 7,
+        });
+        let renamed_snapshot = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot-id",
+            42,
+            Vec::new(),
+            HerdrInventory::Available {
+                executable: "/opt/herdr/bin/herdr".to_owned(),
+                sessions: vec![session::HerdrSessionRecord::new(
+                    "renamed",
+                    false,
+                    HerdrSessionState::Running,
+                    "/tmp/herdr/review",
+                    "/tmp/herdr/review/herdr.sock",
+                )],
+            },
+        );
+
+        assert!(retained.reconcile_session_names(&renamed_snapshot, None));
+
+        assert!(retained.contains(&key));
+        assert_eq!(retained.entries[0].selection.kind(), SessionKind::Herdr);
+        assert_eq!(retained.entries[0].selection.session(), "renamed");
+        assert_eq!(
+            retained.key_for_selection(&SessionSelection::herdr("wsl", "Ubuntu", "renamed")),
+            Some(key)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn retained_rename_advances_the_workspace_revision_once() {
         let identity = session::SessionIdentity::new(100, "$1", 200);
         let original_snapshot = HostSnapshot::test_fixture(
@@ -7971,7 +8012,9 @@ mod tests {
         );
     }
 
-    fn herdr_workspace_fixture() -> (Workspace, Arc<ManualRefreshRuntime>) {
+    fn herdr_workspace_with_sessions(
+        herdr_sessions: Vec<session::HerdrSessionRecord>,
+    ) -> (Workspace, Arc<ManualRefreshRuntime>) {
         let runtime = Arc::new(ManualRefreshRuntime::default());
         let snapshot = HostSnapshot::test_fixture_with_herdr(
             "Ubuntu",
@@ -7984,22 +8027,7 @@ mod tests {
             )],
             HerdrInventory::Available {
                 executable: "/opt/herdr/bin/herdr".to_owned(),
-                sessions: vec![
-                    session::HerdrSessionRecord::new(
-                        "default",
-                        true,
-                        HerdrSessionState::Running,
-                        "/tmp/herdr/default",
-                        "/tmp/herdr/default/herdr.sock",
-                    ),
-                    session::HerdrSessionRecord::new(
-                        "review",
-                        false,
-                        HerdrSessionState::Stopped,
-                        "/tmp/herdr/review",
-                        "/tmp/herdr/review/herdr.sock",
-                    ),
-                ],
+                sessions: herdr_sessions,
             },
         );
         let discovery = Arc::new(FixedDiscovery::new(snapshot));
@@ -8018,6 +8046,25 @@ mod tests {
         workspace.connect_enabled_hosts().expect("start refresh");
         runtime.run_next_work();
         (workspace, runtime)
+    }
+
+    fn herdr_workspace_fixture() -> (Workspace, Arc<ManualRefreshRuntime>) {
+        herdr_workspace_with_sessions(vec![
+            session::HerdrSessionRecord::new(
+                "default",
+                true,
+                HerdrSessionState::Running,
+                "/tmp/herdr/default",
+                "/tmp/herdr/default/herdr.sock",
+            ),
+            session::HerdrSessionRecord::new(
+                "review",
+                false,
+                HerdrSessionState::Stopped,
+                "/tmp/herdr/review",
+                "/tmp/herdr/review/herdr.sock",
+            ),
+        ])
     }
 
     #[test]
@@ -8097,6 +8144,57 @@ mod tests {
                 .expect("delete confirmation")
                 .action(),
             HerdrLifecycleAction::Delete
+        );
+    }
+
+    #[test]
+    fn restart_preserves_an_authoritative_name_outside_the_creation_subset() {
+        let name = "review session";
+        let (workspace, _runtime) =
+            herdr_workspace_with_sessions(vec![session::HerdrSessionRecord::new(
+                name,
+                false,
+                HerdrSessionState::Stopped,
+                "/tmp/herdr/review session",
+                "/tmp/herdr/review session/herdr.sock",
+            )]);
+
+        let request = capture_herdr_restart_request(
+            &workspace.inner,
+            &SessionSelection::herdr("wsl", "Ubuntu", name),
+        )
+        .expect("discovered session names remain restartable");
+
+        assert_eq!(request.name.as_str(), name);
+        assert!(matches!(
+            request.precondition,
+            HerdrLaunchPrecondition::Stopped(record) if record.name() == name
+        ));
+    }
+
+    #[test]
+    fn restart_rejects_a_session_whose_default_role_changed() {
+        let expected = session::HerdrSessionRecord::new(
+            "review",
+            false,
+            HerdrSessionState::Stopped,
+            "/tmp/herdr/review",
+            "/tmp/herdr/review/herdr.sock",
+        );
+        let current = session::HerdrSessionRecord::new(
+            "review",
+            true,
+            HerdrSessionState::Stopped,
+            "/tmp/herdr/review",
+            "/tmp/herdr/review/herdr.sock",
+        );
+
+        assert!(
+            validate_herdr_launch_precondition(
+                &HerdrLaunchPrecondition::Stopped(expected),
+                Some(&current),
+            )
+            .is_err()
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -974,8 +974,15 @@ struct PresentationKey {
 }
 
 struct SuppressedHerdrPresentation {
-    key: PresentationKey,
+    active_selection: Option<SessionSelection>,
+    retained: Option<ClosedRetainedHerdrPresentation>,
     navigation_generation: u64,
+}
+
+struct ClosedRetainedHerdrPresentation {
+    key: PresentationKey,
+    attachment: ActiveAttachment<AttachRequest>,
+    presentation_id: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1242,6 +1249,22 @@ impl<T> RetainedPresentations<T> {
         self.restarting.retain(|entry| !matches(&entry.key));
         changed |= self.restarting.len() != restart_before;
         changed
+    }
+
+    fn take_matching(
+        &mut self,
+        mut matches: impl FnMut(&PresentationKey) -> bool,
+    ) -> Vec<RetainedPresentation<T>> {
+        let mut removed = Vec::new();
+        let mut index = 0;
+        while index < self.entries.len() {
+            if matches(&self.entries[index].key) {
+                removed.push(self.entries.remove(index));
+            } else {
+                index += 1;
+            }
+        }
+        removed
     }
 
     fn contains(&self, key: &PresentationKey) -> bool {
@@ -1977,6 +2000,10 @@ impl Workspace {
             .navigation
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.switch_session_locked(selection)
+    }
+
+    fn switch_session_locked(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
         let same_visible_selection = matches!(
             self.inner
                 .state
@@ -2931,45 +2958,88 @@ impl Workspace {
         }
     }
 
-    fn suppress_active_herdr_presentation(
+    fn close_herdr_presentations(
         &self,
         pending: &PendingHerdrLifecycle,
     ) -> Option<SuppressedHerdrPresentation> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _navigation = self
             .inner
             .navigation
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let active_matches = self
+        let navigation_generation = self.inner.navigation_generation.load(Ordering::Acquire);
+        let mut attachment = self
             .inner
             .attachment
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .active()
-            .is_some_and(|active| {
-                active.request.endpoint == pending.endpoint
-                    && active.request.runtime == pending.runtime
-                    && active.request.name == pending.record.name()
-                    && active.request.target.herdr_matches(&pending.record)
-            });
-        if !active_matches {
-            return None;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let active_selection = attachment.active().and_then(|active| {
+            let matches = active.request.endpoint == pending.endpoint
+                && active.request.runtime == pending.runtime
+                && active.request.target.herdr_matches(&pending.record);
+            matches.then(|| active.request.selection())
+        });
+        if active_selection.is_some() {
+            attachment.invalidate();
+            self.inner
+                .worker
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .invalidate();
+            clear_pending_paste(&self.inner);
+            clear_terminal_notice(&self.inner);
+            self.restore_inventory_state();
         }
-        let navigation_generation = self.inner.navigation_generation.load(Ordering::Acquire);
-        self.retain_active_presentation()
-            .ok()
-            .flatten()
-            .map(|key| SuppressedHerdrPresentation {
-                key,
-                navigation_generation,
-            })
+        drop(attachment);
+
+        let removed = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take_matching(|key| {
+                key.endpoint == pending.endpoint.distro()
+                    && key.runtime == pending.runtime
+                    && key.target.herdr_matches(&pending.record)
+            });
+        let changed = active_selection.is_some() || !removed.is_empty();
+        let retained = active_selection.is_none().then(|| {
+            removed
+                .into_iter()
+                .next()
+                .map(|presentation| ClosedRetainedHerdrPresentation {
+                    key: presentation.key,
+                    attachment: presentation.attachment,
+                    presentation_id: presentation.presentation_id,
+                })
+        });
+        if changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+        (active_selection.is_some() || retained.is_some()).then_some(SuppressedHerdrPresentation {
+            active_selection,
+            retained: retained.flatten(),
+            navigation_generation,
+        })
     }
 
     fn restore_suppressed_herdr_presentation(
         &self,
-        suppressed: Option<&SuppressedHerdrPresentation>,
+        suppressed: Option<SuppressedHerdrPresentation>,
     ) {
         let Some(suppressed) = suppressed else {
+            return;
+        };
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        if let Some(retained) = suppressed.retained
+            && let Err(error) = restore_closed_retained_herdr_presentation(&self.inner, retained)
+        {
+            self.push_operation_error(format!(
+                "could not restore a retained Herdr presentation after a failed lifecycle action: {error}"
+            ));
+        }
+        let Some(selection) = suppressed.active_selection else {
             return;
         };
         let _navigation = self
@@ -2982,7 +3052,11 @@ impl Workspace {
         {
             return;
         }
-        let _restored = self.activate_retained_presentation(&suppressed.key, None);
+        if let Err(error) = self.switch_session_locked(&selection) {
+            self.push_operation_error(format!(
+                "could not restore the Herdr presentation after a failed lifecycle action: {error}"
+            ));
+        }
     }
 
     /// Update the desired grid and resize an active VT/PTTY pair together.
@@ -4490,7 +4564,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
         || {
             reserve_constructive_inventory(&workspace.inner);
             if pending.action == HerdrLifecycleAction::Stop {
-                suppressed = workspace.suppress_active_herdr_presentation(pending);
+                suppressed = workspace.close_herdr_presentations(pending);
             }
         },
     ) {
@@ -4521,12 +4595,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
             }
         }
         Err(error) => {
-            reconcile_herdr_lifecycle_failure(
-                workspace,
-                pending,
-                error.to_string(),
-                suppressed.as_ref(),
-            );
+            reconcile_herdr_lifecycle_failure(workspace, pending, error.to_string(), suppressed);
         }
     }
 }
@@ -4535,7 +4604,7 @@ fn reconcile_herdr_lifecycle_failure(
     workspace: &Workspace,
     pending: &PendingHerdrLifecycle,
     operation_error: String,
-    suppressed: Option<&SuppressedHerdrPresentation>,
+    suppressed: Option<SuppressedHerdrPresentation>,
 ) {
     match reconcile_herdr_lifecycle_inventory(
         &workspace.inner,
@@ -5271,7 +5340,7 @@ fn publish_herdr_lifecycle_response(
                 "the WSL endpoint changed while publishing the Herdr lifecycle response",
             )
         })?
-        .with_herdr_lifecycle(pending.action, record)
+        .with_herdr_lifecycle(pending.action, &pending.record, record)
         .ok_or_else(|| {
             WorkspaceError::new(
                 "the Herdr lifecycle response no longer matches published inventory",
@@ -5605,6 +5674,46 @@ fn restore_presentation_inventory(inner: &Inner) {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
     set_inner_state(inner, state);
+}
+
+fn restore_closed_retained_herdr_presentation(
+    inner: &Inner,
+    mut closed: ClosedRetainedHerdrPresentation,
+) -> Result<(), WorkspaceError> {
+    let term = closed.attachment.term;
+    let (worker, _snapshot, attached_name, initial_geometry) =
+        attach_fresh(inner, &closed.attachment.request, term).map_err(|error| match error {
+            AttachFreshError::Host(error) | AttachFreshError::SessionChanged { error, .. } => error,
+        })?;
+    let latest_geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if latest_geometry != initial_geometry {
+        worker
+            .resize_with_metadata(
+                latest_geometry.grid,
+                latest_geometry.sequence,
+                latest_geometry.pixels,
+            )
+            .map_err(|error| WorkspaceError::from_worker(&error))?;
+    }
+    attached_name.clone_into(&mut closed.attachment.request.name);
+    let selection = closed.attachment.request.selection();
+    worker.set_clipboard_writes_enabled(false);
+    inner
+        .retained_presentations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(RetainedPresentation {
+            key: closed.key,
+            selection,
+            attachment: closed.attachment,
+            worker,
+            presentation_id: closed.presentation_id,
+        });
+    inner.revision.fetch_add(1, Ordering::Release);
+    Ok(())
 }
 
 fn attach_fresh(
@@ -9088,6 +9197,41 @@ mod tests {
             workspace.snapshot().hosts()[0].herdr_sessions()[0].lifecycle_action(),
             Some(HerdrLifecycleAction::Stop),
         );
+    }
+
+    #[test]
+    fn stop_preparation_removes_every_matching_retained_client() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let selection = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        let request = capture_attach_request(&workspace.inner, &selection)
+            .expect("running Herdr session is attachable");
+        let key = request.presentation_key();
+        let attachment = |generation| ActiveAttachment {
+            request: request.clone(),
+            term: AttachTerm::Xterm256Color,
+            generation,
+            fallback: None,
+        };
+        let mut retained = RetainedPresentations::new();
+        retained.insert(RetainedPresentation {
+            key: key.clone(),
+            selection: selection.clone(),
+            attachment: attachment(1),
+            worker: 1_u8,
+            presentation_id: 1,
+        });
+        retained.entries.push(RetainedPresentation {
+            key: key.clone(),
+            selection,
+            attachment: attachment(2),
+            worker: 2_u8,
+            presentation_id: 2,
+        });
+
+        let removed = retained.take_matching(|candidate| candidate == &key);
+
+        assert_eq!(removed.len(), 2);
+        assert!(!retained.contains(&key));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -4388,6 +4388,23 @@ fn reserve_constructive_inventory(inner: &Inner) -> u64 {
     generation
 }
 
+fn reserve_current_constructive_inventory(
+    inner: &Inner,
+    navigation_generation: u64,
+    cancellation: &CancellationToken,
+) -> Option<u64> {
+    let _navigation = inner
+        .navigation
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if cancellation.is_cancelled()
+        || inner.navigation_generation.load(Ordering::Acquire) != navigation_generation
+    {
+        return None;
+    }
+    Some(reserve_constructive_inventory(inner))
+}
+
 fn settle_constructive_inventory(inner: &Inner, generation: u64) {
     let _publication = inner
         .refresh_publication
@@ -4396,14 +4413,19 @@ fn settle_constructive_inventory(inner: &Inner, generation: u64) {
     if inner.refresh_generation.load(Ordering::Acquire) != generation {
         return;
     }
-    if let Some(published) = inner
-        .host
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .as_mut()
-    {
+    let _snapshot_write = begin_snapshot_write(inner);
+    let ready = {
+        let mut host = inner
+            .host
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(published) = host.as_mut() else {
+            return;
+        };
         published.generation = generation;
-    }
+        ready_content(&published.value.snapshot)
+    };
+    set_inventory_state(inner, ready);
 }
 
 fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bool {
@@ -4518,7 +4540,11 @@ fn run_create(
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let inventory_publication = reserve_constructive_inventory(inner);
+    let Some(inventory_publication) =
+        reserve_current_constructive_inventory(inner, navigation_generation, cancellation)
+    else {
+        return;
+    };
     let created = create_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry, term) = match created {
         Ok(created) => created,
@@ -4583,7 +4609,11 @@ fn run_herdr_create(
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let inventory_publication = reserve_constructive_inventory(inner);
+    let Some(inventory_publication) =
+        reserve_current_constructive_inventory(inner, navigation_generation, cancellation)
+    else {
+        return;
+    };
     let created = create_herdr_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry) = match created {
         Ok(created) => created,
@@ -8065,6 +8095,67 @@ mod tests {
         let published = host.as_ref().expect("published host");
         assert_eq!(published.generation, merged);
         assert_eq!(published.value.snapshot.sessions()[0].name(), "created");
+    }
+
+    #[test]
+    fn failed_herdr_restart_during_refresh_restores_cached_ready_host() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let navigation_generation = workspace.begin_navigation();
+        let operation_cancellation = CancellationToken::new();
+        let refresh_cancellation = CancellationToken::new();
+        let refresh_generation = begin_refresh(&workspace.inner, &refresh_cancellation);
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Connecting
+        );
+
+        let operation_generation = reserve_current_constructive_inventory(
+            &workspace.inner,
+            navigation_generation,
+            &operation_cancellation,
+        )
+        .expect("current restart reserves inventory publication");
+        assert!(operation_generation > refresh_generation);
+        assert!(refresh_cancellation.is_cancelled());
+
+        settle_constructive_inventory(&workspace.inner, operation_generation);
+
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        assert_eq!(host.connection(), HostConnectionState::Ready);
+        assert_eq!(host.sessions()[0].name(), "work");
+        assert_eq!(host.herdr_sessions().len(), 2);
+    }
+
+    #[test]
+    fn stale_or_cancelled_herdr_restart_cannot_cancel_a_newer_refresh() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let queued_navigation = workspace.begin_navigation();
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+        let refresh_cancellation = CancellationToken::new();
+        let refresh_generation = begin_refresh(&workspace.inner, &refresh_cancellation);
+
+        assert_eq!(
+            reserve_current_constructive_inventory(&workspace.inner, queued_navigation, &cancelled,),
+            None
+        );
+        let active = CancellationToken::new();
+        workspace.begin_navigation();
+        assert_eq!(
+            reserve_current_constructive_inventory(&workspace.inner, queued_navigation, &active,),
+            None
+        );
+
+        assert!(!refresh_cancellation.is_cancelled());
+        assert_eq!(
+            workspace.inner.refresh_generation.load(Ordering::Acquire),
+            refresh_generation
+        );
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Connecting
+        );
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1234,11 +1234,7 @@ impl<T> RetainedPresentations<T> {
         };
         let mut restart = self.restarting.remove(index);
         if restart.attachment.request.name == original_name {
-            restart.selection = SessionSelection::new(
-                &restart.key.host_id,
-                restart.key.endpoint.clone(),
-                &resolved_request.name,
-            );
+            restart.selection = resolved_request.selection();
             resolved_request
                 .name
                 .clone_into(&mut restart.attachment.request.name);
@@ -1480,6 +1476,7 @@ struct Inner {
     kill_generation: AtomicU64,
     herdr_lifecycle: Mutex<HerdrLifecycleState>,
     herdr_lifecycle_generation: AtomicU64,
+    session_operations: Mutex<()>,
     operation_events: Mutex<std::collections::VecDeque<WorkspaceEvent>>,
     terminal_geometry: Mutex<TerminalGeometry>,
     allow_remote_clipboard_write: bool,
@@ -1546,6 +1543,7 @@ impl Workspace {
                 kill_generation: AtomicU64::new(0),
                 herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
+                session_operations: Mutex::new(()),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write: true,
@@ -1610,6 +1608,7 @@ impl Workspace {
                 kill_generation: AtomicU64::new(0),
                 herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
+                session_operations: Mutex::new(()),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -1658,6 +1657,7 @@ impl Workspace {
                 kill_generation: AtomicU64::new(0),
                 herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
+                session_operations: Mutex::new(()),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -3123,6 +3123,7 @@ impl Workspace {
                     &request.host_id,
                     request.endpoint.distro(),
                     &request.name,
+                    request.target.kind(),
                 );
             } else {
                 clear_pending_paste(&self.inner);
@@ -3999,6 +4000,10 @@ fn run_create(
     navigation_generation: u64,
     cancellation: &CancellationToken,
 ) {
+    let _operation = inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let created = create_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry, term) = match created {
         Ok(created) => created,
@@ -4055,6 +4060,10 @@ fn run_herdr_create(
     navigation_generation: u64,
     cancellation: &CancellationToken,
 ) {
+    let _operation = inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let created = create_herdr_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry) = match created {
         Ok(created) => created,
@@ -4111,6 +4120,11 @@ fn run_herdr_create(
 }
 
 fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
+    let _operation = workspace
+        .inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     if pending.action == HerdrLifecycleAction::Stop {
         workspace.finish_herdr_presentation(&pending.endpoint, &pending.runtime, &pending.record);
     }
@@ -4521,6 +4535,18 @@ fn restore_inventory_after_creation_failure(
 }
 
 fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generation: u64) {
+    let _operation = inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !inner
+        .attachment
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .is_current(generation)
+    {
+        return;
+    }
     match attach_fresh(inner, request, term) {
         Ok((worker, snapshot, attached_session, initial_geometry)) => {
             let mut attachment = inner
@@ -4617,6 +4643,10 @@ fn current_inventory_session_name(inner: &Inner, key: &PresentationKey) -> Optio
 }
 
 fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
+    let _operation = inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     match attach_fresh_retained(inner, retry) {
         Ok((worker, snapshot, resolved_request, initial_geometry)) => {
             let latest_geometry = *inner
@@ -4811,25 +4841,20 @@ fn merge_constructive_inventory(
             ))
         })?;
     let current_generation = inner.refresh_generation.load(Ordering::Acquire);
-    let inventory_generation = match published_generation.cmp(&current_generation) {
-        std::cmp::Ordering::Equal => current_generation,
-        std::cmp::Ordering::Less => {
-            if let Some(cancellation) = inner
-                .discovery_cancel
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .take()
-            {
-                cancellation.cancel();
-            }
-            inner.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1
-        }
-        std::cmp::Ordering::Greater => {
-            return Err(WorkspaceError::new(
-                "session inventory generation moved backwards during creation",
-            ));
-        }
-    };
+    if published_generation > current_generation {
+        return Err(WorkspaceError::new(
+            "session inventory generation moved backwards during publication",
+        ));
+    }
+    if let Some(cancellation) = inner
+        .discovery_cancel
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+    {
+        cancellation.cancel();
+    }
+    let inventory_generation = inner.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1;
 
     let inventory_state = ready_content(&snapshot);
     set_herdr_inventory(inner, snapshot.herdr());
@@ -5455,7 +5480,13 @@ fn clear_pending_paste(inner: &Inner) {
         .take();
 }
 
-fn publish_terminfo_retry_boundary(inner: &Inner, host_id: &str, endpoint: &str, session: &str) {
+fn publish_terminfo_retry_boundary(
+    inner: &Inner,
+    host_id: &str,
+    endpoint: &str,
+    session: &str,
+    kind: SessionKind,
+) {
     clear_pending_paste(inner);
     set_inner_state(
         inner,
@@ -5463,7 +5494,7 @@ fn publish_terminfo_retry_boundary(inner: &Inner, host_id: &str, endpoint: &str,
             host_id: host_id.to_owned(),
             endpoint: endpoint.to_owned(),
             session: session.to_owned(),
-            kind: SessionKind::Tmux,
+            kind,
         },
     );
 }
@@ -5544,7 +5575,44 @@ fn default_terminal_geometry() -> TerminalGeometry {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::sync::{Barrier, atomic::AtomicUsize};
+    use std::sync::{Barrier, atomic::AtomicUsize, mpsc};
+
+    #[test]
+    fn session_operation_fence_spans_launch_until_publication() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let launch = workspace
+            .inner
+            .session_operations
+            .lock()
+            .expect("launch operation");
+        let (waiting_tx, waiting_rx) = mpsc::channel();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let lifecycle_workspace = workspace.clone();
+        let lifecycle = thread::spawn(move || {
+            waiting_tx.send(()).expect("announce lifecycle wait");
+            let _lifecycle = lifecycle_workspace
+                .inner
+                .session_operations
+                .lock()
+                .expect("lifecycle operation");
+            entered_tx.send(()).expect("announce lifecycle entry");
+        });
+
+        waiting_rx.recv().expect("lifecycle reached fence");
+        assert!(
+            entered_rx.try_recv().is_err(),
+            "lifecycle mutation must wait while client publication is in flight"
+        );
+        drop(launch);
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("lifecycle enters after publication");
+        lifecycle.join().expect("lifecycle thread");
+    }
 
     #[test]
     fn lifecycle_registration_waits_for_the_herdr_launch_fence() {
@@ -5743,6 +5811,29 @@ mod tests {
             endpoint: snapshot.endpoint().clone(),
             runtime: snapshot.runtime().clone(),
             target: AttachTarget::Tmux(identity),
+            name: name.to_owned(),
+            inventory_generation: 1,
+        }
+    }
+
+    #[cfg(windows)]
+    fn herdr_attach_request_fixture(snapshot: &HostSnapshot, name: &str) -> AttachRequest {
+        AttachRequest {
+            host_id: "wsl".to_owned(),
+            host: WslHost::new(
+                WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+                Arc::new(StdCommandRunner) as SharedCommandRunner,
+                WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                    .expect("absolute WSL path"),
+            ),
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            target: AttachTarget::Herdr {
+                executable: "/opt/herdr/bin/herdr".to_owned(),
+                is_default: false,
+                session_directory: "/tmp/herdr/review".to_owned(),
+                socket_path: "/tmp/herdr/review/herdr.sock".to_owned(),
+            },
             name: name.to_owned(),
             inventory_generation: 1,
         }
@@ -6205,6 +6296,36 @@ mod tests {
         assert_eq!(retained.entries[0].attachment.request.name, "renamed");
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn retained_terminfo_retry_preserves_herdr_selection_kind() {
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = herdr_attach_request_fixture(&snapshot, "original");
+        let key = request.presentation_key();
+        let mut resolved_request = request.clone();
+        resolved_request.name = "renamed".to_owned();
+        let mut retained = RetainedPresentations::new();
+        retained.restarting.push(RetainedRestart {
+            key: key.clone(),
+            selection: SessionSelection::herdr("wsl", "Ubuntu", "original"),
+            attachment: ActiveAttachment {
+                request,
+                term: AttachTerm::Xterm,
+                generation: 1,
+                fallback: None,
+            },
+            presentation_id: 7,
+        });
+
+        assert!(retained.finish_restart(&key, (), "original", &resolved_request));
+        assert_eq!(retained.entries[0].selection.kind(), SessionKind::Herdr);
+        assert_eq!(retained.entries[0].selection.session(), "renamed");
+        assert_eq!(
+            retained.entries[0].attachment.request.selection().kind(),
+            SessionKind::Herdr
+        );
+    }
+
     #[test]
     fn presentation_identity_survives_rename_but_not_a_wsl_runtime_restart() {
         let identity = session::SessionIdentity::new(100, "$1", 200);
@@ -6511,7 +6632,7 @@ mod tests {
     }
 
     #[test]
-    fn terminfo_retry_unpublishes_terminal_and_clears_pending_paste() {
+    fn terminfo_retry_unpublishes_terminal_and_preserves_session_kind() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let workspace = Workspace::preview(WorkspaceSnapshot {
             revision: 1,
@@ -6537,7 +6658,13 @@ mod tests {
             ),
         });
 
-        publish_terminfo_retry_boundary(&workspace.inner, "wsl", "Ubuntu", "work");
+        publish_terminfo_retry_boundary(
+            &workspace.inner,
+            "wsl",
+            "Ubuntu",
+            "work",
+            SessionKind::Herdr,
+        );
 
         assert!(
             workspace
@@ -6549,8 +6676,11 @@ mod tests {
         );
         assert!(matches!(
             workspace.snapshot().content(),
-            WorkspaceContent::Attaching { host_id, endpoint, session, .. }
-                if host_id == "wsl" && endpoint == "Ubuntu" && session == "work"
+            WorkspaceContent::Attaching { host_id, endpoint, session, kind, .. }
+                if host_id == "wsl"
+                    && endpoint == "Ubuntu"
+                    && session == "work"
+                    && *kind == SessionKind::Herdr
         ));
         assert_eq!(next_presentation_id(&workspace.inner), 8);
     }
@@ -6817,10 +6947,10 @@ mod tests {
         let merged = merge_created_inventory(&workspace.inner, &request, created)
             .expect("merge post-create inventory");
 
-        assert_eq!(merged, refresh_generation);
+        assert!(merged > refresh_generation);
         let host = workspace.inner.host.lock().expect("host context");
         let published = host.as_ref().expect("published host");
-        assert_eq!(published.generation, refresh_generation);
+        assert_eq!(published.generation, merged);
         assert_eq!(published.value.snapshot.sessions()[0].name(), "created");
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1,7 +1,7 @@
 //! Application workflow and capability boundary for GPUI.
 
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::Duration;
@@ -1455,6 +1455,7 @@ struct Inner {
     selected_host: RwLock<Option<String>>,
     inventory_state: Mutex<WorkspaceContent>,
     revision: AtomicU64,
+    snapshot_writers: AtomicUsize,
     presentation_generation: AtomicU64,
     navigation_generation: AtomicU64,
     navigation: Mutex<()>,
@@ -1487,11 +1488,35 @@ pub struct Workspace {
     inner: Arc<Inner>,
 }
 
-fn read_revision_consistent<T>(revision: &AtomicU64, mut read: impl FnMut(u64) -> T) -> T {
+struct SnapshotWrite<'a> {
+    writers: &'a AtomicUsize,
+}
+
+impl Drop for SnapshotWrite<'_> {
+    fn drop(&mut self) {
+        self.writers.fetch_sub(1, Ordering::Release);
+    }
+}
+
+fn begin_snapshot_write(inner: &Inner) -> SnapshotWrite<'_> {
+    inner.snapshot_writers.fetch_add(1, Ordering::AcqRel);
+    SnapshotWrite {
+        writers: &inner.snapshot_writers,
+    }
+}
+
+fn read_revision_consistent<T>(
+    revision: &AtomicU64,
+    writers: &AtomicUsize,
+    mut read: impl FnMut(u64) -> T,
+) -> T {
     loop {
+        while writers.load(Ordering::Acquire) != 0 {
+            std::thread::yield_now();
+        }
         let before = revision.load(Ordering::Acquire);
         let value = read(before);
-        if revision.load(Ordering::Acquire) == before {
+        if writers.load(Ordering::Acquire) == 0 && revision.load(Ordering::Acquire) == before {
             return value;
         }
     }
@@ -1532,6 +1557,7 @@ impl Workspace {
                 selected_host: RwLock::new(snapshot.selected_host),
                 inventory_state: Mutex::new(snapshot.content),
                 revision: AtomicU64::new(snapshot.revision),
+                snapshot_writers: AtomicUsize::new(0),
                 presentation_generation: AtomicU64::new(presentation_generation),
                 navigation_generation: AtomicU64::new(0),
                 navigation: Mutex::new(()),
@@ -1597,6 +1623,7 @@ impl Workspace {
                 selected_host: RwLock::new(selected_host),
                 inventory_state: Mutex::new(WorkspaceContent::Shell),
                 revision: AtomicU64::new(0),
+                snapshot_writers: AtomicUsize::new(0),
                 presentation_generation: AtomicU64::new(0),
                 navigation_generation: AtomicU64::new(0),
                 navigation: Mutex::new(()),
@@ -1646,6 +1673,7 @@ impl Workspace {
                 selected_host: RwLock::new(Some("wsl".to_owned())),
                 inventory_state: Mutex::new(WorkspaceContent::Loading),
                 revision: AtomicU64::new(0),
+                snapshot_writers: AtomicUsize::new(0),
                 presentation_generation: AtomicU64::new(0),
                 navigation_generation: AtomicU64::new(0),
                 navigation: Mutex::new(()),
@@ -1753,60 +1781,64 @@ impl Workspace {
 
     #[must_use]
     pub fn snapshot(&self) -> WorkspaceSnapshot {
-        read_revision_consistent(&self.inner.revision, |revision| {
-            let mut hosts = self
-                .inner
-                .hosts
-                .read()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            let current_runtime = self
-                .inner
-                .host
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .as_ref()
-                .map(|published| {
-                    (
-                        published.value.snapshot.endpoint().clone(),
-                        published.value.snapshot.runtime().clone(),
-                    )
-                });
-            project_herdr_lifecycle(
-                &mut hosts,
-                current_runtime.as_ref(),
-                &self.inner.herdr_lifecycle,
-            );
-            WorkspaceSnapshot {
-                revision,
-                appearance: self.inner.appearance.clone(),
-                content: self
+        read_revision_consistent(
+            &self.inner.revision,
+            &self.inner.snapshot_writers,
+            |revision| {
+                let mut hosts = self
                     .inner
-                    .state
+                    .hosts
                     .read()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .clone(),
-                hosts,
-                selected_host: self
+                    .clone();
+                let current_runtime = self
                     .inner
-                    .selected_host
-                    .read()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .clone(),
-                notice: self
-                    .inner
-                    .terminal_notice
-                    .read()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .clone(),
-                retained_selections: self
-                    .inner
-                    .retained_presentations
+                    .host
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .selections(),
-            }
-        })
+                    .as_ref()
+                    .map(|published| {
+                        (
+                            published.value.snapshot.endpoint().clone(),
+                            published.value.snapshot.runtime().clone(),
+                        )
+                    });
+                project_herdr_lifecycle(
+                    &mut hosts,
+                    current_runtime.as_ref(),
+                    &self.inner.herdr_lifecycle,
+                );
+                WorkspaceSnapshot {
+                    revision,
+                    appearance: self.inner.appearance.clone(),
+                    content: self
+                        .inner
+                        .state
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone(),
+                    hosts,
+                    selected_host: self
+                        .inner
+                        .selected_host
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone(),
+                    notice: self
+                        .inner
+                        .terminal_notice
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone(),
+                    retained_selections: self
+                        .inner
+                        .retained_presentations
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .selections(),
+                }
+            },
+        )
     }
 
     /// Begin an attach-only presentation for one discovered session.
@@ -1855,6 +1887,7 @@ impl Workspace {
     /// Returns an error if the requested session is absent from the latest
     /// inventory or the replacement attachment cannot be started.
     pub fn switch_session(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _navigation = self
             .inner
             .navigation
@@ -1956,6 +1989,7 @@ impl Workspace {
         endpoint: &str,
         name: &str,
     ) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let name =
             SessionName::parse(name).map_err(|error| WorkspaceError::new(error.to_string()))?;
         let navigation = self
@@ -2065,6 +2099,7 @@ impl Workspace {
         request: &HerdrCreateRequest,
         navigation: std::sync::MutexGuard<'_, ()>,
     ) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let navigation_generation = self.begin_navigation();
         let in_flight_fallback = self.supersede_inflight_attachment()?;
         let visible_previous = self.retain_active_presentation()?;
@@ -2178,6 +2213,7 @@ impl Workspace {
     }
 
     fn retain_active_presentation(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let mut attachment = self
             .inner
             .attachment
@@ -2252,6 +2288,7 @@ impl Workspace {
         fallback: Option<FallbackAuthority>,
         navigation_generation: u64,
     ) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let generation;
         {
             let mut attachment = self
@@ -2545,6 +2582,7 @@ impl Workspace {
         selection: &SessionSelection,
         action: HerdrLifecycleAction,
     ) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let (generation, removed) = invalidate_pending_herdr_lifecycle(&self.inner);
         if removed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2597,6 +2635,7 @@ impl Workspace {
     }
 
     pub fn cancel_herdr_lifecycle(&self) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let (_generation, removed) = invalidate_pending_herdr_lifecycle(&self.inner);
         if removed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2610,6 +2649,7 @@ impl Workspace {
     /// Returns an error when no confirmation is pending or the lifecycle task
     /// cannot be started.
     pub fn confirm_herdr_lifecycle(&self) -> Result<(), WorkspaceError> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let mut lifecycle = self
             .inner
             .herdr_lifecycle
@@ -2687,6 +2727,7 @@ impl Workspace {
         runtime: &host::WslRuntimeIdentity,
         identity: &session::SessionIdentity,
     ) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _navigation = self
             .inner
             .navigation
@@ -2728,6 +2769,7 @@ impl Workspace {
         runtime: &host::WslRuntimeIdentity,
         record: &session::HerdrSessionRecord,
     ) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _navigation = self
             .inner
             .navigation
@@ -2854,6 +2896,7 @@ impl Workspace {
     }
 
     fn detach_locked(&self) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         self.begin_navigation();
         if let Some(pending) = self
             .inner
@@ -2881,6 +2924,7 @@ impl Workspace {
 
     #[must_use]
     pub fn drain_events(&self) -> (Vec<WorkspaceEvent>, bool) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _drain = self
             .inner
             .event_drain
@@ -3355,6 +3399,7 @@ fn activate_retained_presentation(
     key: &PresentationKey,
     fallback: Option<FallbackAuthority>,
 ) -> Result<bool, WorkspaceError> {
+    let _snapshot_write = begin_snapshot_write(inner);
     let mut attachment = inner
         .attachment
         .lock()
@@ -3915,6 +3960,41 @@ fn reserve_refresh(inner: &Inner, cancellation: &CancellationToken) -> u64 {
     generation
 }
 
+fn reserve_constructive_inventory(inner: &Inner) -> u64 {
+    let _publication = inner
+        .refresh_publication
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let generation = inner.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1;
+    if let Some(previous) = inner
+        .discovery_cancel
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+    {
+        previous.cancel();
+    }
+    generation
+}
+
+fn settle_constructive_inventory(inner: &Inner, generation: u64) {
+    let _publication = inner
+        .refresh_publication
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.refresh_generation.load(Ordering::Acquire) != generation {
+        return;
+    }
+    if let Some(published) = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_mut()
+    {
+        published.generation = generation;
+    }
+}
+
 fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bool {
     let _publication = inner
         .refresh_publication
@@ -3923,6 +4003,7 @@ fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bo
     if inner.refresh_generation.load(Ordering::Acquire) != generation {
         return false;
     }
+    let _snapshot_write = begin_snapshot_write(inner);
     publish();
     true
 }
@@ -4008,10 +4089,12 @@ fn run_create(
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let inventory_publication = reserve_constructive_inventory(inner);
     let created = create_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry, term) = match created {
         Ok(created) => created,
         Err(error) => {
+            settle_constructive_inventory(inner, inventory_publication);
             restore_inventory_after_creation_failure(
                 inner,
                 None,
@@ -4022,23 +4105,26 @@ fn run_create(
         }
     };
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        settle_constructive_inventory(inner, inventory_publication);
         drop(worker);
         return;
     }
 
-    let inventory_generation = match merge_created_inventory(inner, request, snapshot.clone()) {
-        Ok(generation) => generation,
-        Err(error) => {
-            drop(worker);
-            restore_inventory_after_creation_failure(
-                inner,
-                None,
-                navigation_generation,
-                error.to_string(),
-            );
-            return;
-        }
-    };
+    let inventory_generation =
+        match merge_created_inventory(inner, request, snapshot.clone(), inventory_publication) {
+            Ok(generation) => generation,
+            Err(error) => {
+                settle_constructive_inventory(inner, inventory_publication);
+                drop(worker);
+                restore_inventory_after_creation_failure(
+                    inner,
+                    None,
+                    navigation_generation,
+                    error.to_string(),
+                );
+                return;
+            }
+        };
     let attached = AttachRequest {
         host_id: request.host_id.clone(),
         host: request.host.clone(),
@@ -4068,10 +4154,12 @@ fn run_herdr_create(
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let inventory_publication = reserve_constructive_inventory(inner);
     let created = create_herdr_fresh(inner, request, navigation_generation, cancellation);
     let (worker, snapshot, session, initial_geometry) = match created {
         Ok(created) => created,
         Err(error) => {
+            settle_constructive_inventory(inner, inventory_publication);
             restore_inventory_after_creation_failure(
                 inner,
                 None,
@@ -4082,13 +4170,19 @@ fn run_herdr_create(
         }
     };
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        settle_constructive_inventory(inner, inventory_publication);
         drop(worker);
         return;
     }
-    let inventory_generation = match merge_herdr_created_inventory(inner, request, snapshot.clone())
-    {
+    let inventory_generation = match merge_herdr_created_inventory(
+        inner,
+        request,
+        snapshot.clone(),
+        inventory_publication,
+    ) {
         Ok(generation) => generation,
         Err(error) => {
+            settle_constructive_inventory(inner, inventory_publication);
             drop(worker);
             restore_inventory_after_creation_failure(
                 inner,
@@ -4132,33 +4226,39 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
     if pending.action == HerdrLifecycleAction::Stop {
         workspace.finish_herdr_presentation(&pending.endpoint, &pending.runtime, &pending.record);
     }
-    let result = pending
-        .host
-        .mutate_herdr_session(
-            &pending.endpoint,
-            &pending.runtime,
-            &pending.record,
-            pending.action,
-            &CancellationToken::new(),
-        )
-        .map_err(|error| WorkspaceError::new(error.to_string()))
-        .and_then(|_record| {
-            pending
-                .host
-                .discover(&ConptyAdmissionAttacher::new())
-                .map_err(|error| WorkspaceError::new(error.to_string()))
-        })
-        .and_then(|snapshot| merge_herdr_lifecycle_inventory(&workspace.inner, pending, snapshot));
-    if let Err(error) = result {
-        workspace.push_operation_error(error.to_string());
+    match pending.host.mutate_herdr_session(
+        &pending.endpoint,
+        &pending.runtime,
+        &pending.record,
+        pending.action,
+        &CancellationToken::new(),
+    ) {
+        Ok(record) => {
+            if let Err(error) = publish_herdr_lifecycle_response(&workspace.inner, pending, record)
+            {
+                workspace.push_operation_error(format!(
+                    "Herdr {} succeeded, but Ghosthub could not publish the result: {error}",
+                    pending.action.command()
+                ));
+            } else {
+                finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
+                reconcile_herdr_lifecycle_inventory(&workspace.inner, pending);
+                return;
+            }
+        }
+        Err(error) => workspace.push_operation_error(error.to_string()),
     }
-    workspace
-        .inner
+    finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
+}
+
+fn finish_herdr_lifecycle_state(inner: &Inner, generation: u64) {
+    let _snapshot_write = begin_snapshot_write(inner);
+    inner
         .herdr_lifecycle
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .finish(pending.generation);
-    workspace.inner.revision.fetch_add(1, Ordering::Release);
+        .finish(generation);
+    inner.revision.fetch_add(1, Ordering::Release);
 }
 
 fn create_herdr_fresh(
@@ -4317,6 +4417,7 @@ fn publish_created_presentation(
     term: AttachTerm,
     navigation_generation: u64,
 ) {
+    let _snapshot_write = begin_snapshot_write(inner);
     let navigation = inner
         .navigation
         .lock()
@@ -4506,6 +4607,7 @@ fn restore_inventory_after_creation_failure(
     navigation_generation: u64,
     message: String,
 ) {
+    let _snapshot_write = begin_snapshot_write(inner);
     let _navigation = inner
         .navigation
         .lock()
@@ -4555,6 +4657,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
     }
     match attach_fresh(inner, request, term) {
         Ok((worker, snapshot, attached_session, initial_geometry)) => {
+            let _snapshot_write = begin_snapshot_write(inner);
             let mut attachment = inner
                 .attachment
                 .lock()
@@ -4608,6 +4711,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
             );
         }
         Err(error) => {
+            let _snapshot_write = begin_snapshot_write(inner);
             let mut attachment = inner
                 .attachment
                 .lock()
@@ -4655,6 +4759,7 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     match attach_fresh_retained(inner, retry) {
         Ok((worker, snapshot, resolved_request, initial_geometry)) => {
+            let _snapshot_write = begin_snapshot_write(inner);
             let latest_geometry = *inner
                 .terminal_geometry
                 .lock()
@@ -4681,9 +4786,11 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
             }
         }
         Err(AttachFreshError::Host(error)) => {
+            let _snapshot_write = begin_snapshot_write(inner);
             fail_retained_retry(inner, &retry.key, Some(error.to_string()));
         }
         Err(AttachFreshError::SessionChanged { error, snapshot }) => {
+            let _snapshot_write = begin_snapshot_write(inner);
             remove_failed_retained_retry(inner, &retry.key);
             publish_retained_stale_failure(inner, &retry.request, snapshot, &error);
         }
@@ -4773,6 +4880,7 @@ fn merge_created_inventory(
     inner: &Inner,
     request: &CreateRequest,
     snapshot: HostSnapshot,
+    publication_generation: u64,
 ) -> Result<u64, WorkspaceError> {
     merge_constructive_inventory(
         inner,
@@ -4780,6 +4888,7 @@ fn merge_created_inventory(
         &request.endpoint,
         &request.runtime,
         snapshot,
+        publication_generation,
         "the created tmux session",
     )
 }
@@ -4788,6 +4897,7 @@ fn merge_herdr_created_inventory(
     inner: &Inner,
     request: &HerdrCreateRequest,
     snapshot: HostSnapshot,
+    publication_generation: u64,
 ) -> Result<u64, WorkspaceError> {
     merge_constructive_inventory(
         inner,
@@ -4795,6 +4905,7 @@ fn merge_herdr_created_inventory(
         &request.endpoint,
         &request.runtime,
         snapshot,
+        publication_generation,
         "the created Herdr session",
     )
 }
@@ -4803,6 +4914,7 @@ fn merge_herdr_lifecycle_inventory(
     inner: &Inner,
     pending: &PendingHerdrLifecycle,
     snapshot: HostSnapshot,
+    publication_generation: u64,
 ) -> Result<u64, WorkspaceError> {
     merge_constructive_inventory(
         inner,
@@ -4810,8 +4922,69 @@ fn merge_herdr_lifecycle_inventory(
         &pending.endpoint,
         &pending.runtime,
         snapshot,
+        publication_generation,
         "the Herdr lifecycle result",
     )
+}
+
+fn publish_herdr_lifecycle_response(
+    inner: &Inner,
+    pending: &PendingHerdrLifecycle,
+    record: session::HerdrSessionRecord,
+) -> Result<u64, WorkspaceError> {
+    let publication_generation = reserve_constructive_inventory(inner);
+    let snapshot = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .filter(|published| {
+            published.value.snapshot.endpoint() == &pending.endpoint
+                && published.value.snapshot.runtime() == &pending.runtime
+        })
+        .map(|published| published.value.snapshot.clone())
+        .ok_or_else(|| {
+            WorkspaceError::new(
+                "the WSL endpoint changed while publishing the Herdr lifecycle response",
+            )
+        })?
+        .with_herdr_lifecycle(pending.action, record)
+        .ok_or_else(|| {
+            WorkspaceError::new(
+                "the Herdr lifecycle response no longer matches published inventory",
+            )
+        })?;
+    merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation)
+}
+
+fn reconcile_herdr_lifecycle_inventory(inner: &Inner, pending: &PendingHerdrLifecycle) {
+    let publication_generation = inner.refresh_generation.load(Ordering::Acquire);
+    let Ok(snapshot) = pending.host.discover(&ConptyAdmissionAttacher::new()) else {
+        return;
+    };
+    if !herdr_lifecycle_is_reflected(&snapshot, pending) {
+        return;
+    }
+    let _reconciled =
+        merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation);
+}
+
+fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrLifecycle) -> bool {
+    let HerdrInventory::Available { sessions, .. } = snapshot.herdr() else {
+        return false;
+    };
+    let current = sessions
+        .iter()
+        .find(|session| session.name() == pending.record.name());
+    match pending.action {
+        HerdrLifecycleAction::Stop => current.is_some_and(|record| {
+            record.state() == HerdrSessionState::Stopped
+                && record.is_default() == pending.record.is_default()
+                && record.session_directory() == pending.record.session_directory()
+                && record.socket_path() == pending.record.socket_path()
+        }),
+        HerdrLifecycleAction::Delete => current.is_none(),
+    }
 }
 
 fn merge_constructive_inventory(
@@ -4820,12 +4993,19 @@ fn merge_constructive_inventory(
     endpoint: &host::WslEndpoint,
     runtime: &host::WslRuntimeIdentity,
     snapshot: HostSnapshot,
+    publication_generation: u64,
     operation: &str,
 ) -> Result<u64, WorkspaceError> {
     let _publication = inner
         .refresh_publication
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if inner.refresh_generation.load(Ordering::Acquire) != publication_generation {
+        return Err(WorkspaceError::new(format!(
+            "newer inventory superseded {operation}; refresh before trying again"
+        )));
+    }
+    let _snapshot_write = begin_snapshot_write(inner);
     if snapshot.endpoint() != endpoint || snapshot.runtime() != runtime {
         return Err(WorkspaceError::new(format!(
             "WSL changed while publishing {operation}"
@@ -4846,21 +5026,12 @@ fn merge_constructive_inventory(
                 "the WSL endpoint changed while publishing {operation}; refresh before trying again"
             ))
         })?;
-    let current_generation = inner.refresh_generation.load(Ordering::Acquire);
-    if published_generation > current_generation {
+    if published_generation > publication_generation {
         return Err(WorkspaceError::new(
             "session inventory generation moved backwards during publication",
         ));
     }
-    if let Some(cancellation) = inner
-        .discovery_cancel
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .take()
-    {
-        cancellation.cancel();
-    }
-    let inventory_generation = inner.refresh_generation.fetch_add(1, Ordering::AcqRel) + 1;
+    let inventory_generation = publication_generation;
 
     let inventory_state = ready_content(&snapshot);
     set_herdr_inventory(inner, snapshot.herdr());
@@ -4908,6 +5079,7 @@ fn reconcile_presentation_session_names(
     snapshot: &HostSnapshot,
     socket_directory: Option<&str>,
 ) {
+    let _snapshot_write = begin_snapshot_write(inner);
     let mut attachment = inner
         .attachment
         .lock()
@@ -5586,9 +5758,10 @@ mod tests {
     #[test]
     fn revision_consistent_read_retries_a_projection_crossing_an_update() {
         let revision = AtomicU64::new(1);
+        let writers = AtomicUsize::new(0);
         let mut reads = 0;
 
-        let observed = read_revision_consistent(&revision, |captured| {
+        let observed = read_revision_consistent(&revision, &writers, |captured| {
             reads += 1;
             if reads == 1 {
                 revision.fetch_add(1, Ordering::Release);
@@ -5597,6 +5770,30 @@ mod tests {
         });
 
         assert_eq!(observed, (2, 2));
+    }
+
+    #[test]
+    fn revision_consistent_read_waits_for_a_multi_field_publication() {
+        let revision = Arc::new(AtomicU64::new(1));
+        let writers = Arc::new(AtomicUsize::new(1));
+        let value = Arc::new(AtomicUsize::new(1));
+        let (read_tx, read_rx) = mpsc::channel();
+        let reader_revision = Arc::clone(&revision);
+        let reader_writers = Arc::clone(&writers);
+        let reader_value = Arc::clone(&value);
+        let reader = thread::spawn(move || {
+            read_revision_consistent(&reader_revision, &reader_writers, |captured| {
+                read_tx.send(()).expect("announce snapshot read");
+                (captured, reader_value.load(Ordering::Acquire))
+            })
+        });
+
+        assert!(read_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        value.store(2, Ordering::Release);
+        revision.fetch_add(1, Ordering::Release);
+        writers.fetch_sub(1, Ordering::Release);
+
+        assert_eq!(reader.join().expect("snapshot reader"), (2, 2));
     }
 
     #[test]
@@ -6939,7 +7136,7 @@ mod tests {
     }
 
     #[test]
-    fn post_create_inventory_merges_into_a_completed_refresh_generation() {
+    fn post_create_inventory_cannot_overwrite_a_newer_refresh() {
         let workspace = Workspace::preview(WorkspaceSnapshot::ready(
             Appearance::default(),
             "Ubuntu",
@@ -6978,6 +7175,7 @@ mod tests {
             name: SessionName::parse("created").expect("valid name"),
         };
 
+        let operation_generation = reserve_constructive_inventory(&workspace.inner);
         let refresh_generation = begin_refresh(&workspace.inner, &CancellationToken::new());
         let refreshed = HostSnapshot::test_fixture(
             "Ubuntu",
@@ -7013,14 +7211,14 @@ mod tests {
             )],
         );
 
-        let merged = merge_created_inventory(&workspace.inner, &request, created)
-            .expect("merge post-create inventory");
+        let merged =
+            merge_created_inventory(&workspace.inner, &request, created, operation_generation);
 
-        assert!(merged > refresh_generation);
+        assert!(merged.is_err());
         let host = workspace.inner.host.lock().expect("host context");
         let published = host.as_ref().expect("published host");
-        assert_eq!(published.generation, merged);
-        assert_eq!(published.value.snapshot.sessions()[0].name(), "created");
+        assert_eq!(published.generation, refresh_generation);
+        assert_eq!(published.value.snapshot.sessions()[0].name(), "refreshed");
     }
 
     #[test]
@@ -7064,6 +7262,7 @@ mod tests {
         };
         let cancellation = CancellationToken::new();
         let refresh_generation = begin_refresh(&workspace.inner, &cancellation);
+        let operation_generation = reserve_constructive_inventory(&workspace.inner);
         let created = HostSnapshot::test_fixture(
             "Ubuntu",
             "boot-id",
@@ -7075,9 +7274,11 @@ mod tests {
             )],
         );
 
-        let merged = merge_created_inventory(&workspace.inner, &request, created)
-            .expect("merge post-create inventory");
+        let merged =
+            merge_created_inventory(&workspace.inner, &request, created, operation_generation)
+                .expect("merge post-create inventory");
 
+        assert_eq!(merged, operation_generation);
         assert!(merged > refresh_generation);
         assert!(cancellation.is_cancelled());
         assert!(!publish_refresh(
@@ -8173,6 +8374,60 @@ mod tests {
                 .action(),
             HerdrLifecycleAction::Delete
         );
+    }
+
+    #[test]
+    fn lifecycle_response_is_published_without_full_host_discovery() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        workspace
+            .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+            .expect("running session may be stopped");
+        let pending = workspace
+            .inner
+            .herdr_lifecycle
+            .lock()
+            .expect("lifecycle state")
+            .pending
+            .clone()
+            .expect("pending stop");
+        let stopped = session::HerdrSessionRecord::new(
+            "default",
+            true,
+            HerdrSessionState::Stopped,
+            "/tmp/herdr/default",
+            "/tmp/herdr/default/herdr.sock",
+        );
+        let before = workspace
+            .inner
+            .host
+            .lock()
+            .expect("host context")
+            .as_ref()
+            .expect("published host")
+            .value
+            .snapshot
+            .clone();
+        assert!(!herdr_lifecycle_is_reflected(&before, &pending));
+
+        publish_herdr_lifecycle_response(&workspace.inner, &pending, stopped)
+            .expect("authoritative response publishes");
+
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        assert_eq!(host.sessions()[0].name(), "work");
+        assert_eq!(host.herdr_sessions()[0].state(), HerdrSessionState::Stopped);
+        let published = workspace
+            .inner
+            .host
+            .lock()
+            .expect("host context")
+            .as_ref()
+            .expect("published host")
+            .value
+            .snapshot
+            .clone();
+        assert!(herdr_lifecycle_is_reflected(&published, &pending));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -13,7 +13,9 @@ use host::{
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
-pub use session::{HerdrSessionState, SessionName, SessionNameError};
+pub use session::{
+    HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName, SessionNameError,
+};
 use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
     ClipboardPolicy, ClipboardReadRequest as TerminalClipboardRead, ClipboardTarget, DefaultColors,
@@ -105,6 +107,13 @@ pub struct SessionSelection {
     host_id: String,
     endpoint: String,
     session: String,
+    kind: SessionKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionKind {
+    Tmux,
+    Herdr,
 }
 
 impl SessionSelection {
@@ -118,6 +127,21 @@ impl SessionSelection {
             host_id: host_id.into(),
             endpoint: endpoint.into(),
             session: session.into(),
+            kind: SessionKind::Tmux,
+        }
+    }
+
+    #[must_use]
+    pub fn herdr(
+        host_id: impl Into<String>,
+        endpoint: impl Into<String>,
+        session: impl Into<String>,
+    ) -> Self {
+        Self {
+            host_id: host_id.into(),
+            endpoint: endpoint.into(),
+            session: session.into(),
+            kind: SessionKind::Herdr,
         }
     }
 
@@ -134,6 +158,11 @@ impl SessionSelection {
     #[must_use]
     pub fn session(&self) -> &str {
         &self.session
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> SessionKind {
+        self.kind
     }
 }
 
@@ -304,11 +333,13 @@ pub enum WorkspaceContent {
         host_id: String,
         endpoint: String,
         session: String,
+        kind: SessionKind,
     },
     Terminal {
         host_id: String,
         endpoint: String,
         session: String,
+        kind: SessionKind,
         presentation_id: u64,
         surface: Arc<SurfaceStore>,
     },
@@ -635,9 +666,36 @@ struct AttachRequest {
     host: RuntimeHost,
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
-    identity: session::SessionIdentity,
+    target: AttachTarget,
     name: String,
     inventory_generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum AttachTarget {
+    Tmux(session::SessionIdentity),
+    Herdr {
+        executable: String,
+        is_default: bool,
+        session_directory: String,
+        socket_path: String,
+    },
+}
+
+impl AttachTarget {
+    fn tmux(&self) -> Option<&session::SessionIdentity> {
+        match self {
+            Self::Tmux(identity) => Some(identity),
+            Self::Herdr { .. } => None,
+        }
+    }
+
+    const fn kind(&self) -> SessionKind {
+        match self {
+            Self::Tmux(_) => SessionKind::Tmux,
+            Self::Herdr { .. } => SessionKind::Herdr,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -647,6 +705,16 @@ struct CreateRequest {
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
     name: SessionName,
+}
+
+#[derive(Clone)]
+struct HerdrCreateRequest {
+    host_id: String,
+    host: RuntimeHost,
+    endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
+    executable: String,
+    name: HerdrSessionName,
 }
 
 struct PendingCreation {
@@ -661,7 +729,7 @@ struct PresentationKey {
     endpoint: String,
     socket_directory: Option<String>,
     runtime: host::WslRuntimeIdentity,
-    identity: session::SessionIdentity,
+    target: AttachTarget,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -678,7 +746,18 @@ impl AttachRequest {
             endpoint: self.endpoint.distro().to_owned(),
             socket_directory: self.host.socket_directory().map(str::to_owned),
             runtime: self.runtime.clone(),
-            identity: self.identity.clone(),
+            target: self.target.clone(),
+        }
+    }
+
+    fn selection(&self) -> SessionSelection {
+        match self.target.kind() {
+            SessionKind::Tmux => {
+                SessionSelection::new(&self.host_id, self.endpoint.distro(), &self.name)
+            }
+            SessionKind::Herdr => {
+                SessionSelection::herdr(&self.host_id, self.endpoint.distro(), &self.name)
+            }
         }
     }
 }
@@ -1067,12 +1146,31 @@ fn refreshed_session_name<'a>(
         && key.endpoint == snapshot.endpoint().distro()
         && key.socket_directory.as_deref() == socket_directory
         && key.runtime == *snapshot.runtime())
-    .then(|| {
-        snapshot
+    .then(|| match &key.target {
+        AttachTarget::Tmux(identity) => snapshot
             .sessions()
             .iter()
-            .find(|session| session.identity() == &key.identity)
-            .map(session::DiscoveredSession::name)
+            .find(|session| session.identity() == identity)
+            .map(session::DiscoveredSession::name),
+        AttachTarget::Herdr {
+            executable,
+            is_default,
+            session_directory,
+            socket_path,
+        } => match snapshot.herdr() {
+            HerdrInventory::Available {
+                executable: current_executable,
+                sessions,
+            } if current_executable == executable => sessions
+                .iter()
+                .find(|session| {
+                    session.is_default() == *is_default
+                        && session.session_directory() == session_directory
+                        && session.socket_path() == socket_path
+                })
+                .map(session::HerdrSessionRecord::name),
+            _ => None,
+        },
     })
     .flatten()
 }
@@ -1576,10 +1674,11 @@ impl Workspace {
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone(),
-            WorkspaceContent::Terminal { host_id, endpoint, session, .. }
+            WorkspaceContent::Terminal { host_id, endpoint, session, kind, .. }
                 if host_id == selection.host_id()
                     && endpoint == selection.endpoint()
                     && session == selection.session()
+                    && kind == selection.kind()
         );
         let has_active_attachment = self
             .inner
@@ -1694,6 +1793,7 @@ impl Workspace {
                 host_id: request.host_id.clone(),
                 endpoint: request.endpoint.distro().to_owned(),
                 session: request.name.as_str().to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -1714,6 +1814,76 @@ impl Workspace {
             );
             return Err(WorkspaceError::new(format!(
                 "start tmux creation task: {error}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Launch one new named Herdr session and attach its ordinary client.
+    ///
+    /// The launch authority is consumed once. Failure never repeats the
+    /// constructive action automatically.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is invalid, Herdr is unavailable, the
+    /// endpoint changed, or the task cannot be started.
+    pub fn create_herdr_session(
+        &self,
+        host_id: &str,
+        endpoint: &str,
+        name: &str,
+    ) -> Result<(), WorkspaceError> {
+        let name = HerdrSessionName::parse(name)
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        let navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let request = capture_herdr_create_request(&self.inner, host_id, endpoint, name)?;
+        let navigation_generation = self.begin_navigation();
+        let in_flight_fallback = self.supersede_inflight_attachment()?;
+        let visible_previous = self.retain_active_presentation()?;
+        let previous = in_flight_fallback.or(visible_previous);
+        let cancellation = CancellationToken::new();
+        *self
+            .inner
+            .pending_creation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(PendingCreation {
+            navigation_generation,
+            previous: previous.clone(),
+            cancellation: cancellation.clone(),
+        });
+        clear_terminal_notice(&self.inner);
+        set_inner_state(
+            &self.inner,
+            WorkspaceContent::Attaching {
+                host_id: request.host_id.clone(),
+                endpoint: request.endpoint.distro().to_owned(),
+                session: request.name.as_str().to_owned(),
+                kind: SessionKind::Herdr,
+            },
+        );
+
+        let inner = Arc::clone(&self.inner);
+        let spawn_request = request.clone();
+        if let Err(error) = thread::Builder::new()
+            .name("ghosthub-herdr-create".to_owned())
+            .spawn(move || {
+                run_herdr_create(&inner, &spawn_request, navigation_generation, &cancellation);
+            })
+        {
+            drop(navigation);
+            restore_inventory_after_creation_failure(
+                &self.inner,
+                None,
+                navigation_generation,
+                format!("start Herdr creation task: {error}"),
+            );
+            return Err(WorkspaceError::new(format!(
+                "start Herdr creation task: {error}"
             )));
         }
         Ok(())
@@ -1792,11 +1962,7 @@ impl Workspace {
         let Some(active_attachment) = attachment.active() else {
             return Ok(None);
         };
-        let selection = SessionSelection::new(
-            &active_attachment.request.host_id,
-            active_attachment.request.endpoint.distro(),
-            &active_attachment.request.name,
-        );
+        let selection = active_attachment.request.selection();
         let presentation_id = {
             let state = self
                 .inner
@@ -1890,6 +2056,7 @@ impl Workspace {
                 host_id: request.host_id.clone(),
                 endpoint: request.endpoint.distro().to_owned(),
                 session: request.name.clone(),
+                kind: request.target.kind(),
             };
         }
         self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2167,7 +2334,7 @@ impl Workspace {
         let key_matches = |request: &AttachRequest| {
             request.endpoint == *endpoint
                 && request.runtime == *runtime
-                && request.identity == *identity
+                && request.target.tmux() == Some(identity)
         };
         let active_matches = self
             .inner
@@ -2187,7 +2354,7 @@ impl Workspace {
             .remove_matching(|key| {
                 key.endpoint == endpoint.distro()
                     && key.runtime == *runtime
-                    && key.identity == *identity
+                    && key.target.tmux() == Some(identity)
             });
         if changed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2823,13 +2990,7 @@ fn activate_retained_presentation(
     }
     let selection = attachment
         .active()
-        .map(|active| {
-            SessionSelection::new(
-                &active.request.host_id,
-                active.request.endpoint.distro(),
-                &active.request.name,
-            )
-        })
+        .map(|active| active.request.selection())
         .expect("retained attachment was just reserved");
     let RetainedPresentation {
         key: _,
@@ -2851,6 +3012,7 @@ fn activate_retained_presentation(
             host_id: selection.host_id().to_owned(),
             endpoint: selection.endpoint().to_owned(),
             session: selection.session().to_owned(),
+            kind: selection.kind(),
             presentation_id,
             surface,
         },
@@ -2927,19 +3089,58 @@ fn capture_attach_request(
                 "host endpoint changed; refresh the session selection",
             ));
         }
-        let session = context
-            .snapshot
-            .sessions()
-            .iter()
-            .find(|session| session.name() == selection.session())
-            .ok_or_else(|| WorkspaceError::new("session is not in the current inventory"))?;
+        let (target, name) = match selection.kind() {
+            SessionKind::Tmux => {
+                let session = context
+                    .snapshot
+                    .sessions()
+                    .iter()
+                    .find(|session| session.name() == selection.session())
+                    .ok_or_else(|| {
+                        WorkspaceError::new("session is not in the current inventory")
+                    })?;
+                (
+                    AttachTarget::Tmux(session.identity().clone()),
+                    session.name().to_owned(),
+                )
+            }
+            SessionKind::Herdr => {
+                let HerdrInventory::Available {
+                    executable,
+                    sessions,
+                } = context.snapshot.herdr()
+                else {
+                    return Err(WorkspaceError::new("Herdr is not available on this host"));
+                };
+                let session = sessions
+                    .iter()
+                    .find(|session| session.name() == selection.session())
+                    .ok_or_else(|| {
+                        WorkspaceError::new("Herdr session is not in the current inventory")
+                    })?;
+                if session.state() != HerdrSessionState::Running {
+                    return Err(WorkspaceError::new(
+                        "Herdr session is stopped; restart it before opening",
+                    ));
+                }
+                (
+                    AttachTarget::Herdr {
+                        executable: executable.clone(),
+                        is_default: session.is_default(),
+                        session_directory: session.session_directory().to_owned(),
+                        socket_path: session.socket_path().to_owned(),
+                    },
+                    session.name().to_owned(),
+                )
+            }
+        };
         Ok(AttachRequest {
             host_id: selection.host_id().to_owned(),
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
-            identity: session.identity().clone(),
-            name: session.name().to_owned(),
+            target,
+            name,
             inventory_generation,
         })
     })
@@ -2949,6 +3150,11 @@ fn capture_kill_request(
     inner: &Inner,
     selection: &SessionSelection,
 ) -> Result<KillCaptureRequest, WorkspaceError> {
+    if selection.kind() != SessionKind::Tmux {
+        return Err(WorkspaceError::new(
+            "Kill Session is available only for tmux sessions",
+        ));
+    }
     if inner
         .selected_host
         .read()
@@ -3076,6 +3282,60 @@ fn capture_create_request(
     })
 }
 
+fn capture_herdr_create_request(
+    inner: &Inner,
+    host_id: &str,
+    endpoint: &str,
+    name: HerdrSessionName,
+) -> Result<HerdrCreateRequest, WorkspaceError> {
+    if inner
+        .selected_host
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_deref()
+        != Some(host_id)
+    {
+        return Err(WorkspaceError::new("host is not selected"));
+    }
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, _inventory_generation| {
+        if context.snapshot.endpoint().distro() != endpoint {
+            return Err(WorkspaceError::new(
+                "the WSL endpoint changed; choose the host again before creating a session",
+            ));
+        }
+        let HerdrInventory::Available {
+            executable,
+            sessions,
+        } = context.snapshot.herdr()
+        else {
+            return Err(WorkspaceError::new("Herdr is not available on this host"));
+        };
+        if sessions
+            .iter()
+            .any(|session| session.name() == name.as_str())
+        {
+            return Err(WorkspaceError::new(
+                "a Herdr session with this name already exists; restart it instead",
+            ));
+        }
+        Ok(HerdrCreateRequest {
+            host_id: host_id.to_owned(),
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
+            executable: executable.clone(),
+            name,
+        })
+    })
+}
+
 fn choose_navigation_target(
     retained: Option<PresentationKey>,
     current: Result<AttachRequest, WorkspaceError>,
@@ -3096,7 +3356,19 @@ fn choose_navigation_target(
 fn begin_refresh(inner: &Inner, cancellation: &CancellationToken) -> u64 {
     let generation = reserve_refresh(inner, cancellation);
     publish_refresh(inner, generation, || {
-        set_inventory_state(inner, WorkspaceContent::Loading);
+        if inner.host_scoped_inventory {
+            let mut hosts = inner
+                .hosts
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(host) = hosts.iter_mut().find(|host| host.id == "wsl") {
+                host.connection = HostConnectionState::Connecting;
+                host.diagnostic = None;
+            }
+            inner.revision.fetch_add(1, Ordering::Release);
+        } else {
+            set_inventory_state(inner, WorkspaceContent::Loading);
+        }
     });
     generation
 }
@@ -3243,7 +3515,7 @@ fn run_create(
         host: request.host.clone(),
         endpoint: snapshot.endpoint().clone(),
         runtime: snapshot.runtime().clone(),
-        identity: session.identity().clone(),
+        target: AttachTarget::Tmux(session.identity().clone()),
         name: session.name().to_owned(),
         inventory_generation,
     };
@@ -3255,6 +3527,172 @@ fn run_create(
         term,
         navigation_generation,
     );
+}
+
+fn run_herdr_create(
+    inner: &Inner,
+    request: &HerdrCreateRequest,
+    navigation_generation: u64,
+    cancellation: &CancellationToken,
+) {
+    let created = create_herdr_fresh(inner, request, navigation_generation, cancellation);
+    let (worker, snapshot, session, initial_geometry) = match created {
+        Ok(created) => created,
+        Err(error) => {
+            restore_inventory_after_creation_failure(
+                inner,
+                None,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        drop(worker);
+        return;
+    }
+    let inventory_generation = match merge_herdr_created_inventory(inner, request, snapshot.clone())
+    {
+        Ok(generation) => generation,
+        Err(error) => {
+            drop(worker);
+            restore_inventory_after_creation_failure(
+                inner,
+                None,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
+    let attached = AttachRequest {
+        host_id: request.host_id.clone(),
+        host: request.host.clone(),
+        endpoint: snapshot.endpoint().clone(),
+        runtime: snapshot.runtime().clone(),
+        target: AttachTarget::Herdr {
+            executable: request.executable.clone(),
+            is_default: session.is_default(),
+            session_directory: session.session_directory().to_owned(),
+            socket_path: session.socket_path().to_owned(),
+        },
+        name: session.name().to_owned(),
+        inventory_generation,
+    };
+    publish_created_presentation(
+        inner,
+        attached,
+        worker,
+        initial_geometry,
+        AttachTerm::Xterm256Color,
+        navigation_generation,
+    );
+}
+
+fn create_herdr_fresh(
+    inner: &Inner,
+    request: &HerdrCreateRequest,
+    navigation_generation: u64,
+    cancellation: &CancellationToken,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        session::HerdrSessionRecord,
+        TerminalGeometry,
+    ),
+    WorkspaceError,
+> {
+    let before = request
+        .host
+        .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    if before.endpoint() != &request.endpoint || before.runtime() != &request.runtime {
+        return Err(WorkspaceError::new(
+            "WSL changed; refresh before creating the Herdr session",
+        ));
+    }
+    let HerdrInventory::Available {
+        executable,
+        sessions,
+    } = before.herdr()
+    else {
+        return Err(WorkspaceError::new("Herdr is not available on this host"));
+    };
+    if executable != &request.executable {
+        return Err(WorkspaceError::new(
+            "the Herdr executable changed; refresh before creating the session",
+        ));
+    }
+    if sessions
+        .iter()
+        .any(|session| session.name() == request.name.as_str())
+    {
+        return Err(WorkspaceError::new(
+            "a Herdr session with this name already exists; restart it instead",
+        ));
+    }
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        return Err(WorkspaceError::new("Herdr creation was superseded"));
+    }
+    let authority = request.host.herdr_launch_once(
+        before.endpoint(),
+        &request.executable,
+        request.name.clone(),
+    );
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::launch_herdr_with_metadata(
+        authority,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+        default_colors(&inner.appearance),
+    )
+    .map_err(|error| WorkspaceError::new(error.to_string()))?;
+
+    for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
+        if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+            drop(worker);
+            return Err(WorkspaceError::new("Herdr creation was superseded"));
+        }
+        let snapshot = request
+            .host
+            .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        if snapshot.endpoint() != &request.endpoint || snapshot.runtime() != &request.runtime {
+            drop(worker);
+            return Err(WorkspaceError::new(
+                "WSL changed while creating the Herdr session",
+            ));
+        }
+        if let HerdrInventory::Available {
+            executable,
+            sessions,
+        } = snapshot.herdr()
+            && executable == &request.executable
+            && let Some(session) = sessions
+                .iter()
+                .find(|session| {
+                    session.name() == request.name.as_str()
+                        && session.state() == HerdrSessionState::Running
+                })
+                .cloned()
+        {
+            return Ok((worker, snapshot, session, geometry));
+        }
+        if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
+            thread::sleep(CREATE_DISCOVERY_DELAY);
+        }
+    }
+    drop(worker);
+    Err(WorkspaceError::new(
+        "Herdr started, but the new session did not appear in inventory; refresh before trying again",
+    ))
 }
 
 fn publish_created_presentation(
@@ -3337,6 +3775,7 @@ fn publish_created_presentation(
             host_id: attached.host_id,
             endpoint: attached.endpoint.distro().to_owned(),
             session: attached.name,
+            kind: attached.target.kind(),
             presentation_id: next_presentation_id(inner),
             surface,
         },
@@ -3536,6 +3975,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                     host_id: request.host_id.clone(),
                     endpoint,
                     session,
+                    kind: request.target.kind(),
                     presentation_id,
                     surface,
                 },
@@ -3704,14 +4144,47 @@ fn merge_created_inventory(
     request: &CreateRequest,
     snapshot: HostSnapshot,
 ) -> Result<u64, WorkspaceError> {
+    merge_constructive_inventory(
+        inner,
+        &request.host,
+        &request.endpoint,
+        &request.runtime,
+        snapshot,
+        "tmux",
+    )
+}
+
+fn merge_herdr_created_inventory(
+    inner: &Inner,
+    request: &HerdrCreateRequest,
+    snapshot: HostSnapshot,
+) -> Result<u64, WorkspaceError> {
+    merge_constructive_inventory(
+        inner,
+        &request.host,
+        &request.endpoint,
+        &request.runtime,
+        snapshot,
+        "Herdr",
+    )
+}
+
+fn merge_constructive_inventory(
+    inner: &Inner,
+    runtime_host: &RuntimeHost,
+    endpoint: &host::WslEndpoint,
+    runtime: &host::WslRuntimeIdentity,
+    snapshot: HostSnapshot,
+    session_type: &str,
+) -> Result<u64, WorkspaceError> {
     let _publication = inner
         .refresh_publication
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if snapshot.endpoint() != &request.endpoint || snapshot.runtime() != &request.runtime {
-        return Err(WorkspaceError::new(
-            "WSL changed while publishing the created tmux session",
-        ));
+    if snapshot.endpoint() != endpoint || snapshot.runtime() != runtime {
+        return Err(WorkspaceError::new(format!(
+            "WSL changed while publishing the created {session_type} session"
+        )));
     }
     let published_generation = inner
         .host
@@ -3719,14 +4192,14 @@ fn merge_created_inventory(
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .as_ref()
         .and_then(|published| {
-            (published.value.snapshot.endpoint() == &request.endpoint
-                && published.value.snapshot.runtime() == &request.runtime)
+            (published.value.snapshot.endpoint() == endpoint
+                && published.value.snapshot.runtime() == runtime)
                 .then_some(published.generation)
         })
         .ok_or_else(|| {
-            WorkspaceError::new(
-                "the WSL endpoint changed while creating the tmux session; refresh before trying again",
-            )
+            WorkspaceError::new(format!(
+                "the WSL endpoint changed while creating the {session_type} session; refresh before trying again"
+            ))
         })?;
     let current_generation = inner.refresh_generation.load(Ordering::Acquire);
     let inventory_generation = match published_generation.cmp(&current_generation) {
@@ -3744,20 +4217,20 @@ fn merge_created_inventory(
         }
         std::cmp::Ordering::Greater => {
             return Err(WorkspaceError::new(
-                "tmux inventory generation moved backwards during creation",
+                "session inventory generation moved backwards during creation",
             ));
         }
     };
 
     let inventory_state = ready_content(&snapshot);
     set_herdr_inventory(inner, snapshot.herdr());
-    reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
+    reconcile_retained_session_names(inner, &snapshot, runtime_host.socket_directory());
     *inner
         .host
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Published::new(
         HostContext {
-            host: request.host.clone(),
+            host: runtime_host.clone(),
             snapshot,
         },
         inventory_generation,
@@ -3836,6 +4309,7 @@ fn reconcile_presentation_session_names(
                 host_id,
                 endpoint,
                 session,
+                ..
             }
             | WorkspaceContent::Terminal {
                 host_id,
@@ -3923,28 +4397,43 @@ fn attach_fresh(
     term: AttachTerm,
 ) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
     let fresh = discover_fresh_runtime(request)?;
-    let session = fresh
-        .sessions()
-        .iter()
-        .find(|session| session.name() == request.name)
-        .cloned();
-    let Some(session) = session else {
-        return Err(AttachFreshError::SessionChanged {
-            error: WorkspaceError::new(
-                "session no longer exists; refresh and choose another session",
-            ),
-            snapshot: fresh,
-        });
-    };
-    if session.identity() != &request.identity {
-        return Err(AttachFreshError::SessionChanged {
-            error: WorkspaceError::new(
-                "session identity changed since discovery; refusing stale attachment",
-            ),
-            snapshot: fresh,
-        });
+    match &request.target {
+        AttachTarget::Tmux(identity) => {
+            let session = fresh
+                .sessions()
+                .iter()
+                .find(|session| session.name() == request.name)
+                .cloned();
+            let Some(session) = session else {
+                return Err(AttachFreshError::SessionChanged {
+                    error: WorkspaceError::new(
+                        "session no longer exists; refresh and choose another session",
+                    ),
+                    snapshot: fresh,
+                });
+            };
+            if identity != session.identity() {
+                return Err(AttachFreshError::SessionChanged {
+                    error: WorkspaceError::new(
+                        "session identity changed since discovery; refusing stale attachment",
+                    ),
+                    snapshot: fresh,
+                });
+            }
+            launch_fresh_tmux(inner, request, term, &fresh, &session)
+        }
+        AttachTarget::Herdr { .. } => {
+            let Some(session) = fresh_herdr_session(&fresh, &request.target) else {
+                return Err(AttachFreshError::SessionChanged {
+                    error: WorkspaceError::new(
+                        "Herdr session changed since discovery; refresh and choose it again",
+                    ),
+                    snapshot: fresh,
+                });
+            };
+            launch_fresh_herdr(inner, request, term, &fresh, &session)
+        }
     }
-    launch_fresh_session(inner, request, term, &fresh, &session)
 }
 
 fn attach_fresh_retained(
@@ -3968,19 +4457,34 @@ fn attach_fresh_retained(
             snapshot: fresh,
         });
     };
-    let session = fresh
-        .sessions()
-        .iter()
-        .find(|session| session.identity() == &retry.key.identity)
-        .cloned()
-        .expect("resolved retained request has a matching session");
-    let (worker, snapshot, _, geometry) = launch_fresh_session(
-        inner,
-        &resolved_request,
-        AttachTerm::Xterm,
-        &fresh,
-        &session,
-    )?;
+    let (worker, snapshot, _, geometry) = match &retry.key.target {
+        AttachTarget::Tmux(identity) => {
+            let session = fresh
+                .sessions()
+                .iter()
+                .find(|session| session.identity() == identity)
+                .cloned()
+                .expect("resolved retained request has a matching tmux session");
+            launch_fresh_tmux(
+                inner,
+                &resolved_request,
+                AttachTerm::Xterm,
+                &fresh,
+                &session,
+            )?
+        }
+        AttachTarget::Herdr { .. } => {
+            let session = fresh_herdr_session(&fresh, &retry.key.target)
+                .expect("resolved retained request has a matching Herdr session");
+            launch_fresh_herdr(
+                inner,
+                &resolved_request,
+                AttachTerm::Xterm,
+                &fresh,
+                &session,
+            )?
+        }
+    };
     Ok((worker, snapshot, resolved_request, geometry))
 }
 
@@ -4010,7 +4514,7 @@ fn resolve_retained_retry_request(
     Some(request)
 }
 
-fn launch_fresh_session(
+fn launch_fresh_tmux(
     inner: &Inner,
     request: &AttachRequest,
     term: AttachTerm,
@@ -4039,6 +4543,68 @@ fn launch_fresh_session(
         plan.target_name().to_owned(),
         geometry,
     ))
+}
+
+fn fresh_herdr_session(
+    snapshot: &HostSnapshot,
+    target: &AttachTarget,
+) -> Option<session::HerdrSessionRecord> {
+    let AttachTarget::Herdr {
+        executable,
+        is_default,
+        session_directory,
+        socket_path,
+    } = target
+    else {
+        return None;
+    };
+    let HerdrInventory::Available {
+        executable: current_executable,
+        sessions,
+    } = snapshot.herdr()
+    else {
+        return None;
+    };
+    (current_executable == executable)
+        .then(|| {
+            sessions.iter().find(|session| {
+                session.is_default() == *is_default
+                    && session.session_directory() == session_directory
+                    && session.socket_path() == socket_path
+                    && session.state() == HerdrSessionState::Running
+            })
+        })
+        .flatten()
+        .cloned()
+}
+
+fn launch_fresh_herdr(
+    inner: &Inner,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    session: &session::HerdrSessionRecord,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
+    let AttachTarget::Herdr { executable, .. } = &request.target else {
+        unreachable!("Herdr launch requires a Herdr target");
+    };
+    let plan = request
+        .host
+        .herdr_attach_plan(fresh.endpoint(), executable, session, term);
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::attach_herdr_with_metadata(
+        &plan,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+        default_colors(&inner.appearance),
+    )
+    .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+    Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
 }
 
 fn set_terminal_notice(inner: &Inner, term: AttachTerm) {
@@ -4246,6 +4812,7 @@ fn publish_terminfo_retry_boundary(inner: &Inner, host_id: &str, endpoint: &str,
             host_id: host_id.to_owned(),
             endpoint: endpoint.to_owned(),
             session: session.to_owned(),
+            kind: SessionKind::Tmux,
         },
     );
 }
@@ -4433,7 +5000,7 @@ mod tests {
             endpoint: "Ubuntu".to_owned(),
             socket_directory: None,
             runtime: snapshot.runtime().clone(),
-            identity,
+            target: AttachTarget::Tmux(identity),
         }
     }
 
@@ -4449,6 +5016,14 @@ mod tests {
             presentation,
             navigation_generation,
         }
+    }
+
+    fn captured_request(workspace: &Workspace, name: &str) -> AttachRequest {
+        capture_attach_request(
+            &workspace.inner,
+            &SessionSelection::new("wsl", "Ubuntu", name),
+        )
+        .expect("fixture session is present")
     }
 
     #[cfg(windows)]
@@ -4467,7 +5042,7 @@ mod tests {
             ),
             endpoint: snapshot.endpoint().clone(),
             runtime: snapshot.runtime().clone(),
-            identity,
+            target: AttachTarget::Tmux(identity),
             name: name.to_owned(),
             inventory_generation: 1,
         }
@@ -4542,6 +5117,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -4576,6 +5152,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "stale".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -4711,6 +5288,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "visible".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 9,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(
                     1,
@@ -4812,14 +5390,14 @@ mod tests {
             host,
             endpoint: snapshot.endpoint().clone(),
             runtime: snapshot.runtime().clone(),
-            identity: identity.clone(),
+            target: AttachTarget::Tmux(identity.clone()),
             name: "replacement".to_owned(),
             inventory_generation: 1,
         };
         let key = request.presentation_key();
         let fallback = FallbackAuthority {
             presentation: PresentationKey {
-                identity: session::SessionIdentity::new(100, "$2", 201),
+                target: AttachTarget::Tmux(session::SessionIdentity::new(100, "$2", 201)),
                 ..key.clone()
             },
             target: key.clone(),
@@ -4958,10 +5536,7 @@ mod tests {
                 .expect("current session remains selectable");
 
         assert_eq!(selected, current.presentation_key());
-        assert_eq!(
-            request.map(|request| request.identity),
-            Some(current.identity)
-        );
+        assert_eq!(request.map(|request| request.target), Some(current.target));
     }
 
     #[cfg(windows)]
@@ -5047,6 +5622,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "original".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -5140,7 +5716,7 @@ mod tests {
             host,
             endpoint: snapshot.endpoint().clone(),
             runtime: snapshot.runtime().clone(),
-            identity: session::SessionIdentity::new(100, "$1", 200),
+            target: AttachTarget::Tmux(session::SessionIdentity::new(100, "$1", 200)),
             name: "replacement".to_owned(),
             inventory_generation: 1,
         };
@@ -5165,6 +5741,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "replacement".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -5220,6 +5797,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "original".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -5242,6 +5820,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 7,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -5270,7 +5849,7 @@ mod tests {
         );
         assert!(matches!(
             workspace.snapshot().content(),
-            WorkspaceContent::Attaching { host_id, endpoint, session }
+            WorkspaceContent::Attaching { host_id, endpoint, session, .. }
                 if host_id == "wsl" && endpoint == "Ubuntu" && session == "work"
         ));
         assert_eq!(next_presentation_id(&workspace.inner), 8);
@@ -5367,6 +5946,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(
                     1,
@@ -6050,6 +6630,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -6093,6 +6674,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -6158,16 +6740,8 @@ mod tests {
             0,
         ));
         set_inventory_state(&workspace.inner, ready_content(&snapshot));
-        let opening = capture_attach_request(
-            &workspace.inner,
-            &SessionSelection::new("wsl", "Ubuntu", "opening"),
-        )
-        .expect("opening request");
-        let selected = capture_attach_request(
-            &workspace.inner,
-            &SessionSelection::new("wsl", "Ubuntu", "selected"),
-        )
-        .expect("selected request");
+        let opening = captured_request(&workspace, "opening");
+        let selected = captured_request(&workspace, "selected");
         let opening_navigation = workspace.begin_navigation();
         let mut fallback = fallback_fixture(
             "boot-id",
@@ -6189,9 +6763,9 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "opening".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
-
         let carried_fallback = workspace
             .supersede_inflight_attachment()
             .expect("supersede opening attachment");
@@ -6208,7 +6782,6 @@ mod tests {
             .expect("attachment")
             .reserve_with_fallback(selected, AttachTerm::Xterm256Color, carried_fallback)
             .expect("reserve selected attachment");
-
         let attachment = workspace.inner.attachment.lock().expect("attachment");
         let active = attachment.active().expect("selected attachment active");
         assert_eq!(
@@ -6245,6 +6818,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "creating".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -6301,6 +6875,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "creating".to_owned(),
+                kind: SessionKind::Tmux,
             },
         );
 
@@ -6382,6 +6957,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -6424,6 +7000,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "active".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -6448,8 +7025,8 @@ mod tests {
                 .active()
                 .expect("active attachment")
                 .request
-                .identity,
-            active_identity
+                .target,
+            AttachTarget::Tmux(active_identity)
         );
     }
 
@@ -6467,6 +7044,7 @@ mod tests {
                 host_id: "wsl".to_owned(),
                 endpoint: "Ubuntu".to_owned(),
                 session: "work".to_owned(),
+                kind: SessionKind::Tmux,
                 presentation_id: 1,
                 surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
             },
@@ -6538,12 +7116,7 @@ mod tests {
             DiagnosticKind::Timeout
         );
 
-        set_inner_state(
-            &workspace.inner,
-            WorkspaceContent::Error {
-                message: "attachment failed".to_owned(),
-            },
-        );
+        set_inner_state(&workspace.inner, WorkspaceContent::Shell);
         workspace.refresh().expect("start retry");
         assert!(matches!(
             workspace.snapshot().content(),
@@ -6667,6 +7240,37 @@ mod tests {
             host.herdr_diagnostic().expect("scoped diagnostic").kind(),
             DiagnosticKind::MalformedOutput
         );
+    }
+
+    #[test]
+    fn host_refresh_keeps_cached_tmux_and_herdr_rows_visible() {
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application(TerminalAppearance::default(), Some(spec));
+        {
+            let mut hosts = workspace.inner.hosts.write().expect("hosts");
+            let host = &mut hosts[0];
+            host.connection = HostConnectionState::Ready;
+            host.sessions = vec![SessionItem::new("tmux-work", 0)];
+            host.herdr_available = true;
+            host.herdr_sessions = vec![HerdrSessionItem::new(
+                "herdr-work",
+                false,
+                HerdrSessionState::Running,
+            )];
+        }
+
+        begin_refresh(&workspace.inner, &CancellationToken::new());
+
+        let snapshot = workspace.snapshot();
+        assert!(matches!(snapshot.content(), WorkspaceContent::Shell));
+        let host = &snapshot.hosts()[0];
+        assert_eq!(host.connection(), HostConnectionState::Connecting);
+        assert_eq!(host.sessions()[0].name(), "tmux-work");
+        assert_eq!(host.herdr_sessions()[0].name(), "herdr-work");
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -8,12 +8,12 @@ use std::time::Duration;
 
 use config::TerminalAppearance;
 use host::{
-    AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HostError, HostSnapshot,
-    LiveSessionTarget, StdCommandRunner, WslConfig, WslExecutable, WslHost,
+    AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HerdrInventory, HostError,
+    HostSnapshot, LiveSessionTarget, StdCommandRunner, WslConfig, WslExecutable, WslHost,
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
-pub use session::{SessionName, SessionNameError};
+pub use session::{HerdrSessionState, SessionName, SessionNameError};
 use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
     ClipboardPolicy, ClipboardReadRequest as TerminalClipboardRead, ClipboardTarget, DefaultColors,
@@ -180,6 +180,42 @@ pub struct HostItem {
     connection: HostConnectionState,
     sessions: Vec<SessionItem>,
     diagnostic: Option<HostDiagnostic>,
+    herdr_available: bool,
+    herdr_sessions: Vec<HerdrSessionItem>,
+    herdr_diagnostic: Option<HostDiagnostic>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrSessionItem {
+    name: String,
+    is_default: bool,
+    state: HerdrSessionState,
+}
+
+impl HerdrSessionItem {
+    #[must_use]
+    pub fn new(name: impl Into<String>, is_default: bool, state: HerdrSessionState) -> Self {
+        Self {
+            name: name.into(),
+            is_default,
+            state,
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub const fn is_default(&self) -> bool {
+        self.is_default
+    }
+
+    #[must_use]
+    pub const fn state(&self) -> HerdrSessionState {
+        self.state
+    }
 }
 
 impl HostItem {
@@ -199,6 +235,9 @@ impl HostItem {
             connection,
             sessions,
             diagnostic,
+            herdr_available: false,
+            herdr_sessions: Vec::new(),
+            herdr_diagnostic: None,
         }
     }
 
@@ -235,6 +274,21 @@ impl HostItem {
     #[must_use]
     pub const fn diagnostic(&self) -> Option<&HostDiagnostic> {
         self.diagnostic.as_ref()
+    }
+
+    #[must_use]
+    pub const fn herdr_available(&self) -> bool {
+        self.herdr_available
+    }
+
+    #[must_use]
+    pub fn herdr_sessions(&self) -> &[HerdrSessionItem] {
+        &self.herdr_sessions
+    }
+
+    #[must_use]
+    pub const fn herdr_diagnostic(&self) -> Option<&HostDiagnostic> {
+        self.herdr_diagnostic.as_ref()
     }
 }
 
@@ -2583,6 +2637,7 @@ impl Workspace {
                     match resolved {
                         Ok(context) => {
                             let state = ready_content(&context.snapshot);
+                            set_herdr_inventory(&task_inner, context.snapshot.herdr());
                             *task_inner
                                 .host
                                 .lock()
@@ -3350,7 +3405,12 @@ fn create_fresh(
         }
         let snapshot = request
             .host
-            .discover_after_create(before.endpoint(), &request.runtime, cancellation)
+            .discover_after_create(
+                before.endpoint(),
+                &request.runtime,
+                before.herdr(),
+                cancellation,
+            )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
         if let Some(session) = created_session(&snapshot, &client_identity) {
             return Ok((worker, snapshot, session, launch_geometry, term));
@@ -3690,6 +3750,7 @@ fn merge_created_inventory(
     };
 
     let inventory_state = ready_content(&snapshot);
+    set_herdr_inventory(inner, snapshot.herdr());
     reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
     *inner
         .host
@@ -3713,6 +3774,7 @@ fn publish_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: Ho
 
 fn set_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSnapshot) {
     let inventory_state = ready_content(&snapshot);
+    set_herdr_inventory(inner, snapshot.herdr());
     reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
     *inner
         .host
@@ -4026,6 +4088,36 @@ fn ready_content(snapshot: &HostSnapshot) -> WorkspaceContent {
             .iter()
             .map(|session| SessionItem::new(session.name(), session.attached_clients()))
             .collect(),
+    }
+}
+
+fn set_herdr_inventory(inner: &Inner, inventory: &HerdrInventory) {
+    let mut hosts = inner
+        .hosts
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(host) = hosts.iter_mut().find(|host| host.id == "wsl") else {
+        return;
+    };
+    match inventory {
+        HerdrInventory::Unavailable => {
+            host.herdr_available = false;
+            host.herdr_sessions.clear();
+            host.herdr_diagnostic = None;
+        }
+        HerdrInventory::Available { sessions, .. } => {
+            host.herdr_available = true;
+            host.herdr_sessions = sessions
+                .iter()
+                .map(|session| {
+                    HerdrSessionItem::new(session.name(), session.is_default(), session.state())
+                })
+                .collect();
+            host.herdr_diagnostic = None;
+        }
+        HerdrInventory::Failed(error) => {
+            host.herdr_diagnostic = Some(HostDiagnostic::new(error.kind(), error.to_string()));
+        }
     }
 }
 
@@ -6473,6 +6565,107 @@ mod tests {
         assert_eq!(
             workspace.snapshot().hosts()[0].connection(),
             HostConnectionState::Ready
+        );
+    }
+
+    #[test]
+    fn successful_refresh_projects_herdr_without_changing_tmux_readiness() {
+        let runtime = Arc::new(ManualRefreshRuntime::default());
+        let snapshot = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot",
+            42,
+            vec![session::DiscoveredSession::new(
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+            HerdrInventory::Available {
+                executable: "/opt/herdr/bin/herdr".to_owned(),
+                sessions: vec![
+                    session::HerdrSessionRecord::new(
+                        "default",
+                        true,
+                        HerdrSessionState::Running,
+                        "/tmp/herdr/default",
+                        "/tmp/herdr/default/herdr.sock",
+                    ),
+                    session::HerdrSessionRecord::new(
+                        "review",
+                        false,
+                        HerdrSessionState::Stopped,
+                        "/tmp/herdr/review",
+                        "/tmp/herdr/review/herdr.sock",
+                    ),
+                ],
+            },
+        );
+        let discovery = Arc::new(FixedDiscovery::new(snapshot));
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            Some(spec),
+            discovery,
+            runtime.clone(),
+        );
+
+        workspace.connect_enabled_hosts().expect("start refresh");
+        runtime.run_next_work();
+
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        assert_eq!(host.connection(), HostConnectionState::Ready);
+        assert_eq!(host.sessions()[0].name(), "work");
+        assert!(host.herdr_available());
+        assert_eq!(host.herdr_sessions().len(), 2);
+        assert!(host.herdr_sessions()[0].is_default());
+        assert_eq!(host.herdr_sessions()[1].state(), HerdrSessionState::Stopped);
+        assert!(host.herdr_diagnostic().is_none());
+    }
+
+    #[test]
+    fn herdr_refresh_failure_preserves_cached_rows() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::shell(
+            Appearance::default(),
+            vec![HostItem::wsl(
+                "Ubuntu",
+                None,
+                HostConnectionState::Ready,
+                Vec::new(),
+                None,
+            )],
+        ));
+        set_herdr_inventory(
+            &workspace.inner,
+            &HerdrInventory::Available {
+                executable: "/opt/herdr/bin/herdr".to_owned(),
+                sessions: vec![session::HerdrSessionRecord::new(
+                    "review",
+                    false,
+                    HerdrSessionState::Running,
+                    "/tmp/herdr/review",
+                    "/tmp/herdr/review/herdr.sock",
+                )],
+            },
+        );
+        set_herdr_inventory(
+            &workspace.inner,
+            &HerdrInventory::Failed(
+                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
+            ),
+        );
+
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        assert!(host.herdr_available());
+        assert_eq!(host.herdr_sessions()[0].name(), "review");
+        assert_eq!(
+            host.herdr_diagnostic().expect("scoped diagnostic").kind(),
+            DiagnosticKind::MalformedOutput
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -755,6 +755,20 @@ impl HerdrLifecycleState {
             .retain(|operation| operation.generation != generation);
         self.in_flight.len() != previous_len
     }
+
+    fn reconcile(&mut self, snapshot: &HostSnapshot) -> bool {
+        let previous_len = self.in_flight.len();
+        self.in_flight.retain(|operation| {
+            if operation.key.endpoint != *snapshot.endpoint() {
+                return true;
+            }
+            if operation.key.runtime != *snapshot.runtime() {
+                return false;
+            }
+            matches!(snapshot.herdr(), HerdrInventory::Failed(_))
+        });
+        self.in_flight.len() != previous_len
+    }
 }
 
 fn with_herdr_launch_fence<T, E>(
@@ -3250,16 +3264,7 @@ impl Workspace {
                         return;
                     }
                     match resolved {
-                        Ok(context) => {
-                            let state = ready_content(&context.snapshot);
-                            set_herdr_inventory(&task_inner, context.snapshot.herdr());
-                            *task_inner
-                                .host
-                                .lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                                Some(Published::new(context, generation));
-                            set_inventory_state(&task_inner, state);
-                        }
+                        Ok(context) => publish_discovered_host(&task_inner, context, generation),
                         Err(error) => {
                             set_wsl_host_unavailable(&task_inner, error.kind(), error.to_string());
                         }
@@ -4008,6 +4013,18 @@ fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bo
     true
 }
 
+fn publish_discovered_host(inner: &Inner, context: HostContext, generation: u64) {
+    let state = ready_content(&context.snapshot);
+    reconcile_herdr_lifecycle_fences(inner, &context.snapshot);
+    set_herdr_inventory(inner, context.snapshot.herdr());
+    *inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+        Some(Published::new(context, generation));
+    set_inventory_state(inner, state);
+}
+
 fn cancel_refresh(inner: &Inner) -> bool {
     let _publication = inner
         .refresh_publication
@@ -4236,19 +4253,49 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
         Ok(record) => {
             if let Err(error) = publish_herdr_lifecycle_response(&workspace.inner, pending, record)
             {
-                workspace.push_operation_error(format!(
-                    "Herdr {} succeeded, but Ghosthub could not publish the result: {error}",
-                    pending.action.command()
-                ));
+                reconcile_herdr_lifecycle_failure(
+                    workspace,
+                    pending,
+                    format!(
+                        "Herdr {} succeeded, but Ghosthub could not publish the result: {error}",
+                        pending.action.command()
+                    ),
+                );
             } else {
                 finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
-                reconcile_herdr_lifecycle_inventory(&workspace.inner, pending);
-                return;
+                let _reconciled = reconcile_herdr_lifecycle_inventory(
+                    &workspace.inner,
+                    pending,
+                    HerdrReconcileMode::ConfirmedOutcome,
+                );
             }
         }
-        Err(error) => workspace.push_operation_error(error.to_string()),
+        Err(error) => reconcile_herdr_lifecycle_failure(workspace, pending, error.to_string()),
     }
-    finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
+}
+
+fn reconcile_herdr_lifecycle_failure(
+    workspace: &Workspace,
+    pending: &PendingHerdrLifecycle,
+    operation_error: String,
+) {
+    match reconcile_herdr_lifecycle_inventory(
+        &workspace.inner,
+        pending,
+        HerdrReconcileMode::CurrentInventory,
+    ) {
+        Ok(()) => {
+            finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
+            workspace.push_operation_error(operation_error);
+        }
+        Err(reconciliation_error) => {
+            let message = format!(
+                "{operation_error}; Ghosthub could not reconcile the Herdr session: {reconciliation_error}"
+            );
+            publish_herdr_lifecycle_uncertain(&workspace.inner, pending, &message);
+            workspace.push_operation_error(message);
+        }
+    }
 }
 
 fn finish_herdr_lifecycle_state(inner: &Inner, generation: u64) {
@@ -4957,16 +5004,28 @@ fn publish_herdr_lifecycle_response(
     merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation)
 }
 
-fn reconcile_herdr_lifecycle_inventory(inner: &Inner, pending: &PendingHerdrLifecycle) {
+#[derive(Clone, Copy)]
+enum HerdrReconcileMode {
+    CurrentInventory,
+    ConfirmedOutcome,
+}
+
+fn reconcile_herdr_lifecycle_inventory(
+    inner: &Inner,
+    pending: &PendingHerdrLifecycle,
+    mode: HerdrReconcileMode,
+) -> Result<(), WorkspaceError> {
     let publication_generation = inner.refresh_generation.load(Ordering::Acquire);
-    let Ok(snapshot) = pending.host.discover(&ConptyAdmissionAttacher::new()) else {
-        return;
-    };
-    if !herdr_lifecycle_is_reflected(&snapshot, pending) {
-        return;
+    let snapshot = pending
+        .host
+        .discover(&ConptyAdmissionAttacher::new())
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    if matches!(mode, HerdrReconcileMode::ConfirmedOutcome)
+        && !herdr_lifecycle_is_reflected(&snapshot, pending)
+    {
+        return Ok(());
     }
-    let _reconciled =
-        merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation);
+    merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation).map(|_| ())
 }
 
 fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrLifecycle) -> bool {
@@ -4984,6 +5043,28 @@ fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrL
                 && record.socket_path() == pending.record.socket_path()
         }),
         HerdrLifecycleAction::Delete => current.is_none(),
+    }
+}
+
+fn publish_herdr_lifecycle_uncertain(
+    inner: &Inner,
+    pending: &PendingHerdrLifecycle,
+    message: &str,
+) {
+    let _snapshot_write = begin_snapshot_write(inner);
+    let mut hosts = inner
+        .hosts
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(host) = hosts
+        .iter_mut()
+        .find(|host| host.endpoint == pending.endpoint.distro())
+    {
+        host.herdr_diagnostic = Some(HostDiagnostic::new(
+            DiagnosticKind::Transport,
+            message.to_owned(),
+        ));
+        inner.revision.fetch_add(1, Ordering::Release);
     }
 }
 
@@ -5034,6 +5115,7 @@ fn merge_constructive_inventory(
     let inventory_generation = publication_generation;
 
     let inventory_state = ready_content(&snapshot);
+    reconcile_herdr_lifecycle_fences(inner, &snapshot);
     set_herdr_inventory(inner, snapshot.herdr());
     reconcile_retained_session_names(inner, &snapshot, runtime_host.socket_directory());
     *inner
@@ -5539,6 +5621,14 @@ fn project_herdr_lifecycle(
             name: session.name.clone(),
         });
     }
+}
+
+fn reconcile_herdr_lifecycle_fences(inner: &Inner, snapshot: &HostSnapshot) -> bool {
+    inner
+        .herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .reconcile(snapshot)
 }
 
 fn set_inner_state(inner: &Inner, state: WorkspaceContent) {
@@ -8374,6 +8464,58 @@ mod tests {
                 .action(),
             HerdrLifecycleAction::Delete
         );
+    }
+
+    #[test]
+    fn uncertain_lifecycle_stays_fenced_until_fresh_inventory_arrives() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        workspace
+            .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+            .expect("running session may be stopped");
+        let pending = {
+            let mut lifecycle = workspace
+                .inner
+                .herdr_lifecycle
+                .lock()
+                .expect("lifecycle state");
+            let pending = lifecycle.pending.take().expect("pending stop");
+            assert!(lifecycle.start(&pending));
+            pending
+        };
+
+        publish_herdr_lifecycle_uncertain(
+            &workspace.inner,
+            &pending,
+            "could not reconcile the stopped session",
+        );
+
+        let uncertain = workspace.snapshot();
+        let host = &uncertain.hosts()[0];
+        assert_eq!(
+            host.herdr_sessions()[0].lifecycle_action(),
+            Some(HerdrLifecycleAction::Stop)
+        );
+        assert!(host.herdr_diagnostic().is_some());
+
+        let fresh = workspace
+            .inner
+            .host
+            .lock()
+            .expect("host context")
+            .as_ref()
+            .expect("published host")
+            .value
+            .snapshot
+            .clone();
+        assert!(reconcile_herdr_lifecycle_fences(&workspace.inner, &fresh));
+        set_herdr_inventory(&workspace.inner, fresh.herdr());
+        workspace.inner.revision.fetch_add(1, Ordering::Release);
+
+        let reconciled = workspace.snapshot();
+        let host = &reconciled.hosts()[0];
+        assert_eq!(host.herdr_sessions()[0].lifecycle_action(), None);
+        assert!(host.herdr_diagnostic().is_none());
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -222,6 +222,7 @@ pub struct HerdrSessionItem {
     is_default: bool,
     state: HerdrSessionState,
     lifecycle_action: Option<HerdrLifecycleAction>,
+    launch_pending: bool,
 }
 
 impl HerdrSessionItem {
@@ -232,6 +233,7 @@ impl HerdrSessionItem {
             is_default,
             state,
             lifecycle_action: None,
+            launch_pending: false,
         }
     }
 
@@ -253,6 +255,11 @@ impl HerdrSessionItem {
     #[must_use]
     pub const fn lifecycle_action(&self) -> Option<HerdrLifecycleAction> {
         self.lifecycle_action
+    }
+
+    #[must_use]
+    pub const fn launch_pending(&self) -> bool {
+        self.launch_pending
     }
 }
 
@@ -283,6 +290,12 @@ impl HostItem {
     pub fn with_herdr_sessions(mut self, sessions: Vec<HerdrSessionItem>) -> Self {
         self.herdr_available = true;
         self.herdr_sessions = sessions;
+        self
+    }
+
+    #[must_use]
+    pub fn with_herdr_diagnostic(mut self, diagnostic: HostDiagnostic) -> Self {
+        self.herdr_diagnostic = Some(diagnostic);
         self
     }
 
@@ -734,9 +747,28 @@ struct InFlightHerdrLifecycle {
 struct HerdrLifecycleState {
     pending: Option<PendingHerdrLifecycle>,
     in_flight: Vec<InFlightHerdrLifecycle>,
+    launches: Vec<HerdrOperationKey>,
 }
 
 impl HerdrLifecycleState {
+    fn reserve_launch(&mut self, key: &HerdrOperationKey) -> bool {
+        if self.launches.contains(key) || self.in_flight_action(key).is_some() {
+            return false;
+        }
+        self.launches.push(key.clone());
+        true
+    }
+
+    fn finish_launch(&mut self, key: &HerdrOperationKey) -> bool {
+        let previous_len = self.launches.len();
+        self.launches.retain(|candidate| candidate != key);
+        self.launches.len() != previous_len
+    }
+
+    fn launch_pending(&self, key: &HerdrOperationKey) -> bool {
+        self.launches.contains(key)
+    }
+
     fn in_flight_action(&self, key: &HerdrOperationKey) -> Option<HerdrLifecycleAction> {
         self.in_flight
             .iter()
@@ -906,6 +938,7 @@ struct PendingCreation {
     navigation_generation: u64,
     previous: Option<PresentationKey>,
     cancellation: CancellationToken,
+    herdr_operation: Option<HerdrOperationKey>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -915,6 +948,11 @@ struct PresentationKey {
     socket_directory: Option<String>,
     runtime: host::WslRuntimeIdentity,
     target: AttachTarget,
+}
+
+struct SuppressedHerdrPresentation {
+    key: PresentationKey,
+    navigation_generation: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1938,6 +1976,13 @@ impl Workspace {
         if same_visible_selection && !has_active_attachment {
             return Ok(());
         }
+        if selection.kind() == SessionKind::Herdr
+            && herdr_operation_pending_for_selection(&self.inner, selection)
+        {
+            return Err(WorkspaceError::new(
+                "this Herdr session is already starting or changing lifecycle",
+            ));
+        }
 
         let (key, request) = self.navigation_target(selection)?;
         if self
@@ -2034,6 +2079,7 @@ impl Workspace {
             navigation_generation,
             previous: previous.clone(),
             cancellation: cancellation.clone(),
+            herdr_operation: None,
         });
         clear_terminal_notice(&self.inner);
         set_inner_state(
@@ -2123,9 +2169,33 @@ impl Workspace {
         navigation: std::sync::MutexGuard<'_, ()>,
     ) -> Result<(), WorkspaceError> {
         let _snapshot_write = begin_snapshot_write(&self.inner);
+        let operation_key = request.operation_key();
+        if !self
+            .inner
+            .herdr_lifecycle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .reserve_launch(&operation_key)
+        {
+            return Err(WorkspaceError::new(
+                "this Herdr session is already starting or changing lifecycle",
+            ));
+        }
         let navigation_generation = self.begin_navigation();
-        let in_flight_fallback = self.supersede_inflight_attachment()?;
-        let visible_previous = self.retain_active_presentation()?;
+        let in_flight_fallback = match self.supersede_inflight_attachment() {
+            Ok(fallback) => fallback,
+            Err(error) => {
+                finish_herdr_launch(&self.inner, &operation_key);
+                return Err(error);
+            }
+        };
+        let visible_previous = match self.retain_active_presentation() {
+            Ok(previous) => previous,
+            Err(error) => {
+                finish_herdr_launch(&self.inner, &operation_key);
+                return Err(error);
+            }
+        };
         let previous = in_flight_fallback.or(visible_previous);
         let cancellation = CancellationToken::new();
         *self
@@ -2136,6 +2206,7 @@ impl Workspace {
             navigation_generation,
             previous: previous.clone(),
             cancellation: cancellation.clone(),
+            herdr_operation: Some(operation_key),
         });
         clear_terminal_notice(&self.inner);
         set_inner_state(
@@ -2228,6 +2299,7 @@ impl Workspace {
                     WorkspaceError::new("the in-flight terminal presentation is not available")
                 })?;
             pending.cancellation.cancel();
+            finish_pending_creation(&self.inner, &pending);
             pending.previous
         };
         clear_pending_paste(&self.inner);
@@ -2622,6 +2694,9 @@ impl Workspace {
                 "a lifecycle action is already running for this Herdr session",
             ));
         }
+        if lifecycle.launch_pending(&pending.key()) {
+            return Err(WorkspaceError::new("this Herdr session is still starting"));
+        }
         if self
             .inner
             .herdr_lifecycle_generation
@@ -2833,6 +2908,60 @@ impl Workspace {
         }
     }
 
+    fn suppress_active_herdr_presentation(
+        &self,
+        pending: &PendingHerdrLifecycle,
+    ) -> Option<SuppressedHerdrPresentation> {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let active_matches = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some_and(|active| {
+                active.request.endpoint == pending.endpoint
+                    && active.request.runtime == pending.runtime
+                    && active.request.name == pending.record.name()
+                    && active.request.target.herdr_matches(&pending.record)
+            });
+        if !active_matches {
+            return None;
+        }
+        let navigation_generation = self.inner.navigation_generation.load(Ordering::Acquire);
+        self.retain_active_presentation()
+            .ok()
+            .flatten()
+            .map(|key| SuppressedHerdrPresentation {
+                key,
+                navigation_generation,
+            })
+    }
+
+    fn restore_suppressed_herdr_presentation(
+        &self,
+        suppressed: Option<&SuppressedHerdrPresentation>,
+    ) {
+        let Some(suppressed) = suppressed else {
+            return;
+        };
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.inner.navigation_generation.load(Ordering::Acquire)
+            != suppressed.navigation_generation
+        {
+            return;
+        }
+        let _restored = self.activate_retained_presentation(&suppressed.key, None);
+    }
+
     /// Update the desired grid and resize an active VT/PTTY pair together.
     ///
     /// # Errors
@@ -2933,6 +3062,7 @@ impl Workspace {
             .take()
         {
             pending.cancellation.cancel();
+            finish_pending_creation(&self.inner, &pending);
         }
         self.inner
             .attachment
@@ -3412,6 +3542,23 @@ fn invalidate_pending_herdr_lifecycle(inner: &Inner) -> (u64, bool) {
     (generation, lifecycle.pending.take().is_some())
 }
 
+fn finish_herdr_launch(inner: &Inner, key: &HerdrOperationKey) {
+    if inner
+        .herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .finish_launch(key)
+    {
+        inner.revision.fetch_add(1, Ordering::Release);
+    }
+}
+
+fn finish_pending_creation(inner: &Inner, pending: &PendingCreation) {
+    if let Some(key) = &pending.herdr_operation {
+        finish_herdr_launch(inner, key);
+    }
+}
+
 fn activate_retained_presentation(
     inner: &Inner,
     key: &PresentationKey,
@@ -3548,6 +3695,9 @@ fn capture_attach_request(
     inner: &Inner,
     selection: &SessionSelection,
 ) -> Result<AttachRequest, WorkspaceError> {
+    if selection.kind() == SessionKind::Herdr {
+        require_host_session_actions(inner, selection)?;
+    }
     let selected_host = inner
         .selected_host
         .read()
@@ -3840,6 +3990,10 @@ fn capture_herdr_create_request(
     {
         return Err(WorkspaceError::new("host is not selected"));
     }
+    require_host_session_actions(
+        inner,
+        &SessionSelection::herdr(host_id, endpoint, name.as_str()),
+    )?;
     let host = inner
         .host
         .lock()
@@ -3953,7 +4107,25 @@ fn require_host_session_actions(
             "connect the WSL host before changing a Herdr session",
         ));
     }
+    if host.herdr_diagnostic.is_some() {
+        return Err(WorkspaceError::new(
+            "refresh Herdr inventory before changing a session",
+        ));
+    }
     Ok(())
+}
+
+fn herdr_operation_pending_for_selection(inner: &Inner, selection: &SessionSelection) -> bool {
+    let lifecycle = inner
+        .herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    lifecycle.launches.iter().any(|operation| {
+        operation.endpoint.distro() == selection.endpoint() && operation.name == selection.session()
+    }) || lifecycle.in_flight.iter().any(|operation| {
+        operation.key.endpoint.distro() == selection.endpoint()
+            && operation.key.name == selection.session()
+    })
 }
 
 fn choose_navigation_target(
@@ -4285,18 +4457,25 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if pending.action == HerdrLifecycleAction::Stop {
-        workspace.finish_herdr_presentation(&pending.endpoint, &pending.runtime, &pending.record);
-    }
+    let mut suppressed = None;
     match pending.host.mutate_herdr_session(
-        &pending.endpoint,
-        &pending.runtime,
+        (&pending.endpoint, &pending.runtime),
         &pending.executable,
         &pending.record,
         pending.action,
         &CancellationToken::new(),
+        || {
+            if pending.action == HerdrLifecycleAction::Stop {
+                suppressed = workspace.suppress_active_herdr_presentation(pending);
+            }
+        },
     ) {
         Ok(record) => {
+            workspace.finish_herdr_presentation(
+                &pending.endpoint,
+                &pending.runtime,
+                &pending.record,
+            );
             if let Err(error) = publish_herdr_lifecycle_response(&workspace.inner, pending, record)
             {
                 reconcile_herdr_lifecycle_failure(
@@ -4306,6 +4485,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
                         "Herdr {} succeeded, but Ghosthub could not publish the result: {error}",
                         pending.action.command()
                     ),
+                    None,
                 );
             } else {
                 finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
@@ -4316,7 +4496,14 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
                 );
             }
         }
-        Err(error) => reconcile_herdr_lifecycle_failure(workspace, pending, error.to_string()),
+        Err(error) => {
+            reconcile_herdr_lifecycle_failure(
+                workspace,
+                pending,
+                error.to_string(),
+                suppressed.as_ref(),
+            );
+        }
     }
 }
 
@@ -4324,14 +4511,24 @@ fn reconcile_herdr_lifecycle_failure(
     workspace: &Workspace,
     pending: &PendingHerdrLifecycle,
     operation_error: String,
+    suppressed: Option<&SuppressedHerdrPresentation>,
 ) {
     match reconcile_herdr_lifecycle_inventory(
         &workspace.inner,
         pending,
         HerdrReconcileMode::CurrentInventory,
     ) {
-        Ok(()) => {
+        Ok(snapshot) => {
             finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
+            if herdr_session_is_still_running(&snapshot, pending) {
+                workspace.restore_suppressed_herdr_presentation(suppressed);
+            } else {
+                workspace.finish_herdr_presentation(
+                    &pending.endpoint,
+                    &pending.runtime,
+                    &pending.record,
+                );
+            }
             workspace.push_operation_error(operation_error);
         }
         Err(reconciliation_error) => {
@@ -4533,11 +4730,14 @@ fn publish_created_presentation(
         return;
     };
     let key = attached.presentation_key();
-    let fallback = pending.previous.map(|presentation| FallbackAuthority {
-        presentation,
-        target: key,
-        navigation_generation,
-    });
+    let fallback = pending
+        .previous
+        .clone()
+        .map(|presentation| FallbackAuthority {
+            presentation,
+            target: key,
+            navigation_generation,
+        });
     let mut attachment = inner
         .attachment
         .lock()
@@ -4545,6 +4745,7 @@ fn publish_created_presentation(
     let Some(generation) =
         attachment.reserve_with_fallback(attached.clone(), term, fallback.clone())
     else {
+        finish_pending_creation(inner, &pending);
         drop(attachment);
         drop(navigation);
         drop(worker);
@@ -4567,6 +4768,7 @@ fn publish_created_presentation(
         },
     ) {
         attachment.clear_if_current(generation);
+        finish_pending_creation(inner, &pending);
         drop(attachment);
         drop(navigation);
         restore_inventory_after_creation_failure(
@@ -4589,6 +4791,7 @@ fn publish_created_presentation(
             surface,
         },
     );
+    finish_pending_creation(inner, &pending);
     drop(attachment);
     drop(navigation);
 }
@@ -4718,6 +4921,7 @@ fn restore_inventory_after_creation_failure(
         .filter(|pending| pending.navigation_generation == navigation_generation);
     if let Some(pending) = &pending {
         pending.cancellation.cancel();
+        finish_pending_creation(inner, pending);
     }
     let previous = pending.and_then(|pending| pending.previous).or(previous);
     restore_presentation_inventory(inner);
@@ -5062,7 +5266,7 @@ fn reconcile_herdr_lifecycle_inventory(
     inner: &Inner,
     pending: &PendingHerdrLifecycle,
     mode: HerdrReconcileMode,
-) -> Result<(), WorkspaceError> {
+) -> Result<HostSnapshot, WorkspaceError> {
     let publication_generation = inner.refresh_generation.load(Ordering::Acquire);
     let snapshot = pending
         .host
@@ -5071,9 +5275,32 @@ fn reconcile_herdr_lifecycle_inventory(
     if matches!(mode, HerdrReconcileMode::ConfirmedOutcome)
         && !herdr_lifecycle_is_reflected(&snapshot, pending)
     {
-        return Ok(());
+        return Ok(snapshot);
     }
-    merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation).map(|_| ())
+    merge_herdr_lifecycle_inventory(inner, pending, snapshot.clone(), publication_generation)?;
+    Ok(snapshot)
+}
+
+fn herdr_session_is_still_running(
+    snapshot: &HostSnapshot,
+    pending: &PendingHerdrLifecycle,
+) -> bool {
+    snapshot.endpoint() == &pending.endpoint
+        && snapshot.runtime() == &pending.runtime
+        && matches!(
+            snapshot.herdr(),
+            HerdrInventory::Available {
+                executable,
+                sessions,
+            } if executable == &pending.executable
+                && sessions.iter().any(|record| {
+                    record.name() == pending.record.name()
+                        && record.state() == HerdrSessionState::Running
+                        && record.is_default() == pending.record.is_default()
+                        && record.session_directory() == pending.record.session_directory()
+                        && record.socket_path() == pending.record.socket_path()
+                })
+        )
 }
 
 fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrLifecycle) -> bool {
@@ -5663,11 +5890,13 @@ fn project_herdr_lifecycle(
         return;
     };
     for session in &mut host.herdr_sessions {
-        session.lifecycle_action = lifecycle.in_flight_action(&HerdrOperationKey {
+        let key = HerdrOperationKey {
             endpoint: endpoint.clone(),
             runtime: runtime.clone(),
             name: session.name.clone(),
-        });
+        };
+        session.lifecycle_action = lifecycle.in_flight_action(&key);
+        session.launch_pending = lifecycle.launch_pending(&key);
     }
 }
 
@@ -8049,6 +8278,7 @@ mod tests {
             navigation_generation: creation_navigation,
             previous: None,
             cancellation: cancellation.clone(),
+            herdr_operation: None,
         });
         set_inner_state(
             &workspace.inner,
@@ -8106,6 +8336,7 @@ mod tests {
             navigation_generation: creation_navigation,
             previous: None,
             cancellation: cancellation.clone(),
+            herdr_operation: None,
         });
         set_inner_state(
             &workspace.inner,
@@ -8582,6 +8813,102 @@ mod tests {
                 .expect("delete confirmation")
                 .action(),
             HerdrLifecycleAction::Delete
+        );
+    }
+
+    #[test]
+    fn pending_herdr_launch_is_visible_and_rejects_duplicate_operations() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let stopped = SessionSelection::herdr("wsl", "Ubuntu", "review");
+        let request = capture_herdr_restart_request(&workspace.inner, &stopped)
+            .expect("stopped session may restart");
+        let key = request.operation_key();
+
+        assert!(
+            workspace
+                .inner
+                .herdr_lifecycle
+                .lock()
+                .expect("lifecycle state")
+                .reserve_launch(&key)
+        );
+
+        let snapshot = workspace.snapshot();
+        let review = snapshot.hosts()[0]
+            .herdr_sessions()
+            .iter()
+            .find(|session| session.name() == "review")
+            .expect("review session");
+        assert!(review.launch_pending());
+        assert!(
+            !workspace
+                .inner
+                .herdr_lifecycle
+                .lock()
+                .expect("lifecycle state")
+                .reserve_launch(&key)
+        );
+        assert!(
+            workspace
+                .switch_session(&stopped)
+                .expect_err("a pending restart blocks presentation changes")
+                .to_string()
+                .contains("already starting")
+        );
+        assert!(
+            workspace
+                .request_herdr_lifecycle(&stopped, HerdrLifecycleAction::Delete)
+                .expect_err("lifecycle mutation is blocked while restart is pending")
+                .to_string()
+                .contains("still starting")
+        );
+
+        finish_herdr_launch(&workspace.inner, &key);
+        assert!(!workspace.snapshot().hosts()[0].herdr_sessions()[1].launch_pending());
+    }
+
+    #[test]
+    fn failed_herdr_inventory_blocks_fresh_and_mutating_actions() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        set_herdr_inventory(
+            &workspace.inner,
+            &HerdrInventory::Failed(
+                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
+            ),
+        );
+
+        let create = capture_herdr_create_request(
+            &workspace.inner,
+            "wsl",
+            "Ubuntu",
+            HerdrSessionName::parse("created").expect("valid name"),
+        )
+        .err()
+        .expect("failed inventory blocks creation");
+        assert!(create.to_string().contains("refresh Herdr inventory"));
+
+        let stopped = SessionSelection::herdr("wsl", "Ubuntu", "review");
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        assert!(
+            workspace
+                .switch_session(&running)
+                .expect_err("failed inventory blocks a fresh open")
+                .to_string()
+                .contains("refresh Herdr inventory")
+        );
+        assert!(
+            capture_herdr_restart_request(&workspace.inner, &stopped)
+                .err()
+                .expect("failed inventory blocks restart")
+                .to_string()
+                .contains("refresh Herdr inventory")
+        );
+        assert!(
+            workspace
+                .request_herdr_lifecycle(&stopped, HerdrLifecycleAction::Delete)
+                .expect_err("failed inventory blocks mutation")
+                .to_string()
+                .contains("refresh Herdr inventory")
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -3041,17 +3041,22 @@ impl Workspace {
         let Some(suppressed) = suppressed else {
             return;
         };
-        let _snapshot_write = begin_snapshot_write(&self.inner);
-        if let Some(retained) = suppressed.retained
-            && let Err(error) = restore_closed_retained_herdr_presentation(&self.inner, retained)
-        {
-            self.push_operation_error(format!(
-                "could not restore a retained Herdr presentation after a failed lifecycle action: {error}"
-            ));
+        if let Some(retained) = suppressed.retained {
+            match reopen_closed_retained_herdr_presentation(&self.inner, retained) {
+                Ok(presentation) => {
+                    publish_restored_retained_herdr_presentation(&self.inner, presentation);
+                }
+                Err(error) => {
+                    self.push_operation_error(format!(
+                        "could not restore a retained Herdr presentation after a failed lifecycle action: {error}"
+                    ));
+                }
+            }
         }
         let Some(selection) = suppressed.active_selection else {
             return;
         };
+        let _snapshot_write = begin_snapshot_write(&self.inner);
         let _navigation = self
             .inner
             .navigation
@@ -5705,10 +5710,10 @@ fn restore_presentation_inventory(inner: &Inner) {
     set_inner_state(inner, state);
 }
 
-fn restore_closed_retained_herdr_presentation(
+fn reopen_closed_retained_herdr_presentation(
     inner: &Inner,
     mut closed: ClosedRetainedHerdrPresentation,
-) -> Result<(), WorkspaceError> {
+) -> Result<RetainedPresentation<TerminalWorker>, WorkspaceError> {
     let term = closed.attachment.term;
     let (worker, _snapshot, attached_name, initial_geometry) =
         attach_fresh(inner, &closed.attachment.request, term).map_err(|error| match error {
@@ -5730,19 +5735,26 @@ fn restore_closed_retained_herdr_presentation(
     attached_name.clone_into(&mut closed.attachment.request.name);
     let selection = closed.attachment.request.selection();
     worker.set_clipboard_writes_enabled(false);
+    Ok(RetainedPresentation {
+        key: closed.key,
+        selection,
+        attachment: closed.attachment,
+        worker,
+        presentation_id: closed.presentation_id,
+    })
+}
+
+fn publish_restored_retained_herdr_presentation(
+    inner: &Inner,
+    presentation: RetainedPresentation<TerminalWorker>,
+) {
+    let _snapshot_write = begin_snapshot_write(inner);
     inner
         .retained_presentations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(RetainedPresentation {
-            key: closed.key,
-            selection,
-            attachment: closed.attachment,
-            worker,
-            presentation_id: closed.presentation_id,
-        });
+        .insert(presentation);
     inner.revision.fetch_add(1, Ordering::Release);
-    Ok(())
 }
 
 fn attach_fresh(
@@ -6437,6 +6449,110 @@ mod tests {
             .is_err()
         );
         assert!(!launched, "an in-flight Stop must fence client launch");
+    }
+
+    struct BlockingRestoreRunner {
+        entered: Mutex<Option<mpsc::SyncSender<()>>>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl CommandRunner for BlockingRestoreRunner {
+        fn run(
+            &self,
+            _program: &std::ffi::OsStr,
+            _args: &[std::ffi::OsString],
+            _cancellation: &CancellationToken,
+            _timeout: Duration,
+        ) -> std::io::Result<host::CommandOutput> {
+            if let Some(entered) = self.entered.lock().expect("entered signal").take() {
+                entered.send(()).expect("announce blocked discovery");
+                self.release
+                    .lock()
+                    .expect("release signal")
+                    .recv()
+                    .expect("release blocked discovery");
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "fixture discovery stopped",
+            ))
+        }
+    }
+
+    #[test]
+    fn retained_herdr_recovery_does_not_block_snapshots_during_discovery() {
+        let workspace =
+            Workspace::preview(WorkspaceSnapshot::shell(Appearance::default(), Vec::new()));
+        let snapshot = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot",
+            42,
+            Vec::new(),
+            HerdrInventory::Unavailable,
+        );
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        let runner: SharedCommandRunner = Arc::new(BlockingRestoreRunner {
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        });
+        let host = WslHost::new(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            runner,
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let request = AttachRequest {
+            host_id: "wsl".to_owned(),
+            host,
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            target: AttachTarget::Herdr {
+                executable: "/opt/herdr/bin/herdr".to_owned(),
+                is_default: false,
+                session_directory: "/tmp/herdr/review".to_owned(),
+                socket_path: "/tmp/herdr/review/herdr.sock".to_owned(),
+            },
+            name: "review".to_owned(),
+            inventory_generation: 1,
+        };
+        let suppressed = SuppressedHerdrPresentation {
+            active_selection: None,
+            retained: Some(ClosedRetainedHerdrPresentation {
+                key: request.presentation_key(),
+                attachment: ActiveAttachment {
+                    request,
+                    term: AttachTerm::Xterm256Color,
+                    generation: 1,
+                    fallback: None,
+                },
+                presentation_id: 1,
+            }),
+            navigation_generation: 0,
+        };
+        let recovery_workspace = workspace.clone();
+        let recovery = thread::spawn(move || {
+            recovery_workspace.restore_suppressed_herdr_presentation(Some(suppressed));
+        });
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("recovery reached WSL discovery");
+
+        let snapshot_workspace = workspace.clone();
+        let (snapshot_tx, snapshot_rx) = mpsc::sync_channel(1);
+        let snapshot_reader = thread::spawn(move || {
+            let _snapshot = snapshot_workspace.snapshot();
+            snapshot_tx.send(()).expect("publish completed read");
+        });
+        let snapshot_completed = snapshot_rx.recv_timeout(Duration::from_millis(250)).is_ok();
+
+        release_tx.send(()).expect("release WSL discovery");
+        recovery.join().expect("recovery task");
+        snapshot_reader.join().expect("snapshot reader");
+        assert!(
+            snapshot_completed,
+            "slow retained recovery must not hold the snapshot publication guard"
+        );
     }
 
     #[derive(Default)]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -26,8 +26,18 @@ use terminal::{
 
 const REDUCED_COLOR_NOTICE: &str =
     "Using TERM=xterm because xterm-256color terminfo is unavailable in WSL";
-const CREATE_DISCOVERY_ATTEMPTS: usize = 5;
-const CREATE_DISCOVERY_DELAY: Duration = Duration::from_millis(40);
+const TMUX_CREATE_DISCOVERY_ATTEMPTS: usize = 5;
+const TMUX_CREATE_DISCOVERY_DELAY: Duration = Duration::from_millis(40);
+const HERDR_STARTUP_BACKOFF: [Duration; 8] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+    Duration::from_millis(800),
+    Duration::from_secs(1),
+    Duration::from_secs(1),
+    Duration::from_secs(1),
+];
 const CREATE_IDENTITY_TIMEOUT: Duration = Duration::from_secs(5);
 const CREATE_IDENTITY_MIN_COLUMNS: usize = 120;
 
@@ -4587,11 +4597,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
                 );
             } else {
                 finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
-                let _reconciled = reconcile_herdr_lifecycle_inventory(
-                    &workspace.inner,
-                    pending,
-                    HerdrReconcileMode::ConfirmedOutcome,
-                );
+                let _reconciled = reconcile_herdr_lifecycle_inventory(&workspace.inner, pending);
             }
         }
         Err(error) => {
@@ -4606,11 +4612,7 @@ fn reconcile_herdr_lifecycle_failure(
     operation_error: String,
     suppressed: Option<SuppressedHerdrPresentation>,
 ) {
-    match reconcile_herdr_lifecycle_inventory(
-        &workspace.inner,
-        pending,
-        HerdrReconcileMode::CurrentInventory,
-    ) {
+    match reconcile_herdr_lifecycle_inventory(&workspace.inner, pending) {
         Ok(snapshot) => {
             finish_herdr_lifecycle_state(&workspace.inner, pending.generation);
             if herdr_session_is_still_running(&snapshot, pending) {
@@ -4720,9 +4722,8 @@ fn create_herdr_fresh(
     )?;
 
     let expected_name = request.name.as_str();
-    for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
+    let discovered = poll_herdr_startup(cancellation, &HERDR_STARTUP_BACKOFF, || {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
-            drop(worker);
             return Err(WorkspaceError::new("Herdr creation was superseded"));
         }
         let snapshot = request
@@ -4730,33 +4731,54 @@ fn create_herdr_fresh(
             .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
         if snapshot.endpoint() != &request.endpoint || snapshot.runtime() != &request.runtime {
-            drop(worker);
             return Err(WorkspaceError::new(
                 "WSL changed while creating the Herdr session",
             ));
         }
-        if let HerdrInventory::Available {
-            executable,
-            sessions,
-        } = snapshot.herdr()
-            && executable == &request.executable
-            && let Some(session) = sessions
+        let session = match snapshot.herdr() {
+            HerdrInventory::Available {
+                executable,
+                sessions,
+            } if executable == &request.executable => sessions
                 .iter()
                 .find(|session| {
                     herdr_launch_result_matches(&request.precondition, expected_name, session)
                 })
-                .cloned()
-        {
-            return Ok((worker, snapshot, session, geometry));
-        }
-        if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
-            thread::sleep(CREATE_DISCOVERY_DELAY);
-        }
+                .cloned(),
+            _ => None,
+        };
+        Ok(session.map(|session| (snapshot, session)))
+    })?;
+    if let Some((snapshot, session)) = discovered {
+        return Ok((worker, snapshot, session, geometry));
     }
     drop(worker);
     Err(WorkspaceError::new(
         "Herdr started, but the new session did not appear in inventory; refresh before trying again",
     ))
+}
+
+fn poll_herdr_startup<T>(
+    cancellation: &CancellationToken,
+    delays: &[Duration],
+    mut probe: impl FnMut() -> Result<Option<T>, WorkspaceError>,
+) -> Result<Option<T>, WorkspaceError> {
+    let mut delay_index = 0;
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(WorkspaceError::new("Herdr startup was cancelled"));
+        }
+        if let Some(value) = probe()? {
+            return Ok(Some(value));
+        }
+        let Some(delay) = delays.get(delay_index).copied() else {
+            return Ok(None);
+        };
+        delay_index += 1;
+        if cancellation.wait_cancelled(delay) {
+            return Err(WorkspaceError::new("Herdr startup was cancelled"));
+        }
+    }
 }
 
 fn validate_herdr_launch_precondition(
@@ -4961,7 +4983,7 @@ fn create_fresh(
     let client_identity = worker
         .wait_for_creation_identity(CREATE_IDENTITY_TIMEOUT)
         .map_err(|error| WorkspaceError::new(error.to_string()))?;
-    for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
+    for attempt in 0..TMUX_CREATE_DISCOVERY_ATTEMPTS {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
             drop(worker);
             return Err(WorkspaceError::new("tmux creation was superseded"));
@@ -4979,8 +5001,8 @@ fn create_fresh(
         if let Some(session) = created_session(&snapshot, &client_identity) {
             return Ok((worker, snapshot, session, launch_geometry, term));
         }
-        if attempt + 1 < CREATE_DISCOVERY_ATTEMPTS {
-            thread::sleep(CREATE_DISCOVERY_DELAY);
+        if attempt + 1 < TMUX_CREATE_DISCOVERY_ATTEMPTS {
+            thread::sleep(TMUX_CREATE_DISCOVERY_DELAY);
         }
     }
     drop(worker);
@@ -5368,16 +5390,9 @@ fn publish_herdr_lifecycle_response(
     merge_herdr_lifecycle_inventory(inner, pending, snapshot, publication_generation)
 }
 
-#[derive(Clone, Copy)]
-enum HerdrReconcileMode {
-    CurrentInventory,
-    ConfirmedOutcome,
-}
-
 fn reconcile_herdr_lifecycle_inventory(
     inner: &Inner,
     pending: &PendingHerdrLifecycle,
-    mode: HerdrReconcileMode,
 ) -> Result<HostSnapshot, WorkspaceError> {
     let publication_generation = reserve_constructive_inventory(inner);
     let snapshot = match pending.host.discover(&ConptyAdmissionAttacher::new()) {
@@ -5399,12 +5414,6 @@ fn reconcile_herdr_lifecycle_inventory(
                 "Herdr became unavailable while reconciling the lifecycle action",
             ));
         }
-    }
-    if matches!(mode, HerdrReconcileMode::ConfirmedOutcome)
-        && !herdr_lifecycle_is_reflected(&snapshot, pending)
-    {
-        settle_constructive_inventory(inner, publication_generation);
-        return Ok(snapshot);
     }
     merge_herdr_lifecycle_inventory(inner, pending, snapshot.clone(), publication_generation)?;
     Ok(snapshot)
@@ -5432,6 +5441,7 @@ fn herdr_session_is_still_running(
         )
 }
 
+#[cfg(test)]
 fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrLifecycle) -> bool {
     let HerdrInventory::Available { sessions, .. } = snapshot.herdr() else {
         return false;
@@ -9254,7 +9264,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_response_is_published_without_full_host_discovery() {
+    fn fresh_inventory_supersedes_a_synthetic_lifecycle_response() {
         let (workspace, _runtime) = herdr_workspace_fixture();
         let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
         workspace
@@ -9305,6 +9315,20 @@ mod tests {
             .snapshot
             .clone();
         assert!(herdr_lifecycle_is_reflected(&published, &pending));
+
+        let fresh_generation = reserve_constructive_inventory(&workspace.inner);
+        merge_herdr_lifecycle_inventory(
+            &workspace.inner,
+            &pending,
+            before.clone(),
+            fresh_generation,
+        )
+        .expect("fresh contradictory inventory publishes");
+        assert!(!herdr_lifecycle_is_reflected(&before, &pending));
+        assert_eq!(
+            workspace.snapshot().hosts()[0].herdr_sessions()[0].state(),
+            HerdrSessionState::Running,
+        );
     }
 
     #[test]
@@ -9380,6 +9404,25 @@ mod tests {
             "review",
             &replacement,
         ));
+    }
+
+    #[test]
+    fn herdr_startup_polling_accepts_a_session_after_early_misses() {
+        let cancellation = CancellationToken::new();
+        let mut probes = 0;
+
+        let result = poll_herdr_startup(
+            &cancellation,
+            &[Duration::ZERO; 6],
+            || -> Result<Option<&'static str>, WorkspaceError> {
+                probes += 1;
+                Ok((probes == 6).then_some("running"))
+            },
+        )
+        .expect("polling succeeds");
+
+        assert_eq!(result, Some("running"));
+        assert_eq!(probes, 6);
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -220,6 +220,7 @@ pub struct HerdrSessionItem {
     name: String,
     is_default: bool,
     state: HerdrSessionState,
+    lifecycle_action: Option<HerdrLifecycleAction>,
 }
 
 impl HerdrSessionItem {
@@ -229,6 +230,7 @@ impl HerdrSessionItem {
             name: name.into(),
             is_default,
             state,
+            lifecycle_action: None,
         }
     }
 
@@ -245,6 +247,11 @@ impl HerdrSessionItem {
     #[must_use]
     pub const fn state(&self) -> HerdrSessionState {
         self.state
+    }
+
+    #[must_use]
+    pub const fn lifecycle_action(&self) -> Option<HerdrLifecycleAction> {
+        self.lifecycle_action
     }
 }
 
@@ -690,6 +697,80 @@ struct PendingHerdrLifecycle {
     record: session::HerdrSessionRecord,
 }
 
+impl PendingHerdrLifecycle {
+    fn key(&self) -> HerdrOperationKey {
+        HerdrOperationKey {
+            endpoint: self.endpoint.clone(),
+            runtime: self.runtime.clone(),
+            name: self.record.name().to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HerdrOperationKey {
+    endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
+    name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InFlightHerdrLifecycle {
+    generation: u64,
+    key: HerdrOperationKey,
+    action: HerdrLifecycleAction,
+}
+
+#[derive(Default)]
+struct HerdrLifecycleState {
+    pending: Option<PendingHerdrLifecycle>,
+    in_flight: Vec<InFlightHerdrLifecycle>,
+}
+
+impl HerdrLifecycleState {
+    fn in_flight_action(&self, key: &HerdrOperationKey) -> Option<HerdrLifecycleAction> {
+        self.in_flight
+            .iter()
+            .find(|operation| &operation.key == key)
+            .map(|operation| operation.action)
+    }
+
+    fn start(&mut self, pending: &PendingHerdrLifecycle) -> bool {
+        let key = pending.key();
+        if self.in_flight_action(&key).is_some() {
+            return false;
+        }
+        self.in_flight.push(InFlightHerdrLifecycle {
+            generation: pending.generation,
+            key,
+            action: pending.action,
+        });
+        true
+    }
+
+    fn finish(&mut self, generation: u64) -> bool {
+        let previous_len = self.in_flight.len();
+        self.in_flight
+            .retain(|operation| operation.generation != generation);
+        self.in_flight.len() != previous_len
+    }
+}
+
+fn with_herdr_launch_fence<T, E>(
+    lifecycle: &Mutex<HerdrLifecycleState>,
+    key: &HerdrOperationKey,
+    blocked: impl FnOnce() -> E,
+    launch: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E> {
+    let lifecycle = lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if lifecycle.in_flight_action(key).is_some() {
+        return Err(blocked());
+    }
+    launch()
+}
+
 #[derive(Clone)]
 struct AttachRequest {
     host_id: String,
@@ -699,6 +780,16 @@ struct AttachRequest {
     target: AttachTarget,
     name: String,
     inventory_generation: u64,
+}
+
+impl AttachRequest {
+    fn herdr_operation_key(&self) -> Option<HerdrOperationKey> {
+        (self.target.kind() == SessionKind::Herdr).then(|| HerdrOperationKey {
+            endpoint: self.endpoint.clone(),
+            runtime: self.runtime.clone(),
+            name: self.name.clone(),
+        })
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -760,6 +851,16 @@ struct HerdrCreateRequest {
     executable: String,
     name: HerdrSessionName,
     precondition: HerdrLaunchPrecondition,
+}
+
+impl HerdrCreateRequest {
+    fn operation_key(&self) -> HerdrOperationKey {
+        HerdrOperationKey {
+            endpoint: self.endpoint.clone(),
+            runtime: self.runtime.clone(),
+            name: self.name.as_str().to_owned(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1377,7 +1478,7 @@ struct Inner {
     pending_creation: Mutex<Option<PendingCreation>>,
     pending_kill: Mutex<Option<PendingKill>>,
     kill_generation: AtomicU64,
-    pending_herdr_lifecycle: Mutex<Option<PendingHerdrLifecycle>>,
+    herdr_lifecycle: Mutex<HerdrLifecycleState>,
     herdr_lifecycle_generation: AtomicU64,
     operation_events: Mutex<std::collections::VecDeque<WorkspaceEvent>>,
     terminal_geometry: Mutex<TerminalGeometry>,
@@ -1443,7 +1544,7 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
-                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
@@ -1507,7 +1608,7 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
-                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
@@ -1555,7 +1656,7 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
-                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
@@ -1649,6 +1750,29 @@ impl Workspace {
 
     #[must_use]
     pub fn snapshot(&self) -> WorkspaceSnapshot {
+        let mut hosts = self
+            .inner
+            .hosts
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let current_runtime = self
+            .inner
+            .host
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|published| {
+                (
+                    published.value.snapshot.endpoint().clone(),
+                    published.value.snapshot.runtime().clone(),
+                )
+            });
+        project_herdr_lifecycle(
+            &mut hosts,
+            current_runtime.as_ref(),
+            &self.inner.herdr_lifecycle,
+        );
         WorkspaceSnapshot {
             revision: self.inner.revision.load(Ordering::Acquire),
             appearance: self.inner.appearance.clone(),
@@ -1658,12 +1782,7 @@ impl Workspace {
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone(),
-            hosts: self
-                .inner
-                .hosts
-                .read()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone(),
+            hosts,
             selected_host: self
                 .inner
                 .selected_host
@@ -2427,11 +2546,28 @@ impl Workspace {
         }
         self.cancel_session_kill();
         let pending = capture_herdr_lifecycle(&self.inner, selection, action, generation)?;
-        *self
+        let mut lifecycle = self
             .inner
-            .pending_herdr_lifecycle
+            .herdr_lifecycle
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(pending);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if lifecycle.in_flight_action(&pending.key()).is_some() {
+            return Err(WorkspaceError::new(
+                "a lifecycle action is already running for this Herdr session",
+            ));
+        }
+        if self
+            .inner
+            .herdr_lifecycle_generation
+            .load(Ordering::Acquire)
+            != generation
+        {
+            return Err(WorkspaceError::new(
+                "Herdr lifecycle request is no longer current",
+            ));
+        }
+        lifecycle.pending = Some(pending);
+        drop(lifecycle);
         self.inner.revision.fetch_add(1, Ordering::Release);
         Ok(())
     }
@@ -2443,9 +2579,10 @@ impl Workspace {
             .herdr_lifecycle_generation
             .load(Ordering::Acquire);
         self.inner
-            .pending_herdr_lifecycle
+            .herdr_lifecycle
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pending
             .as_ref()
             .filter(|pending| pending.generation == generation)
             .map(|pending| HerdrLifecycleConfirmation {
@@ -2468,15 +2605,14 @@ impl Workspace {
     /// Returns an error when no confirmation is pending or the lifecycle task
     /// cannot be started.
     pub fn confirm_herdr_lifecycle(&self) -> Result<(), WorkspaceError> {
-        let pending = self
+        let mut lifecycle = self
             .inner
-            .pending_herdr_lifecycle
+            .herdr_lifecycle
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take()
-            .ok_or_else(|| {
-                WorkspaceError::new("no Herdr lifecycle action is awaiting confirmation")
-            })?;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let pending = lifecycle.pending.take().ok_or_else(|| {
+            WorkspaceError::new("no Herdr lifecycle action is awaiting confirmation")
+        })?;
         if self
             .inner
             .herdr_lifecycle_generation
@@ -2487,38 +2623,35 @@ impl Workspace {
                 "Herdr lifecycle confirmation is no longer current",
             ));
         }
+        if !lifecycle.start(&pending) {
+            return Err(WorkspaceError::new(
+                "a lifecycle action is already running for this Herdr session",
+            ));
+        }
+        drop(lifecycle);
         self.inner.revision.fetch_add(1, Ordering::Release);
         let workspace = self.clone();
         let retry = pending.clone();
         if let Err(error) = thread::Builder::new()
             .name(format!("ghosthub-herdr-{}", pending.action.command()))
-            .spawn(move || {
-                if pending.action == HerdrLifecycleAction::Stop {
-                    workspace.finish_herdr_presentation(
-                        &pending.endpoint,
-                        &pending.runtime,
-                        &pending.record,
-                    );
-                }
-                let result = pending.host.mutate_herdr_session(
-                    &pending.endpoint,
-                    &pending.runtime,
-                    &pending.record,
-                    pending.action,
-                    &CancellationToken::new(),
-                );
-                if let Err(error) = result {
-                    workspace.push_operation_error(error.to_string());
-                }
-                let _refresh_started = workspace.refresh();
-                workspace.inner.revision.fetch_add(1, Ordering::Release);
-            })
+            .spawn(move || run_herdr_lifecycle(&workspace, &pending))
         {
-            *self
+            let mut lifecycle = self
                 .inner
-                .pending_herdr_lifecycle
+                .herdr_lifecycle
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(retry);
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            lifecycle.finish(retry.generation);
+            if self
+                .inner
+                .herdr_lifecycle_generation
+                .load(Ordering::Acquire)
+                == retry.generation
+                && lifecycle.pending.is_none()
+            {
+                lifecycle.pending = Some(retry);
+            }
+            drop(lifecycle);
             self.inner.revision.fetch_add(1, Ordering::Release);
             return Err(WorkspaceError::new(format!(
                 "start Herdr lifecycle task: {error}"
@@ -3200,15 +3333,15 @@ fn invalidate_pending_kill(inner: &Inner) -> (u64, bool) {
 }
 
 fn invalidate_pending_herdr_lifecycle(inner: &Inner) -> (u64, bool) {
-    let mut pending = inner
-        .pending_herdr_lifecycle
+    let mut lifecycle = inner
+        .herdr_lifecycle
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let generation = inner
         .herdr_lifecycle_generation
         .fetch_add(1, Ordering::AcqRel)
         + 1;
-    (generation, pending.take().is_some())
+    (generation, lifecycle.pending.take().is_some())
 }
 
 fn activate_retained_presentation(
@@ -3977,6 +4110,39 @@ fn run_herdr_create(
     );
 }
 
+fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
+    if pending.action == HerdrLifecycleAction::Stop {
+        workspace.finish_herdr_presentation(&pending.endpoint, &pending.runtime, &pending.record);
+    }
+    let result = pending
+        .host
+        .mutate_herdr_session(
+            &pending.endpoint,
+            &pending.runtime,
+            &pending.record,
+            pending.action,
+            &CancellationToken::new(),
+        )
+        .map_err(|error| WorkspaceError::new(error.to_string()))
+        .and_then(|_record| {
+            pending
+                .host
+                .discover(&ConptyAdmissionAttacher::new())
+                .map_err(|error| WorkspaceError::new(error.to_string()))
+        })
+        .and_then(|snapshot| merge_herdr_lifecycle_inventory(&workspace.inner, pending, snapshot));
+    if let Err(error) = result {
+        workspace.push_operation_error(error.to_string());
+    }
+    workspace
+        .inner
+        .herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .finish(pending.generation);
+    workspace.inner.revision.fetch_add(1, Ordering::Release);
+}
+
 fn create_herdr_fresh(
     inner: &Inner,
     request: &HerdrCreateRequest,
@@ -4019,25 +4185,37 @@ fn create_herdr_fresh(
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
         return Err(WorkspaceError::new("Herdr creation was superseded"));
     }
-    let authority = request.host.herdr_launch_once(
-        before.endpoint(),
-        &request.executable,
-        request.name.clone(),
-        request.precondition.is_default(),
-    );
-    let geometry = *inner
-        .terminal_geometry
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let worker = TerminalWorker::launch_herdr_with_metadata(
-        authority,
-        geometry.grid,
-        geometry.sequence,
-        geometry.pixels,
-        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
-    )
-    .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    let (worker, geometry) = with_herdr_launch_fence(
+        &inner.herdr_lifecycle,
+        &request.operation_key(),
+        || {
+            WorkspaceError::new(
+                "Herdr session lifecycle is changing; wait for inventory to refresh",
+            )
+        },
+        || {
+            let authority = request.host.herdr_launch_once(
+                before.endpoint(),
+                &request.executable,
+                request.name.clone(),
+                request.precondition.is_default(),
+            );
+            let geometry = *inner
+                .terminal_geometry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let worker = TerminalWorker::launch_herdr_with_metadata(
+                authority,
+                geometry.grid,
+                geometry.sequence,
+                geometry.pixels,
+                ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+                default_colors(&inner.appearance),
+            )
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+            Ok((worker, geometry))
+        },
+    )?;
 
     for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
@@ -4566,7 +4744,7 @@ fn merge_created_inventory(
         &request.endpoint,
         &request.runtime,
         snapshot,
-        "tmux",
+        "the created tmux session",
     )
 }
 
@@ -4581,7 +4759,22 @@ fn merge_herdr_created_inventory(
         &request.endpoint,
         &request.runtime,
         snapshot,
-        "Herdr",
+        "the created Herdr session",
+    )
+}
+
+fn merge_herdr_lifecycle_inventory(
+    inner: &Inner,
+    pending: &PendingHerdrLifecycle,
+    snapshot: HostSnapshot,
+) -> Result<u64, WorkspaceError> {
+    merge_constructive_inventory(
+        inner,
+        &pending.host,
+        &pending.endpoint,
+        &pending.runtime,
+        snapshot,
+        "the Herdr lifecycle result",
     )
 }
 
@@ -4591,7 +4784,7 @@ fn merge_constructive_inventory(
     endpoint: &host::WslEndpoint,
     runtime: &host::WslRuntimeIdentity,
     snapshot: HostSnapshot,
-    session_type: &str,
+    operation: &str,
 ) -> Result<u64, WorkspaceError> {
     let _publication = inner
         .refresh_publication
@@ -4599,7 +4792,7 @@ fn merge_constructive_inventory(
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     if snapshot.endpoint() != endpoint || snapshot.runtime() != runtime {
         return Err(WorkspaceError::new(format!(
-            "WSL changed while publishing the created {session_type} session"
+            "WSL changed while publishing {operation}"
         )));
     }
     let published_generation = inner
@@ -4614,7 +4807,7 @@ fn merge_constructive_inventory(
         })
         .ok_or_else(|| {
             WorkspaceError::new(format!(
-                "the WSL endpoint changed while creating the {session_type} session; refresh before trying again"
+                "the WSL endpoint changed while publishing {operation}; refresh before trying again"
             ))
         })?;
     let current_generation = inner.refresh_generation.load(Ordering::Acquire);
@@ -5004,22 +5197,38 @@ fn launch_fresh_herdr(
     let AttachTarget::Herdr { executable, .. } = &request.target else {
         unreachable!("Herdr launch requires a Herdr target");
     };
-    let plan = request
-        .host
-        .herdr_attach_plan(fresh.endpoint(), executable, session, term);
-    let geometry = *inner
-        .terminal_geometry
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let worker = TerminalWorker::attach_herdr_with_metadata(
-        &plan,
-        geometry.grid,
-        geometry.sequence,
-        geometry.pixels,
-        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
-    )
-    .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+    let operation_key = request
+        .herdr_operation_key()
+        .expect("Herdr launch has an operation key");
+    let (worker, geometry) = with_herdr_launch_fence(
+        &inner.herdr_lifecycle,
+        &operation_key,
+        || AttachFreshError::SessionChanged {
+            error: WorkspaceError::new(
+                "Herdr session lifecycle is changing; wait for inventory to refresh",
+            ),
+            snapshot: fresh.clone(),
+        },
+        || {
+            let plan = request
+                .host
+                .herdr_attach_plan(fresh.endpoint(), executable, session, term);
+            let geometry = *inner
+                .terminal_geometry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let worker = TerminalWorker::attach_herdr_with_metadata(
+                &plan,
+                geometry.grid,
+                geometry.sequence,
+                geometry.pixels,
+                ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+                default_colors(&inner.appearance),
+            )
+            .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+            Ok((worker, geometry))
+        },
+    )?;
     Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
 }
 
@@ -5100,6 +5309,32 @@ fn set_herdr_inventory(inner: &Inner, inventory: &HerdrInventory) {
         HerdrInventory::Failed(error) => {
             host.herdr_diagnostic = Some(HostDiagnostic::new(error.kind(), error.to_string()));
         }
+    }
+}
+
+fn project_herdr_lifecycle(
+    hosts: &mut [HostItem],
+    current_runtime: Option<&(host::WslEndpoint, host::WslRuntimeIdentity)>,
+    lifecycle: &Mutex<HerdrLifecycleState>,
+) {
+    let Some((endpoint, runtime)) = current_runtime else {
+        return;
+    };
+    let lifecycle = lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(host) = hosts
+        .iter_mut()
+        .find(|host| host.endpoint == endpoint.distro())
+    else {
+        return;
+    };
+    for session in &mut host.herdr_sessions {
+        session.lifecycle_action = lifecycle.in_flight_action(&HerdrOperationKey {
+            endpoint: endpoint.clone(),
+            runtime: runtime.clone(),
+            name: session.name.clone(),
+        });
     }
 }
 
@@ -5310,6 +5545,55 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::sync::{Barrier, atomic::AtomicUsize};
+
+    #[test]
+    fn lifecycle_registration_waits_for_the_herdr_launch_fence() {
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot", 42, Vec::new());
+        let key = HerdrOperationKey {
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            name: "review".to_owned(),
+        };
+        let lifecycle = Mutex::new(HerdrLifecycleState::default());
+
+        with_herdr_launch_fence(
+            &lifecycle,
+            &key,
+            || (),
+            || {
+                assert!(
+                    lifecycle.try_lock().is_err(),
+                    "client launch must hold the lifecycle registration lock"
+                );
+                Ok(())
+            },
+        )
+        .expect("launch without an operation");
+
+        lifecycle
+            .lock()
+            .expect("lifecycle state")
+            .in_flight
+            .push(InFlightHerdrLifecycle {
+                generation: 1,
+                key: key.clone(),
+                action: HerdrLifecycleAction::Stop,
+            });
+        let mut launched = false;
+        assert!(
+            with_herdr_launch_fence(
+                &lifecycle,
+                &key,
+                || "blocked",
+                || {
+                    launched = true;
+                    Ok("launched")
+                },
+            )
+            .is_err()
+        );
+        assert!(!launched, "an in-flight Stop must fence client launch");
+    }
 
     #[derive(Default)]
     struct ManualRefreshRuntime {
@@ -7557,8 +7841,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn successful_refresh_projects_herdr_without_changing_tmux_readiness() {
+    fn herdr_workspace_fixture() -> (Workspace, Arc<ManualRefreshRuntime>) {
         let runtime = Arc::new(ManualRefreshRuntime::default());
         let snapshot = HostSnapshot::test_fixture_with_herdr(
             "Ubuntu",
@@ -7604,6 +7887,12 @@ mod tests {
 
         workspace.connect_enabled_hosts().expect("start refresh");
         runtime.run_next_work();
+        (workspace, runtime)
+    }
+
+    #[test]
+    fn successful_refresh_projects_herdr_without_changing_tmux_readiness() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
 
         let snapshot = workspace.snapshot();
         let host = &snapshot.hosts()[0];
@@ -7614,6 +7903,11 @@ mod tests {
         assert!(host.herdr_sessions()[0].is_default());
         assert_eq!(host.herdr_sessions()[1].state(), HerdrSessionState::Stopped);
         assert!(host.herdr_diagnostic().is_none());
+    }
+
+    #[test]
+    fn in_flight_herdr_lifecycle_is_visible_and_rejects_duplicates() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
 
         let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
         workspace
@@ -7626,7 +7920,36 @@ mod tests {
                 .action(),
             HerdrLifecycleAction::Stop
         );
-        workspace.cancel_herdr_lifecycle();
+        let stop_generation = {
+            let mut lifecycle = workspace
+                .inner
+                .herdr_lifecycle
+                .lock()
+                .expect("lifecycle state");
+            let pending = lifecycle.pending.take().expect("pending stop");
+            assert!(lifecycle.start(&pending));
+            pending.generation
+        };
+        assert_eq!(
+            workspace.snapshot().hosts()[0].herdr_sessions()[0].lifecycle_action(),
+            Some(HerdrLifecycleAction::Stop)
+        );
+        assert!(
+            workspace
+                .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+                .is_err(),
+            "a duplicate lifecycle action is rejected while Stop is in flight"
+        );
+        workspace
+            .inner
+            .herdr_lifecycle
+            .lock()
+            .expect("lifecycle state")
+            .finish(stop_generation);
+        assert_eq!(
+            workspace.snapshot().hosts()[0].herdr_sessions()[0].lifecycle_action(),
+            None
+        );
 
         let stopped = SessionSelection::herdr("wsl", "Ubuntu", "review");
         let restart = capture_herdr_restart_request(&workspace.inner, &stopped)

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -14,7 +14,8 @@ use host::{
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
 pub use session::{
-    HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName, SessionNameError,
+    HerdrLifecycleAction, HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName,
+    SessionNameError,
 };
 use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
@@ -453,6 +454,24 @@ pub struct SessionKillConfirmation {
     selection: SessionSelection,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrLifecycleConfirmation {
+    selection: SessionSelection,
+    action: HerdrLifecycleAction,
+}
+
+impl HerdrLifecycleConfirmation {
+    #[must_use]
+    pub const fn selection(&self) -> &SessionSelection {
+        &self.selection
+    }
+
+    #[must_use]
+    pub const fn action(&self) -> HerdrLifecycleAction {
+        self.action
+    }
+}
+
 impl SessionKillConfirmation {
     #[must_use]
     pub const fn selection(&self) -> &SessionSelection {
@@ -661,6 +680,17 @@ struct PendingKill {
 }
 
 #[derive(Clone)]
+struct PendingHerdrLifecycle {
+    generation: u64,
+    selection: SessionSelection,
+    action: HerdrLifecycleAction,
+    host: RuntimeHost,
+    endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
+    record: session::HerdrSessionRecord,
+}
+
+#[derive(Clone)]
 struct AttachRequest {
     host_id: String,
     host: RuntimeHost,
@@ -690,6 +720,20 @@ impl AttachTarget {
         }
     }
 
+    fn herdr_matches(&self, record: &session::HerdrSessionRecord) -> bool {
+        matches!(
+            self,
+            Self::Herdr {
+                is_default,
+                session_directory,
+                socket_path,
+                ..
+            } if *is_default == record.is_default()
+                && session_directory == record.session_directory()
+                && socket_path == record.socket_path()
+        )
+    }
+
     const fn kind(&self) -> SessionKind {
         match self {
             Self::Tmux(_) => SessionKind::Tmux,
@@ -715,6 +759,22 @@ struct HerdrCreateRequest {
     runtime: host::WslRuntimeIdentity,
     executable: String,
     name: HerdrSessionName,
+    precondition: HerdrLaunchPrecondition,
+}
+
+#[derive(Clone)]
+enum HerdrLaunchPrecondition {
+    Absent,
+    Stopped(session::HerdrSessionRecord),
+}
+
+impl HerdrLaunchPrecondition {
+    const fn is_default(&self) -> bool {
+        match self {
+            Self::Absent => false,
+            Self::Stopped(record) => record.is_default(),
+        }
+    }
 }
 
 struct PendingCreation {
@@ -1317,6 +1377,8 @@ struct Inner {
     pending_creation: Mutex<Option<PendingCreation>>,
     pending_kill: Mutex<Option<PendingKill>>,
     kill_generation: AtomicU64,
+    pending_herdr_lifecycle: Mutex<Option<PendingHerdrLifecycle>>,
+    herdr_lifecycle_generation: AtomicU64,
     operation_events: Mutex<std::collections::VecDeque<WorkspaceEvent>>,
     terminal_geometry: Mutex<TerminalGeometry>,
     allow_remote_clipboard_write: bool,
@@ -1381,6 +1443,8 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
+                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write: true,
@@ -1443,6 +1507,8 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
+                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -1489,6 +1555,8 @@ impl Workspace {
                 pending_creation: Mutex::new(None),
                 pending_kill: Mutex::new(None),
                 kill_generation: AtomicU64::new(0),
+                pending_herdr_lifecycle: Mutex::new(None),
+                herdr_lifecycle_generation: AtomicU64::new(0),
                 operation_events: Mutex::new(std::collections::VecDeque::new()),
                 terminal_geometry: Mutex::new(default_terminal_geometry()),
                 allow_remote_clipboard_write,
@@ -1842,6 +1910,37 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let request = capture_herdr_create_request(&self.inner, host_id, endpoint, name)?;
+        self.start_herdr_launch(&request, navigation)
+    }
+
+    /// Restart one stopped Herdr session and attach the launched client.
+    ///
+    /// Restart consumes the same one-shot constructive authority as creation,
+    /// but only after the stopped record and its configuration paths are
+    /// revalidated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the selected session is no longer stopped, the
+    /// endpoint changed, or the launch task cannot be started.
+    pub fn restart_herdr_session(
+        &self,
+        selection: &SessionSelection,
+    ) -> Result<(), WorkspaceError> {
+        let navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let request = capture_herdr_restart_request(&self.inner, selection)?;
+        self.start_herdr_launch(&request, navigation)
+    }
+
+    fn start_herdr_launch(
+        &self,
+        request: &HerdrCreateRequest,
+        navigation: std::sync::MutexGuard<'_, ()>,
+    ) -> Result<(), WorkspaceError> {
         let navigation_generation = self.begin_navigation();
         let in_flight_fallback = self.supersede_inflight_attachment()?;
         let visible_previous = self.retain_active_presentation()?;
@@ -1870,7 +1969,7 @@ impl Workspace {
         let inner = Arc::clone(&self.inner);
         let spawn_request = request.clone();
         if let Err(error) = thread::Builder::new()
-            .name("ghosthub-herdr-create".to_owned())
+            .name("ghosthub-herdr-launch".to_owned())
             .spawn(move || {
                 run_herdr_create(&inner, &spawn_request, navigation_generation, &cancellation);
             })
@@ -1880,10 +1979,10 @@ impl Workspace {
                 &self.inner,
                 None,
                 navigation_generation,
-                format!("start Herdr creation task: {error}"),
+                format!("start Herdr launch task: {error}"),
             );
             return Err(WorkspaceError::new(format!(
-                "start Herdr creation task: {error}"
+                "start Herdr launch task: {error}"
             )));
         }
         Ok(())
@@ -1891,6 +1990,7 @@ impl Workspace {
 
     fn begin_navigation(&self) -> u64 {
         invalidate_pending_kill(&self.inner);
+        invalidate_pending_herdr_lifecycle(&self.inner);
         self.inner
             .navigation_generation
             .fetch_add(1, Ordering::AcqRel)
@@ -2187,6 +2287,10 @@ impl Workspace {
         if removed {
             self.inner.revision.fetch_add(1, Ordering::Release);
         }
+        let (_herdr_generation, herdr_removed) = invalidate_pending_herdr_lifecycle(&self.inner);
+        if herdr_removed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
         let request = capture_kill_request(&self.inner, selection)?;
         let workspace = self.clone();
         thread::Builder::new()
@@ -2304,6 +2408,125 @@ impl Workspace {
         Ok(())
     }
 
+    /// Prepare a confirmed Herdr Stop or Delete action from current inventory.
+    ///
+    /// The host revalidates the record again immediately before mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the selected record is missing, in the wrong
+    /// state, or is Herdr's non-deletable default session.
+    pub fn request_herdr_lifecycle(
+        &self,
+        selection: &SessionSelection,
+        action: HerdrLifecycleAction,
+    ) -> Result<(), WorkspaceError> {
+        let (generation, removed) = invalidate_pending_herdr_lifecycle(&self.inner);
+        if removed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+        self.cancel_session_kill();
+        let pending = capture_herdr_lifecycle(&self.inner, selection, action, generation)?;
+        *self
+            .inner
+            .pending_herdr_lifecycle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(pending);
+        self.inner.revision.fetch_add(1, Ordering::Release);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn herdr_lifecycle_confirmation(&self) -> Option<HerdrLifecycleConfirmation> {
+        let generation = self
+            .inner
+            .herdr_lifecycle_generation
+            .load(Ordering::Acquire);
+        self.inner
+            .pending_herdr_lifecycle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|pending| pending.generation == generation)
+            .map(|pending| HerdrLifecycleConfirmation {
+                selection: pending.selection.clone(),
+                action: pending.action,
+            })
+    }
+
+    pub fn cancel_herdr_lifecycle(&self) {
+        let (_generation, removed) = invalidate_pending_herdr_lifecycle(&self.inner);
+        if removed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    /// Execute the confirmed, freshly revalidated Herdr mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no confirmation is pending or the lifecycle task
+    /// cannot be started.
+    pub fn confirm_herdr_lifecycle(&self) -> Result<(), WorkspaceError> {
+        let pending = self
+            .inner
+            .pending_herdr_lifecycle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .ok_or_else(|| {
+                WorkspaceError::new("no Herdr lifecycle action is awaiting confirmation")
+            })?;
+        if self
+            .inner
+            .herdr_lifecycle_generation
+            .load(Ordering::Acquire)
+            != pending.generation
+        {
+            return Err(WorkspaceError::new(
+                "Herdr lifecycle confirmation is no longer current",
+            ));
+        }
+        self.inner.revision.fetch_add(1, Ordering::Release);
+        let workspace = self.clone();
+        let retry = pending.clone();
+        if let Err(error) = thread::Builder::new()
+            .name(format!("ghosthub-herdr-{}", pending.action.command()))
+            .spawn(move || {
+                if pending.action == HerdrLifecycleAction::Stop {
+                    workspace.finish_herdr_presentation(
+                        &pending.endpoint,
+                        &pending.runtime,
+                        &pending.record,
+                    );
+                }
+                let result = pending.host.mutate_herdr_session(
+                    &pending.endpoint,
+                    &pending.runtime,
+                    &pending.record,
+                    pending.action,
+                    &CancellationToken::new(),
+                );
+                if let Err(error) = result {
+                    workspace.push_operation_error(error.to_string());
+                }
+                let _refresh_started = workspace.refresh();
+                workspace.inner.revision.fetch_add(1, Ordering::Release);
+            })
+        {
+            *self
+                .inner
+                .pending_herdr_lifecycle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(retry);
+            self.inner.revision.fetch_add(1, Ordering::Release);
+            return Err(WorkspaceError::new(format!(
+                "start Herdr lifecycle task: {error}"
+            )));
+        }
+        Ok(())
+    }
+
     fn push_operation_error(&self, error: String) {
         let mut events = self
             .inner
@@ -2355,6 +2578,48 @@ impl Workspace {
                 key.endpoint == endpoint.distro()
                     && key.runtime == *runtime
                     && key.target.tmux() == Some(identity)
+            });
+        if changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    fn finish_herdr_presentation(
+        &self,
+        endpoint: &host::WslEndpoint,
+        runtime: &host::WslRuntimeIdentity,
+        record: &session::HerdrSessionRecord,
+    ) {
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let key_matches = |request: &AttachRequest| {
+            request.endpoint == *endpoint
+                && request.runtime == *runtime
+                && request.name == record.name()
+                && request.target.herdr_matches(record)
+        };
+        let active_matches = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some_and(|active| key_matches(&active.request));
+        if active_matches {
+            self.detach_locked();
+        }
+        let changed = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove_matching(|key| {
+                key.endpoint == endpoint.distro()
+                    && key.runtime == *runtime
+                    && key.target.herdr_matches(record)
             });
         if changed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -2934,6 +3199,18 @@ fn invalidate_pending_kill(inner: &Inner) -> (u64, bool) {
     (generation, pending_kill.take().is_some())
 }
 
+fn invalidate_pending_herdr_lifecycle(inner: &Inner) -> (u64, bool) {
+    let mut pending = inner
+        .pending_herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let generation = inner
+        .herdr_lifecycle_generation
+        .fetch_add(1, Ordering::AcqRel)
+        + 1;
+    (generation, pending.take().is_some())
+}
+
 fn activate_retained_presentation(
     inner: &Inner,
     key: &PresentationKey,
@@ -3215,6 +3492,64 @@ fn capture_kill_request(
     })
 }
 
+fn capture_herdr_lifecycle(
+    inner: &Inner,
+    selection: &SessionSelection,
+    action: HerdrLifecycleAction,
+    generation: u64,
+) -> Result<PendingHerdrLifecycle, WorkspaceError> {
+    if selection.kind() != SessionKind::Herdr {
+        return Err(WorkspaceError::new(
+            "Herdr lifecycle actions require a Herdr session",
+        ));
+    }
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, _inventory_generation| {
+        if context.snapshot.endpoint().distro() != selection.endpoint() {
+            return Err(WorkspaceError::new(
+                "host endpoint changed; refresh the Herdr session selection",
+            ));
+        }
+        let HerdrInventory::Available { sessions, .. } = context.snapshot.herdr() else {
+            return Err(WorkspaceError::new("Herdr is not available on this host"));
+        };
+        let record = sessions
+            .iter()
+            .find(|session| session.name() == selection.session())
+            .cloned()
+            .ok_or_else(|| WorkspaceError::new("Herdr session is not in current inventory"))?;
+        if record.state() != action.expected_state() {
+            let expected = match action.expected_state() {
+                HerdrSessionState::Running => "running",
+                HerdrSessionState::Stopped => "stopped",
+            };
+            return Err(WorkspaceError::new(format!(
+                "Herdr session is no longer {expected}"
+            )));
+        }
+        if action == HerdrLifecycleAction::Delete && record.is_default() {
+            return Err(WorkspaceError::new(
+                "Herdr's default session cannot be deleted",
+            ));
+        }
+        Ok(PendingHerdrLifecycle {
+            generation,
+            selection: selection.clone(),
+            action,
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
+            record,
+        })
+    })
+}
+
 fn capture_create_request(
     inner: &Inner,
     host_id: &str,
@@ -3332,6 +3667,58 @@ fn capture_herdr_create_request(
             runtime: context.snapshot.runtime().clone(),
             executable: executable.clone(),
             name,
+            precondition: HerdrLaunchPrecondition::Absent,
+        })
+    })
+}
+
+fn capture_herdr_restart_request(
+    inner: &Inner,
+    selection: &SessionSelection,
+) -> Result<HerdrCreateRequest, WorkspaceError> {
+    if selection.kind() != SessionKind::Herdr {
+        return Err(WorkspaceError::new(
+            "the selected session is not a Herdr session",
+        ));
+    }
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, _inventory_generation| {
+        if context.snapshot.endpoint().distro() != selection.endpoint() {
+            return Err(WorkspaceError::new(
+                "the WSL endpoint changed; refresh before restarting the session",
+            ));
+        }
+        let HerdrInventory::Available {
+            executable,
+            sessions,
+        } = context.snapshot.herdr()
+        else {
+            return Err(WorkspaceError::new("Herdr is not available on this host"));
+        };
+        let record = sessions
+            .iter()
+            .find(|session| session.name() == selection.session())
+            .cloned()
+            .ok_or_else(|| WorkspaceError::new("Herdr session is no longer in inventory"))?;
+        if record.state() != HerdrSessionState::Stopped {
+            return Err(WorkspaceError::new("Herdr session is already running"));
+        }
+        let name = HerdrSessionName::parse(record.name())
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        Ok(HerdrCreateRequest {
+            host_id: selection.host_id().to_owned(),
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
+            executable: executable.clone(),
+            name,
+            precondition: HerdrLaunchPrecondition::Stopped(record),
         })
     })
 }
@@ -3625,14 +4012,10 @@ fn create_herdr_fresh(
             "the Herdr executable changed; refresh before creating the session",
         ));
     }
-    if sessions
+    let current = sessions
         .iter()
-        .any(|session| session.name() == request.name.as_str())
-    {
-        return Err(WorkspaceError::new(
-            "a Herdr session with this name already exists; restart it instead",
-        ));
-    }
+        .find(|session| session.name() == request.name.as_str());
+    validate_herdr_launch_precondition(&request.precondition, current)?;
     if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
         return Err(WorkspaceError::new("Herdr creation was superseded"));
     }
@@ -3640,6 +4023,7 @@ fn create_herdr_fresh(
         before.endpoint(),
         &request.executable,
         request.name.clone(),
+        request.precondition.is_default(),
     );
     let geometry = *inner
         .terminal_geometry
@@ -3693,6 +4077,38 @@ fn create_herdr_fresh(
     Err(WorkspaceError::new(
         "Herdr started, but the new session did not appear in inventory; refresh before trying again",
     ))
+}
+
+fn validate_herdr_launch_precondition(
+    precondition: &HerdrLaunchPrecondition,
+    current: Option<&session::HerdrSessionRecord>,
+) -> Result<(), WorkspaceError> {
+    match (precondition, current) {
+        (HerdrLaunchPrecondition::Absent, None) => {}
+        (HerdrLaunchPrecondition::Absent, Some(_)) => {
+            return Err(WorkspaceError::new(
+                "a Herdr session with this name already exists; restart it instead",
+            ));
+        }
+        (HerdrLaunchPrecondition::Stopped(expected), Some(current))
+            if current.state() == HerdrSessionState::Stopped
+                && current.session_directory() == expected.session_directory()
+                && current.socket_path() == expected.socket_path() => {}
+        (HerdrLaunchPrecondition::Stopped(_), Some(current))
+            if current.state() == HerdrSessionState::Running =>
+        {
+            return Err(WorkspaceError::new("Herdr session is already running"));
+        }
+        (HerdrLaunchPrecondition::Stopped(_), Some(_)) => {
+            return Err(WorkspaceError::new(
+                "Herdr session moved to a different configuration",
+            ));
+        }
+        (HerdrLaunchPrecondition::Stopped(_), None) => {
+            return Err(WorkspaceError::new("Herdr session no longer exists"));
+        }
+    }
+    Ok(())
 }
 
 fn publish_created_presentation(
@@ -7198,6 +7614,37 @@ mod tests {
         assert!(host.herdr_sessions()[0].is_default());
         assert_eq!(host.herdr_sessions()[1].state(), HerdrSessionState::Stopped);
         assert!(host.herdr_diagnostic().is_none());
+
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        workspace
+            .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+            .expect("running session may be stopped");
+        assert_eq!(
+            workspace
+                .herdr_lifecycle_confirmation()
+                .expect("stop confirmation")
+                .action(),
+            HerdrLifecycleAction::Stop
+        );
+        workspace.cancel_herdr_lifecycle();
+
+        let stopped = SessionSelection::herdr("wsl", "Ubuntu", "review");
+        let restart = capture_herdr_restart_request(&workspace.inner, &stopped)
+            .expect("stopped session may restart");
+        assert!(matches!(
+            restart.precondition,
+            HerdrLaunchPrecondition::Stopped(record) if record.name() == "review"
+        ));
+        workspace
+            .request_herdr_lifecycle(&stopped, HerdrLifecycleAction::Delete)
+            .expect("stopped named session may be deleted");
+        assert_eq!(
+            workspace
+                .herdr_lifecycle_confirmation()
+                .expect("delete confirmation")
+                .action(),
+            HerdrLifecycleAction::Delete
+        );
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -4719,6 +4719,7 @@ fn create_herdr_fresh(
         },
     )?;
 
+    let expected_name = request.name.as_str();
     for attempt in 0..CREATE_DISCOVERY_ATTEMPTS {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
             drop(worker);
@@ -4742,9 +4743,7 @@ fn create_herdr_fresh(
             && let Some(session) = sessions
                 .iter()
                 .find(|session| {
-                    session.name() == request.name.as_str()
-                        && session.is_default() == request.precondition.is_default()
-                        && session.state() == HerdrSessionState::Running
+                    herdr_launch_result_matches(&request.precondition, expected_name, session)
                 })
                 .cloned()
         {
@@ -4791,6 +4790,26 @@ fn validate_herdr_launch_precondition(
         }
     }
     Ok(())
+}
+
+fn herdr_launch_result_matches(
+    precondition: &HerdrLaunchPrecondition,
+    expected_name: &str,
+    current: &session::HerdrSessionRecord,
+) -> bool {
+    if current.name() != expected_name
+        || current.is_default() != precondition.is_default()
+        || current.state() != HerdrSessionState::Running
+    {
+        return false;
+    }
+    match precondition {
+        HerdrLaunchPrecondition::Absent => true,
+        HerdrLaunchPrecondition::Stopped(expected) => {
+            current.session_directory() == expected.session_directory()
+                && current.socket_path() == expected.socket_path()
+        }
+    }
 }
 
 fn publish_created_presentation(
@@ -5340,7 +5359,7 @@ fn publish_herdr_lifecycle_response(
                 "the WSL endpoint changed while publishing the Herdr lifecycle response",
             )
         })?
-        .with_herdr_lifecycle(pending.action, &pending.record, record)
+        .with_herdr_lifecycle(pending.action, &pending.executable, &pending.record, record)
         .ok_or_else(|| {
             WorkspaceError::new(
                 "the Herdr lifecycle response no longer matches published inventory",
@@ -9337,6 +9356,30 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn restart_result_rejects_a_same_named_replacement() {
+        let expected = session::HerdrSessionRecord::new(
+            "review",
+            false,
+            HerdrSessionState::Stopped,
+            "/tmp/herdr/review",
+            "/tmp/herdr/review/herdr.sock",
+        );
+        let replacement = session::HerdrSessionRecord::new(
+            "review",
+            false,
+            HerdrSessionState::Running,
+            "/tmp/herdr/replacement",
+            "/tmp/herdr/replacement/herdr.sock",
+        );
+
+        assert!(!herdr_launch_result_matches(
+            &HerdrLaunchPrecondition::Stopped(expected),
+            "review",
+            &replacement,
+        ));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -741,6 +741,7 @@ struct InFlightHerdrLifecycle {
     generation: u64,
     key: HerdrOperationKey,
     action: HerdrLifecycleAction,
+    reconcile_after_generation: Option<u64>,
 }
 
 #[derive(Default)]
@@ -785,6 +786,7 @@ impl HerdrLifecycleState {
             generation: pending.generation,
             key,
             action: pending.action,
+            reconcile_after_generation: None,
         });
         true
     }
@@ -796,16 +798,37 @@ impl HerdrLifecycleState {
         self.in_flight.len() != previous_len
     }
 
-    fn reconcile(&mut self, snapshot: &HostSnapshot) -> bool {
+    fn mark_uncertain(&mut self, generation: u64, reconcile_after_generation: u64) -> bool {
+        let Some(operation) = self
+            .in_flight
+            .iter_mut()
+            .find(|operation| operation.generation == generation)
+        else {
+            return false;
+        };
+        operation.reconcile_after_generation = Some(reconcile_after_generation);
+        true
+    }
+
+    fn reconcile(&mut self, snapshot: &HostSnapshot, publication_generation: u64) -> bool {
         let previous_len = self.in_flight.len();
         self.in_flight.retain(|operation| {
+            let Some(reconcile_after_generation) = operation.reconcile_after_generation else {
+                return true;
+            };
+            if publication_generation <= reconcile_after_generation {
+                return true;
+            }
             if operation.key.endpoint != *snapshot.endpoint() {
+                return true;
+            }
+            if !matches!(snapshot.herdr(), HerdrInventory::Available { .. }) {
                 return true;
             }
             if operation.key.runtime != *snapshot.runtime() {
                 return false;
             }
-            matches!(snapshot.herdr(), HerdrInventory::Failed(_))
+            false
         });
         self.in_flight.len() != previous_len
     }
@@ -4232,7 +4255,7 @@ fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bo
 
 fn publish_discovered_host(inner: &Inner, context: HostContext, generation: u64) {
     let state = ready_content(&context.snapshot);
-    reconcile_herdr_lifecycle_fences(inner, &context.snapshot);
+    reconcile_herdr_lifecycle_fences(inner, &context.snapshot, generation);
     set_herdr_inventory(inner, context.snapshot.herdr());
     *inner
         .host
@@ -4465,6 +4488,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
         pending.action,
         &CancellationToken::new(),
         || {
+            reserve_constructive_inventory(&workspace.inner);
             if pending.action == HerdrLifecycleAction::Stop {
                 suppressed = workspace.suppress_active_herdr_presentation(pending);
             }
@@ -5267,14 +5291,31 @@ fn reconcile_herdr_lifecycle_inventory(
     pending: &PendingHerdrLifecycle,
     mode: HerdrReconcileMode,
 ) -> Result<HostSnapshot, WorkspaceError> {
-    let publication_generation = inner.refresh_generation.load(Ordering::Acquire);
-    let snapshot = pending
-        .host
-        .discover(&ConptyAdmissionAttacher::new())
-        .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    let publication_generation = reserve_constructive_inventory(inner);
+    let snapshot = match pending.host.discover(&ConptyAdmissionAttacher::new()) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            settle_constructive_inventory(inner, publication_generation);
+            return Err(WorkspaceError::new(error.to_string()));
+        }
+    };
+    match snapshot.herdr() {
+        HerdrInventory::Available { .. } => {}
+        HerdrInventory::Failed(error) => {
+            settle_constructive_inventory(inner, publication_generation);
+            return Err(WorkspaceError::new(error.to_string()));
+        }
+        HerdrInventory::Unavailable => {
+            settle_constructive_inventory(inner, publication_generation);
+            return Err(WorkspaceError::new(
+                "Herdr became unavailable while reconciling the lifecycle action",
+            ));
+        }
+    }
     if matches!(mode, HerdrReconcileMode::ConfirmedOutcome)
         && !herdr_lifecycle_is_reflected(&snapshot, pending)
     {
+        settle_constructive_inventory(inner, publication_generation);
         return Ok(snapshot);
     }
     merge_herdr_lifecycle_inventory(inner, pending, snapshot.clone(), publication_generation)?;
@@ -5327,6 +5368,12 @@ fn publish_herdr_lifecycle_uncertain(
     message: &str,
 ) {
     let _snapshot_write = begin_snapshot_write(inner);
+    let reconcile_after_generation = inner.refresh_generation.load(Ordering::Acquire);
+    inner
+        .herdr_lifecycle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .mark_uncertain(pending.generation, reconcile_after_generation);
     let mut hosts = inner
         .hosts
         .write()
@@ -5390,7 +5437,7 @@ fn merge_constructive_inventory(
     let inventory_generation = publication_generation;
 
     let inventory_state = ready_content(&snapshot);
-    reconcile_herdr_lifecycle_fences(inner, &snapshot);
+    reconcile_herdr_lifecycle_fences(inner, &snapshot, publication_generation);
     set_herdr_inventory(inner, snapshot.herdr());
     reconcile_retained_session_names(inner, &snapshot, runtime_host.socket_directory());
     *inner
@@ -5900,12 +5947,16 @@ fn project_herdr_lifecycle(
     }
 }
 
-fn reconcile_herdr_lifecycle_fences(inner: &Inner, snapshot: &HostSnapshot) -> bool {
+fn reconcile_herdr_lifecycle_fences(
+    inner: &Inner,
+    snapshot: &HostSnapshot,
+    publication_generation: u64,
+) -> bool {
     inner
         .herdr_lifecycle
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .reconcile(snapshot)
+        .reconcile(snapshot, publication_generation)
 }
 
 fn set_inner_state(inner: &Inner, state: WorkspaceContent) {
@@ -6232,6 +6283,7 @@ mod tests {
                 generation: 1,
                 key: key.clone(),
                 action: HerdrLifecycleAction::Stop,
+                reconcile_after_generation: None,
             });
         let mut launched = false;
         assert!(
@@ -8954,7 +9006,43 @@ mod tests {
             .value
             .snapshot
             .clone();
-        assert!(reconcile_herdr_lifecycle_fences(&workspace.inner, &fresh));
+        let reconciliation_floor = workspace.inner.refresh_generation.load(Ordering::Acquire);
+        assert!(!reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &fresh,
+            reconciliation_floor,
+        ));
+        let failed = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot",
+            42,
+            Vec::new(),
+            HerdrInventory::Failed(
+                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
+            ),
+        );
+        assert!(!reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &failed,
+            reconciliation_floor + 1,
+        ));
+        let unavailable_after_restart = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "restarted-boot",
+            84,
+            Vec::new(),
+            HerdrInventory::Unavailable,
+        );
+        assert!(!reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &unavailable_after_restart,
+            reconciliation_floor + 2,
+        ));
+        assert!(reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &fresh,
+            reconciliation_floor + 3,
+        ));
         set_herdr_inventory(&workspace.inner, fresh.herdr());
         workspace.inner.revision.fetch_add(1, Ordering::Release);
 
@@ -8962,6 +9050,44 @@ mod tests {
         let host = &reconciled.hosts()[0];
         assert_eq!(host.herdr_sessions()[0].lifecycle_action(), None);
         assert!(host.herdr_diagnostic().is_none());
+    }
+
+    #[test]
+    fn ordinary_refresh_cannot_reconcile_an_active_lifecycle_operation() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        workspace
+            .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+            .expect("running session may be stopped");
+        {
+            let mut lifecycle = workspace
+                .inner
+                .herdr_lifecycle
+                .lock()
+                .expect("lifecycle state");
+            let pending = lifecycle.pending.take().expect("pending stop");
+            assert!(lifecycle.start(&pending));
+        }
+        let snapshot = workspace
+            .inner
+            .host
+            .lock()
+            .expect("host context")
+            .as_ref()
+            .expect("published host")
+            .value
+            .snapshot
+            .clone();
+
+        assert!(!reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &snapshot,
+            u64::MAX,
+        ));
+        assert_eq!(
+            workspace.snapshot().hosts()[0].herdr_sessions()[0].lifecycle_action(),
+            Some(HerdrLifecycleAction::Stop),
+        );
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -746,12 +746,24 @@ struct HerdrOperationKey {
     name: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 struct InFlightHerdrLifecycle {
     generation: u64,
     key: HerdrOperationKey,
     action: HerdrLifecycleAction,
     reconcile_after_generation: Option<u64>,
+    recovery: Option<DelayedHerdrRecovery>,
+}
+
+struct DelayedHerdrRecovery {
+    executable: String,
+    record: session::HerdrSessionRecord,
+    presentation: SuppressedHerdrPresentation,
+}
+
+#[derive(Default)]
+struct HerdrLifecycleReconciliation {
+    changed: bool,
+    recoveries: Vec<SuppressedHerdrPresentation>,
 }
 
 #[derive(Default)]
@@ -797,6 +809,7 @@ impl HerdrLifecycleState {
             key,
             action: pending.action,
             reconcile_after_generation: None,
+            recovery: None,
         });
         true
     }
@@ -808,39 +821,77 @@ impl HerdrLifecycleState {
         self.in_flight.len() != previous_len
     }
 
-    fn mark_uncertain(&mut self, generation: u64, reconcile_after_generation: u64) -> bool {
+    fn mark_uncertain(
+        &mut self,
+        pending: &PendingHerdrLifecycle,
+        reconcile_after_generation: u64,
+        presentation: Option<SuppressedHerdrPresentation>,
+    ) -> bool {
         let Some(operation) = self
             .in_flight
             .iter_mut()
-            .find(|operation| operation.generation == generation)
+            .find(|operation| operation.generation == pending.generation)
         else {
             return false;
         };
         operation.reconcile_after_generation = Some(reconcile_after_generation);
+        operation.recovery = presentation.map(|presentation| DelayedHerdrRecovery {
+            executable: pending.executable.clone(),
+            record: pending.record.clone(),
+            presentation,
+        });
         true
     }
 
-    fn reconcile(&mut self, snapshot: &HostSnapshot, publication_generation: u64) -> bool {
-        let previous_len = self.in_flight.len();
-        self.in_flight.retain(|operation| {
+    fn reconcile(
+        &mut self,
+        snapshot: &HostSnapshot,
+        publication_generation: u64,
+        release_recoveries: bool,
+    ) -> HerdrLifecycleReconciliation {
+        let mut result = HerdrLifecycleReconciliation::default();
+        let mut remaining = Vec::with_capacity(self.in_flight.len());
+        for mut operation in self.in_flight.drain(..) {
             let Some(reconcile_after_generation) = operation.reconcile_after_generation else {
-                return true;
+                remaining.push(operation);
+                continue;
             };
             if publication_generation <= reconcile_after_generation {
-                return true;
+                remaining.push(operation);
+                continue;
             }
             if operation.key.endpoint != *snapshot.endpoint() {
-                return true;
+                remaining.push(operation);
+                continue;
             }
             if !matches!(snapshot.herdr(), HerdrInventory::Available { .. }) {
-                return true;
+                remaining.push(operation);
+                continue;
             }
             if operation.key.runtime != *snapshot.runtime() {
-                return false;
+                result.changed = true;
+                continue;
             }
-            false
-        });
-        self.in_flight.len() != previous_len
+            let recoverable = operation.recovery.as_ref().is_some_and(|recovery| {
+                herdr_record_is_still_running(
+                    snapshot,
+                    &operation.key.endpoint,
+                    &operation.key.runtime,
+                    &recovery.executable,
+                    &recovery.record,
+                )
+            });
+            if recoverable && !release_recoveries {
+                remaining.push(operation);
+                continue;
+            }
+            if recoverable && let Some(recovery) = operation.recovery.take() {
+                result.recoveries.push(recovery.presentation);
+            }
+            result.changed = true;
+        }
+        self.in_flight = remaining;
+        result
     }
 }
 
@@ -3514,12 +3565,16 @@ impl Workspace {
                         context.host.socket_directory().map(str::to_owned),
                     )
                 });
+                let mut delayed_recoveries = Vec::new();
                 let published = publish_refresh(&task_inner, generation, || {
                     if task_cancellation.is_cancelled() {
                         return;
                     }
                     match resolved {
-                        Ok(context) => publish_discovered_host(&task_inner, context, generation),
+                        Ok(context) => {
+                            delayed_recoveries =
+                                publish_discovered_host(&task_inner, context, generation);
+                        }
                         Err(error) => {
                             set_wsl_host_unavailable(&task_inner, error.kind(), error.to_string());
                         }
@@ -3537,6 +3592,9 @@ impl Workspace {
                     );
                 }
                 task_cancellation.cancel();
+                if published {
+                    Self::restore_delayed_herdr_presentations(&task_inner, delayed_recoveries);
+                }
             }),
         );
         if let Err(error) = spawn_result {
@@ -3547,6 +3605,25 @@ impl Workspace {
                 "start WSL discovery task",
                 &error,
             );
+        }
+    }
+
+    fn restore_delayed_herdr_presentations(
+        inner: &Arc<Inner>,
+        recoveries: Vec<SuppressedHerdrPresentation>,
+    ) {
+        if recoveries.is_empty() {
+            return;
+        }
+        let workspace = Self {
+            inner: Arc::clone(inner),
+        };
+        let _operation = inner
+            .session_operations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for suppressed in recoveries {
+            workspace.restore_suppressed_herdr_presentation(Some(suppressed));
         }
     }
 
@@ -4342,9 +4419,14 @@ fn publish_refresh(inner: &Inner, generation: u64, publish: impl FnOnce()) -> bo
     true
 }
 
-fn publish_discovered_host(inner: &Inner, context: HostContext, generation: u64) {
+fn publish_discovered_host(
+    inner: &Inner,
+    context: HostContext,
+    generation: u64,
+) -> Vec<SuppressedHerdrPresentation> {
     let state = ready_content(&context.snapshot);
-    reconcile_herdr_lifecycle_fences(inner, &context.snapshot, generation);
+    let reconciliation =
+        reconcile_herdr_lifecycle_fences(inner, &context.snapshot, generation, true);
     set_herdr_inventory(inner, context.snapshot.herdr());
     *inner
         .host
@@ -4352,6 +4434,7 @@ fn publish_discovered_host(inner: &Inner, context: HostContext, generation: u64)
         .unwrap_or_else(std::sync::PoisonError::into_inner) =
         Some(Published::new(context, generation));
     set_inventory_state(inner, state);
+    reconciliation.recoveries
 }
 
 fn cancel_refresh(inner: &Inner) -> bool {
@@ -4635,7 +4718,7 @@ fn reconcile_herdr_lifecycle_failure(
             let message = format!(
                 "{operation_error}; Ghosthub could not reconcile the Herdr session: {reconciliation_error}"
             );
-            publish_herdr_lifecycle_uncertain(&workspace.inner, pending, &message);
+            publish_herdr_lifecycle_uncertain(&workspace.inner, pending, suppressed, &message);
             workspace.push_operation_error(message);
         }
     }
@@ -5428,20 +5511,36 @@ fn herdr_session_is_still_running(
     snapshot: &HostSnapshot,
     pending: &PendingHerdrLifecycle,
 ) -> bool {
-    snapshot.endpoint() == &pending.endpoint
-        && snapshot.runtime() == &pending.runtime
+    herdr_record_is_still_running(
+        snapshot,
+        &pending.endpoint,
+        &pending.runtime,
+        &pending.executable,
+        &pending.record,
+    )
+}
+
+fn herdr_record_is_still_running(
+    snapshot: &HostSnapshot,
+    endpoint: &host::WslEndpoint,
+    runtime: &host::WslRuntimeIdentity,
+    expected_executable: &str,
+    expected: &session::HerdrSessionRecord,
+) -> bool {
+    snapshot.endpoint() == endpoint
+        && snapshot.runtime() == runtime
         && matches!(
             snapshot.herdr(),
             HerdrInventory::Available {
                 executable,
                 sessions,
-            } if executable == &pending.executable
+            } if executable == expected_executable
                 && sessions.iter().any(|record| {
-                    record.name() == pending.record.name()
+                    record.name() == expected.name()
                         && record.state() == HerdrSessionState::Running
-                        && record.is_default() == pending.record.is_default()
-                        && record.session_directory() == pending.record.session_directory()
-                        && record.socket_path() == pending.record.socket_path()
+                        && record.is_default() == expected.is_default()
+                        && record.session_directory() == expected.session_directory()
+                        && record.socket_path() == expected.socket_path()
                 })
         )
 }
@@ -5468,6 +5567,7 @@ fn herdr_lifecycle_is_reflected(snapshot: &HostSnapshot, pending: &PendingHerdrL
 fn publish_herdr_lifecycle_uncertain(
     inner: &Inner,
     pending: &PendingHerdrLifecycle,
+    suppressed: Option<SuppressedHerdrPresentation>,
     message: &str,
 ) {
     let _snapshot_write = begin_snapshot_write(inner);
@@ -5476,7 +5576,7 @@ fn publish_herdr_lifecycle_uncertain(
         .herdr_lifecycle
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .mark_uncertain(pending.generation, reconcile_after_generation);
+        .mark_uncertain(pending, reconcile_after_generation, suppressed);
     let mut hosts = inner
         .hosts
         .write()
@@ -5540,7 +5640,7 @@ fn merge_constructive_inventory(
     let inventory_generation = publication_generation;
 
     let inventory_state = ready_content(&snapshot);
-    reconcile_herdr_lifecycle_fences(inner, &snapshot, publication_generation);
+    reconcile_herdr_lifecycle_fences(inner, &snapshot, publication_generation, false);
     set_herdr_inventory(inner, snapshot.herdr());
     reconcile_retained_session_names(inner, &snapshot, runtime_host.socket_directory());
     *inner
@@ -6101,12 +6201,13 @@ fn reconcile_herdr_lifecycle_fences(
     inner: &Inner,
     snapshot: &HostSnapshot,
     publication_generation: u64,
-) -> bool {
+    release_recoveries: bool,
+) -> HerdrLifecycleReconciliation {
     inner
         .herdr_lifecycle
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .reconcile(snapshot, publication_generation)
+        .reconcile(snapshot, publication_generation, release_recoveries)
 }
 
 fn set_inner_state(inner: &Inner, state: WorkspaceContent) {
@@ -6434,6 +6535,7 @@ mod tests {
                 key: key.clone(),
                 action: HerdrLifecycleAction::Stop,
                 reconcile_after_generation: None,
+                recovery: None,
             });
         let mut launched = false;
         assert!(
@@ -9218,6 +9320,51 @@ mod tests {
         );
     }
 
+    fn assert_inconclusive_inventory_keeps_lifecycle_fenced(
+        workspace: &Workspace,
+        fresh: &HostSnapshot,
+        reconciliation_floor: u64,
+    ) {
+        assert!(
+            !reconcile_herdr_lifecycle_fences(&workspace.inner, fresh, reconciliation_floor, true,)
+                .changed
+        );
+        let failed = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "boot",
+            42,
+            Vec::new(),
+            HerdrInventory::Failed(
+                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
+            ),
+        );
+        assert!(
+            !reconcile_herdr_lifecycle_fences(
+                &workspace.inner,
+                &failed,
+                reconciliation_floor + 1,
+                true,
+            )
+            .changed
+        );
+        let unavailable_after_restart = HostSnapshot::test_fixture_with_herdr(
+            "Ubuntu",
+            "restarted-boot",
+            84,
+            Vec::new(),
+            HerdrInventory::Unavailable,
+        );
+        assert!(
+            !reconcile_herdr_lifecycle_fences(
+                &workspace.inner,
+                &unavailable_after_restart,
+                reconciliation_floor + 2,
+                true,
+            )
+            .changed
+        );
+    }
+
     #[test]
     fn uncertain_lifecycle_stays_fenced_until_fresh_inventory_arrives() {
         let (workspace, _runtime) = herdr_workspace_fixture();
@@ -9239,6 +9386,14 @@ mod tests {
         publish_herdr_lifecycle_uncertain(
             &workspace.inner,
             &pending,
+            Some(SuppressedHerdrPresentation {
+                active_selection: Some(running.clone()),
+                retained: None,
+                navigation_generation: workspace
+                    .inner
+                    .navigation_generation
+                    .load(Ordering::Acquire),
+            }),
             "could not reconcile the stopped session",
         );
 
@@ -9261,42 +9416,34 @@ mod tests {
             .snapshot
             .clone();
         let reconciliation_floor = workspace.inner.refresh_generation.load(Ordering::Acquire);
-        assert!(!reconcile_herdr_lifecycle_fences(
-            &workspace.inner,
+        assert_inconclusive_inventory_keeps_lifecycle_fenced(
+            &workspace,
             &fresh,
             reconciliation_floor,
-        ));
-        let failed = HostSnapshot::test_fixture_with_herdr(
-            "Ubuntu",
-            "boot",
-            42,
-            Vec::new(),
-            HerdrInventory::Failed(
-                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
-            ),
         );
-        assert!(!reconcile_herdr_lifecycle_fences(
-            &workspace.inner,
-            &failed,
-            reconciliation_floor + 1,
-        ));
-        let unavailable_after_restart = HostSnapshot::test_fixture_with_herdr(
-            "Ubuntu",
-            "restarted-boot",
-            84,
-            Vec::new(),
-            HerdrInventory::Unavailable,
-        );
-        assert!(!reconcile_herdr_lifecycle_fences(
-            &workspace.inner,
-            &unavailable_after_restart,
-            reconciliation_floor + 2,
-        ));
-        assert!(reconcile_herdr_lifecycle_fences(
+        let deferred = reconcile_herdr_lifecycle_fences(
             &workspace.inner,
             &fresh,
             reconciliation_floor + 3,
-        ));
+            false,
+        );
+        assert!(!deferred.changed);
+        assert!(deferred.recoveries.is_empty());
+        let mut reconciled_recovery = reconcile_herdr_lifecycle_fences(
+            &workspace.inner,
+            &fresh,
+            reconciliation_floor + 4,
+            true,
+        );
+        assert!(reconciled_recovery.changed);
+        assert_eq!(reconciled_recovery.recoveries.len(), 1);
+        assert_eq!(
+            reconciled_recovery
+                .recoveries
+                .pop()
+                .and_then(|recovery| recovery.active_selection),
+            Some(running),
+        );
         set_herdr_inventory(&workspace.inner, fresh.herdr());
         workspace.inner.revision.fetch_add(1, Ordering::Release);
 
@@ -9333,11 +9480,9 @@ mod tests {
             .snapshot
             .clone();
 
-        assert!(!reconcile_herdr_lifecycle_fences(
-            &workspace.inner,
-            &snapshot,
-            u64::MAX,
-        ));
+        assert!(
+            !reconcile_herdr_lifecycle_fences(&workspace.inner, &snapshot, u64::MAX, true).changed
+        );
         assert_eq!(
             workspace.snapshot().hosts()[0].herdr_sessions()[0].lifecycle_action(),
             Some(HerdrLifecycleAction::Stop),

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1487,6 +1487,16 @@ pub struct Workspace {
     inner: Arc<Inner>,
 }
 
+fn read_revision_consistent<T>(revision: &AtomicU64, mut read: impl FnMut(u64) -> T) -> T {
+    loop {
+        let before = revision.load(Ordering::Acquire);
+        let value = read(before);
+        if revision.load(Ordering::Acquire) == before {
+            return value;
+        }
+    }
+}
+
 impl Workspace {
     #[must_use]
     pub fn startup_error(appearance: TerminalAppearance, message: impl Into<String>) -> Self {
@@ -1743,58 +1753,60 @@ impl Workspace {
 
     #[must_use]
     pub fn snapshot(&self) -> WorkspaceSnapshot {
-        let mut hosts = self
-            .inner
-            .hosts
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-        let current_runtime = self
-            .inner
-            .host
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .as_ref()
-            .map(|published| {
-                (
-                    published.value.snapshot.endpoint().clone(),
-                    published.value.snapshot.runtime().clone(),
-                )
-            });
-        project_herdr_lifecycle(
-            &mut hosts,
-            current_runtime.as_ref(),
-            &self.inner.herdr_lifecycle,
-        );
-        WorkspaceSnapshot {
-            revision: self.inner.revision.load(Ordering::Acquire),
-            appearance: self.inner.appearance.clone(),
-            content: self
+        read_revision_consistent(&self.inner.revision, |revision| {
+            let mut hosts = self
                 .inner
-                .state
+                .hosts
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone(),
-            hosts,
-            selected_host: self
+                .clone();
+            let current_runtime = self
                 .inner
-                .selected_host
-                .read()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone(),
-            notice: self
-                .inner
-                .terminal_notice
-                .read()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone(),
-            retained_selections: self
-                .inner
-                .retained_presentations
+                .host
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .selections(),
-        }
+                .as_ref()
+                .map(|published| {
+                    (
+                        published.value.snapshot.endpoint().clone(),
+                        published.value.snapshot.runtime().clone(),
+                    )
+                });
+            project_herdr_lifecycle(
+                &mut hosts,
+                current_runtime.as_ref(),
+                &self.inner.herdr_lifecycle,
+            );
+            WorkspaceSnapshot {
+                revision,
+                appearance: self.inner.appearance.clone(),
+                content: self
+                    .inner
+                    .state
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+                hosts,
+                selected_host: self
+                    .inner
+                    .selected_host
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+                notice: self
+                    .inner
+                    .terminal_notice
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+                retained_selections: self
+                    .inner
+                    .retained_presentations
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .selections(),
+            }
+        })
     }
 
     /// Begin an attach-only presentation for one discovered session.
@@ -5570,6 +5582,22 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::sync::{Barrier, atomic::AtomicUsize, mpsc};
+
+    #[test]
+    fn revision_consistent_read_retries_a_projection_crossing_an_update() {
+        let revision = AtomicU64::new(1);
+        let mut reads = 0;
+
+        let observed = read_revision_consistent(&revision, |captured| {
+            reads += 1;
+            if reads == 1 {
+                revision.fetch_add(1, Ordering::Release);
+            }
+            (captured, reads)
+        });
+
+        assert_eq!(observed, (2, 2));
+    }
 
     #[test]
     fn session_operation_fence_spans_launch_until_publication() {

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -280,6 +280,13 @@ impl HostItem {
     }
 
     #[must_use]
+    pub fn with_herdr_sessions(mut self, sessions: Vec<HerdrSessionItem>) -> Self {
+        self.herdr_available = true;
+        self.herdr_sessions = sessions;
+        self
+    }
+
+    #[must_use]
     pub fn id(&self) -> &str {
         &self.id
     }
@@ -695,6 +702,7 @@ struct PendingHerdrLifecycle {
     host: RuntimeHost,
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
+    executable: String,
     record: session::HerdrSessionRecord,
 }
 
@@ -864,6 +872,7 @@ struct HerdrCreateRequest {
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
     executable: String,
+    term: AttachTerm,
     name: HerdrLaunchTarget,
     precondition: HerdrLaunchPrecondition,
 }
@@ -942,7 +951,7 @@ enum AttachFreshError {
     Host(WorkspaceError),
     SessionChanged {
         error: WorkspaceError,
-        snapshot: HostSnapshot,
+        snapshot: Box<HostSnapshot>,
     },
 }
 
@@ -2682,6 +2691,10 @@ impl Workspace {
                 "Herdr lifecycle confirmation is no longer current",
             ));
         }
+        if let Err(error) = require_host_session_actions(&self.inner, &pending.selection) {
+            lifecycle.pending = Some(pending);
+            return Err(error);
+        }
         if !lifecycle.start(&pending) {
             return Err(WorkspaceError::new(
                 "a lifecycle action is already running for this Herdr session",
@@ -3692,6 +3705,7 @@ fn capture_herdr_lifecycle(
             "Herdr lifecycle actions require a Herdr session",
         ));
     }
+    require_host_session_actions(inner, selection)?;
     let host = inner
         .host
         .lock()
@@ -3705,7 +3719,11 @@ fn capture_herdr_lifecycle(
                 "host endpoint changed; refresh the Herdr session selection",
             ));
         }
-        let HerdrInventory::Available { sessions, .. } = context.snapshot.herdr() else {
+        let HerdrInventory::Available {
+            executable,
+            sessions,
+        } = context.snapshot.herdr()
+        else {
             return Err(WorkspaceError::new("Herdr is not available on this host"));
         };
         let record = sessions
@@ -3734,6 +3752,7 @@ fn capture_herdr_lifecycle(
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
+            executable: executable.clone(),
             record,
         })
     })
@@ -3855,6 +3874,7 @@ fn capture_herdr_create_request(
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
             executable: executable.clone(),
+            term: context.snapshot.creation_term(),
             name: HerdrLaunchTarget::created(name),
             precondition: HerdrLaunchPrecondition::Absent,
         })
@@ -3870,6 +3890,7 @@ fn capture_herdr_restart_request(
             "the selected session is not a Herdr session",
         ));
     }
+    require_host_session_actions(inner, selection)?;
     let host = inner
         .host
         .lock()
@@ -3905,10 +3926,34 @@ fn capture_herdr_restart_request(
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
             executable: executable.clone(),
+            term: context.snapshot.creation_term(),
             name,
             precondition: HerdrLaunchPrecondition::Stopped(record),
         })
     })
+}
+
+fn require_host_session_actions(
+    inner: &Inner,
+    selection: &SessionSelection,
+) -> Result<(), WorkspaceError> {
+    let hosts = inner
+        .hosts
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let host = hosts
+        .iter()
+        .find(|host| host.id == selection.host_id() && host.endpoint == selection.endpoint())
+        .ok_or_else(|| WorkspaceError::new("the selected host is not available"))?;
+    if matches!(
+        host.connection,
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    ) {
+        return Err(WorkspaceError::new(
+            "connect the WSL host before changing a Herdr session",
+        ));
+    }
+    Ok(())
 }
 
 fn choose_navigation_target(
@@ -4229,7 +4274,7 @@ fn run_herdr_create(
         attached,
         worker,
         initial_geometry,
-        AttachTerm::Xterm256Color,
+        request.term,
         navigation_generation,
     );
 }
@@ -4246,6 +4291,7 @@ fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
     match pending.host.mutate_herdr_session(
         &pending.endpoint,
         &pending.runtime,
+        &pending.executable,
         &pending.record,
         pending.action,
         &CancellationToken::new(),
@@ -4364,6 +4410,7 @@ fn create_herdr_fresh(
                 &request.executable,
                 request.name.clone(),
                 request.precondition.is_default(),
+                request.term,
             );
             let geometry = *inner
                 .terminal_geometry
@@ -4609,6 +4656,7 @@ fn create_fresh(
             .discover_after_create(
                 before.endpoint(),
                 &request.runtime,
+                before.creation_term(),
                 before.herdr(),
                 cancellation,
             )
@@ -4775,7 +4823,7 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                     publish_attachment_failure(inner, current_request.inventory_generation, error);
                 }
                 AttachFreshError::SessionChanged { error, snapshot } => {
-                    publish_stale_attachment_failure(inner, &current_request, snapshot, &error);
+                    publish_stale_attachment_failure(inner, &current_request, *snapshot, &error);
                 }
             }
             restore_attach_fallback(inner, fallback);
@@ -4839,7 +4887,7 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
         Err(AttachFreshError::SessionChanged { error, snapshot }) => {
             let _snapshot_write = begin_snapshot_write(inner);
             remove_failed_retained_retry(inner, &retry.key);
-            publish_retained_stale_failure(inner, &retry.request, snapshot, &error);
+            publish_retained_stale_failure(inner, &retry.request, *snapshot, &error);
         }
     }
 }
@@ -5303,7 +5351,7 @@ fn attach_fresh(
                     error: WorkspaceError::new(
                         "session no longer exists; refresh and choose another session",
                     ),
-                    snapshot: fresh,
+                    snapshot: Box::new(fresh),
                 });
             };
             if identity != session.identity() {
@@ -5311,7 +5359,7 @@ fn attach_fresh(
                     error: WorkspaceError::new(
                         "session identity changed since discovery; refusing stale attachment",
                     ),
-                    snapshot: fresh,
+                    snapshot: Box::new(fresh),
                 });
             }
             launch_fresh_tmux(inner, request, term, &fresh, &session)
@@ -5322,7 +5370,7 @@ fn attach_fresh(
                     error: WorkspaceError::new(
                         "Herdr session changed since discovery; refresh and choose it again",
                     ),
-                    snapshot: fresh,
+                    snapshot: Box::new(fresh),
                 });
             };
             launch_fresh_herdr(inner, request, term, &fresh, &session)
@@ -5348,7 +5396,7 @@ fn attach_fresh_retained(
             error: WorkspaceError::new(
                 "session identity changed since discovery; refusing stale attachment",
             ),
-            snapshot: fresh,
+            snapshot: Box::new(fresh),
         });
     };
     let (worker, snapshot, _, geometry) = match &retry.key.target {
@@ -5392,7 +5440,7 @@ fn discover_fresh_runtime(request: &AttachRequest) -> Result<HostSnapshot, Attac
             error: WorkspaceError::new(
                 "WSL runtime changed since session discovery; refresh and try again",
             ),
-            snapshot: fresh,
+            snapshot: Box::new(fresh),
         });
     }
     Ok(fresh)
@@ -5492,7 +5540,7 @@ fn launch_fresh_herdr(
             error: WorkspaceError::new(
                 "Herdr session lifecycle is changing; wait for inventory to refresh",
             ),
-            snapshot: fresh.clone(),
+            snapshot: Box::new(fresh.clone()),
         },
         || {
             let plan = request
@@ -8334,6 +8382,13 @@ mod tests {
     fn herdr_workspace_with_sessions(
         herdr_sessions: Vec<session::HerdrSessionRecord>,
     ) -> (Workspace, Arc<ManualRefreshRuntime>) {
+        herdr_workspace_with_sessions_and_term(herdr_sessions, AttachTerm::Xterm256Color)
+    }
+
+    fn herdr_workspace_with_sessions_and_term(
+        herdr_sessions: Vec<session::HerdrSessionRecord>,
+        term: AttachTerm,
+    ) -> (Workspace, Arc<ManualRefreshRuntime>) {
         let runtime = Arc::new(ManualRefreshRuntime::default());
         let snapshot = HostSnapshot::test_fixture_with_herdr(
             "Ubuntu",
@@ -8348,7 +8403,8 @@ mod tests {
                 executable: "/opt/herdr/bin/herdr".to_owned(),
                 sessions: herdr_sessions,
             },
-        );
+        )
+        .test_fixture_with_creation_term(term);
         let discovery = Arc::new(FixedDiscovery::new(snapshot));
         let spec = WslHostSpec::available(
             WslConfig::with_distro("Ubuntu").expect("valid config"),
@@ -8399,6 +8455,69 @@ mod tests {
         assert!(host.herdr_sessions()[0].is_default());
         assert_eq!(host.herdr_sessions()[1].state(), HerdrSessionState::Stopped);
         assert!(host.herdr_diagnostic().is_none());
+    }
+
+    #[test]
+    fn herdr_constructive_requests_use_the_admitted_terminal_capability() {
+        let (workspace, _runtime) = herdr_workspace_with_sessions_and_term(
+            vec![session::HerdrSessionRecord::new(
+                "review",
+                false,
+                HerdrSessionState::Stopped,
+                "/tmp/herdr/review",
+                "/tmp/herdr/review/herdr.sock",
+            )],
+            AttachTerm::Xterm,
+        );
+
+        let created = capture_herdr_create_request(
+            &workspace.inner,
+            "wsl",
+            "Ubuntu",
+            HerdrSessionName::parse("created").expect("valid name"),
+        )
+        .expect("capture creation");
+        let restarted = capture_herdr_restart_request(
+            &workspace.inner,
+            &SessionSelection::herdr("wsl", "Ubuntu", "review"),
+        )
+        .expect("capture restart");
+
+        assert_eq!(created.term, AttachTerm::Xterm);
+        assert_eq!(restarted.term, AttachTerm::Xterm);
+    }
+
+    #[test]
+    fn unavailable_hosts_reject_herdr_mutations_and_preserve_confirmation() {
+        let (workspace, _runtime) = herdr_workspace_fixture();
+        let running = SessionSelection::herdr("wsl", "Ubuntu", "default");
+        workspace
+            .request_herdr_lifecycle(&running, HerdrLifecycleAction::Stop)
+            .expect("prepare stop while ready");
+        workspace
+            .inner
+            .hosts
+            .write()
+            .expect("hosts")
+            .iter_mut()
+            .find(|host| host.id == "wsl")
+            .expect("WSL host")
+            .connection = HostConnectionState::Unavailable;
+
+        let error = workspace
+            .confirm_herdr_lifecycle()
+            .expect_err("unavailable host must block confirmed mutation");
+        assert!(error.to_string().contains("connect the WSL host"));
+        assert!(workspace.herdr_lifecycle_confirmation().is_some());
+
+        let stopped = SessionSelection::herdr("wsl", "Ubuntu", "review");
+        assert!(workspace.restart_herdr_session(&stopped).is_err());
+        workspace.cancel_herdr_lifecycle();
+        assert!(
+            workspace
+                .request_herdr_lifecycle(&stopped, HerdrLifecycleAction::Delete)
+                .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Adds optional Herdr sessions beside tmux under the automatic WSL host, with missing Herdr installations remaining silent and non-blocking.
- Shows running and stopped Herdr sessions, creates named sessions, attaches ordinary clients, and retains opened presentations for fast switching.
- Exposes backend-specific lifecycle controls: tmux keeps Create, Detach, and confirmed Kill; Herdr gets Create, Attach, confirmed Stop, Restart, and confirmed Delete.
- Keeps cached tmux and Herdr rows mounted during activation refresh so the compact sidebar does not flicker or replace navigation with loading chrome.
- Resolves Herdr through the WSL account login profile, scrubs inherited routing state, and keeps every client on the direct-argv ConPTY boundary.
- Freshly revalidates the WSL runtime, Herdr executable, expected state, session directory, and socket before destructive actions; the default Herdr session cannot be deleted.
- Keeps SSH, Herdr remote mode, persistence, pane actions, and the native Linux UI outside this local Windows slice.
- Passes the full locked Rust workspace, strict Clippy, and cargo-deny checks.