### PR TITLE
Keep Rust activation responsive during inventory refresh

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,9 +166,11 @@ changes only the host entry to an unavailable state with Retry and never
 replaces the application shell. The first refresh has a 45-second total budget
 for cold start; later attempts have 30 seconds, in addition to per-command
 timeouts. An application-owned background cadence refreshes ready WSL inventory
-every three seconds. Window activation performs no inventory, process sampling,
-filesystem, database, or reconciliation work. Disconnected and failed hosts are
-not retried in a loop. Later refreshes reuse the admitted host capability so
+every ten seconds while the window is active. Window activation changes only an
+in-memory polling flag; it performs no inventory, process sampling, filesystem,
+database, or reconciliation work. The cadence starts no new inventory refresh
+while the window is inactive. Disconnected and failed hosts are not retried in a loop. Later
+refreshes reuse the admitted host capability so
 they perform ordinary inventory reads instead of repeating tmux admission. The
 same refresh resolves optional Herdr through WSL's POSIX login profile,
 scrubs inherited Herdr routing variables, and publishes running and stopped

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,9 +165,10 @@ frame. Missing WSL omits that host. A slow, failed, or unsupported WSL runtime
 changes only the host entry to an unavailable state with Retry and never
 replaces the application shell. The first refresh has a 45-second total budget
 for cold start; later attempts have 30 seconds, in addition to per-command
-timeouts. Returning focus to a window refreshes a ready WSL inventory, matching
-the Swift app's activation-driven discovery without retrying disconnected or
-failed hosts in a loop. Later refreshes reuse the admitted host capability so
+timeouts. An application-owned background cadence refreshes ready WSL inventory
+every three seconds. Window activation performs no inventory, process sampling,
+filesystem, database, or reconciliation work. Disconnected and failed hosts are
+not retried in a loop. Later refreshes reuse the admitted host capability so
 they perform ordinary inventory reads instead of repeating tmux admission. The
 same refresh resolves optional Herdr through WSL's POSIX login profile,
 scrubs inherited Herdr routing variables, and publishes running and stopped
@@ -199,7 +200,7 @@ non-cloneable CreateOnce as an ordinary ConPTY client running atomic
 `new-session -A`; it then captures the fresh WSL runtime and tmux live identity
 and retains only attach authority. Creation failure never authorizes a rerun or
 server cleanup. The creation interaction pins its selected endpoint and may use
-the existing admitted host while an activation-driven inventory refresh is in
+the existing admitted host while a background inventory refresh is in
 flight; it never follows a changed default distro implicitly.
 
 Rust keeps backend and authority boundaries structural: the UI package has
@@ -209,6 +210,15 @@ dependency. The terminal backend remains private behind a capability-shaped
 seam. A small leaf surface package carries Rust-owned paint buffers and
 scroll-aware damage between the terminal worker and GPUI without granting UI
 any PTY capability.
+
+Rust UI responsiveness is a hard invariant. Window activation, input, paint,
+and snapshot reads never run host commands, filesystem probes, database work,
+resource sampling, or project/worktree reconciliation. Cancellable background
+read lanes build owned host-scoped results before a short generation-checked
+publication; publication guards never cross external I/O, process waits, or an
+await point. Runtime-only session refresh cannot replay project/worktree
+reconciliation, and each host publishes independently so a slow host cannot
+delay completed inventory from another host.
 
 Ghosthub still has one UI application process and no Ghosthub-owned daemon.
 For the Windows MVP, tmux inside WSL2 is the long-lived session owner. Closing

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -152,11 +152,12 @@ Expiry cancels the active generation and discards late publication. Retry
 supersedes the earlier generation without changing the configured distro,
 binary, socket directory, or identity rules.
 
-An application-owned background cadence refreshes a ready WSL host every three
-seconds so sessions created or removed elsewhere appear without an explicit
-Refresh click. Window activation is presentation-only: it may update focus and
-other in-memory view state, but it never starts host discovery, process
-sampling, filesystem access, database work, or inventory reconciliation.
+An application-owned background cadence refreshes a ready WSL host every ten
+seconds while the window is active, so sessions created or removed elsewhere
+appear without an explicit Refresh click without polling WSL from an inactive
+window. Window activation is presentation-only: it updates an in-memory polling
+flag, focus, and other in-memory view state, but it never starts host discovery,
+process sampling, filesystem access, database work, or inventory reconciliation.
 Connecting, disconnected, and unavailable hosts do not retry automatically;
 their existing Cancel, Connect, and Retry actions remain authoritative. Refresh
 retains the last published session rows while work is in flight and reuses the

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -152,15 +152,18 @@ Expiry cancels the active generation and discards late publication. Retry
 supersedes the earlier generation without changing the configured distro,
 binary, socket directory, or identity rules.
 
