### PR TITLE
Keep window activation off the inventory path

### DIFF
--- a/Sources/App/ActivityMonitoringController.swift
+++ b/Sources/App/ActivityMonitoringController.swift
@@ -37,7 +37,7 @@ final class ActivityMonitoringController: ObservableObject {
     @Published private(set) var activatedWorktreeIDs: Set<UUID> = []
     @Published private(set) var activeAgentWorktreeIDs: Set<UUID> = []
     @Published private(set) var activeProcessWorktreeIDs: Set<UUID> = []
-    @Published private(set) var activityReferenceDate = Date()
+    private(set) var activityReferenceDate = Date()
 
     // MARK: - Private stored state
 
@@ -543,7 +543,6 @@ final class ActivityMonitoringController: ObservableObject {
             .mapValues(\.activityHint)
         let defaultIdleThresholdSeconds =
             defaultIdleThresholdSecondsProvider()
-        activityReferenceDate = now
         let evaluation = WorkspaceActivityTracker.evaluate(
             now: now,
             input: ActivityEvaluationInput(
@@ -570,8 +569,10 @@ final class ActivityMonitoringController: ObservableObject {
                 activeProcessLeafIDs: activeProcessLeafIDs
             )
         )
-        paneAgentActivities =
-            evaluation.paneAgentActivities
+        activityReferenceDate = now
+        if paneAgentActivities != evaluation.paneAgentActivities {
+            paneAgentActivities = evaluation.paneAgentActivities
+        }
         notifiedIdleWorktreeIDs =
             evaluation.nextNotifiedWorktreeIDs
 

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -449,14 +449,60 @@ struct KwtInventoryClient: Sendable {
 }
 
 enum KwtSnapshotMerger {
+    private struct WorktreePathKey: Hashable {
+        let projectID: UUID
+        let path: String
+    }
+
+    private struct WorktreeGenerationKey: Hashable {
+        let projectID: UUID
+        let generation: String
+    }
+
     static func merge(
         _ inventory: KwtHostInventory,
         hostID: UUID,
-        into snapshot: WorkspaceSnapshot
+        into snapshot: WorkspaceSnapshot,
+        normalizePath: (String) -> String = normalizedPath
     ) -> WorkspaceSnapshot {
         var updated = snapshot
         let existingProjects = snapshot.projects.filter { $0.hostID == hostID }
         let existingWorktrees = snapshot.worktrees.filter { $0.hostID == hostID }
+        let existingProjectsByRepository = Dictionary(
+            grouping: existingProjects.filter { !$0.scopedKey.isEmpty },
+            by: \.scopedKey
+        )
+        let existingProjectsByPath = Dictionary(
+            grouping: existingProjects,
+            by: { normalizePath($0.rootPath) }
+        )
+        let existingWorktreesByProject = Dictionary(
+            grouping: existingWorktrees,
+            by: \.projectID
+        )
+        let existingWorktreesByProjectAndPath = Dictionary(
+            grouping: existingWorktrees,
+            by: {
+                WorktreePathKey(
+                    projectID: $0.projectID,
+                    path: normalizePath($0.path)
+                )
+            }
+        )
+        var existingSocketByProjectAndGeneration:
+            [WorktreeGenerationKey: String] = [:]
+        var seenWorktreeGenerations = Set<WorktreeGenerationKey>()
+        for worktree in existingWorktrees {
+            guard let generation = worktree.generation else { continue }
+            let key = WorktreeGenerationKey(
+                projectID: worktree.projectID,
+                generation: generation
+            )
+            guard seenWorktreeGenerations.insert(key).inserted,
+                  let socketName = worktree.tmuxSocketName
+            else { continue }
+            existingSocketByProjectAndGeneration[key] = socketName
+        }
         var projects: [ProjectSummary] = []
         var worktrees: [WorktreeSummary] = []
         if inventory.projectsWarning != nil,
@@ -475,6 +521,12 @@ enum KwtSnapshotMerger {
         let existingDirectoryWorkspaces = snapshot.directoryWorkspaces.filter {
             $0.hostID == hostID
         }
+        let existingDirectoryWorkspacesByPath = Dictionary(
+            existingDirectoryWorkspaces.map {
+                (normalizePath($0.path), $0)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
         let directoryRecords = inventory.directoryWorkspaceWarning != nil
             && inventory.directoryWorkspaces.isEmpty
             ? existingDirectoryWorkspaces.map {
@@ -487,13 +539,12 @@ enum KwtSnapshotMerger {
             }
             : inventory.directoryWorkspaces
         let directoryWorkspaces = directoryRecords.map { record in
-            let existing = existingDirectoryWorkspaces.first {
-                normalizedPath($0.path) == normalizedPath(record.path)
-            }
+            let recordPath = normalizePath(record.path)
+            let existing = existingDirectoryWorkspacesByPath[recordPath]
             var workspace = existing ?? DirectoryWorkspaceSummary(
                 id: stableID(
                     "directory-workspace|\(hostID.uuidString)"
-                        + "|\(normalizedPath(record.path))"
+                        + "|\(recordPath)"
                 ),
                 hostID: hostID,
                 name: record.name,
@@ -515,26 +566,24 @@ enum KwtSnapshotMerger {
         var reconciledProjectIDs = Set<UUID>()
         for item in inventory.projects {
             let record = item.project
-            let recordPath = normalizedPath(record.path)
-            let repositoryMatch = existingProjects.first {
-                !record.repository.isEmpty
-                    && !$0.scopedKey.isEmpty
-                    && $0.scopedKey == record.repository
-                    && !reconciledProjectIDs.contains($0.id)
-            }
+            let recordPath = normalizePath(record.path)
+            let repositoryMatch = record.repository.isEmpty
+                ? nil
+                : existingProjectsByRepository[record.repository]?.first {
+                    !reconciledProjectIDs.contains($0.id)
+                }
             // Repository identity survives a move. Path is only a legacy
             // fallback for transitional records or when it does not belong to
             // a different repository, and an existing runtime ID can be
             // consumed at most once.
             let existingProject = repositoryMatch
-                ?? existingProjects.first { candidate in
-                    normalizedPath(candidate.rootPath) == recordPath
-                        && ((candidate.registryID != nil
-                                && !inventoryRepositories.contains(
-                                    candidate.scopedKey
-                                ))
-                            || candidate.scopedKey.isEmpty
-                            || candidate.scopedKey == record.repository)
+                ?? existingProjectsByPath[recordPath]?.first { candidate in
+                    ((candidate.registryID != nil
+                            && !inventoryRepositories.contains(
+                                candidate.scopedKey
+                            ))
+                        || candidate.scopedKey.isEmpty
+                        || candidate.scopedKey == record.repository)
                         && !reconciledProjectIDs.contains(candidate.id)
                 }
             let projectID = existingProject?.id ?? stableID(
@@ -560,9 +609,9 @@ enum KwtSnapshotMerger {
 
             if item.warning != nil, item.worktrees.isEmpty {
                 worktrees.append(
-                    contentsOf: existingWorktrees.filter {
-                        $0.projectID == existingProject?.id
-                    }.map { existing in
+                    contentsOf: (existingProject.flatMap {
+                        existingWorktreesByProject[$0.id]
+                    } ?? []).map { existing in
                         var retained = existing
                         retained.hostID = hostID
                         retained.projectID = projectID
@@ -574,11 +623,13 @@ enum KwtSnapshotMerger {
             }
 
             for record in item.worktrees {
-                let recordPath = normalizedPath(record.path)
-                let existing = existingWorktrees.first {
-                    $0.projectID == projectID
-                        && normalizedPath($0.path) == recordPath
-                }
+                let recordPath = normalizePath(record.path)
+                let existing = existingWorktreesByProjectAndPath[
+                    WorktreePathKey(
+                        projectID: projectID,
+                        path: recordPath
+                    )
+                ]?.first
                 let consistentExisting = existing.flatMap { candidate in
                     candidate.branch == record.branch
                         && candidate.isPrimary == record.isMain
@@ -627,10 +678,12 @@ enum KwtSnapshotMerger {
                     record.generation
                 ) {
                     worktree.tmuxSocketName = record.tmuxSocketName
-                        ?? existingWorktrees.first {
-                            $0.projectID == projectID
-                                && $0.generation == generation
-                        }?.tmuxSocketName
+                        ?? existingSocketByProjectAndGeneration[
+                            WorktreeGenerationKey(
+                                projectID: projectID,
+                                generation: generation
+                            )
+                        ]
                 } else {
                     worktree.tmuxSocketName = record.tmuxSocketName
                         ?? consistentExisting?.tmuxSocketName
@@ -657,7 +710,28 @@ enum KwtSnapshotMerger {
     }
 
     private static func normalizedPath(_ path: String) -> String {
-        URL(fileURLWithPath: path).standardizedFileURL.path
+        guard path.contains("/") else { return path }
+        let isAbsolute = path.hasPrefix("/")
+        var components: [Substring] = []
+        for component in path.split(separator: "/") {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                if components.last.map({ $0 != ".." }) == true {
+                    components.removeLast()
+                } else if !isAbsolute {
+                    components.append(component)
+                }
+            default:
+                components.append(component)
+            }
+        }
+        let normalized = components.joined(separator: "/")
+        if isAbsolute {
+            return normalized.isEmpty ? "/" : "/\(normalized)"
+        }
+        return normalized.isEmpty ? "." : normalized
     }
 
     private static func stableID(_ material: String) -> UUID {
@@ -684,13 +758,53 @@ enum HostInventoryOverlay {
         tmuxLastSeenByHost: [UUID: Date] = [:],
         to source: WorkspaceSnapshot
     ) -> WorkspaceSnapshot {
-        var updated = kwtInventoriesByHost.reduce(source) { partial, entry in
+        let updated = kwtInventoriesByHost.reduce(source) { partial, entry in
             KwtSnapshotMerger.merge(
                 entry.value,
                 hostID: entry.key,
                 into: partial
             )
         }
+        return applyHostState(
+            kwtAvailabilityByHost: kwtAvailabilityByHost,
+            tmuxSessionsByHost: tmuxSessionsByHost,
+            herdrSessionsByHost: herdrSessionsByHost,
+            herdrAvailabilityByHost: herdrAvailabilityByHost,
+            tmuxReachabilityByHost: tmuxReachabilityByHost,
+            tmuxLastSeenByHost: tmuxLastSeenByHost,
+            to: updated
+        )
+    }
+
+    static func applyRuntimeSessions(
+        tmuxSessionsByHost: [UUID: [TmuxSessionSummary]],
+        herdrSessionsByHost: [UUID: [HerdrSessionSummary]] = [:],
+        herdrAvailabilityByHost: [UUID: Bool] = [:],
+        tmuxReachabilityByHost: [UUID: Bool] = [:],
+        tmuxLastSeenByHost: [UUID: Date] = [:],
+        to source: WorkspaceSnapshot
+    ) -> WorkspaceSnapshot {
+        applyHostState(
+            kwtAvailabilityByHost: [:],
+            tmuxSessionsByHost: tmuxSessionsByHost,
+            herdrSessionsByHost: herdrSessionsByHost,
+            herdrAvailabilityByHost: herdrAvailabilityByHost,
+            tmuxReachabilityByHost: tmuxReachabilityByHost,
+            tmuxLastSeenByHost: tmuxLastSeenByHost,
+            to: source
+        )
+    }
+
+    private static func applyHostState(
+        kwtAvailabilityByHost: [UUID: Bool],
+        tmuxSessionsByHost: [UUID: [TmuxSessionSummary]],
+        herdrSessionsByHost: [UUID: [HerdrSessionSummary]],
+        herdrAvailabilityByHost: [UUID: Bool],
+        tmuxReachabilityByHost: [UUID: Bool],
+        tmuxLastSeenByHost: [UUID: Date],
+        to source: WorkspaceSnapshot
+    ) -> WorkspaceSnapshot {
+        var updated = source
         for (hostID, sessions) in tmuxSessionsByHost {
             guard let index = updated.hosts.firstIndex(where: {
                 $0.id == hostID

--- a/Sources/App/ResourceMonitoringPolicy.swift
+++ b/Sources/App/ResourceMonitoringPolicy.swift
@@ -36,7 +36,7 @@ enum ResourceMonitoringPolicy {
             refreshIntervalSeconds: refreshIntervalSeconds(
                 isAppActive: isAppActive
             ),
-            sampleImmediately: isAppActive
+            sampleImmediately: false
         )
     }
 }

--- a/Sources/App/WorkspaceSceneModel+Subscriptions.swift
+++ b/Sources/App/WorkspaceSceneModel+Subscriptions.swift
@@ -40,7 +40,6 @@ extension WorkspaceSceneModel {
         isAppActive = true
         activityController
             .handleApplicationDidBecomeActiveForResourceMonitoring()
-        refreshTmuxSessionDiscovery()
     }
 
     func handleApplicationDidResignActiveForResourceMonitoring() {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3021,6 +3021,23 @@ final class WorkspaceSceneModel: ObservableObject {
         attemptPendingRestoration()
     }
 
+    private func applyRuntimeInventoryOverlayIfNeeded() {
+        let overlaid = HostInventoryOverlay.applyRuntimeSessions(
+            tmuxSessionsByHost: tmuxSessionsByHost,
+            herdrSessionsByHost: herdrSessionsByHost,
+            herdrAvailabilityByHost: herdrAvailabilityByHost,
+            tmuxReachabilityByHost: tmuxReachabilityByHost,
+            tmuxLastSeenByHost: tmuxLastSeenByHost,
+            to: snapshot
+        )
+        if overlaid != snapshot {
+            isApplyingInventoryOverlay = true
+            snapshot = overlaid
+            isApplyingInventoryOverlay = false
+        }
+        attemptPendingRestoration()
+    }
+
     private func scheduleKwtInventory() {
         guard kwtInventoryEnabled,
               !ownsWorktreeMutation else { return }
@@ -3062,6 +3079,8 @@ final class WorkspaceSceneModel: ObservableObject {
         let kwtInventoryLoader = kwtInventoryLoader
         let kwtRemoteProvisioner = kwtRemoteProvisioner
         kwtInventoryTask = Task { [weak self] in
+            var receivedResult = false
+            var authoritativeHostIDs: [UUID] = []
             await withTaskGroup(
                 of: (UUID, Result<KwtHostInventory, Error>).self
             ) { group in
@@ -3099,8 +3118,10 @@ final class WorkspaceSceneModel: ObservableObject {
                         self.applyAuthoritativeKwtInventory(
                             inventory,
                             hostID: hostID,
-                            excludingWorktrees: tombstones
+                            excludingWorktrees: tombstones,
+                            publish: false
                         )
+                        authoritativeHostIDs.append(hostID)
                     case let .failure(error):
                         if error is KwtRemoteInstallError {
                             // Provisioning failures disable worktree actions
@@ -3126,14 +3147,19 @@ final class WorkspaceSceneModel: ObservableObject {
                                 error.localizedDescription
                         }
                     }
-                    if case .failure = result {
-                        self.applyInventoryOverlayIfNeeded()
-                        self.updateWorkspaceInventoryState()
-                    }
+                    receivedResult = true
                 }
             }
             guard let self, !Task.isCancelled,
                   generation == kwtInventoryGeneration else { return }
+            if receivedResult {
+                applyInventoryOverlayIfNeeded()
+                for hostID in authoritativeHostIDs {
+                    reconcileRetainedTmuxPresentations(
+                        afterAuthoritativeInventoryFor: hostID
+                    )
+                }
+            }
             isKwtInventoryLoading = false
             inventoryRefreshProgress.kwtCompleted = true
             updateWorkspaceInventoryState()
@@ -3617,7 +3643,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private func applyAuthoritativeKwtInventory(
         _ inventory: KwtHostInventory,
         hostID: UUID,
-        excludingWorktrees: [String: Set<KwtWorktreeIdentity>] = [:]
+        excludingWorktrees: [String: Set<KwtWorktreeIdentity>] = [:],
+        publish: Bool = true
     ) {
         let previous = kwtInventoriesByHost[hostID]
         kwtInventoriesByHost[hostID] =
@@ -3627,11 +3654,13 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         kwtAvailabilityByHost[hostID] = true
         kwtInventoryFailuresByHost.removeValue(forKey: hostID)
-        applyInventoryOverlayIfNeeded()
-        reconcileRetainedTmuxPresentations(
-            afterAuthoritativeInventoryFor: hostID
-        )
-        updateWorkspaceInventoryState()
+        if publish {
+            applyInventoryOverlayIfNeeded()
+            reconcileRetainedTmuxPresentations(
+                afterAuthoritativeInventoryFor: hostID
+            )
+            updateWorkspaceInventoryState()
+        }
     }
 
     private func isRemoteKwtUnavailable(
@@ -3698,6 +3727,7 @@ final class WorkspaceSceneModel: ObservableObject {
         updateWorkspaceInventoryState()
         let broker = tmuxSessionProbeBroker
         tmuxDiscoveryTask = Task { [weak self] in
+            var receivedResult = false
             await withTaskGroup(
                 of: (UUID, Result<[DiscoveredTmuxSession], TmuxBinaryError>).self
             ) { group in
@@ -3712,11 +3742,20 @@ final class WorkspaceSceneModel: ObservableObject {
                         group.cancelAll()
                         return
                     }
-                    self.applyTmuxDiscoveryResult(result, hostID: hostID)
+                    self.applyTmuxDiscoveryResult(
+                        result,
+                        hostID: hostID,
+                        publish: false
+                    )
+                    receivedResult = true
                 }
             }
             guard let self, !Task.isCancelled,
                   generation == tmuxDiscoveryGeneration else { return }
+            if receivedResult {
+                applyRuntimeInventoryOverlayIfNeeded()
+                applyDeferredTmuxPresentationsIfReady()
+            }
             isTmuxDiscoveryLoading = false
             inventoryRefreshProgress.tmuxCompleted = true
             updateWorkspaceInventoryState()
@@ -3760,6 +3799,7 @@ final class WorkspaceSceneModel: ObservableObject {
         let lifecycleCoordinator = herdrLifecycleCoordinator
         herdrDiscoveryTask = Task { [weak self] in
             var needsFreshDiscovery = false
+            var receivedResult = false
             await withTaskGroup(
                 of: (UUID, HerdrDiscoveryResult).self
             ) { group in
@@ -3792,11 +3832,19 @@ final class WorkspaceSceneModel: ObservableObject {
                         self.herdrFreshHostIDs.remove(hostID)
                         continue
                     }
-                    self.applyHerdrDiscoveryResult(result, hostID: hostID)
+                    self.applyHerdrDiscoveryResult(
+                        result,
+                        hostID: hostID,
+                        publish: false
+                    )
+                    receivedResult = true
                 }
             }
             guard let self, !Task.isCancelled, !isShutDown,
                   generation == herdrDiscoveryGeneration else { return }
+            if receivedResult {
+                applyRuntimeInventoryOverlayIfNeeded()
+            }
             isHerdrDiscoveryLoading = false
             inventoryRefreshProgress.herdrCompleted = true
             updateWorkspaceInventoryState()
@@ -3811,7 +3859,8 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func applyHerdrDiscoveryResult(
         _ result: HerdrDiscoveryResult,
-        hostID: UUID
+        hostID: UUID,
+        publish: Bool = true
     ) {
         herdrFreshHostIDs.insert(hostID)
         switch result {
@@ -3830,8 +3879,10 @@ final class WorkspaceSceneModel: ObservableObject {
             herdrDiscoveryFailuresByHost[hostID] =
                 "\(hostName): \(error.localizedDescription)"
         }
-        applyInventoryOverlayIfNeeded()
-        updateWorkspaceInventoryState()
+        if publish {
+            applyRuntimeInventoryOverlayIfNeeded()
+            updateWorkspaceInventoryState()
+        }
     }
 
     private static func supportsHerdr(_ host: CommandHost) -> Bool {
@@ -3845,7 +3896,8 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func applyTmuxDiscoveryResult(
         _ result: Result<[DiscoveredTmuxSession], TmuxBinaryError>,
-        hostID: UUID
+        hostID: UUID,
+        publish: Bool = true
     ) {
         guard case let .success(discovered) = result else {
             if case let .failure(error) = result {
@@ -3856,8 +3908,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 tmuxDiscoveryFailuresByHost[hostID] =
                     "\(hostName): \(error.localizedDescription)"
             }
-            applyInventoryOverlayIfNeeded()
-            updateWorkspaceInventoryState()
+            if publish {
+                applyRuntimeInventoryOverlayIfNeeded()
+                updateWorkspaceInventoryState()
+            }
             return
         }
         tmuxDiscoveryFailuresByHost.removeValue(forKey: hostID)
@@ -3882,9 +3936,11 @@ final class WorkspaceSceneModel: ObservableObject {
             presentation.establishmentConfirmationTask?.cancel()
             presentation.establishmentConfirmationTask = nil
         }
-        applyInventoryOverlayIfNeeded()
-        updateWorkspaceInventoryState()
-        applyDeferredTmuxPresentationsIfReady()
+        if publish {
+            applyRuntimeInventoryOverlayIfNeeded()
+            updateWorkspaceInventoryState()
+            applyDeferredTmuxPresentationsIfReady()
+        }
     }
 
     private func reconcileEndedTmuxSession(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3021,7 +3021,14 @@ final class WorkspaceSceneModel: ObservableObject {
         attemptPendingRestoration()
     }
 
-    private func applyRuntimeInventoryOverlayIfNeeded() {
+    private func applyRuntimeInventoryOverlayIfNeeded(hostID: UUID? = nil) {
+        if let hostID {
+            applyHostInventoryOverlayIfNeeded(
+                hostID: hostID,
+                includeKwtInventory: false
+            )
+            return
+        }
         let overlaid = HostInventoryOverlay.applyRuntimeSessions(
             tmuxSessionsByHost: tmuxSessionsByHost,
             herdrSessionsByHost: herdrSessionsByHost,
@@ -3036,6 +3043,56 @@ final class WorkspaceSceneModel: ObservableObject {
             isApplyingInventoryOverlay = false
         }
         attemptPendingRestoration()
+    }
+
+    private func applyHostInventoryOverlayIfNeeded(
+        hostID: UUID,
+        includeKwtInventory: Bool
+    ) {
+        let overlaid = HostInventoryOverlay.apply(
+            kwtInventoriesByHost: includeKwtInventory
+                ? hostScopedValue(kwtInventoriesByHost, hostID: hostID)
+                : [:],
+            kwtAvailabilityByHost: hostScopedValue(
+                kwtAvailabilityByHost,
+                hostID: hostID
+            ),
+            tmuxSessionsByHost: hostScopedValue(
+                tmuxSessionsByHost,
+                hostID: hostID
+            ),
+            herdrSessionsByHost: hostScopedValue(
+                herdrSessionsByHost,
+                hostID: hostID
+            ),
+            herdrAvailabilityByHost: hostScopedValue(
+                herdrAvailabilityByHost,
+                hostID: hostID
+            ),
+            tmuxReachabilityByHost: hostScopedValue(
+                tmuxReachabilityByHost,
+                hostID: hostID
+            ),
+            tmuxLastSeenByHost: hostScopedValue(
+                tmuxLastSeenByHost,
+                hostID: hostID
+            ),
+            to: snapshot
+        )
+        if overlaid != snapshot {
+            isApplyingInventoryOverlay = true
+            snapshot = overlaid
+            isApplyingInventoryOverlay = false
+        }
+        attemptPendingRestoration()
+    }
+
+    private func hostScopedValue<Value>(
+        _ values: [UUID: Value],
+        hostID: UUID
+    ) -> [UUID: Value] {
+        guard let value = values[hostID] else { return [:] }
+        return [hostID: value]
     }
 
     private func scheduleKwtInventory() {
@@ -3079,8 +3136,6 @@ final class WorkspaceSceneModel: ObservableObject {
         let kwtInventoryLoader = kwtInventoryLoader
         let kwtRemoteProvisioner = kwtRemoteProvisioner
         kwtInventoryTask = Task { [weak self] in
-            var receivedResult = false
-            var authoritativeHostIDs: [UUID] = []
             await withTaskGroup(
                 of: (UUID, Result<KwtHostInventory, Error>).self
             ) { group in
@@ -3121,7 +3176,6 @@ final class WorkspaceSceneModel: ObservableObject {
                             excludingWorktrees: tombstones,
                             publish: false
                         )
-                        authoritativeHostIDs.append(hostID)
                     case let .failure(error):
                         if error is KwtRemoteInstallError {
                             // Provisioning failures disable worktree actions
@@ -3147,19 +3201,20 @@ final class WorkspaceSceneModel: ObservableObject {
                                 error.localizedDescription
                         }
                     }
-                    receivedResult = true
+                    self.applyHostInventoryOverlayIfNeeded(
+                        hostID: hostID,
+                        includeKwtInventory: true
+                    )
+                    if case .success = result {
+                        self.reconcileRetainedTmuxPresentations(
+                            afterAuthoritativeInventoryFor: hostID
+                        )
+                    }
+                    self.updateWorkspaceInventoryState()
                 }
             }
             guard let self, !Task.isCancelled,
                   generation == kwtInventoryGeneration else { return }
-            if receivedResult {
-                applyInventoryOverlayIfNeeded()
-                for hostID in authoritativeHostIDs {
-                    reconcileRetainedTmuxPresentations(
-                        afterAuthoritativeInventoryFor: hostID
-                    )
-                }
-            }
             isKwtInventoryLoading = false
             inventoryRefreshProgress.kwtCompleted = true
             updateWorkspaceInventoryState()
@@ -3727,7 +3782,6 @@ final class WorkspaceSceneModel: ObservableObject {
         updateWorkspaceInventoryState()
         let broker = tmuxSessionProbeBroker
         tmuxDiscoveryTask = Task { [weak self] in
-            var receivedResult = false
             await withTaskGroup(
                 of: (UUID, Result<[DiscoveredTmuxSession], TmuxBinaryError>).self
             ) { group in
@@ -3742,20 +3796,11 @@ final class WorkspaceSceneModel: ObservableObject {
                         group.cancelAll()
                         return
                     }
-                    self.applyTmuxDiscoveryResult(
-                        result,
-                        hostID: hostID,
-                        publish: false
-                    )
-                    receivedResult = true
+                    self.applyTmuxDiscoveryResult(result, hostID: hostID)
                 }
             }
             guard let self, !Task.isCancelled,
                   generation == tmuxDiscoveryGeneration else { return }
-            if receivedResult {
-                applyRuntimeInventoryOverlayIfNeeded()
-                applyDeferredTmuxPresentationsIfReady()
-            }
             isTmuxDiscoveryLoading = false
             inventoryRefreshProgress.tmuxCompleted = true
             updateWorkspaceInventoryState()
@@ -3799,7 +3844,6 @@ final class WorkspaceSceneModel: ObservableObject {
         let lifecycleCoordinator = herdrLifecycleCoordinator
         herdrDiscoveryTask = Task { [weak self] in
             var needsFreshDiscovery = false
-            var receivedResult = false
             await withTaskGroup(
                 of: (UUID, HerdrDiscoveryResult).self
             ) { group in
@@ -3834,17 +3878,12 @@ final class WorkspaceSceneModel: ObservableObject {
                     }
                     self.applyHerdrDiscoveryResult(
                         result,
-                        hostID: hostID,
-                        publish: false
+                        hostID: hostID
                     )
-                    receivedResult = true
                 }
             }
             guard let self, !Task.isCancelled, !isShutDown,
                   generation == herdrDiscoveryGeneration else { return }
-            if receivedResult {
-                applyRuntimeInventoryOverlayIfNeeded()
-            }
             isHerdrDiscoveryLoading = false
             inventoryRefreshProgress.herdrCompleted = true
             updateWorkspaceInventoryState()
@@ -3880,7 +3919,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 "\(hostName): \(error.localizedDescription)"
         }
         if publish {
-            applyRuntimeInventoryOverlayIfNeeded()
+            applyRuntimeInventoryOverlayIfNeeded(hostID: hostID)
             updateWorkspaceInventoryState()
         }
     }
@@ -3909,7 +3948,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     "\(hostName): \(error.localizedDescription)"
             }
             if publish {
-                applyRuntimeInventoryOverlayIfNeeded()
+                applyRuntimeInventoryOverlayIfNeeded(hostID: hostID)
                 updateWorkspaceInventoryState()
             }
             return
@@ -3937,7 +3976,7 @@ final class WorkspaceSceneModel: ObservableObject {
             presentation.establishmentConfirmationTask = nil
         }
         if publish {
-            applyRuntimeInventoryOverlayIfNeeded()
+            applyRuntimeInventoryOverlayIfNeeded(hostID: hostID)
             updateWorkspaceInventoryState()
             applyDeferredTmuxPresentationsIfReady()
         }

--- a/Tests/App/ActivityMonitoringControllerTests.swift
+++ b/Tests/App/ActivityMonitoringControllerTests.swift
@@ -171,4 +171,29 @@ final class ActivityMonitoringControllerTests: XCTestCase {
         )
     }
 
+    func testUnchangedActivityRefreshDoesNotPublish() throws {
+        let env = try setupStandardEnvironment()
+        let model = try makeModel(
+            database: env.database,
+            localHostID: env.host.id,
+            snapshot: env.snapshot
+        )
+        let now = Date(
+            timeIntervalSinceReferenceDate: 800_000_000
+        )
+
+        model.activityController.refreshActivityState(now: now)
+        var updateCount = 0
+        let updates = model.activityController.objectWillChange.sink {
+            updateCount += 1
+        }
+
+        model.activityController.refreshActivityState(
+            now: now.addingTimeInterval(1)
+        )
+
+        XCTAssertEqual(updateCount, 0)
+        withExtendedLifetime(updates) {}
+    }
+
 }

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -7,6 +7,74 @@ import GhosthubWorkspace
 
 @Suite("kwt inventory")
 struct KwtInventoryClientTests {
+    @Test("snapshot reconciliation normalizes paths linearly")
+    func snapshotReconciliationNormalizesPathsLinearly() {
+        let hostID = UUID()
+        let count = 200
+        let projects = (0 ..< count).map { index in
+            ProjectSummary(
+                id: UUID(),
+                hostID: hostID,
+                scopedKey: "repo-\(index)",
+                name: "repo-\(index)",
+                rootPath: "/code/repo-\(index)"
+            )
+        }
+        let worktrees = projects.enumerated().map { index, project in
+            WorktreeSummary(
+                id: UUID(),
+                hostID: hostID,
+                projectID: project.id,
+                scopedKey: "/code/repo-\(index)",
+                name: "main",
+                path: "/code/repo-\(index)",
+                branch: "main",
+                isPrimary: true,
+                tmuxSessionName: "repo-\(index)"
+            )
+        }
+        let inventory = KwtHostInventory(projects: projects.enumerated().map {
+            index, _ in
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "repo-\(index)",
+                    name: "repo-\(index)",
+                    path: "/code/repo-\(index)",
+                    lastTouched: nil
+                ),
+                worktrees: [KwtWorktreeRecord(
+                    path: "/code/repo-\(index)",
+                    branch: "main",
+                    commitHash: "abc",
+                    isMain: true,
+                    createdAt: nil,
+                    generation: nil,
+                    repository: "repo-\(index)",
+                    sessionName: "repo-\(index)"
+                )],
+                warning: nil
+            )
+        })
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: projects,
+            worktrees: worktrees
+        )
+        var normalizationCount = 0
+
+        _ = KwtSnapshotMerger.merge(
+            inventory,
+            hostID: hostID,
+            into: snapshot,
+            normalizePath: { path in
+                normalizationCount += 1
+                return path
+            }
+        )
+
+        #expect(normalizationCount <= count * 4)
+    }
+
     @Test("remote status 255 does not assume an SSH transport failure")
     func describesAmbiguousRemoteFailure() {
         let error = KwtInventoryError.commandFailed(
@@ -1232,6 +1300,21 @@ struct KwtInventoryClientTests {
     @Test("successful host inventory overlays a later stored snapshot")
     func successfulInventorySurvivesStoredRefresh() {
         let hostID = UUID()
+        let project = ProjectSummary(
+            id: UUID(),
+            hostID: hostID,
+            scopedKey: "repo",
+            name: "repo",
+            rootPath: "/code/repo"
+        )
+        let worktree = WorktreeSummary(
+            id: UUID(),
+            hostID: hostID,
+            projectID: project.id,
+            name: "main",
+            path: "/code/repo",
+            branch: "main"
+        )
         let storedSession = TmuxSessionSummary(
             name: "stale-stored-session",
             managed: false,
@@ -1250,17 +1333,18 @@ struct KwtInventoryClientTests {
                 platform: .linux,
                 tmuxSessions: [storedSession]
             )],
-            projects: [],
-            worktrees: []
+            projects: [project],
+            worktrees: [worktree]
         )
 
-        let overlaid = HostInventoryOverlay.apply(
-            kwtInventoriesByHost: [:],
+        let overlaid = HostInventoryOverlay.applyRuntimeSessions(
             tmuxSessionsByHost: [hostID: [discoveredSession]],
             to: storedSnapshot
         )
 
         #expect(overlaid.hosts[0].tmuxSessions == [discoveredSession])
+        #expect(overlaid.projects == [project])
+        #expect(overlaid.worktrees == [worktree])
     }
 
     @Test("Herdr inventory overlays only Herdr sessions")
@@ -1287,8 +1371,7 @@ struct KwtInventoryClientTests {
         )
         let herdr = HerdrSessionSummary(name: "api", isDefault: true, state: .running)
 
-        let overlaid = HostInventoryOverlay.apply(
-            kwtInventoriesByHost: [:],
+        let overlaid = HostInventoryOverlay.applyRuntimeSessions(
             tmuxSessionsByHost: [:],
             herdrSessionsByHost: [hostID: [herdr]],
             herdrAvailabilityByHost: [hostID: true],

--- a/Tests/App/NativeHerdrSessionCoordinatorTests.swift
+++ b/Tests/App/NativeHerdrSessionCoordinatorTests.swift
@@ -325,7 +325,8 @@ struct NativeHerdrSessionCoordinatorTests {
         _ = coordinator.surface(handle: retried)
 
         #expect(resolutionCount.withLock { $0 } == 2)
-        #expect((store.requestedConfigurations.last?.command ?? "").contains(
+        let retryCommand = store.requestedConfigurations.last?.command ?? ""
+        #expect(retryCommand.contains(
             "/new/bin/herdr"
         ))
     }
@@ -367,7 +368,8 @@ struct NativeHerdrSessionCoordinatorTests {
         _ = coordinator.surface(handle: retry)
 
         #expect(resolutionCount.withLock { $0 } == 2)
-        #expect((store.requestedConfigurations.last?.command ?? "").contains(
+        let retryCommand = store.requestedConfigurations.last?.command ?? ""
+        #expect(retryCommand.contains(
             "/new/bin/herdr"
         ))
     }

--- a/Tests/App/ResourceMonitoringPolicyTests.swift
+++ b/Tests/App/ResourceMonitoringPolicyTests.swift
@@ -79,13 +79,13 @@ struct ResourceMonitoringPolicyTests {
         )
     }
 
-    @Test("active loop plan samples immediately")
-    func activeLoopPlanSamplesImmediately() {
+    @Test("active loop plan leaves activation responsive")
+    func activeLoopPlanDefersSampling() {
         let plan = ResourceMonitoringPolicy.loopPlan(
             isAppActive: true
         )
         #expect(plan.refreshIntervalSeconds == 5)
-        #expect(plan.sampleImmediately)
+        #expect(!plan.sampleImmediately)
     }
 
     @Test("inactive loop plan backs off without immediate sampling")

--- a/Tests/App/WorkspaceHerdrDiscoveryTests.swift
+++ b/Tests/App/WorkspaceHerdrDiscoveryTests.swift
@@ -111,6 +111,44 @@ private final class HerdrLifecycleRaceDiscovery: @unchecked Sendable {
 @Suite("Workspace Herdr discovery", .serialized)
 struct WorkspaceHerdrDiscoveryTests {
     @MainActor
+    @Test("local Herdr inventory publishes while a remote probe is blocked")
+    func localHerdrInventoryPublishesBeforeRemoteCompletes() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let remoteDiscovery = HerdrBlockingDiscovery()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            herdrSessionDiscovery: { host in
+                guard host.isRemote else {
+                    return .available([
+                        HerdrSessionSummary(
+                            name: "local-fast",
+                            isDefault: false,
+                            state: .running
+                        ),
+                    ])
+                }
+                return remoteDiscovery.discover()
+            }
+        )
+
+        model.startHerdrSessionDiscovery()
+        await waitUntilMainActor { remoteDiscovery.didStart }
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.localHostID)?
+                .herdrSessions.map(\.name) == ["local-fast"]
+        }
+        let localSessions = model.snapshot.host(
+            id: environment.localHostID
+        )?.herdrSessions.map(\.name)
+
+        remoteDiscovery.release()
+        #expect(localSessions == ["local-fast"])
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("scene shutdown prevents Herdr discovery from restarting")
     func shutdownPreventsHerdrDiscoveryRespawn() async throws {
         let database = try WorkspaceDatabase.inMemory()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -48,6 +48,80 @@ struct WorkspaceTmuxDiscoveryTests {
         await model.shutdown()
     }
 
+    @Test("local tmux inventory publishes while a remote probe is blocked")
+    @MainActor
+    func localTmuxInventoryPublishesBeforeRemoteCompletes() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let remoteGate = BlockingGate()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            tmuxSessionDiscovery: { host in
+                guard host.isRemote else {
+                    return .success([
+                        DiscoveredTmuxSession(
+                            name: "local-fast",
+                            windowCount: 1,
+                            createdAt: "1721552400",
+                            managed: false
+                        ),
+                    ])
+                }
+                remoteGate.wait()
+                return .success([])
+            }
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { remoteGate.didStart }
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.localHostID)?
+                .tmuxSessions.map(\.name) == ["local-fast"]
+        }
+        let localSessions = model.snapshot.host(
+            id: environment.localHostID
+        )?.tmuxSessions.map(\.name)
+
+        remoteGate.release()
+        #expect(localSessions == ["local-fast"])
+        await model.shutdown()
+    }
+
+    @Test("local kwt inventory publishes while a remote load is blocked")
+    @MainActor
+    func localKwtInventoryPublishesBeforeRemoteCompletes() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let remoteGate = BlockingGate()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            kwtInventoryLoader: { host in
+                guard host.isRemote else {
+                    return KwtHostInventory(projects: [])
+                }
+                remoteGate.wait()
+                return KwtHostInventory(projects: [])
+            }
+        )
+
+        model.startKwtInventory()
+        await waitUntilMainActor { remoteGate.didStart }
+        await waitUntilMainActor {
+            model.snapshot.projects.allSatisfy {
+                $0.hostID != environment.localHostID
+            }
+        }
+        let hasLocalProject = model.snapshot.projects.contains {
+            $0.hostID == environment.localHostID
+        }
+
+        remoteGate.release()
+        #expect(!hasLocalProject)
+        await model.shutdown()
+    }
+
     @Test("workspace refresh includes exe.dev inventory")
     @MainActor
     func workspaceRefreshIncludesExeInventory() async throws {

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -24,6 +24,30 @@ struct WorkspaceTmuxDiscoveryTests {
             .joined(separator: "\n")
     }
 
+    @Test("application activation does not refresh tmux inventory")
+    @MainActor
+    func applicationActivationDoesNotRefreshTmuxInventory() async throws {
+        let environment = try setupStandardEnvironment()
+        let discoveries = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            tmuxSessionDiscovery: { _ in
+                _ = discoveries.increment()
+                return .success([])
+            }
+        )
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { discoveries.count == 1 }
+
+        model.handleApplicationDidBecomeActiveForResourceMonitoring()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(discoveries.count == 1)
+        await model.shutdown()
+    }
+
     @Test("workspace refresh includes exe.dev inventory")
     @MainActor
     func workspaceRefreshIncludesExeInventory() async throws {


### PR DESCRIPTION
Switching back to Ghosthub was doing work unrelated to presenting the window: every scene started tmux discovery and immediate process sampling, then each host result replayed all cached KWT reconciliation on the main actor. With several hosts and workspaces, focus latency therefore scaled with fleet size instead of behaving like Ghostty.app.

- Keeps activation limited to active-state handling; resource sampling resumes on its normal interval, while inventory freshness continues through startup, explicit refreshes, lifecycle operations, and reconnect paths.
- Publishes KWT, tmux, and Herdr results as each host completes through host-scoped overlays, so a slow remote cannot hold back local inventory. Tmux and Herdr session discovery cannot replay repository/worktree reconciliation.
- Makes KWT matching linear and filesystem-free, and avoids scene invalidation for unchanged activity evaluations.
- Adds red/green regression coverage for activation work, runtime-only overlays, bounded path normalization, and local publication while a remote host remains blocked.

A fresh activation sample reduced the former 322 discovery/overlay samples and 277 `lstat` samples to zero; no KWT reconciliation or process sampling appeared in the activation window. The full Swift suite, essential workflows, warnings-as-errors, formatting, and `make build` pass.