### PR TITLE
Isolate exe summary tests to the main actor

### DIFF
--- a/Tests/UI/ExeAccountsSettingsTests.swift
+++ b/Tests/UI/ExeAccountsSettingsTests.swift
@@ -87,6 +87,7 @@ struct ExeAccountsSettingsTests {
     }
 
     @Test("discovery counts name the tags they were scoped to")
+    @MainActor
     func discoveryCountsNameScopedTags() {
         #expect(ExeAccountsSettingsView.loadedSummary(
             totalVMs: 4,
@@ -120,6 +121,7 @@ struct ExeAccountsSettingsTests {
             ("exe.dev", "dev", "other.exe.dev", "prod", "Destination and tags"),
         ]
     )
+    @MainActor
     func editedAccountsDoNotRelabelStaleCounts(
         discoveredDestination: String,
         discoveredTags: String,


### PR DESCRIPTION
SwiftUI correctly isolates `ExeAccountsSettingsView` and its summary helper to the main actor, but two synchronous tests called that helper from a nonisolated context. Newer warning diagnostics therefore make the warnings-as-errors build fail even though the assertions are valid.

- Isolates only the two affected summary tests, preserving concurrency for unrelated pure-logic coverage.
- Keeps the production UI isolation contract and warning policy unchanged.
- Resolves Kata `trmr`; all 1,374 Swift tests, the targeted UI suite, `make swift-warning-check`, formatting, and `make build` pass.