-When a Ghosthub window becomes active, workspace refreshes a ready WSL host so
-sessions created or removed in another terminal appear without an explicit
-Refresh click. Connecting, disconnected, and unavailable hosts do not start an
-activation retry; their existing Cancel, Connect, and Retry actions remain
-authoritative. Refresh retains the last published session rows while work is in
-flight and reuses the admitted WSL host capability, including its endpoint- and
-runtime-bound tmux verification cache. A resolved default-distro change always
-requires fresh admission even when two WSL distributions report the same
-kernel boot ID and PID 1 start time.
+An application-owned background cadence refreshes a ready WSL host every three
+seconds so sessions created or removed elsewhere appear without an explicit
+Refresh click. Window activation is presentation-only: it may update focus and
+other in-memory view state, but it never starts host discovery, process
+sampling, filesystem access, database work, or inventory reconciliation.
+Connecting, disconnected, and unavailable hosts do not retry automatically;
+their existing Cancel, Connect, and Retry actions remain authoritative. Refresh
+retains the last published session rows while work is in flight and reuses the
+admitted WSL host capability, including its endpoint- and runtime-bound tmux
+verification cache. A resolved default-distro change always requires fresh
+admission even when two WSL distributions report the same kernel boot ID and
+PID 1 start time.
 
 Each host command runs in a disposable descendant container: a kill-on-close
 Job Object on Windows and a dedicated process group on Unix. Stdout and stderr
@@ -657,6 +660,16 @@ Per host:
   connection testing
 - reads are cancellable and superseded by newer reads of the same kind
 - every operation has a timeout
+
+UI responsiveness is a hard architecture invariant. GPUI activation, input,
+painting, and snapshot reads never execute host commands, filesystem probes,
+database transactions, Kwt reconciliation, or resource sampling. Host reads
+and future project/worktree inventory merges run on cancellable background read
+lanes. They build owned results before entering the short publication section;
+no snapshot publication guard may cross external I/O, process waits, or an
+await point. Runtime-only tmux or Herdr updates cannot replay project/worktree
+reconciliation. Each host publishes independently, so one slow host cannot
+delay completed inventory from another host.
 
 Refresh generations are allocated monotonically. A result publishes only when
 its generation is newer than the published generation. Cancelled, timed-out,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -597,23 +597,11 @@ impl RootView {
         })
         .detach();
 
