### PR TITLE
Harden Zellij reconnect and kill recovery

### DIFF
--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -4036,6 +4036,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 == pendingCreationHandleIDs
                 && fence.sessions == sessions
         guard statePredatesKill else {
+            if fence.presentationIntentID != nil,
+               zellijPresentationIntent?.id == fence.presentationIntentID {
+                invalidateZellijPresentationIntent()
+            }
             zellijFreshHostIDs.remove(selection.hostID)
             scheduleZellijSessionDiscovery()
             return

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -715,10 +715,21 @@ final class WorkspaceSceneModel: ObservableObject {
     private var zellijRestorationValidationTask: Task<Void, Never>?
     private var zellijRestorationValidationID: UUID?
     private struct ZellijRestorationRoute {
+        let id: UUID
         var state: WorkspaceWindowState
         var selection: WorkspaceZellijSessionSelection
         var host: CommandHost
         var connectionCacheKey: SSHConnectionArgumentsCacheKey?
+    }
+    private struct ZellijSuccessfulKillFence {
+        var killRevision: UInt64
+        var presentationRevision: UInt64
+        var discoveryGeneration: Int
+        var activeHandleID: UUID?
+        var presentationIntentID: UUID?
+        var pendingCreationHandleIDs: Set<UUID>
+        var sessions: [ZellijSessionSummary]
+        var restorationRouteID: UUID?
     }
     private var zellijRestorationRoute: ZellijRestorationRoute?
     var activeBorrowedTmuxSessionIsConnected: Bool {
@@ -1804,6 +1815,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 Self.supportsZellij(host)
             else { return nil }
             return ZellijRestorationRoute(
+                id: UUID(),
                 state: state,
                 selection: WorkspaceZellijSessionSelection(
                     hostID: hostSummary.id,
@@ -2096,6 +2108,7 @@ final class WorkspaceSceneModel: ObservableObject {
             }
         } else {
             zellijRestorationRoute = ZellijRestorationRoute(
+                id: UUID(),
                 state: expectedState,
                 selection: zellijSelection,
                 host: host,
@@ -3872,10 +3885,35 @@ final class WorkspaceSceneModel: ObservableObject {
             suppressedZellijKillPresentations.removeValue(
                 forKey: event.operation.id
             )
+            let sessions = zellijSessionsByHost[selection.hostID]
+                ?? snapshot.host(id: selection.hostID)?.zellijSessions
+                ?? []
+            let fence = ZellijSuccessfulKillFence(
+                killRevision: zellijSessionKillCoordinator.revision(
+                    for: event.operation.key
+                ),
+                presentationRevision: zellijPresentationRevision,
+                discoveryGeneration: zellijDiscoveryGeneration,
+                activeHandleID: activeBorrowedZellijSelection == selection
+                    ? activeBorrowedZellijHandle?.id
+                    : nil,
+                presentationIntentID: zellijPresentationIntent?.selection
+                    == selection
+                    ? zellijPresentationIntent?.id
+                    : nil,
+                pendingCreationHandleIDs: Set(
+                    pendingCreatedZellijSessions.compactMap { handleID, pending in
+                        pending == selection ? handleID : nil
+                    }
+                ),
+                sessions: sessions,
+                restorationRouteID: zellijRestorationRoute?.id
+            )
             Task { [weak self] in
                 await self?.reconcileSuccessfulZellijKill(
                     event.operation,
-                    selection: selection
+                    selection: selection,
+                    fence: fence
                 )
             }
         case .failed:
@@ -3930,11 +3968,11 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func reconcileSuccessfulZellijKill(
         _ operation: ZellijSessionKillCoordinator.Operation,
-        selection: WorkspaceZellijSessionSelection
+        selection: WorkspaceZellijSessionSelection,
+        fence: ZellijSuccessfulKillFence
     ) async {
         guard !isShutDown,
               let hostSummary = snapshot.host(id: selection.hostID),
-              hostSummary.zellijAvailable,
               CommandHostResolver.resolve(hostSummary) == operation.host
         else {
             resumeZellijRouteAfterIgnoredKill(selection)
@@ -3943,7 +3981,6 @@ final class WorkspaceSceneModel: ObservableObject {
         let connection = await zellijConnectionSnapshot(on: operation.host)
         guard !Task.isCancelled, !isShutDown,
               let currentHostSummary = snapshot.host(id: selection.hostID),
-              currentHostSummary.zellijAvailable,
               CommandHostResolver.resolve(currentHostSummary)
               == operation.host,
               connection.cacheKey == operation.connectionCacheKey
@@ -3951,25 +3988,48 @@ final class WorkspaceSceneModel: ObservableObject {
             resumeZellijRouteAfterIgnoredKill(selection)
             return
         }
-        if zellijPresentationIntent?.selection == selection {
-            invalidateZellijPresentationIntent()
-        }
-        if let restorationState = pendingRestoration,
-           let restoration = restorationState.zellij,
-           restoration.sessionName == selection.name,
-           var route = zellijRestorationRoute,
-           route.state == restorationState,
+        let activeHandleID = activeBorrowedZellijSelection == selection
+            ? activeBorrowedZellijHandle?.id
+            : nil
+        let presentationIntentID = zellijPresentationIntent?.selection
+            == selection
+            ? zellijPresentationIntent?.id
+            : nil
+        let pendingCreationHandleIDs = Set(
+            pendingCreatedZellijSessions.compactMap { handleID, pending in
+                pending == selection ? handleID : nil
+            }
+        )
+        let sessions = zellijSessionsByHost[selection.hostID]
+            ?? snapshot.host(id: selection.hostID)?.zellijSessions
+            ?? []
+        if let restorationRouteID = fence.restorationRouteID,
+           let route = zellijRestorationRoute,
+           route.id == restorationRouteID,
            route.selection == selection,
            route.host == operation.host,
            route.connectionCacheKey == nil
            || route.connectionCacheKey == operation.connectionCacheKey {
-            route.connectionCacheKey = operation.connectionCacheKey
-            zellijRestorationRoute = route
             cancelPendingRestoration()
         }
-        zellijDiscoveryGeneration += 1
-        zellijDiscoveryTask?.cancel()
-        zellijDiscoveryTask = nil
+        let statePredatesKill =
+            fence.killRevision
+                == zellijSessionKillCoordinator.revision(for: operation.key)
+                && fence.presentationRevision == zellijPresentationRevision
+                && fence.discoveryGeneration == zellijDiscoveryGeneration
+                && fence.activeHandleID == activeHandleID
+                && fence.presentationIntentID == presentationIntentID
+                && fence.pendingCreationHandleIDs
+                == pendingCreationHandleIDs
+                && fence.sessions == sessions
+        guard statePredatesKill else {
+            zellijFreshHostIDs.remove(selection.hostID)
+            scheduleZellijSessionDiscovery()
+            return
+        }
+        if zellijPresentationIntent?.selection == selection {
+            invalidateZellijPresentationIntent()
+        }
         zellijFreshHostIDs.remove(selection.hostID)
         pendingCreatedZellijSessions = pendingCreatedZellijSessions.filter {
             $0.value != selection
@@ -3980,9 +4040,6 @@ final class WorkspaceSceneModel: ObservableObject {
         if activeBorrowedZellijSelection == selection {
             closeBorrowedZellijSession(selection)
         }
-        let sessions = zellijSessionsByHost[selection.hostID]
-            ?? snapshot.host(id: selection.hostID)?.zellijSessions
-            ?? []
         zellijSessionsByHost[selection.hostID] = sessions.filter {
             $0.name != selection.name
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3834,8 +3834,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 invalidateZellijPresentationIntent()
             }
             if let restoration = pendingRestoration?.zellij,
-               let host = snapshot.host(id: selection.hostID),
-               restoration.hostKey == host.configKey,
+               restoration.hostKey == event.operation.hostKey,
                restoration.sessionName == selection.name {
                 cancelPendingRestoration()
             }
@@ -6556,7 +6555,10 @@ final class WorkspaceSceneModel: ObservableObject {
             hostID: selection.hostID,
             sessionName: selection.name
         )
-        guard let operation = zellijSessionKillCoordinator.begin(key: key)
+        guard let operation = zellijSessionKillCoordinator.begin(
+            key: key,
+            hostKey: request.confirmedHost.configKey
+        )
         else {
             throw ZellijSessionPresentationError.operationPending(
                 selection.name
@@ -8394,12 +8396,21 @@ final class WorkspaceSceneModel: ObservableObject {
             } onCancel: {
                 probe.cancel()
             }
+            let finalConnection = await zellijConnectionSnapshot(
+                on: context.host
+            )
             guard !Task.isCancelled else { return .retry }
             guard activeZellijReconnectContext == context,
                   activeBorrowedZellijHandle?.id == context.handleID,
                   snapshot.host(id: context.selection.hostID)
                   .flatMap(CommandHostResolver.resolve) == context.host
             else { return .stop }
+            guard finalConnection.cacheKey == connection.cacheKey else {
+                stopZellijReconnect(
+                    "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+                )
+                return .stop
+            }
             switch resolution {
             case let .success(path):
                 executablePath = path
@@ -8411,13 +8422,6 @@ final class WorkspaceSceneModel: ObservableObject {
                     executablePath: nil
                 )
             }
-            let finalConnection = await zellijConnectionSnapshot(
-                on: context.host
-            )
-            guard !Task.isCancelled,
-                  activeZellijReconnectContext == context,
-                  finalConnection.cacheKey == connection.cacheKey
-            else { return .stop }
         } else {
             executablePath = nil
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3855,19 +3855,29 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         switch event.phase {
         case .began:
+            let activePresentationHost = activeZellijReconnectContext?.host
+                ?? snapshot.host(id: selection.hostID)
+                .flatMap(CommandHostResolver.resolve)
+            let activeConnection = activeBorrowedZellijHandle.flatMap {
+                nativeZellijSessionCoordinator
+                    .attachmentConnectionSnapshot($0)
+            } ?? activeZellijReconnectContext?.connection
             let restoresActivePresentation =
                 activeBorrowedZellijSelection == selection
+                    && activePresentationHost == event.operation.host
+                    && (!event.operation.host.isRemote
+                        || activeConnection?.cacheKey
+                        == event.operation.connectionCacheKey)
             let presentationIntent = zellijPresentationIntent.flatMap {
                 $0.selection == selection
                     && $0.navigationRevision == userNavigationRevision
+                    && $0.host == event.operation.host
                     ? $0
                     : nil
             }
             guard restoresActivePresentation || presentationIntent != nil,
                   let host = presentationIntent?.host
-                  ?? activeZellijReconnectContext?.host
-                  ?? snapshot.host(id: selection.hostID)
-                  .flatMap(CommandHostResolver.resolve)
+                  ?? activePresentationHost
             else {
                 return
             }
@@ -3885,6 +3895,9 @@ final class WorkspaceSceneModel: ObservableObject {
             suppressedZellijKillPresentations.removeValue(
                 forKey: event.operation.id
             )
+            zellijDiscoveryGeneration += 1
+            zellijDiscoveryTask?.cancel()
+            zellijDiscoveryTask = nil
             let sessions = zellijSessionsByHost[selection.hostID]
                 ?? snapshot.host(id: selection.hostID)?.zellijSessions
                 ?? []
@@ -4051,6 +4064,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private func resumeZellijRouteAfterIgnoredKill(
         _ selection: WorkspaceZellijSessionSelection
     ) {
+        zellijFreshHostIDs.remove(selection.hostID)
+        scheduleZellijSessionDiscovery()
         let currentHost = snapshot.host(id: selection.hostID)
             .flatMap(CommandHostResolver.resolve)
         if let intent = zellijPresentationIntent,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3833,10 +3833,16 @@ final class WorkspaceSceneModel: ObservableObject {
             if zellijPresentationIntent?.selection == selection {
                 invalidateZellijPresentationIntent()
             }
-            if let restoration = pendingRestoration?.zellij,
-               restoration.hostKey == event.operation.hostKey,
+            if let restorationState = pendingRestoration,
+               let restoration = restorationState.zellij,
                restoration.sessionName == selection.name {
-                cancelPendingRestoration()
+                let matchesStableRoute =
+                    zellijRestorationRoute?.state == restorationState
+                        && zellijRestorationRoute?.selection == selection
+                if restoration.hostKey == event.operation.hostKey
+                    || matchesStableRoute {
+                    cancelPendingRestoration()
+                }
             }
             zellijDiscoveryGeneration += 1
             zellijDiscoveryTask?.cancel()

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -6391,8 +6391,6 @@ final class WorkspaceSceneModel: ObservableObject {
                         handle: handle,
                         selection: selection
                     )
-                } else if failedZellijCreationIntent == selection {
-                    failedZellijCreationIntent = nil
                 }
                 return
             case .unavailable:
@@ -8396,12 +8394,22 @@ final class WorkspaceSceneModel: ObservableObject {
             } onCancel: {
                 probe.cancel()
             }
+            guard !Task.isCancelled else { return .retry }
+            guard activeZellijReconnectContext == context,
+                  activeBorrowedZellijHandle?.id == context.handleID,
+                  snapshot.host(id: context.selection.hostID)
+                  .flatMap(CommandHostResolver.resolve) == context.host
+            else { return .stop }
             switch resolution {
             case let .success(path):
                 executablePath = path
             case let .failure(error):
-                stopZellijReconnect(error.localizedDescription)
-                return .stop
+                return zellijReconnectDecision(
+                    for: context,
+                    result: .failure(error),
+                    connection: connection,
+                    executablePath: nil
+                )
             }
             let finalConnection = await zellijConnectionSnapshot(
                 on: context.host

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -3835,14 +3835,12 @@ final class WorkspaceSceneModel: ObservableObject {
             }
             if let restorationState = pendingRestoration,
                let restoration = restorationState.zellij,
-               restoration.sessionName == selection.name {
-                let matchesStableRoute =
-                    zellijRestorationRoute?.state == restorationState
-                        && zellijRestorationRoute?.selection == selection
-                if restoration.hostKey == event.operation.hostKey
-                    || matchesStableRoute {
-                    cancelPendingRestoration()
-                }
+               restoration.sessionName == selection.name,
+               let route = zellijRestorationRoute,
+               route.state == restorationState,
+               route.selection.name == selection.name,
+               route.host == event.operation.host {
+                cancelPendingRestoration()
             }
             zellijDiscoveryGeneration += 1
             zellijDiscoveryTask?.cancel()
@@ -6563,7 +6561,7 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         guard let operation = zellijSessionKillCoordinator.begin(
             key: key,
-            hostKey: request.confirmedHost.configKey
+            host: authority.host
         )
         else {
             throw ZellijSessionPresentationError.operationPending(
@@ -8402,6 +8400,12 @@ final class WorkspaceSceneModel: ObservableObject {
             } onCancel: {
                 probe.cancel()
             }
+            guard !Task.isCancelled else { return .retry }
+            guard activeZellijReconnectContext == context,
+                  activeBorrowedZellijHandle?.id == context.handleID,
+                  snapshot.host(id: context.selection.hostID)
+                  .flatMap(CommandHostResolver.resolve) == context.host
+            else { return .stop }
             let finalConnection = await zellijConnectionSnapshot(
                 on: context.host
             )

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -718,6 +718,7 @@ final class WorkspaceSceneModel: ObservableObject {
         var state: WorkspaceWindowState
         var selection: WorkspaceZellijSessionSelection
         var host: CommandHost
+        var connectionCacheKey: SSHConnectionArgumentsCacheKey?
     }
     private var zellijRestorationRoute: ZellijRestorationRoute?
     var activeBorrowedTmuxSessionIsConnected: Bool {
@@ -1808,7 +1809,8 @@ final class WorkspaceSceneModel: ObservableObject {
                     hostID: hostSummary.id,
                     name: descriptor.sessionName
                 ),
-                host: host
+                host: host,
+                connectionCacheKey: nil
             )
         }
         pendingRestoration = state
@@ -2096,16 +2098,56 @@ final class WorkspaceSceneModel: ObservableObject {
             zellijRestorationRoute = ZellijRestorationRoute(
                 state: expectedState,
                 selection: zellijSelection,
-                host: host
+                host: host,
+                connectionCacheKey: nil
             )
         }
-        guard !zellijSessionKillCoordinator.isPending(killKey) else { return }
-        let killRevision = zellijSessionKillCoordinator.revision(for: killKey)
         let validationID = UUID()
         zellijRestorationValidationID = validationID
         zellijRestorationValidationTask = Task { [weak self] in
             guard let self else { return }
-            let validation = await validatedZellijSession(on: host)
+            let connection = await zellijConnectionSnapshot(on: host)
+            guard !Task.isCancelled,
+                  zellijRestorationValidationID == validationID,
+                  pendingRestoration == expectedState
+            else { return }
+            guard snapshot.host(id: zellijSelection.hostID)
+                .flatMap(CommandHostResolver.resolve) == host,
+                var route = zellijRestorationRoute,
+                route.state == expectedState,
+                route.selection == zellijSelection,
+                route.host == host
+            else {
+                cancelZellijRestorationValidation(
+                    validationID,
+                    expectedState: expectedState
+                )
+                return
+            }
+            if let frozenKey = route.connectionCacheKey {
+                guard frozenKey == connection.cacheKey else {
+                    cancelZellijRestorationValidation(
+                        validationID,
+                        expectedState: expectedState
+                    )
+                    return
+                }
+            } else {
+                route.connectionCacheKey = connection.cacheKey
+                zellijRestorationRoute = route
+            }
+            guard !zellijSessionKillCoordinator.isPending(killKey) else {
+                zellijRestorationValidationTask = nil
+                zellijRestorationValidationID = nil
+                return
+            }
+            let killRevision = zellijSessionKillCoordinator.revision(
+                for: killKey
+            )
+            let validation = await validatedZellijSession(
+                on: host,
+                connection: connection
+            )
             guard !Task.isCancelled,
                   zellijRestorationValidationID == validationID,
                   pendingRestoration == expectedState
@@ -3830,40 +3872,12 @@ final class WorkspaceSceneModel: ObservableObject {
             suppressedZellijKillPresentations.removeValue(
                 forKey: event.operation.id
             )
-            if zellijPresentationIntent?.selection == selection {
-                invalidateZellijPresentationIntent()
+            Task { [weak self] in
+                await self?.reconcileSuccessfulZellijKill(
+                    event.operation,
+                    selection: selection
+                )
             }
-            if let restorationState = pendingRestoration,
-               let restoration = restorationState.zellij,
-               restoration.sessionName == selection.name,
-               let route = zellijRestorationRoute,
-               route.state == restorationState,
-               route.selection.name == selection.name,
-               route.host == event.operation.host {
-                cancelPendingRestoration()
-            }
-            zellijDiscoveryGeneration += 1
-            zellijDiscoveryTask?.cancel()
-            zellijDiscoveryTask = nil
-            zellijFreshHostIDs.remove(selection.hostID)
-            pendingCreatedZellijSessions = pendingCreatedZellijSessions.filter {
-                $0.value != selection
-            }
-            if failedZellijCreationIntent == selection {
-                failedZellijCreationIntent = nil
-            }
-            if activeBorrowedZellijSelection == selection {
-                closeBorrowedZellijSession(selection)
-            }
-            let sessions = zellijSessionsByHost[selection.hostID]
-                ?? snapshot.host(id: selection.hostID)?.zellijSessions
-                ?? []
-            zellijSessionsByHost[selection.hostID] = sessions.filter {
-                $0.name != selection.name
-            }
-            applyRuntimeInventoryOverlayIfNeeded(hostID: selection.hostID)
-            updateWorkspaceInventoryState()
-            scheduleZellijSessionDiscovery()
         case .failed:
             let suppressed = suppressedZellijKillPresentations.removeValue(
                 forKey: event.operation.id
@@ -3911,6 +3925,95 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
                 attemptPendingRestoration()
             }
+        }
+    }
+
+    private func reconcileSuccessfulZellijKill(
+        _ operation: ZellijSessionKillCoordinator.Operation,
+        selection: WorkspaceZellijSessionSelection
+    ) async {
+        guard !isShutDown,
+              let hostSummary = snapshot.host(id: selection.hostID),
+              hostSummary.zellijAvailable,
+              CommandHostResolver.resolve(hostSummary) == operation.host
+        else {
+            resumeZellijRouteAfterIgnoredKill(selection)
+            return
+        }
+        let connection = await zellijConnectionSnapshot(on: operation.host)
+        guard !Task.isCancelled, !isShutDown,
+              let currentHostSummary = snapshot.host(id: selection.hostID),
+              currentHostSummary.zellijAvailable,
+              CommandHostResolver.resolve(currentHostSummary)
+              == operation.host,
+              connection.cacheKey == operation.connectionCacheKey
+        else {
+            resumeZellijRouteAfterIgnoredKill(selection)
+            return
+        }
+        if zellijPresentationIntent?.selection == selection {
+            invalidateZellijPresentationIntent()
+        }
+        if let restorationState = pendingRestoration,
+           let restoration = restorationState.zellij,
+           restoration.sessionName == selection.name,
+           var route = zellijRestorationRoute,
+           route.state == restorationState,
+           route.selection == selection,
+           route.host == operation.host,
+           route.connectionCacheKey == nil
+           || route.connectionCacheKey == operation.connectionCacheKey {
+            route.connectionCacheKey = operation.connectionCacheKey
+            zellijRestorationRoute = route
+            cancelPendingRestoration()
+        }
+        zellijDiscoveryGeneration += 1
+        zellijDiscoveryTask?.cancel()
+        zellijDiscoveryTask = nil
+        zellijFreshHostIDs.remove(selection.hostID)
+        pendingCreatedZellijSessions = pendingCreatedZellijSessions.filter {
+            $0.value != selection
+        }
+        if failedZellijCreationIntent == selection {
+            failedZellijCreationIntent = nil
+        }
+        if activeBorrowedZellijSelection == selection {
+            closeBorrowedZellijSession(selection)
+        }
+        let sessions = zellijSessionsByHost[selection.hostID]
+            ?? snapshot.host(id: selection.hostID)?.zellijSessions
+            ?? []
+        zellijSessionsByHost[selection.hostID] = sessions.filter {
+            $0.name != selection.name
+        }
+        applyRuntimeInventoryOverlayIfNeeded(hostID: selection.hostID)
+        updateWorkspaceInventoryState()
+        scheduleZellijSessionDiscovery()
+    }
+
+    private func resumeZellijRouteAfterIgnoredKill(
+        _ selection: WorkspaceZellijSessionSelection
+    ) {
+        let currentHost = snapshot.host(id: selection.hostID)
+            .flatMap(CommandHostResolver.resolve)
+        if let intent = zellijPresentationIntent,
+           intent.selection == selection,
+           intent.navigationRevision == userNavigationRevision,
+           intent.revision == zellijPresentationRevision,
+           intent.host == currentHost,
+           activeBorrowedTmuxSelection == nil,
+           activeBorrowedHerdrSelection == nil,
+           activeBorrowedZellijSelection == nil {
+            validateAndPresentZellijSession(selection)
+            return
+        }
+        if let restorationState = pendingRestoration,
+           restorationState.zellij?.sessionName == selection.name,
+           let route = zellijRestorationRoute,
+           route.state == restorationState,
+           route.selection == selection,
+           route.host == currentHost {
+            attemptPendingRestoration()
         }
     }
 
@@ -6412,9 +6515,14 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func validatedZellijSession(
-        on host: CommandHost
+        on host: CommandHost,
+        connection frozenConnection: SSHConnectionArgumentsSnapshot? = nil
     ) async -> ZellijSessionValidation? {
-        let connection = await zellijConnectionSnapshot(on: host)
+        let connection = if let frozenConnection {
+            frozenConnection
+        } else {
+            await zellijConnectionSnapshot(on: host)
+        }
         let result = await zellijSessionValidationDiscovery(
             host,
             connection.arguments
@@ -6561,7 +6669,8 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         guard let operation = zellijSessionKillCoordinator.begin(
             key: key,
-            host: authority.host
+            host: authority.host,
+            connectionCacheKey: authority.connection.cacheKey
         )
         else {
             throw ZellijSessionPresentationError.operationPending(
@@ -6602,9 +6711,6 @@ final class WorkspaceSceneModel: ObservableObject {
         try killResult.get()
         outcome = .succeeded
         try requireActiveScene(activityGeneration)
-        if activeBorrowedZellijSelection == selection {
-            closeBorrowedZellijSession(selection)
-        }
     }
 
     func cancelPreparedZellijSessionKill(

--- a/Sources/App/ZellijSessionKillCoordinator.swift
+++ b/Sources/App/ZellijSessionKillCoordinator.swift
@@ -24,6 +24,7 @@ final class ZellijSessionKillCoordinator {
         let id: UUID
         let key: Key
         let host: CommandHost
+        let connectionCacheKey: SSHConnectionArgumentsCacheKey
     }
 
     struct Event: Equatable, Sendable {
@@ -41,9 +42,18 @@ final class ZellijSessionKillCoordinator {
         eventSubject.eraseToAnyPublisher()
     }
 
-    func begin(key: Key, host: CommandHost) -> Operation? {
+    func begin(
+        key: Key,
+        host: CommandHost,
+        connectionCacheKey: SSHConnectionArgumentsCacheKey
+    ) -> Operation? {
         guard activeOperations[key] == nil else { return nil }
-        let operation = Operation(id: UUID(), key: key, host: host)
+        let operation = Operation(
+            id: UUID(),
+            key: key,
+            host: host,
+            connectionCacheKey: connectionCacheKey
+        )
         activeOperations[key] = operation
         revisions[key, default: 0] &+= 1
         eventSubject.send(Event(operation: operation, phase: .began))

--- a/Sources/App/ZellijSessionKillCoordinator.swift
+++ b/Sources/App/ZellijSessionKillCoordinator.swift
@@ -1,5 +1,6 @@
 @preconcurrency import Combine
 import Foundation
+import GhosthubTransport
 
 @MainActor
 final class ZellijSessionKillCoordinator {
@@ -22,7 +23,7 @@ final class ZellijSessionKillCoordinator {
     struct Operation: Identifiable, Equatable, Sendable {
         let id: UUID
         let key: Key
-        let hostKey: String
+        let host: CommandHost
     }
 
     struct Event: Equatable, Sendable {
@@ -40,9 +41,9 @@ final class ZellijSessionKillCoordinator {
         eventSubject.eraseToAnyPublisher()
     }
 
-    func begin(key: Key, hostKey: String) -> Operation? {
+    func begin(key: Key, host: CommandHost) -> Operation? {
         guard activeOperations[key] == nil else { return nil }
-        let operation = Operation(id: UUID(), key: key, hostKey: hostKey)
+        let operation = Operation(id: UUID(), key: key, host: host)
         activeOperations[key] = operation
         revisions[key, default: 0] &+= 1
         eventSubject.send(Event(operation: operation, phase: .began))

--- a/Sources/App/ZellijSessionKillCoordinator.swift
+++ b/Sources/App/ZellijSessionKillCoordinator.swift
@@ -22,6 +22,7 @@ final class ZellijSessionKillCoordinator {
     struct Operation: Identifiable, Equatable, Sendable {
         let id: UUID
         let key: Key
+        let hostKey: String
     }
 
     struct Event: Equatable, Sendable {
@@ -39,9 +40,9 @@ final class ZellijSessionKillCoordinator {
         eventSubject.eraseToAnyPublisher()
     }
 
-    func begin(key: Key) -> Operation? {
+    func begin(key: Key, hostKey: String) -> Operation? {
         guard activeOperations[key] == nil else { return nil }
-        let operation = Operation(id: UUID(), key: key)
+        let operation = Operation(id: UUID(), key: key, hostKey: hostKey)
         activeOperations[key] = operation
         revisions[key, default: 0] &+= 1
         eventSubject.send(Event(operation: operation, phase: .began))

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -856,7 +856,10 @@ struct WorkspaceRestorationTests {
             hostID: environment.host.id,
             sessionName: "editor"
         )
-        let operation = try #require(killCoordinator.begin(key: key))
+        let operation = try #require(killCoordinator.begin(
+            key: key,
+            hostKey: environment.host.configKey
+        ))
 
         model.startZellijSessionDiscovery()
         model.beginRestoration(state)
@@ -919,10 +922,13 @@ struct WorkspaceRestorationTests {
                 sessionName: "editor"
             )
         )
-        let operation = try #require(killCoordinator.begin(key: .init(
-            hostID: environment.host.id,
-            sessionName: "editor"
-        )))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            hostKey: environment.host.configKey
+        ))
 
         model.startZellijSessionDiscovery()
         model.beginRestoration(state)
@@ -941,6 +947,112 @@ struct WorkspaceRestorationTests {
                 && model.snapshot.host(id: environment.host.id)?
                 .zellijSessions.map(\.name) == ["editor"]
         }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(!model.isWorkspaceRestorationPending)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("successful Zellij kill retires restoration across host rename")
+    func zellijRestorationStopsAfterHostRenameDuringKill() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let configuredHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        )
+        let renamedHost = SSHHost(
+            configKey: "renamed-office-linux",
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        )
+        let configuredHosts = Mutex([configuredHost])
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let discoveryState = Mutex((
+            attempts: 0,
+            blocked: false,
+            released: false
+        ))
+        defer { discoveryState.withLock { $0.released = true } }
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                let attempt = discoveryState.withLock {
+                    $0.attempts += 1
+                    return $0.attempts
+                }
+                if attempt == 2 {
+                    discoveryState.withLock { $0.blocked = true }
+                    while !discoveryState.withLock({ $0.released }) {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+                return .available(["editor"])
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            },
+            configuredSSHHostsProvider: {
+                configuredHosts.withLock { $0 }
+            }
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            hostKey: environment.host.configKey
+        ))
+
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            discoveryState.withLock { $0.attempts } >= 1
+                && model.isWorkspaceRestorationPending
+        }
+
+        configuredHosts.withLock { $0 = [renamedHost] }
+        model.refreshHosts()
+        #expect(
+            model.snapshot.host(id: environment.host.id)?.configKey
+                == renamedHost.configKey
+        )
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            discoveryState.withLock { $0.blocked }
+        }
+
+        configuredHosts.withLock { $0 = [configuredHost] }
+        model.refreshHosts()
+        discoveryState.withLock { $0.released = true }
         try await Task.sleep(for: .milliseconds(50))
 
         #expect(!model.isWorkspaceRestorationPending)
@@ -997,10 +1109,13 @@ struct WorkspaceRestorationTests {
                 sessionName: "editor"
             )
         )
-        let operation = try #require(killCoordinator.begin(key: .init(
-            hostID: environment.host.id,
-            sessionName: "editor"
-        )))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            hostKey: environment.host.configKey
+        ))
         model.startZellijSessionDiscovery()
         model.beginRestoration(state)
         await waitUntilMainActor {

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -1061,6 +1061,87 @@ struct WorkspaceRestorationTests {
         await model.shutdown()
     }
 
+    @Test("successful Zellij kill retires restoration begun after host rename")
+    func zellijRestorationStartedAfterHostRenameStopsDuringKill() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let configuredHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        )
+        let renamedHost = SSHHost(
+            configKey: "renamed-office-linux",
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        )
+        let configuredHosts = Mutex([configuredHost])
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["editor"])
+            },
+            configuredSSHHostsProvider: {
+                configuredHosts.withLock { $0 }
+            }
+        )
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            hostKey: environment.host.configKey
+        ))
+
+        configuredHosts.withLock { $0 = [renamedHost] }
+        model.refreshHosts()
+        #expect(
+            model.snapshot.host(id: environment.host.id)?.configKey
+                == renamedHost.configKey
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: renamedHost.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: renamedHost.configKey,
+                sessionName: "editor"
+            )
+        )
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            model.isWorkspaceRestorationPending
+                && model.snapshot.host(id: environment.host.id)?
+                .zellijSessions.map(\.name) == ["editor"]
+        }
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+
+        #expect(!model.isWorkspaceRestorationPending)
+        #expect(model.activeBorrowedZellijSelection == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
     @Test("Zellij restoration cancels when a pending kill outlives its route")
     func zellijRestorationRejectsRouteDriftDuringPendingKill() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -12,6 +12,11 @@ import Testing
 
 private let restorationWorktreeGeneration =
     "0123456789abcdef0123456789abcdef"
+private let remoteRestorationCommandHost = CommandHost.ssh(SSHHostInfo(
+    user: "wesm",
+    hostname: "office-linux",
+    port: nil
+))
 
 final class RestorationInventoryState: @unchecked Sendable {
     private let lock = NSLock()
@@ -858,7 +863,7 @@ struct WorkspaceRestorationTests {
         )
         let operation = try #require(killCoordinator.begin(
             key: key,
-            hostKey: environment.host.configKey
+            host: remoteRestorationCommandHost
         ))
 
         model.startZellijSessionDiscovery()
@@ -927,7 +932,7 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            hostKey: environment.host.configKey
+            host: remoteRestorationCommandHost
         ))
 
         model.startZellijSessionDiscovery()
@@ -1029,7 +1034,7 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            hostKey: environment.host.configKey
+            host: remoteRestorationCommandHost
         ))
 
         model.startZellijSessionDiscovery()
@@ -1104,7 +1109,7 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            hostKey: environment.host.configKey
+            host: remoteRestorationCommandHost
         ))
 
         configuredHosts.withLock { $0 = [renamedHost] }
@@ -1139,6 +1144,106 @@ struct WorkspaceRestorationTests {
         #expect(!model.isWorkspaceRestorationPending)
         #expect(model.activeBorrowedZellijSelection == nil)
         #expect(store.requestedConfigurations.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("Zellij kill preserves restoration on a replacement endpoint")
+    func zellijKillPreservesReplacementEndpointRestoration() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let originalHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: environment.host.sshDestination ?? ""
+        )
+        let replacementHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: .linux,
+            sshDestination: "dev@replacement.example.test"
+        )
+        let configuredHosts = Mutex([originalHost])
+        let validationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                await withCheckedContinuation { continuation in
+                    validationContinuation.withLock { $0 = continuation }
+                }
+                return .available(["editor"])
+            },
+            configuredSSHHostsProvider: {
+                configuredHosts.withLock { $0 }
+            }
+        )
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            host: remoteRestorationCommandHost
+        ))
+
+        configuredHosts.withLock { $0 = [] }
+        model.refreshHosts()
+        configuredHosts.withLock { $0 = [replacementHost] }
+        model.refreshHosts()
+        let replacementSummary = try #require(model.snapshot.hosts.first {
+            $0.configKey == replacementHost.configKey
+        })
+        #expect(replacementSummary.id != environment.host.id)
+        #expect(replacementSummary.sshDestination == replacementHost.sshDestination)
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: replacementHost.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: replacementHost.configKey,
+                sessionName: "editor"
+            )
+        )
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            validationContinuation.withLock { $0 != nil }
+                && model.isWorkspaceRestorationPending
+        }
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+        #expect(model.isWorkspaceRestorationPending)
+        let continuation = validationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedZellijSurface()
+            return store.lastCommand != nil
+        }
+
+        #expect(model.activeBorrowedZellijSelection?.hostID
+            == replacementSummary.id)
+        #expect(!model.isWorkspaceRestorationPending)
         await model.shutdown()
     }
 