-        cx.observe_window_activation(window, |view, window, cx| {
-            if !window.is_window_active() {
-                return;
-            }
-            match view.workspace.refresh_if_ready() {
-                Ok(true) => cx.notify(),
-                Ok(false) => {}
-                Err(error) => {
-                    view.diagnostic = Some(error.to_string());
-                    cx.notify();
-                }
-            }
-        })
-        .detach();
-
         cx.on_next_frame(window, |view, _window, cx| {
             if let Err(error) = view.workspace.connect_enabled_hosts() {
+                view.diagnostic = Some(error.to_string());
+            }
+            if let Err(error) = view.workspace.start_inventory_cadence() {
                 view.diagnostic = Some(error.to_string());
             }
             cx.notify();
@@ -4339,7 +4327,7 @@ mod tests {
     }
 
     #[test]
-    fn focus_refresh_does_not_insert_a_transient_navigation_status_row() {
+    fn background_refresh_does_not_insert_a_transient_navigation_status_row() {
         let host = HostItem::wsl(
             "Ubuntu",
             None,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -597,7 +597,15 @@ impl RootView {
         })
         .detach();
 
-        cx.on_next_frame(window, |view, _window, cx| {
+        cx.observe_window_activation(window, |view, window, _cx| {
+            view.workspace
+                .set_inventory_polling_enabled(window.is_window_active());
+        })
+        .detach();
+
+        cx.on_next_frame(window, |view, window, cx| {
+            view.workspace
+                .set_inventory_polling_enabled(window.is_window_active());
             if let Err(error) = view.workspace.connect_enabled_hosts() {
                 view.diagnostic = Some(error.to_string());
             }

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1,7 +1,7 @@
 //! Application workflow and capability boundary for GPUI.
 
 use std::fmt;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::Duration;
@@ -40,6 +40,7 @@ const HERDR_STARTUP_BACKOFF: [Duration; 8] = [
 ];
 const CREATE_IDENTITY_TIMEOUT: Duration = Duration::from_secs(5);
 const CREATE_IDENTITY_MIN_COLUMNS: usize = 120;
+const INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Appearance {
@@ -1645,6 +1646,7 @@ struct Inner {
     refresh_generation: AtomicU64,
     refresh_finished: AtomicU64,
     refresh_publication: Mutex<()>,
+    inventory_cadence_started: AtomicBool,
     discovery: Arc<dyn WslDiscovery>,
     refresh_runtime: Arc<dyn RefreshRuntime>,
     attachment: Mutex<AttachmentState<AttachRequest>>,
@@ -1747,6 +1749,7 @@ impl Workspace {
                 refresh_generation: AtomicU64::new(0),
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
+                inventory_cadence_started: AtomicBool::new(false),
                 discovery: Arc::new(SystemWslDiscovery::new()),
                 refresh_runtime: Arc::new(ThreadRefreshRuntime),
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1813,6 +1816,7 @@ impl Workspace {
                 refresh_generation: AtomicU64::new(0),
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
+                inventory_cadence_started: AtomicBool::new(false),
                 discovery,
                 refresh_runtime,
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1863,6 +1867,7 @@ impl Workspace {
                 refresh_generation: AtomicU64::new(0),
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
+                inventory_cadence_started: AtomicBool::new(false),
                 discovery: Arc::new(SystemWslDiscovery::new()),
                 refresh_runtime: Arc::new(ThreadRefreshRuntime),
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1915,16 +1920,39 @@ impl Workspace {
         Ok(())
     }
 
-    /// Refresh a connected WSL host without turning activation into an
-    /// automatic retry loop for disconnected or failed hosts.
+    /// Start the application-owned inventory cadence after the first frame.
     ///
-    /// Returns `true` when a ready host started a refresh.
+    /// The timer and every host read execute through the background refresh
+    /// runtime. Calling this method never performs discovery itself and is
+    /// idempotent for the lifetime of the workspace.
     ///
     /// # Errors
     ///
-    /// Returns an error only when a ready host no longer has refresh
-    /// configuration.
-    pub fn refresh_if_ready(&self) -> Result<bool, WorkspaceError> {
+    /// Returns an error when the background cadence cannot be scheduled.
+    pub fn start_inventory_cadence(&self) -> Result<(), WorkspaceError> {
+        if self.inner.wsl_config.is_none() {
+            return Ok(());
+        }
+        if self
+            .inner
+            .inventory_cadence_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Ok(());
+        }
+        if let Err(error) = schedule_inventory_refresh(&self.inner) {
+            self.inner
+                .inventory_cadence_started
+                .store(false, Ordering::Release);
+            return Err(WorkspaceError::new(format!(
+                "schedule inventory refresh cadence: {error}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn refresh_if_ready(&self) -> Result<bool, WorkspaceError> {
         let ready = self
             .inner
             .hosts
@@ -4486,6 +4514,31 @@ fn cancel_refresh(inner: &Inner) -> bool {
     true
 }
 
+fn schedule_inventory_refresh(inner: &Arc<Inner>) -> std::io::Result<()> {
+    let weak_inner = Arc::downgrade(inner);
+    inner.refresh_runtime.spawn_after(
+        "ghosthub-inventory-cadence",
+        INVENTORY_REFRESH_INTERVAL,
+        CancellationToken::new(),
+        Box::new(move || {
+            let Some(inner) = weak_inner.upgrade() else {
+                return;
+            };
+            let workspace = Workspace {
+                inner: Arc::clone(&inner),
+            };
+            let _refresh_started = workspace.refresh_if_ready();
+            if let Err(error) = schedule_inventory_refresh(&inner) {
+                inner
+                    .inventory_cadence_started
+                    .store(false, Ordering::Release);
+                workspace
+                    .push_operation_error(format!("inventory refresh cadence stopped: {error}"));
+            }
+        }),
+    )
+}
+
 const fn refresh_budget(generation: u64) -> Duration {
     if generation == 1 {
         Duration::from_secs(45)
@@ -6740,6 +6793,37 @@ mod tests {
                 .expect("deadline queue")
                 .push_back((delay, cancellation, task));
             Ok(())
+        }
+    }
+
+    struct BlockingDiscovery {
+        snapshot: HostSnapshot,
+        entered: Mutex<Option<mpsc::SyncSender<()>>>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    impl WslDiscovery for BlockingDiscovery {
+        fn discover(
+            &self,
+            config: WslConfig,
+            executable: WslExecutable,
+            existing_host: Option<RuntimeHost>,
+            _cancellation: &CancellationToken,
+        ) -> Result<HostContext, HostError> {
+            if let Some(entered) = self.entered.lock().expect("entered signal").take() {
+                entered.send(()).expect("announce blocked discovery");
+            }
+            self.release
+                .lock()
+                .expect("release signal")
+                .recv()
+                .expect("release blocked discovery");
+            let host = existing_host
+                .unwrap_or_else(|| WslHost::new(config, Arc::new(StdCommandRunner), executable));
+            Ok(HostContext {
+                host,
+                snapshot: self.snapshot.clone(),
+            })
         }
     }
 
@@ -9044,6 +9128,68 @@ mod tests {
     }
 
     #[test]
+    fn blocked_host_discovery_does_not_block_snapshot_reads() {
+        let snapshot = HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            vec![session::DiscoveredSession::new(
+                "work",
+                session::SessionIdentity::new(100, "$1", 200),
+                0,
+            )],
+        );
+        let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        let discovery = Arc::new(BlockingDiscovery {
+            snapshot,
+            entered: Mutex::new(Some(entered_tx)),
+            release: Mutex::new(release_rx),
+        });
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            Some(spec),
+            discovery,
+            Arc::new(ThreadRefreshRuntime),
+        );
+        workspace.connect_enabled_hosts().expect("start refresh");
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("discovery reached blocking host read");
+
+        let snapshot_workspace = workspace.clone();
+        let (snapshot_tx, snapshot_rx) = mpsc::sync_channel(1);
+        let snapshot_reader = thread::spawn(move || {
+            let snapshot = snapshot_workspace.snapshot();
+            snapshot_tx
+                .send(snapshot.hosts()[0].connection())
+                .expect("publish snapshot result");
+        });
+        let connection = snapshot_rx
+            .recv_timeout(Duration::from_millis(250))
+            .expect("snapshot remains responsive during host I/O");
+        assert_eq!(connection, HostConnectionState::Connecting);
+
+        release_tx.send(()).expect("release host discovery");
+        snapshot_reader.join().expect("snapshot reader");
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while workspace.snapshot().hosts()[0].connection() != HostConnectionState::Ready
+            && std::time::Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Ready
+        );
+    }
+
+    #[test]
     fn refresh_deadlines_and_retry_order_are_manually_driven() {
         let runtime = Arc::new(ManualRefreshRuntime::default());
         let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
@@ -9851,7 +9997,7 @@ mod tests {
     }
 
     #[test]
-    fn activation_refreshes_only_ready_hosts_and_reuses_the_admitted_host() {
+    fn background_cadence_refreshes_ready_hosts_and_reuses_the_admitted_host() {
         let runtime = Arc::new(ManualRefreshRuntime::default());
         let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
             "Ubuntu",
@@ -9875,7 +10021,6 @@ mod tests {
             runtime.clone(),
         );
 
-        assert!(!workspace.refresh_if_ready().expect("disconnected no-op"));
         workspace.connect_enabled_hosts().expect("connect host");
         assert!(!workspace.refresh_if_ready().expect("connecting no-op"));
         runtime.run_next_work();
@@ -9883,8 +10028,20 @@ mod tests {
             workspace.snapshot().hosts()[0].connection(),
             HostConnectionState::Ready
         );
+        runtime.run_next_deadline();
 
-        assert!(workspace.refresh_if_ready().expect("refresh ready host"));
+        workspace
+            .start_inventory_cadence()
+            .expect("start inventory cadence");
+        workspace
+            .start_inventory_cadence()
+            .expect("cadence start is idempotent");
+        assert_eq!(runtime.deadline_delays(), vec![INVENTORY_REFRESH_INTERVAL]);
+        runtime.run_next_deadline();
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Connecting
+        );
         assert!(
             capture_create_request(
                 &workspace.inner,
@@ -9911,6 +10068,29 @@ mod tests {
         assert_eq!(
             workspace.snapshot().hosts()[0].connection(),
             HostConnectionState::Ready
+        );
+    }
+
+    #[test]
+    fn inventory_cadence_is_a_no_op_without_an_enabled_host() {
+        let runtime = Arc::new(ManualRefreshRuntime::default());
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            None,
+            Arc::new(SystemWslDiscovery::new()),
+            runtime.clone(),
+        );
+
+        workspace
+            .start_inventory_cadence()
+            .expect("missing WSL host is not a scheduling error");
+
+        assert!(runtime.deadline_delays().is_empty());
+        assert!(
+            !workspace
+                .inner
+                .inventory_cadence_started
+                .load(Ordering::Acquire)
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -40,7 +40,7 @@ const HERDR_STARTUP_BACKOFF: [Duration; 8] = [
 ];
 const CREATE_IDENTITY_TIMEOUT: Duration = Duration::from_secs(5);
 const CREATE_IDENTITY_MIN_COLUMNS: usize = 120;
-const INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
+const INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Appearance {
@@ -1647,6 +1647,7 @@ struct Inner {
     refresh_finished: AtomicU64,
     refresh_publication: Mutex<()>,
     inventory_cadence_started: AtomicBool,
+    inventory_polling_enabled: AtomicBool,
     discovery: Arc<dyn WslDiscovery>,
     refresh_runtime: Arc<dyn RefreshRuntime>,
     attachment: Mutex<AttachmentState<AttachRequest>>,
@@ -1750,6 +1751,7 @@ impl Workspace {
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
                 inventory_cadence_started: AtomicBool::new(false),
+                inventory_polling_enabled: AtomicBool::new(false),
                 discovery: Arc::new(SystemWslDiscovery::new()),
                 refresh_runtime: Arc::new(ThreadRefreshRuntime),
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1817,6 +1819,7 @@ impl Workspace {
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
                 inventory_cadence_started: AtomicBool::new(false),
+                inventory_polling_enabled: AtomicBool::new(false),
                 discovery,
                 refresh_runtime,
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1868,6 +1871,7 @@ impl Workspace {
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
                 inventory_cadence_started: AtomicBool::new(false),
+                inventory_polling_enabled: AtomicBool::new(false),
                 discovery: Arc::new(SystemWslDiscovery::new()),
                 refresh_runtime: Arc::new(ThreadRefreshRuntime),
                 attachment: Mutex::new(AttachmentState::new()),
@@ -1950,6 +1954,16 @@ impl Workspace {
             )));
         }
         Ok(())
+    }
+
+    /// Enable or suspend automatic inventory reads for the visible window.
+    ///
+    /// This changes only an in-memory flag. It never starts discovery and is
+    /// therefore safe to call from the window-activation callback.
+    pub fn set_inventory_polling_enabled(&self, enabled: bool) {
+        self.inner
+            .inventory_polling_enabled
+            .store(enabled, Ordering::Release);
     }
 
     fn refresh_if_ready(&self) -> Result<bool, WorkspaceError> {
@@ -4527,7 +4541,9 @@ fn schedule_inventory_refresh(inner: &Arc<Inner>) -> std::io::Result<()> {
             let workspace = Workspace {
                 inner: Arc::clone(&inner),
             };
-            let _refresh_started = workspace.refresh_if_ready();
+            if inner.inventory_polling_enabled.load(Ordering::Acquire) {
+                let _refresh_started = workspace.refresh_if_ready();
+            }
             if let Err(error) = schedule_inventory_refresh(&inner) {
                 inner
                     .inventory_cadence_started
@@ -10033,6 +10049,7 @@ mod tests {
         workspace
             .start_inventory_cadence()
             .expect("start inventory cadence");
+        workspace.set_inventory_polling_enabled(true);
         workspace
             .start_inventory_cadence()
             .expect("cadence start is idempotent");
@@ -10092,6 +10109,36 @@ mod tests {
                 .inventory_cadence_started
                 .load(Ordering::Acquire)
         );
+    }
+
+    #[test]
+    fn inactive_inventory_cadence_does_not_start_host_work() {
+        let runtime = Arc::new(ManualRefreshRuntime::default());
+        let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            Vec::new(),
+        )));
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            Some(spec),
+            discovery,
+            runtime.clone(),
+        );
+
+        workspace
+            .start_inventory_cadence()
+            .expect("start inventory cadence");
+        runtime.run_next_deadline();
+
+        assert!(runtime.work.lock().expect("work queue").is_empty());
+        assert_eq!(runtime.deadline_delays(), vec![INVENTORY_REFRESH_INTERVAL]);
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::thread;
 use std::time::Duration;
 
@@ -4542,7 +4542,14 @@ fn schedule_inventory_refresh(inner: &Arc<Inner>) -> std::io::Result<()> {
                 inner: Arc::clone(&inner),
             };
             if inner.inventory_polling_enabled.load(Ordering::Acquire) {
-                let _refresh_started = workspace.refresh_if_ready();
+                let operation = match inner.session_operations.try_lock() {
+                    Ok(operation) => Some(operation),
+                    Err(TryLockError::Poisoned(error)) => Some(error.into_inner()),
+                    Err(TryLockError::WouldBlock) => None,
+                };
+                if let Some(_operation) = operation {
+                    let _refresh_started = workspace.refresh_if_ready();
+                }
             }
             if let Err(error) = schedule_inventory_refresh(&inner) {
                 inner
@@ -10139,6 +10146,77 @@ mod tests {
 
         assert!(runtime.work.lock().expect("work queue").is_empty());
         assert_eq!(runtime.deadline_delays(), vec![INVENTORY_REFRESH_INTERVAL]);
+    }
+
+    #[test]
+    fn inventory_cadence_yields_to_create_and_lifecycle_operations() {
+        let runtime = Arc::new(ManualRefreshRuntime::default());
+        let discovery = Arc::new(FixedDiscovery::new(HostSnapshot::test_fixture(
+            "Ubuntu",
+            "boot",
+            42,
+            Vec::new(),
+        )));
+        let spec = WslHostSpec::available(
+            WslConfig::with_distro("Ubuntu").expect("valid config"),
+            WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                .expect("absolute WSL path"),
+        );
+        let workspace = Workspace::application_with_services(
+            TerminalAppearance::default(),
+            Some(spec),
+            discovery,
+            runtime.clone(),
+        );
+        workspace.connect_enabled_hosts().expect("connect host");
+        runtime.run_next_work();
+        runtime.run_next_deadline();
+        workspace.set_inventory_polling_enabled(true);
+        workspace
+            .start_inventory_cadence()
+            .expect("start inventory cadence");
+        let generation = workspace.inner.refresh_generation.load(Ordering::Acquire);
+
+        {
+            let _create_operation = workspace
+                .inner
+                .session_operations
+                .lock()
+                .expect("hold tmux creation lane");
+            runtime.run_next_deadline();
+            assert!(runtime.work.lock().expect("work queue").is_empty());
+            assert_eq!(
+                workspace.inner.refresh_generation.load(Ordering::Acquire),
+                generation,
+                "cadence cannot supersede tmux creation publication"
+            );
+        }
+
+        {
+            let _lifecycle_operation = workspace
+                .inner
+                .session_operations
+                .lock()
+                .expect("hold Herdr lifecycle lane");
+            runtime.run_next_deadline();
+            assert!(runtime.work.lock().expect("work queue").is_empty());
+            assert_eq!(
+                workspace.inner.refresh_generation.load(Ordering::Acquire),
+                generation,
+                "cadence cannot supersede Herdr lifecycle publication"
+            );
+        }
+
+        runtime.run_next_deadline();
+        assert_eq!(
+            workspace.snapshot().hosts()[0].connection(),
+            HostConnectionState::Connecting,
+            "cadence resumes after the operation lane is released"
+        );
+        assert_eq!(
+            workspace.inner.refresh_generation.load(Ordering::Acquire),
+            generation + 1
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Keeps window activation and terminal interaction independent of tmux, Herdr, and future worktree inventory work, so a slow host cannot freeze the application.
- Refreshes ready WSL inventory on a cancellable ten-second background cadence only while the window is active; inactive windows start no new polls and manual Refresh remains immediate.
- Reuses the runtime-bound tmux admission cache, publishes owned results through a short generation-checked section, and keeps session-only refreshes separate from future project/worktree reconciliation.
- Adds deterministic coverage proving blocked host discovery cannot block workspace snapshots and inactive cadence ticks launch no host work.
- Locks the responsiveness contract into the maintained architecture documentation for the upcoming KWT/worktree implementation.
- The full locked Rust workspace, strict Clippy, architecture/contracts, formatting, and cargo-deny gates pass on Windows ARM64.