@@ -1195,7 +1300,7 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            hostKey: environment.host.configKey
+            host: remoteRestorationCommandHost
         ))
         model.startZellijSessionDiscovery()
         model.beginRestoration(state)

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -17,6 +17,8 @@ private let remoteRestorationCommandHost = CommandHost.ssh(SSHHostInfo(
     hostname: "office-linux",
     port: nil
 ))
+private let remoteRestorationConnectionCacheKey =
+    SSHConnectionArgumentsSnapshot(arguments: []).cacheKey
 
 final class RestorationInventoryState: @unchecked Sendable {
     private let lock = NSLock()
@@ -863,7 +865,8 @@ struct WorkspaceRestorationTests {
         )
         let operation = try #require(killCoordinator.begin(
             key: key,
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
 
         model.startZellijSessionDiscovery()
@@ -932,7 +935,8 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
 
         model.startZellijSessionDiscovery()
@@ -1034,7 +1038,8 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
 
         model.startZellijSessionDiscovery()
@@ -1109,7 +1114,8 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
 
         configuredHosts.withLock { $0 = [renamedHost] }
@@ -1140,6 +1146,9 @@ struct WorkspaceRestorationTests {
         }
 
         killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            !model.isWorkspaceRestorationPending
+        }
 
         #expect(!model.isWorkspaceRestorationPending)
         #expect(model.activeBorrowedZellijSelection == nil)
@@ -1196,7 +1205,8 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
 
         configuredHosts.withLock { $0 = [] }
@@ -1243,6 +1253,98 @@ struct WorkspaceRestorationTests {
 
         #expect(model.activeBorrowedZellijSelection?.hostID
             == replacementSummary.id)
+        #expect(!model.isWorkspaceRestorationPending)
+        await model.shutdown()
+    }
+
+    @Test("Zellij kill preserves restoration on a replacement SSH route")
+    func zellijKillPreservesReplacementSSHRouteRestoration() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].zellijAvailable = true
+        snapshot.hosts[0].zellijSessions = [
+            ZellijSessionSummary(name: "editor"),
+        ]
+        let connectionArguments = Mutex(["-o", "HostName=old.example.test"])
+        let validationContinuation = Mutex<
+            CheckedContinuation<Void, Never>?
+        >(nil)
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in .available(["editor"]) },
+            zellijSessionValidationDiscovery: { _, _ in
+                await withCheckedContinuation { continuation in
+                    validationContinuation.withLock { $0 = continuation }
+                }
+                return .available(["editor"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                SSHConnectionArgumentsSnapshot(
+                    arguments: connectionArguments.withLock { $0 }
+                )
+            }
+        )
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: environment.host.id,
+                sessionName: "editor"
+            ),
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: SSHConnectionArgumentsSnapshot(
+                arguments: ["-o", "HostName=old.example.test"]
+            ).cacheKey
+        ))
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: WorkspaceNavigationDescriptor(
+                hostKey: environment.host.configKey,
+                projectKey: nil,
+                worktreeGeneration: nil
+            ),
+            tmux: nil,
+            zellij: WorkspaceZellijDescriptor(
+                hostKey: environment.host.configKey,
+                sessionName: "editor"
+            )
+        )
+
+        connectionArguments.withLock {
+            $0 = ["-o", "HostName=replacement.example.test"]
+        }
+        model.startZellijSessionDiscovery()
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            model.isWorkspaceRestorationPending
+        }
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            validationContinuation.withLock { $0 != nil }
+                && model.isWorkspaceRestorationPending
+        }
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijSessions.map(\.name) == ["editor"])
+        let continuation = validationContinuation.withLock {
+            let continuation = $0
+            $0 = nil
+            return continuation
+        }
+        continuation?.resume()
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedZellijSurface()
+            return store.lastCommand != nil
+        }
+
+        #expect(model.activeBorrowedZellijSelection?.name == "editor")
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .zellijSessions.map(\.name) == ["editor"])
         #expect(!model.isWorkspaceRestorationPending)
         await model.shutdown()
     }
@@ -1300,7 +1402,8 @@ struct WorkspaceRestorationTests {
                 hostID: environment.host.id,
                 sessionName: "editor"
             ),
-            host: remoteRestorationCommandHost
+            host: remoteRestorationCommandHost,
+            connectionCacheKey: remoteRestorationConnectionCacheKey
         ))
         model.startZellijSessionDiscovery()
         model.beginRestoration(state)

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2009,7 +2009,10 @@ struct WorkspaceZellijTests {
                 hostID: host.id,
                 sessionName: selection.name
             ),
-            host: confirmedHost
+            host: confirmedHost,
+            connectionCacheKey: SSHConnectionArgumentsSnapshot(
+                arguments: []
+            ).cacheKey
         ))
 
         model.openBorrowedZellijSession(selection)
@@ -2087,8 +2090,10 @@ struct WorkspaceZellijTests {
         )
         try await killingModel.killZellijSession(request)
 
-        #expect(inventoryModel.snapshot.host(id: host.id)?
-            .zellijSessions.isEmpty == true)
+        await waitUntilMainActor {
+            inventoryModel.snapshot.host(id: host.id)?
+                .zellijSessions.isEmpty == true
+        }
 
         releaseFirstProbe.signal()
         await waitUntilMainActor {
@@ -2877,6 +2882,10 @@ struct WorkspaceZellijTests {
         #expect(kills.withLock { $0.count } == 1)
         #expect(kills.withLock { $0.first?.0 } == "api")
         #expect(kills.withLock { $0.first?.1 } == .local)
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.host.id)?
+                .zellijSessions.isEmpty == true
+        }
         #expect(model.snapshot.host(id: environment.host.id)?
             .zellijSessions.isEmpty == true)
         await model.shutdown()

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2003,10 +2003,13 @@ struct WorkspaceZellijTests {
             hostID: host.id,
             name: "api"
         )
-        let operation = try #require(killCoordinator.begin(key: .init(
-            hostID: host.id,
-            sessionName: selection.name
-        )))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(
+                hostID: host.id,
+                sessionName: selection.name
+            ),
+            hostKey: host.configKey
+        ))
 
         model.openBorrowedZellijSession(selection)
         configuredHost.withLock {
@@ -2392,6 +2395,91 @@ struct WorkspaceZellijTests {
             (model.sessionConnectionRecoveryRequest != nil)
                 == canReviewConnection
         )
+        await model.shutdown()
+    }
+
+    @Test("Zellij resolver failure rejects SSH connection drift")
+    func resolverFailureRejectsSSHConnectionDrift() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let frozen = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/frozen-config",
+        ])
+        let changed = SSHConnectionArgumentsSnapshot(arguments: [
+            "-F", "/tmp/changed-config",
+        ])
+        let currentConnection = Mutex(frozen)
+        let resolverState = Mutex((calls: 0, blocked: false, released: false))
+        defer { resolverState.withLock { $0.released = true } }
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let call = resolverState.withLock {
+                    $0.calls += 1
+                    return $0.calls
+                }
+                guard call > 1 else { return .success("/usr/bin/zellij") }
+                resolverState.withLock { $0.blocked = true }
+                while !resolverState.withLock({ $0.released }) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return .failure(.commandFailed(
+                    status: 255,
+                    stderr: "Permission denied (publickey)."
+                ))
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                currentConnection.withLock { $0 }
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor {
+            resolverState.withLock { $0.blocked }
+        }
+        currentConnection.withLock { $0 = changed }
+        resolverState.withLock { $0.released = true }
+        let changedConnectionReason =
+            "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
+        await waitUntilMainActor {
+            model.activeBorrowedZellijConnectionState == .disconnected(
+                reason: changedConnectionReason
+            )
+        }
+
+        #expect(model.sessionConnectionRecoveryRequest == nil)
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2110,6 +2110,126 @@ struct WorkspaceZellijTests {
         await killingModel.shutdown()
     }
 
+    @Test("successful kill does not close a newer same-name attachment")
+    func successfulKillPreservesNewerAttachment() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let connectionState = Mutex((
+            calls: 0,
+            blocked: false,
+            released: false
+        ))
+        defer { connectionState.withLock { $0.released = true } }
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                let call = connectionState.withLock {
+                    $0.calls += 1
+                    return $0.calls
+                }
+                if call == 1 {
+                    connectionState.withLock { $0.blocked = true }
+                    while !connectionState.withLock({ $0.released }) {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+                return SSHConnectionArgumentsSnapshot(arguments: [])
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        let resolvedHost = try #require(CommandHostResolver.resolve(host))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: selection.name),
+            host: resolvedHost,
+            connectionCacheKey: SSHConnectionArgumentsSnapshot(
+                arguments: []
+            ).cacheKey
+        ))
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            connectionState.withLock { $0.blocked }
+        }
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == selection
+                && store.requestedConfigurations.count == 1
+        }
+        connectionState.withLock { $0.released = true }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        #expect(model.snapshot.host(id: host.id)?.zellijSessions.map(\.name)
+            == ["api"])
+        await model.shutdown()
+    }
+
+    @Test("successful kill ignores transient Zellij availability")
+    func successfulKillIgnoresTransientAvailability() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: false
+        )
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionKillCoordinator: killCoordinator
+        )
+        let resolvedHost = try #require(CommandHostResolver.resolve(host))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: "api"),
+            host: resolvedHost,
+            connectionCacheKey: SSHConnectionArgumentsSnapshot(
+                arguments: []
+            ).cacheKey
+        ))
+
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.snapshot.host(id: host.id)?.zellijSessions.isEmpty == true
+        }
+
+        #expect(model.snapshot.host(id: host.id)?.zellijSessions.isEmpty == true)
+        await model.shutdown()
+    }
+
     @Test("reconnect rejects SSH route drift before probing")
     func reconnectRejectsSSHRouteDrift() async throws {
         let database = try WorkspaceDatabase.inMemory()

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2189,6 +2189,155 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("kill on a stale SSH route preserves the active attachment")
+    func staleRouteKillPreservesActiveAttachment() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let currentConnection = SSHConnectionArgumentsSnapshot(arguments: [
+            "-p", "2222",
+        ])
+        let staleConnection = SSHConnectionArgumentsSnapshot(arguments: [
+            "-p", "2200",
+        ])
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in currentConnection }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == selection
+                && store.requestedConfigurations.count == 1
+        }
+        let resolvedHost = try #require(CommandHostResolver.resolve(host))
+        let operation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: selection.name),
+            host: resolvedHost,
+            connectionCacheKey: staleConnection.cacheKey
+        ))
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        #expect(store.requestedConfigurations.count == 1)
+        killCoordinator.finish(operation, outcome: .failed)
+        await model.shutdown()
+    }
+
+    @Test("successful kill cancels in-flight inventory before fencing")
+    func successfulKillCancelsInFlightInventory() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let resolvedHost = try #require(CommandHostResolver.resolve(host))
+        let discoveryState = Mutex((
+            attempts: 0,
+            initialStarted: false,
+            initialCancelled: false,
+            releaseAll: false
+        ))
+        let connectionState = Mutex((blocked: false, released: false))
+        defer {
+            discoveryState.withLock { $0.releaseAll = true }
+            connectionState.withLock { $0.released = true }
+        }
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionDiscovery: { _ in
+                let attempt = discoveryState.withLock {
+                    $0.attempts += 1
+                    if $0.attempts == 1 {
+                        $0.initialStarted = true
+                    }
+                    return $0.attempts
+                }
+                while !discoveryState.withLock({ $0.releaseAll }) {
+                    if Task.isCancelled {
+                        if attempt == 1 {
+                            discoveryState.withLock {
+                                $0.initialCancelled = true
+                            }
+                        }
+                        break
+                    }
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                connectionState.withLock { $0.blocked = true }
+                while !connectionState.withLock({ $0.released }) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return SSHConnectionArgumentsSnapshot(arguments: [])
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.startZellijSessionDiscovery()
+        await waitUntilMainActor {
+            discoveryState.withLock { $0.initialStarted }
+        }
+        let operation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: selection.name),
+            host: resolvedHost,
+            connectionCacheKey: SSHConnectionArgumentsSnapshot(
+                arguments: []
+            ).cacheKey
+        ))
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            connectionState.withLock { $0.blocked }
+                && discoveryState.withLock { $0.initialCancelled }
+        }
+        #expect(discoveryState.withLock { $0.initialCancelled })
+        discoveryState.withLock { $0.releaseAll = true }
+        connectionState.withLock { $0.released = true }
+        await model.shutdown()
+    }
+
     @Test("successful kill ignores transient Zellij availability")
     func successfulKillIgnoresTransientAvailability() async throws {
         let host = HostSummary(

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2003,12 +2003,13 @@ struct WorkspaceZellijTests {
             hostID: host.id,
             name: "api"
         )
+        let confirmedHost = try #require(CommandHostResolver.resolve(host))
         let operation = try #require(killCoordinator.begin(
             key: .init(
                 hostID: host.id,
                 sessionName: selection.name
             ),
-            hostKey: host.configKey
+            host: confirmedHost
         ))
 
         model.openBorrowedZellijSession(selection)
@@ -2565,6 +2566,7 @@ struct WorkspaceZellijTests {
             zellijAvailable: true
         )
         let store = RecordingNativeSessionSurfaceStore()
+        let connectionReads = Mutex(0)
         let resolverState = Mutex((
             calls: 0,
             blocked: false,
@@ -2600,6 +2602,10 @@ struct WorkspaceZellijTests {
             zellijSessionValidationDiscovery: { _, _ in
                 .available(["api", "replacement"])
             },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                connectionReads.withLock { $0 += 1 }
+                return SSHConnectionArgumentsSnapshot(arguments: [])
+            },
             tmuxReconnectIntervals: [.zero],
             tmuxReconnectProbeDeadline: .seconds(1)
         )
@@ -2629,9 +2635,11 @@ struct WorkspaceZellijTests {
                 && store.requestedConfigurations.count == 2
                 && resolverState.withLock { $0.cancelled }
         }
+        let readsBeforeRelease = connectionReads.withLock { $0 }
         resolverState.withLock { $0.released = true }
         try await Task.sleep(for: .milliseconds(50))
 
+        #expect(connectionReads.withLock { $0 } == readsBeforeRelease)
         #expect(model.activeBorrowedZellijSelection == replacement)
         #expect(model.activeBorrowedZellijConnectionState == .connected)
         #expect(model.activeBorrowedZellijRecoveryState == nil)

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -2189,6 +2189,87 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("successful kill drops a queued same-name open despite a stale fence")
+    func successfulKillDropsQueuedIntentDespiteStaleFence() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [
+                ZellijSessionSummary(name: "api"),
+                ZellijSessionSummary(name: "worker"),
+            ],
+            zellijAvailable: true
+        )
+        let connectionState = Mutex((
+            calls: 0,
+            blocked: false,
+            released: false
+        ))
+        defer { connectionState.withLock { $0.released = true } }
+        let killCoordinator = ZellijSessionKillCoordinator()
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionKillCoordinator: killCoordinator,
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api", "worker"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in
+                let call = connectionState.withLock {
+                    $0.calls += 1
+                    return $0.calls
+                }
+                if call == 1 {
+                    connectionState.withLock { $0.blocked = true }
+                    while !connectionState.withLock({ $0.released }) {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+                return SSHConnectionArgumentsSnapshot(arguments: [])
+            }
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        let resolvedHost = try #require(CommandHostResolver.resolve(host))
+        let cacheKey = SSHConnectionArgumentsSnapshot(arguments: []).cacheKey
+        let operation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: selection.name),
+            host: resolvedHost,
+            connectionCacheKey: cacheKey
+        ))
+
+        model.openBorrowedZellijSession(selection)
+        #expect(model.pendingZellijPresentationSelection == selection)
+        killCoordinator.finish(operation, outcome: .succeeded)
+        await waitUntilMainActor {
+            connectionState.withLock { $0.blocked }
+        }
+        let workerOperation = try #require(killCoordinator.begin(
+            key: .init(hostID: host.id, sessionName: "worker"),
+            host: resolvedHost,
+            connectionCacheKey: cacheKey
+        ))
+        killCoordinator.finish(workerOperation, outcome: .succeeded)
+        connectionState.withLock { $0.released = true }
+
+        await waitUntilMainActor {
+            model.pendingZellijPresentationSelection == nil
+        }
+        await model.shutdown()
+    }
+
     @Test("kill on a stale SSH route preserves the active attachment")
     func staleRouteKillPreservesActiveAttachment() async throws {
         let host = HostSummary(

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -331,6 +331,7 @@ struct WorkspaceZellijTests {
         let validations = Mutex<[ZellijDiscoveryResult]>([
             .available([]),
             .available(sessionBecameActive ? ["release"] : []),
+            .available([]),
         ])
         let model = try makeModel(
             database: environment.database,
@@ -365,6 +366,19 @@ struct WorkspaceZellijTests {
         if sessionBecameActive {
             #expect(retryCommand.contains("'attach'"))
             #expect(!retryCommand.contains("--session=release"))
+
+            await waitUntilMainActor {
+                model.activeBorrowedZellijConnectionState == .disconnected(
+                    reason: ZellijCommandError.unavailable.localizedDescription
+                )
+            }
+            model.retryBorrowedZellijSession(selection)
+            await waitUntilMainActor(timeout: .seconds(1)) {
+                store.requestedConfigurations.count == 3
+            }
+
+            #expect(store.lastCommand?.contains("--session=release") == true)
+            #expect(store.lastCommand?.contains("'attach'") == false)
         } else {
             #expect(retryCommand.contains("--session=release"))
             #expect(!retryCommand.contains("'attach'"))
@@ -2224,6 +2238,315 @@ struct WorkspaceZellijTests {
         #expect(model.sessionConnectionRecoveryRequest == nil)
         #expect(model.activeBorrowedZellijRecoveryState == nil)
         #expect(model.activeBorrowedZellijConnectionState == .connected)
+        await model.shutdown()
+    }
+
+    @Test("Zellij resolver transport failure retries reconnect")
+    func resolverTransportFailureRetriesReconnect() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolutions = Mutex(0)
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let attempt = resolutions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 2
+                    ? .failure(.commandFailed(
+                        status: 255,
+                        stderr: "ssh: connect to host builder port 22: Network is unreachable"
+                    ))
+                    : .success("/usr/bin/zellij")
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            resolutions.withLock { $0 } >= 3
+                && store.requestedConfigurations.count == 2
+        }
+
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(model.sessionConnectionRecoveryRequest == nil)
+        await model.shutdown()
+    }
+
+    @Test(
+        "Zellij resolver SSH failure publishes connection recovery",
+        arguments: [
+            (
+                "Permission denied (publickey,password).",
+                true
+            ),
+            (
+                "Host key verification failed.",
+                true
+            ),
+            (
+                "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!",
+                false
+            ),
+        ]
+    )
+    func resolverSSHFailurePublishesRecovery(
+        stderr: String,
+        canReviewConnection: Bool
+    ) async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolutions = Mutex(0)
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let attempt = resolutions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                return attempt == 1
+                    ? .success("/usr/bin/zellij")
+                    : .failure(.commandFailed(status: 255, stderr: stderr))
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            if case .needsAttention = model.activeBorrowedZellijRecoveryState {
+                return true
+            }
+            return false
+        }
+
+        guard case let .needsAttention(_, allowsReview) =
+            model.activeBorrowedZellijRecoveryState
+        else {
+            Issue.record("Expected Zellij resolver recovery state")
+            await model.shutdown()
+            return
+        }
+        #expect(allowsReview == canReviewConnection)
+        #expect(
+            (model.sessionConnectionRecoveryRequest != nil)
+                == canReviewConnection
+        )
+        await model.shutdown()
+    }
+
+    @Test("Zellij resolver deadline keeps reconnect retryable")
+    func resolverDeadlineKeepsReconnectRetryable() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolverState = Mutex((calls: 0, cancellations: 0))
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let call = resolverState.withLock {
+                    $0.calls += 1
+                    return $0.calls
+                }
+                guard call > 1 else { return .success("/usr/bin/zellij") }
+                while !Task.isCancelled {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                resolverState.withLock { $0.cancellations += 1 }
+                return .failure(.unavailable)
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            tmuxReconnectIntervals: [.seconds(1)],
+            tmuxReconnectProbeDeadline: .milliseconds(20)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            resolverState.withLock { $0.cancellations } >= 1
+        }
+
+        #expect(model.zellijReconnectSupervisorIsRunning)
+        if case .reconnecting = model.activeBorrowedZellijConnectionState {
+            // Expected: the supervisor remains responsible for recovery.
+        } else {
+            Issue.record("Expected Zellij reconnect to remain retryable")
+        }
+        await model.shutdown()
+    }
+
+    @Test("superseded Zellij resolver cannot disconnect replacement")
+    func supersededResolverPreservesReplacement() async throws {
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [
+                ZellijSessionSummary(name: "api"),
+                ZellijSessionSummary(name: "replacement"),
+            ],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolverState = Mutex((
+            calls: 0,
+            blocked: false,
+            cancelled: false,
+            released: false
+        ))
+        defer { resolverState.withLock { $0.released = true } }
+        let model = try makeModel(
+            database: .inMemory(),
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let call = resolverState.withLock {
+                    $0.calls += 1
+                    return $0.calls
+                }
+                guard call == 2 else { return .success("/usr/bin/zellij") }
+                resolverState.withLock { $0.blocked = true }
+                while !Task.isCancelled {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                resolverState.withLock { $0.cancelled = true }
+                while !resolverState.withLock({ $0.released }) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+                return .failure(.unavailable)
+            },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api", "replacement"])
+            },
+            tmuxReconnectIntervals: [.zero],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let initial = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+        let replacement = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "replacement"
+        )
+
+        model.openBorrowedZellijSession(initial)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor {
+            resolverState.withLock { $0.blocked }
+        }
+
+        model.openBorrowedZellijSession(replacement)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijSelection == replacement
+                && store.requestedConfigurations.count == 2
+                && resolverState.withLock { $0.cancelled }
+        }
+        resolverState.withLock { $0.released = true }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(model.activeBorrowedZellijSelection == replacement)
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
         await model.shutdown()
     }
 

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -444,7 +444,6 @@ private final class SidePanelStabilityTestEnvironment {
     var isSidePanelVisible = false {
         didSet { updateView() }
     }
-    private let window: NSWindow
     private let hostingView: NSHostingView<AnyView>
     private let stableID = "stability-test-main-column"
 
@@ -456,14 +455,12 @@ private final class SidePanelStabilityTestEnvironment {
             )
         )
         hostingView = NSHostingView(rootView: view)
-        window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 960, height: 640),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
+        hostingView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 960,
+            height: 640
         )
-        window.contentView = hostingView
-        window.makeKeyAndOrderFront(nil)
         settle()
     }
 
@@ -473,7 +470,7 @@ private final class SidePanelStabilityTestEnvironment {
     }
 
     func findStableContent() -> NSView? {
-        findView(id: stableID, in: window.contentView!)
+        findView(id: stableID, in: hostingView)
     }
 
     private func updateView() {

--- a/Tests/test_run_swift_tests.py
+++ b/Tests/test_run_swift_tests.py
@@ -105,18 +105,31 @@ def test_forwarded_interrupt_keeps_its_grace(tmp_path: Path) -> None:
     child_pid_file = tmp_path / "child.pid"
     term_file = tmp_path / "term-received"
     done_file = tmp_path / "int-done"
-    command = tmp_path / "graceful-int.sh"
+    command = tmp_path / "graceful_int.py"
     command.write_text(
-        "#!/bin/sh\n"
-        f"trap 'echo term > \"{term_file}\"; exit 1' TERM\n"
-        f"trap 'sleep 1; echo done > \"{done_file}\"; exit 0' INT\n"
-        f'echo $$ > "{child_pid_file}"\n'
-        "while :; do sleep 0.1; done\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "import signal\n"
+        "import time\n"
+        f"child_pid_file = Path({str(child_pid_file)!r})\n"
+        f"term_file = Path({str(term_file)!r})\n"
+        f"done_file = Path({str(done_file)!r})\n"
+        "def handle_term(signum, frame):\n"
+        "    term_file.write_text('term')\n"
+        "    raise SystemExit(1)\n"
+        "def handle_int(signum, frame):\n"
+        "    time.sleep(1)\n"
+        "    done_file.write_text('done')\n"
+        "    raise SystemExit(0)\n"
+        "signal.signal(signal.SIGTERM, handle_term)\n"
+        "signal.signal(signal.SIGINT, handle_int)\n"
+        "child_pid_file.write_text(str(os.getpid()))\n"
+        "while True:\n"
+        "    signal.pause()\n"
     )
-    command.chmod(0o755)
 
     wrapper = subprocess.Popen(
-        ["sh", str(SCRIPT), str(command)],
+        ["sh", str(SCRIPT), sys.executable, str(command)],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         env={**os.environ, "GHOSTHUB_TEST_STOP_GRACE": "5"},


### PR DESCRIPTION
Zellij reconnect, restoration, and kill completion cross asynchronous SSH and host-configuration boundaries. Without durable identity checks at those boundaries, a stale lookup could publish recovery for replaced SSH settings, and a confirmed kill could leave restoration eligible to attach a later same-name session after a host rename.

- Classifies executable-lookup failures through the existing SSH recovery path only after cancellation, attachment identity, host route, and final SSH snapshot validation.
- Preserves constructive failed-create intent until connection success or explicit lifecycle termination.
- Retires matching restoration through either the confirmed host key or the restoration route’s stable host UUID, including restoration begun after a host rename while the kill is pending.
- Removes two hosted-runner races: the layout-only sidebar test no longer opens an InputMethodKit-backed key window, and interrupt-grace coverage uses deterministic Python signal handling instead of macOS shell-trap timing.
- Red/green coverage exercises SSH recovery, cancellation and replacement fencing, failed-create retry, SSH drift, and both orders of host rename versus pending restoration.
- `swift test --no-parallel` passed 1,522 Swift Testing cases and 166 XCTest cases with 5 expected headless skips; essential workflows, 50 bootstrap tests, 141 Python tests, warnings-as-errors, build, formatting, and diff checks also pass.