### PR TITLE
Add local WSL Zellij sessions to the Rust port

### DIFF
--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -2,7 +2,7 @@
 
 This document is the maintained design for native Ghosthub applications on
 Windows and Linux. The first product slice is Windows-only, uses tmux in WSL2,
-and discovers optional Herdr sessions there; Linux remains a
+and discovers optional Herdr and Zellij sessions there; Linux remains a
 compile-and-contract target until a native Linux product slice is authorized.
 The shipped macOS application remains SwiftUI/AppKit with libghostty. The
 shared product and terminal invariants remain authoritative in
@@ -23,8 +23,8 @@ away from SwiftUI.
   a WSL2 distro through `wsl.exe` and ConPTY.
 - Linux remains in Rust CI for compilation, contracts, architecture, lint, and
   dependency policy. A native Linux application is deferred.
-- All platforms preserve the Host, Project, Worktree, and ordinary tmux
-  Session mental model.
+- All platforms preserve the Host, Project, Worktree, and ordinary
+  multiplexer-session mental model.
 - Kwt remains authoritative for project/worktree identity and exact session
   names. Direct tmux-compatible discovery supplies otherwise-unbound sessions.
 - Tmux owns server-side windows, panes, layout, history, alternate-screen
@@ -83,7 +83,7 @@ bytes in, resize, modes queryable, semantic effects, and Rust-owned paint
 state out. No public crate or UI API presumes the outcome.
 
 The exact kwt revision in repository-root `KWT_REVISION` is
-1afb99003adaf686012be693a66adfff4ebfd2a1. That source uses KWT_HOME or the
+03dc3dcc2349282cda3cccfd20a9b1a1ebf83a98. That source uses KWT_HOME or the
 fixed $HOME/.config/kwt default. It does not read Ghosthub init.toml,
 config_home, or XDG_CONFIG_HOME. Rust must not reproduce the unsupported
 Ghosthub init.toml scanner. The two existing Swift copies are outside the Rust
@@ -280,6 +280,34 @@ Every constructive or lifecycle publication advances the inventory generation
 and cancels an older refresh, so an earlier full snapshot cannot overwrite the
 result. Rust does not reinterpret Herdr as a tmux-compatible server or use
 Herdr's remote mode.
+
+### Optional Zellij capability in WSL
+
+Zellij is a third optional capability of the same resolved WSL endpoint. Host
+resolves one absolute executable through the POSIX login profile, removes
+inherited `ZELLIJ`, `ZELLIJ_PANE_ID`, and `ZELLIJ_SESSION_NAME`, and invokes
+`zellij list-sessions --no-formatting` through direct argv. Exit 127 is silent
+absence. Zellij's exact no-active-sessions response is successful empty
+inventory; other failures remain Zellij-scoped diagnostics and never hide tmux
+or Herdr inventory. Exited entries that Zellij could resurrect are deliberately
+excluded.
+
+The sidebar gives Zellij its own compact group and creation action. Opening an
+active row consumes an attach-only plan for `zellij attach -- <exact-name>`.
+Creation consumes a non-cloneable one-shot launch for
+`zellij --session=<exact-name>`. Both run as ordinary ConPTY clients, share the
+retained-presentation switcher with tmux and Herdr, and never replay creation
+after failure. Closing the client only detaches.
+
+Kill Session is separate and confirmed. Host checks the current WSL runtime,
+absolute executable, and exact active name, closes the matching presentation,
+then repeats all checks immediately before `zellij kill-session --
+<exact-name>`. Attachment, creation, and kill share the serialized session
+operation lane, so an older launch cannot complete after an intentional kill.
+Zellij exposes no stable session-generation identity; the same-name
+replacement race described in [Terminal Sessions](terminal-sessions.md)
+remains an explicit backend limitation rather than a false tmux-strength
+guarantee.
 
 ### Terminal ownership
 
@@ -621,8 +649,9 @@ before the requested KWT command runs. Developer builds may omit the bundle,
 in which case KWT inventory alone is unavailable.
 
 KWT project and worktree reads are a separate cancellable host operation from
-tmux and Herdr inventory. The frequent session cadence never installs the KWT
-helper, invokes KWT, or replays worktree reconciliation. One KWT inventory read
+tmux, Herdr, and Zellij inventory. The frequent session cadence never installs
+the KWT helper, invokes KWT, or replays worktree reconciliation. One KWT
+inventory read
 uses exactly three machine-readable crossings: registered projects, the global
 worktree list, and directory workspaces. After the admitted host first
 publishes, Rust performs one background KWT read and then refreshes it every 60
@@ -640,7 +669,9 @@ path to the pinned helper's `projects add <path> --json` command. Each
 registered project also exposes a confirmed **Remove Project** action. Removal
 first re-reads project inventory, then invokes
 `projects remove <exact-path> --expected-repository <credential-free-id>
---json`; KWT performs the final identity check. Unregistration changes KWT
+--expected-registration <opaque-fingerprint> --json`; KWT performs the final
+identity check against both values. Empty or missing registration fingerprints
+are rejected as malformed inventory. Unregistration changes KWT
 metadata only. It cannot delete the repository or worktrees and cannot stop or
 kill tmux sessions. Ghosthub never scans WSL and never edits KWT configuration.
 
@@ -727,9 +758,9 @@ database transactions, Kwt reconciliation, or resource sampling. Host reads
 and future project/worktree inventory merges run on cancellable background read
 lanes. They build owned results before entering the short publication section;
 no snapshot publication guard may cross external I/O, process waits, or an
-await point. Runtime-only tmux or Herdr updates cannot replay project/worktree
-reconciliation. Each host publishes independently, so one slow host cannot
-delay completed inventory from another host.
+await point. Runtime-only tmux, Herdr, or Zellij updates cannot replay
+project/worktree reconciliation. Each host publishes independently, so one
+slow host cannot delay completed inventory from another host.
 
 Refresh generations are allocated monotonically. A result publishes only when
 its generation is newer than the published generation. Cancelled, timed-out,
@@ -824,8 +855,9 @@ exact host, resolved endpoint, socket directory, session, and live identity.
 Explicit close detaches only the selected presentation, and application
 shutdown detaches every retained client. Navigation never sends a mux kill
 command. The chrome is shaped for additional admitted local mux hosts, but
-Slice 1 exposes only WSL tmux; psmux remains rejection evidence until it
-satisfies the same capability bar.
+The initial slice exposed only WSL tmux; optional WSL Herdr and Zellij groups
+now use the same shell and retained-presentation boundary. Psmux remains
+rejection evidence until it satisfies the same capability bar.
 
 The active presentation keeps a detach action that only closes its ordinary
 client. Every session in the current live inventory separately exposes Kill
@@ -983,7 +1015,9 @@ Rust keeps the same separation:
 - cargo test-wsl-kwt-live installs and verifies a staged pinned KWT helper and
   reads its real inventory
 - `make rust-test-wsl-live` launches real isolated tmux servers inside a WSL2
-  distro plus PTYs and supervisor children for detach and app-death survival
+  distro plus PTYs and supervisor children for detach and app-death survival;
+  it also creates, detaches, reattaches, and explicitly kills one nonce-named
+  Zellij session without touching other Zellij sessions
 
 Cargo test binaries own cross-platform orchestration. Make targets are thin
 wrappers; Windows CI invokes the same Cargo tests without POSIX shell

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -249,8 +249,8 @@ guarantee. Closing or disconnecting never implies a kill.
 
 ## Rust Client Lifetime and Application Death
 
-The planned Rust applications use the same ordinary-client boundary. The first
-product slice is a native Windows GPUI client attaching to tmux inside WSL2;
+The Rust applications use the same ordinary-client boundary. The native
+Windows GPUI client attaches to tmux, Herdr, and Zellij inside WSL2;
 Linux remains a compile-and-contract target until its native product slice is
 authorized. A terminal worker and PTY own only the disposable client. The WSL
 tmux server owns session lifetime and must survive client close, graceful

--- a/rust/host/src/kwt.rs
+++ b/rust/host/src/kwt.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct KwtBundle {
@@ -82,6 +82,21 @@ pub struct KwtProject {
     name: String,
     path: String,
     last_touched: Option<String>,
+    #[serde(deserialize_with = "deserialize_nonempty_string")]
+    registration_fingerprint: String,
+}
+
+fn deserialize_nonempty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    if value.is_empty() {
+        return Err(de::Error::custom(
+            "KWT registration_fingerprint must not be empty",
+        ));
+    }
+    Ok(value)
 }
 
 #[derive(Debug, Deserialize)]
@@ -119,6 +134,10 @@ impl KwtProject {
     #[must_use]
     pub fn last_touched(&self) -> Option<&str> {
         self.last_touched.as_deref()
+    }
+    #[must_use]
+    pub fn registration_fingerprint(&self) -> &str {
+        &self.registration_fingerprint
     }
 }
 
@@ -317,7 +336,7 @@ mod tests {
     #[test]
     fn inventory_joins_global_worktrees_without_reordering_projects() {
         let inventory = KwtInventory::parse(
-            br#"[{"repository":"two","name":"Second","path":"/r/two","last_touched":null},{"repository":"one","name":"First","path":"/r/one","last_touched":"now"}]"#,
+            br#"[{"repository":"two","name":"Second","path":"/r/two","last_touched":null,"registration_fingerprint":"two-fingerprint"},{"repository":"one","name":"First","path":"/r/one","last_touched":"now","registration_fingerprint":"one-fingerprint"}]"#,
             br#"[{"path":"/w/one","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"one","session_name":"one-main","tmux_socket_name":null},{"path":"/w/two","branch":"topic","commit_hash":"def","is_main":false,"created_at":"then","generation":null,"repository":"two","session_name":"two-topic","tmux_socket_name":"alt"}]"#,
             br#"[{"name":"scratch","path":"/w/scratch","session_name":"scratch","session_live":false}]"#,
         ).expect("valid inventory");
@@ -334,7 +353,17 @@ mod tests {
     #[test]
     fn inventory_rejects_schema_drift() {
         let error = KwtInventory::parse(
-            br#"[{"repository":"one","name":"One","path":"/r/one","last_touched":null,"surprise":true}]"#,
+            br#"[{"repository":"one","name":"One","path":"/r/one","last_touched":null,"registration_fingerprint":"one-fingerprint","surprise":true}]"#,
+            b"[]",
+            b"[]",
+        );
+        assert!(error.is_err());
+    }
+
+    #[test]
+    fn inventory_rejects_an_empty_registration_fingerprint() {
+        let error = KwtInventory::parse(
+            br#"[{"repository":"one","name":"One","path":"/r/one","last_touched":null,"registration_fingerprint":""}]"#,
             b"[]",
             b"[]",
         );
@@ -344,14 +373,14 @@ mod tests {
     #[test]
     fn project_mutations_require_the_expected_machine_status() {
         let registered = parse_project_mutation(
-            br#"{"status":"registered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null}}"#,
+            br#"{"status":"registered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"opaque-registration"}}"#,
             "registered",
         )
         .expect("valid registration");
         assert_eq!(registered.path(), "/code/widget");
         assert!(
             parse_project_mutation(
-                br#"{"status":"unregistered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null}}"#,
+                br#"{"status":"unregistered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"opaque-registration"}}"#,
                 "registered",
             )
             .is_err()

--- a/rust/host/src/lib.rs
+++ b/rust/host/src/lib.rs
@@ -17,6 +17,7 @@ mod kwt;
 #[cfg(windows)]
 mod windows_system;
 mod wsl;
+mod zellij;
 
 pub use kwt::{
     KwtBundle, KwtDirectoryWorkspace, KwtInventory, KwtProject, KwtProjectInventory, KwtWorktree,
@@ -24,7 +25,7 @@ pub use kwt::{
 pub use wsl::{
     AdmissionAttacher, AttachTerm, CreationReceipt, HerdrInventory, HostError, HostSnapshot,
     KwtHostSnapshot, LiveSessionTarget, SystemWslPresence, WslConfig, WslEndpoint, WslExecutable,
-    WslHost, WslPresence, WslRuntimeIdentity,
+    WslHost, WslPresence, WslRuntimeIdentity, ZellijInventory,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -11,11 +11,13 @@ use session::{
     AdmissionPlan, AttachPlan, CreateOnce, DiscoveredSession, ExecutablePlatform, HerdrAttachPlan,
     HerdrLaunchOnce, HerdrLaunchTarget, HerdrLifecycleAction, HerdrSessionRecord,
     HerdrSessionState, IDENTITY_MISMATCH_MARKER, ProbeObservation, SessionIdentity, SessionName,
-    VerifiedTmuxBinary, resolve_tmux_binary,
+    VerifiedTmuxBinary, ZellijAttachPlan, ZellijLaunchOnce, ZellijSessionName, ZellijSessionRecord,
+    resolve_tmux_binary,
 };
 
 use crate::herdr::{self, ExecutableProbe};
 use crate::kwt::{parse_project_mutation, project_command_error};
+use crate::zellij;
 use crate::{CancellationToken, CommandOutput, CommandRunner, KwtBundle, KwtInventory, KwtProject};
 
 const DEFAULT_TMUX: &str = "/usr/bin/tmux";
@@ -197,6 +199,7 @@ pub struct HostSnapshot {
     creation_term: AttachTerm,
     sessions: Vec<DiscoveredSession>,
     herdr: Box<HerdrInventory>,
+    zellij: Box<ZellijInventory>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -231,6 +234,47 @@ pub enum HerdrInventory {
         sessions: Vec<HerdrSessionRecord>,
     },
     Failed(HostError),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ZellijInventory {
+    Unavailable,
+    Available {
+        executable: String,
+        sessions: Vec<ZellijSessionRecord>,
+    },
+    Failed(HostError),
+}
+
+impl ZellijInventory {
+    #[must_use]
+    pub const fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+
+    #[must_use]
+    pub fn executable(&self) -> Option<&str> {
+        match self {
+            Self::Available { executable, .. } => Some(executable),
+            Self::Unavailable | Self::Failed(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub fn sessions(&self) -> &[ZellijSessionRecord] {
+        match self {
+            Self::Available { sessions, .. } => sessions,
+            Self::Unavailable | Self::Failed(_) => &[],
+        }
+    }
+
+    #[must_use]
+    pub const fn diagnostic(&self) -> Option<&HostError> {
+        match self {
+            Self::Failed(error) => Some(error),
+            Self::Unavailable | Self::Available { .. } => None,
+        }
+    }
 }
 
 impl HerdrInventory {
@@ -336,6 +380,7 @@ impl HostSnapshot {
             creation_term: AttachTerm::Xterm256Color,
             sessions,
             herdr: Box::new(HerdrInventory::Unavailable),
+            zellij: Box::new(ZellijInventory::Unavailable),
         }
     }
 
@@ -351,6 +396,21 @@ impl HostSnapshot {
     ) -> Self {
         let mut snapshot = Self::test_fixture(distro, kernel_boot_id, init_start_ticks, sessions);
         snapshot.herdr = Box::new(herdr);
+        snapshot
+    }
+
+    #[cfg(feature = "test-support")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn test_fixture_with_zellij(
+        distro: impl Into<String>,
+        kernel_boot_id: impl Into<String>,
+        init_start_ticks: u64,
+        sessions: Vec<DiscoveredSession>,
+        zellij: ZellijInventory,
+    ) -> Self {
+        let mut snapshot = Self::test_fixture(distro, kernel_boot_id, init_start_ticks, sessions);
+        snapshot.zellij = Box::new(zellij);
         snapshot
     }
 
@@ -385,6 +445,11 @@ impl HostSnapshot {
     #[must_use]
     pub fn herdr(&self) -> &HerdrInventory {
         self.herdr.as_ref()
+    }
+
+    #[must_use]
+    pub fn zellij(&self) -> &ZellijInventory {
+        self.zellij.as_ref()
     }
 
     /// Apply one authoritative Herdr lifecycle response to this snapshot.
@@ -777,6 +842,7 @@ impl<R: CommandRunner> WslHost<R> {
         runtime: &WslRuntimeIdentity,
         expected_path: &str,
         expected_repository: &str,
+        expected_registration: &str,
         cancellation: &CancellationToken,
     ) -> Result<KwtProject, HostError> {
         let bundle = self.config.kwt_bundle().ok_or_else(|| {
@@ -796,7 +862,9 @@ impl<R: CommandRunner> WslHost<R> {
                 )
             })?;
         if !current.iter().any(|project| {
-            project.path() == expected_path && project.repository() == expected_repository
+            project.path() == expected_path
+                && project.repository() == expected_repository
+                && project.registration_fingerprint() == expected_registration
         }) {
             return Err(HostError::new(
                 DiagnosticKind::MalformedOutput,
@@ -813,6 +881,8 @@ impl<R: CommandRunner> WslHost<R> {
                 expected_path,
                 "--expected-repository",
                 expected_repository,
+                "--expected-registration",
+                expected_registration,
                 "--json",
             ],
             cancellation,
@@ -1073,6 +1143,7 @@ impl<R: CommandRunner> WslHost<R> {
             let creation_term = self.verify_tmux(&endpoint, &runtime, attacher, cancellation)?;
             let sessions = self.discover_sessions(&endpoint, cancellation)?;
             let herdr = self.discover_herdr(&endpoint, cancellation);
+            let zellij = self.discover_zellij(&endpoint, cancellation);
             let observed_runtime = self.resolve_runtime(&endpoint, cancellation)?;
             if runtime == observed_runtime {
                 return Ok(HostSnapshot {
@@ -1081,6 +1152,7 @@ impl<R: CommandRunner> WslHost<R> {
                     creation_term,
                     sessions,
                     herdr: Box::new(herdr),
+                    zellij: Box::new(zellij),
                 });
             }
             runtime = observed_runtime;
@@ -1163,6 +1235,135 @@ impl<R: CommandRunner> WslHost<R> {
                 .map(OsString::from),
         );
         HerdrAttachPlan::attach_only(self.wsl_executable.as_os_str(), args)
+    }
+
+    /// Build an attach-only plan for one freshly discovered active Zellij session.
+    #[must_use]
+    pub fn zellij_attach_plan(
+        &self,
+        endpoint: &WslEndpoint,
+        executable: &str,
+        session: &ZellijSessionRecord,
+        term: AttachTerm,
+    ) -> ZellijAttachPlan {
+        let mut args = pinned_prefix(endpoint);
+        append_zellij_environment(&mut args);
+        args.push(OsString::from(term.environment()));
+        args.extend(
+            [executable, "attach", "--", session.name()]
+                .into_iter()
+                .map(OsString::from),
+        );
+        ZellijAttachPlan::attach_only(self.wsl_executable.as_os_str(), args)
+    }
+
+    /// Build one non-repeatable Zellij session creation client.
+    #[must_use]
+    pub fn zellij_launch_once(
+        &self,
+        endpoint: &WslEndpoint,
+        executable: &str,
+        name: ZellijSessionName,
+        term: AttachTerm,
+    ) -> ZellijLaunchOnce {
+        let mut args = pinned_prefix(endpoint);
+        append_zellij_environment(&mut args);
+        args.push(OsString::from(term.environment()));
+        args.push(OsString::from(executable));
+        args.push(OsString::from(format!("--session={}", name.as_str())));
+        ZellijLaunchOnce::create(self.wsl_executable.as_os_str(), args, name)
+    }
+
+    /// Revalidate and kill one exact active Zellij session.
+    ///
+    /// Zellij does not expose a stable session generation, so an exact
+    /// same-name replacement remains a documented backend limitation. The
+    /// runtime, executable, and active inventory are checked immediately
+    /// before the destructive command.
+    ///
+    /// # Errors
+    ///
+    /// Returns a classified error when the WSL runtime, Zellij executable, or
+    /// active session no longer matches confirmation, or when the direct kill
+    /// command fails.
+    pub fn kill_zellij_session(
+        &self,
+        endpoint: &WslEndpoint,
+        expected_runtime: &WslRuntimeIdentity,
+        expected_executable: &str,
+        name: &str,
+        cancellation: &CancellationToken,
+        before_mutation: impl FnOnce(),
+    ) -> Result<(), HostError> {
+        self.validate_current_zellij_target(
+            endpoint,
+            expected_runtime,
+            expected_executable,
+            name,
+            cancellation,
+        )?;
+        before_mutation();
+        self.validate_current_zellij_target(
+            endpoint,
+            expected_runtime,
+            expected_executable,
+            name,
+            cancellation,
+        )?;
+
+        let mut args = pinned_prefix(endpoint);
+        append_zellij_environment(&mut args);
+        args.extend(
+            [expected_executable, "kill-session", "--", name]
+                .into_iter()
+                .map(OsString::from),
+        );
+        let output = self.run(&args, cancellation)?;
+        if output.status != 0 {
+            return Err(classify_command_failure(
+                output.status,
+                &output.stderr,
+                "kill Zellij session",
+            ));
+        }
+        self.require_runtime(endpoint, expected_runtime, cancellation)
+    }
+
+    fn validate_current_zellij_target(
+        &self,
+        endpoint: &WslEndpoint,
+        expected_runtime: &WslRuntimeIdentity,
+        expected_executable: &str,
+        name: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<(), HostError> {
+        self.require_runtime(endpoint, expected_runtime, cancellation)?;
+        let (executable, sessions) = match self.discover_zellij(endpoint, cancellation) {
+            ZellijInventory::Available {
+                executable,
+                sessions,
+            } => (executable, sessions),
+            ZellijInventory::Unavailable => {
+                return Err(HostError::new(
+                    DiagnosticKind::ExecutableNotFound,
+                    "Zellij is unavailable on this host",
+                ));
+            }
+            ZellijInventory::Failed(error) => return Err(error),
+        };
+        if executable != expected_executable {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                "the Zellij executable changed after kill confirmation",
+            ));
+        }
+        if !sessions.iter().any(|session| session.name() == name) {
+            return Err(HostError::new(
+                DiagnosticKind::Transport,
+                format!("Zellij session ‘{name}’ is no longer active"),
+            ));
+        }
+        self.require_runtime(endpoint, expected_runtime, cancellation)
     }
 
     /// Build one Herdr launch-or-attach client. The returned authority is
@@ -1487,6 +1688,7 @@ impl<R: CommandRunner> WslHost<R> {
         runtime: &WslRuntimeIdentity,
         creation_term: AttachTerm,
         herdr: &HerdrInventory,
+        zellij: &ZellijInventory,
         cancellation: &CancellationToken,
     ) -> Result<HostSnapshot, HostError> {
         let sessions = self.discover_sessions(endpoint, cancellation)?;
@@ -1503,6 +1705,7 @@ impl<R: CommandRunner> WslHost<R> {
             creation_term,
             sessions,
             herdr: Box::new(herdr.clone()),
+            zellij: Box::new(zellij.clone()),
         })
     }
 
@@ -1730,6 +1933,79 @@ impl<R: CommandRunner> WslHost<R> {
             }
             Ok(ExecutableProbe::Unavailable) => HerdrInventory::Unavailable,
             Err(error) => HerdrInventory::Failed(error),
+        }
+    }
+
+    fn discover_zellij(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+    ) -> ZellijInventory {
+        match self.resolve_zellij_executable(endpoint, cancellation) {
+            Ok(zellij::ExecutableProbe::Available(executable)) => {
+                self.list_zellij_sessions(endpoint, cancellation, executable)
+            }
+            Ok(zellij::ExecutableProbe::Unavailable) => ZellijInventory::Unavailable,
+            Err(error) => ZellijInventory::Failed(error),
+        }
+    }
+
+    fn resolve_zellij_executable(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+    ) -> Result<zellij::ExecutableProbe, HostError> {
+        let mut args = pinned_prefix(endpoint);
+        args.extend(
+            ["/bin/sh", "-lc", zellij::RESOLVE_SCRIPT]
+                .into_iter()
+                .map(OsString::from),
+        );
+        let output = self.run(&args, cancellation)?;
+        if output.status != 0 && output.status != 127 {
+            return Err(classify_command_failure(
+                output.status,
+                &output.stderr,
+                "resolve Zellij executable",
+            ));
+        }
+        zellij::parse_executable(output.status, &output.stdout)
+            .map_err(|detail| HostError::new(DiagnosticKind::MalformedOutput, detail))
+    }
+
+    fn list_zellij_sessions(
+        &self,
+        endpoint: &WslEndpoint,
+        cancellation: &CancellationToken,
+        executable: String,
+    ) -> ZellijInventory {
+        let mut args = pinned_prefix(endpoint);
+        append_zellij_environment(&mut args);
+        args.extend(
+            [executable.as_str(), "list-sessions", "--no-formatting"]
+                .into_iter()
+                .map(OsString::from),
+        );
+        let output = match self.run(&args, cancellation) {
+            Ok(output) => output,
+            Err(error) => return ZellijInventory::Failed(error),
+        };
+        if output.status == 127 {
+            return ZellijInventory::Unavailable;
+        }
+        match zellij::parse_inventory(output.status, &output.stdout, &output.stderr) {
+            Ok(sessions) => ZellijInventory::Available {
+                executable,
+                sessions,
+            },
+            Err(detail) => ZellijInventory::Failed(HostError::new(
+                if output.status == 0 {
+                    DiagnosticKind::MalformedOutput
+                } else {
+                    DiagnosticKind::Transport
+                },
+                detail,
+            )),
         }
     }
 
@@ -3157,6 +3433,14 @@ fn append_herdr_environment(args: &mut Vec<OsString>) {
     }
 }
 
+fn append_zellij_environment(args: &mut Vec<OsString>) {
+    args.push(OsString::from("/usr/bin/env"));
+    for variable in zellij::CONTROL_VARIABLES {
+        args.push(OsString::from("-u"));
+        args.push(OsString::from(variable));
+    }
+}
+
 fn settle_uncertain_cleanup(
     mut elapsed: impl FnMut() -> Duration,
     mut wait: impl FnMut(Duration),
@@ -3708,11 +3992,11 @@ mod tests {
             } else if args.iter().any(|argument| argument == "/usr/bin/wslpath") {
                 b"/mnt/c/Users/test/code/widget\n".to_vec()
             } else if args.windows(2).any(|pair| pair == ["projects", "add"]) {
-                br#"{"status":"registered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null}}"#.to_vec()
+                br#"{"status":"registered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"opaque-registration"}}"#.to_vec()
             } else if args.windows(2).any(|pair| pair == ["projects", "remove"]) {
-                br#"{"status":"unregistered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null}}"#.to_vec()
+                br#"{"status":"unregistered","project":{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"opaque-registration"}}"#.to_vec()
             } else if args.iter().any(|argument| argument == "projects") {
-                br#"[{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null}]"#.to_vec()
+                br#"[{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"opaque-registration"}]"#.to_vec()
             } else if args.iter().any(|argument| {
                 matches!(
                     argument.as_str(),
@@ -3803,6 +4087,7 @@ mod tests {
                 &runtime,
                 "/code/widget",
                 "github.com/acme/widget",
+                "opaque-registration",
                 &cancellation,
             )
             .expect("remove project");
@@ -3824,6 +4109,8 @@ mod tests {
                 "/code/widget".to_owned(),
                 "--expected-repository".to_owned(),
                 "github.com/acme/widget".to_owned(),
+                "--expected-registration".to_owned(),
+                "opaque-registration".to_owned(),
                 "--json".to_owned(),
             ])
         }));
@@ -4000,6 +4287,7 @@ mod tests {
                 executable: "/usr/bin/herdr".to_owned(),
                 sessions: vec![running.clone(), other.clone()],
             }),
+            zellij: Box::new(ZellijInventory::Unavailable),
         };
         let stopped = HerdrSessionRecord::new(
             "work",
@@ -4064,6 +4352,7 @@ mod tests {
                 executable: executable.to_owned(),
                 sessions: vec![session],
             }),
+            zellij: Box::new(ZellijInventory::Unavailable),
         };
         let replacement = HerdrSessionRecord::new(
             "work",

--- a/rust/host/src/zellij.rs
+++ b/rust/host/src/zellij.rs
@@ -35,9 +35,15 @@ pub(crate) fn parse_executable(status: i32, stdout: &[u8]) -> Result<ExecutableP
             resolved = lines.next();
         }
     }
-    let Some(path) = resolved.map(str::trim).filter(|path| path.starts_with('/')) else {
-        return Ok(ExecutableProbe::Unavailable);
-    };
+    let path = resolved
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| "Zellij executable probe omitted its resolved path".to_owned())?;
+    if !path.starts_with('/') {
+        return Err(format!(
+            "Zellij executable probe returned a non-absolute path: {path}"
+        ));
+    }
     Ok(ExecutableProbe::Available(path.to_owned()))
 }
 
@@ -108,5 +114,16 @@ mod tests {
     #[test]
     fn malformed_inventory_is_rejected() {
         assert!(parse_inventory(0, b"not an inventory row\n", b"").is_err());
+    }
+
+    #[test]
+    fn only_status_127_means_zellij_is_unavailable() {
+        assert!(matches!(
+            parse_executable(127, b""),
+            Ok(ExecutableProbe::Unavailable)
+        ));
+        assert!(parse_executable(0, b"").is_err());
+        assert!(parse_executable(0, b"GHOSTHUB_ZELLIJ_PATH\n").is_err());
+        assert!(parse_executable(0, b"GHOSTHUB_ZELLIJ_PATH\nrelative/zellij\n").is_err());
     }
 }

--- a/rust/host/src/zellij.rs
+++ b/rust/host/src/zellij.rs
@@ -1,0 +1,112 @@
+use session::ZellijSessionRecord;
+
+pub(crate) const PATH_MARKER: &str = "GHOSTHUB_ZELLIJ_PATH";
+pub(crate) const CONTROL_VARIABLES: [&str; 3] = ["ZELLIJ", "ZELLIJ_PANE_ID", "ZELLIJ_SESSION_NAME"];
+
+pub(crate) const RESOLVE_SCRIPT: &str = concat!(
+    "unset ZELLIJ ZELLIJ_PANE_ID ZELLIJ_SESSION_NAME; ",
+    "ghosthub_zellij_path=$(command -v zellij) || exit 127; ",
+    "[ -n \"$ghosthub_zellij_path\" ] || exit 127; ",
+    "case \"$ghosthub_zellij_path\" in /*) ;; *) exit 127 ;; esac; ",
+    "[ -x \"$ghosthub_zellij_path\" ] || exit 127; ",
+    "printf '%s\\n%s\\n' 'GHOSTHUB_ZELLIJ_PATH' \"$ghosthub_zellij_path\""
+);
+
+pub(crate) enum ExecutableProbe {
+    Available(String),
+    Unavailable,
+}
+
+pub(crate) fn parse_executable(status: i32, stdout: &[u8]) -> Result<ExecutableProbe, String> {
+    if status == 127 {
+        return Ok(ExecutableProbe::Unavailable);
+    }
+    if status != 0 {
+        return Err(format!(
+            "Zellij executable probe exited with status {status}"
+        ));
+    }
+    let stdout = std::str::from_utf8(stdout)
+        .map_err(|_| "Zellij executable probe output is not UTF-8".to_owned())?;
+    let mut lines = stdout.lines();
+    let mut resolved = None;
+    while let Some(line) = lines.next() {
+        if line == PATH_MARKER {
+            resolved = lines.next();
+        }
+    }
+    let Some(path) = resolved.map(str::trim).filter(|path| path.starts_with('/')) else {
+        return Ok(ExecutableProbe::Unavailable);
+    };
+    Ok(ExecutableProbe::Available(path.to_owned()))
+}
+
+pub(crate) fn parse_inventory(
+    status: i32,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<Vec<ZellijSessionRecord>, String> {
+    if status != 0 {
+        let detail = String::from_utf8_lossy(stderr).trim().to_owned();
+        if status == 1 && detail == "No active zellij sessions found." {
+            return Ok(Vec::new());
+        }
+        return Err(if detail.is_empty() {
+            format!("Zellij session inventory exited with status {status}")
+        } else {
+            format!("Zellij session inventory exited with status {status}: {detail}")
+        });
+    }
+
+    let stdout = std::str::from_utf8(stdout)
+        .map_err(|_| "Zellij session inventory is not UTF-8".to_owned())?;
+    stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let metadata = line.rfind(" [Created ");
+            match metadata {
+                Some(index) if line[index..].contains("(EXITED - attach to resurrect)") => None,
+                Some(index) => Some(Ok(ZellijSessionRecord::discovered(&line[..index]))),
+                None => Some(Err(format!(
+                    "Zellij returned an unrecognized session entry: {line}"
+                ))),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inventory_preserves_active_names_and_ignores_resurrectable_sessions() {
+        let sessions = parse_inventory(
+            0,
+            b"work [Created 2m ago] (CURRENT)\nold [Created 3h ago] (EXITED - attach to resurrect)\nname with spaces [Created now]\n",
+            b"",
+        )
+        .expect("valid inventory");
+        assert_eq!(
+            sessions
+                .iter()
+                .map(ZellijSessionRecord::name)
+                .collect::<Vec<_>>(),
+            ["work", "name with spaces"]
+        );
+    }
+
+    #[test]
+    fn no_active_sessions_is_available_empty() {
+        assert_eq!(
+            parse_inventory(1, b"", b"No active zellij sessions found.").expect("empty inventory"),
+            Vec::<ZellijSessionRecord>::new()
+        );
+    }
+
+    #[test]
+    fn malformed_inventory_is_rejected() {
+        assert!(parse_inventory(0, b"not an inventory row\n", b"").is_err());
+    }
+}

--- a/rust/host/tests/wsl_contract.rs
+++ b/rust/host/tests/wsl_contract.rs
@@ -9,12 +9,13 @@ use std::sync::{Arc, Mutex};
 use contracts::{Manifest, PlatformTag};
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandOutput, CommandRunner, HerdrInventory,
-    HostErrorKind, WslConfig, WslExecutable, WslHost,
+    HostErrorKind, WslConfig, WslExecutable, WslHost, ZellijInventory,
 };
 use serde::Deserialize;
 use session::ExecutablePlatform;
 use session::{
     AdmissionPlan, HerdrLifecycleAction, HerdrSessionRecord, HerdrSessionState, SessionName,
+    ZellijSessionName,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -42,6 +43,7 @@ struct RecordingRunner {
     exact_targets_are_strict: bool,
     admission_directory: Mutex<AdmissionDirectoryState>,
     herdr_outputs: Mutex<VecDeque<CommandOutput>>,
+    zellij_outputs: Mutex<VecDeque<CommandOutput>>,
 }
 
 #[derive(Debug, Default)]
@@ -79,6 +81,7 @@ impl RecordingRunner {
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
             herdr_outputs: Mutex::new(VecDeque::new()),
+            zellij_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -100,6 +103,7 @@ impl RecordingRunner {
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
             herdr_outputs: Mutex::new(VecDeque::new()),
+            zellij_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -125,6 +129,7 @@ impl RecordingRunner {
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
             herdr_outputs: Mutex::new(VecDeque::new()),
+            zellij_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -154,6 +159,7 @@ impl RecordingRunner {
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
             herdr_outputs: Mutex::new(VecDeque::new()),
+            zellij_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -175,6 +181,7 @@ impl RecordingRunner {
             exact_targets_are_strict: true,
             admission_directory: Mutex::new(AdmissionDirectoryState::default()),
             herdr_outputs: Mutex::new(VecDeque::new()),
+            zellij_outputs: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -218,7 +225,9 @@ impl RecordingRunner {
             .lock()
             .expect("calls lock")
             .iter()
-            .filter(|(_, args)| !is_admission_call(args) && !is_herdr_call(args))
+            .filter(|(_, args)| {
+                !is_admission_call(args) && !is_herdr_call(args) && !is_zellij_call(args)
+            })
             .cloned()
             .collect()
     }
@@ -229,6 +238,10 @@ impl RecordingRunner {
 
     fn set_herdr_outputs(&self, outputs: Vec<CommandOutput>) {
         *self.herdr_outputs.lock().expect("Herdr outputs lock") = outputs.into();
+    }
+
+    fn set_zellij_outputs(&self, outputs: Vec<CommandOutput>) {
+        *self.zellij_outputs.lock().expect("Zellij outputs lock") = outputs.into();
     }
 
     fn all_timeouts(&self) -> Vec<std::time::Duration> {
@@ -337,6 +350,14 @@ impl CommandRunner for RecordingRunner {
                 .expect("Herdr outputs lock")
                 .pop_front()
                 .unwrap_or_else(|| output(127, "", "herdr: not found")));
+        }
+        if is_zellij_call(args) {
+            return Ok(self
+                .zellij_outputs
+                .lock()
+                .expect("Zellij outputs lock")
+                .pop_front()
+                .unwrap_or_else(|| output(127, "", "zellij: not found")));
         }
         if self
             .admission_failure
@@ -477,6 +498,16 @@ fn is_herdr_call(args: &[OsString]) -> bool {
         || args
             .windows(2)
             .any(|arguments| arguments == ["session", "stop"] || arguments == ["session", "delete"])
+}
+
+fn is_zellij_call(args: &[OsString]) -> bool {
+    args.iter().any(|argument| {
+        argument
+            .to_str()
+            .is_some_and(|argument| argument.contains("GHOSTHUB_ZELLIJ_PATH"))
+    }) || args
+        .windows(2)
+        .any(|arguments| arguments == ["-u", "ZELLIJ"])
 }
 
 #[allow(
@@ -1016,6 +1047,117 @@ fn malformed_herdr_inventory_does_not_hide_tmux_sessions() {
     assert_eq!(snapshot.sessions()[0].name(), "work");
     assert!(
         matches!(snapshot.herdr(), HerdrInventory::Failed(error) if error.kind() == HostErrorKind::MalformedOutput)
+    );
+}
+
+#[test]
+fn zellij_inventory_and_launch_plans_preserve_exact_names_and_scrub_control_environment() {
+    let runner = RecordingRunner::new(vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t1\t4\twork\n", ""),
+        instance_output(),
+    ]);
+    runner.set_zellij_outputs(vec![
+        output(0, "GHOSTHUB_ZELLIJ_PATH\n/opt/zellij/bin/zellij\n", ""),
+        output(0, "--review [Created 1m ago]\n", ""),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+
+    let snapshot = discover(&host).expect("Zellij discovery is host-capability scoped");
+    let ZellijInventory::Available {
+        executable,
+        sessions,
+    } = snapshot.zellij()
+    else {
+        panic!("Zellij is available");
+    };
+    assert_eq!(executable, "/opt/zellij/bin/zellij");
+    assert_eq!(sessions[0].name(), "--review");
+
+    let plan = host.zellij_attach_plan(
+        snapshot.endpoint(),
+        executable,
+        &sessions[0],
+        AttachTerm::Xterm256Color,
+    );
+    assert!(
+        plan.args()
+            .windows(3)
+            .any(|arguments| arguments == ["attach", "--", "--review"])
+    );
+    for variable in ["ZELLIJ", "ZELLIJ_PANE_ID", "ZELLIJ_SESSION_NAME"] {
+        assert!(
+            plan.args()
+                .windows(2)
+                .any(|arguments| arguments == ["-u", variable])
+        );
+    }
+
+    let launch = host.zellij_launch_once(
+        snapshot.endpoint(),
+        executable,
+        ZellijSessionName::parse("--new").expect("valid leading-dash name"),
+        AttachTerm::Xterm256Color,
+    );
+    let (_program, args, target) = launch.into_parts();
+    assert!(args.iter().any(|argument| argument == "--session=--new"));
+    assert_eq!(target.as_str(), "--new");
+}
+
+#[test]
+fn zellij_kill_revalidates_and_uses_an_exact_direct_argument() {
+    let mut command_outputs = vec![
+        instance_output(),
+        output(0, "4242\t$3\t1700000000\t1\t4\twork\n", ""),
+        instance_output(),
+    ];
+    command_outputs.extend((0..5).map(|_| instance_output()));
+    let runner = RecordingRunner::new(command_outputs);
+    runner.set_zellij_outputs(vec![
+        output(0, "GHOSTHUB_ZELLIJ_PATH\n/opt/zellij/bin/zellij\n", ""),
+        output(0, "--review [Created 1m ago]\n", ""),
+        output(0, "GHOSTHUB_ZELLIJ_PATH\n/opt/zellij/bin/zellij\n", ""),
+        output(0, "--review [Created 1m ago]\n", ""),
+        output(0, "GHOSTHUB_ZELLIJ_PATH\n/opt/zellij/bin/zellij\n", ""),
+        output(0, "--review [Created 1m ago]\n", ""),
+        output(0, "", ""),
+    ]);
+    let host = test_host(
+        WslConfig::with_distro("Ubuntu").expect("valid config"),
+        runner,
+    );
+    let snapshot = discover(&host).expect("initial inventory");
+    let callback_ran = AtomicBool::new(false);
+
+    host.kill_zellij_session(
+        snapshot.endpoint(),
+        snapshot.runtime(),
+        "/opt/zellij/bin/zellij",
+        "--review",
+        &CancellationToken::new(),
+        || callback_ran.store(true, Ordering::Release),
+    )
+    .expect("validated Zellij kill");
+
+    assert!(callback_ran.load(Ordering::Acquire));
+    let kill_call = host
+        .runner()
+        .all_calls()
+        .into_iter()
+        .find(|(_, args)| {
+            args.iter()
+                .any(|argument| argument == "/opt/zellij/bin/zellij")
+                && args.iter().any(|argument| argument == "kill-session")
+        })
+        .expect("Zellij kill call");
+    assert!(
+        kill_call
+            .1
+            .windows(3)
+            .any(|arguments| arguments == ["kill-session", "--", "--review"])
     );
 }
 

--- a/rust/session/src/lib.rs
+++ b/rust/session/src/lib.rs
@@ -106,6 +106,73 @@ pub struct DiscoveredSession {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HerdrSessionName(String);
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZellijSessionName(String);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ZellijSessionNameError {
+    Empty,
+    ForbiddenCharacter,
+}
+
+impl ZellijSessionName {
+    /// Normalize and validate a user-supplied Zellij session name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty name, `.` or `..`, or a name containing
+    /// a slash or control character. These are the same restrictions exposed
+    /// by the Swift application; leading dashes remain valid because every
+    /// lifecycle command terminates option parsing explicitly.
+    pub fn parse(value: &str) -> Result<Self, ZellijSessionNameError> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(ZellijSessionNameError::Empty);
+        }
+        if matches!(value, "." | "..")
+            || value
+                .chars()
+                .any(|character| character == '/' || character.is_control())
+        {
+            return Err(ZellijSessionNameError::ForbiddenCharacter);
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ZellijSessionNameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("Name the Zellij session."),
+            Self::ForbiddenCharacter => {
+                formatter.write_str("Use a nonempty name without slashes or control characters.")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZellijSessionRecord {
+    name: String,
+}
+
+impl ZellijSessionRecord {
+    #[must_use]
+    pub fn discovered(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HerdrSessionNameError {
     Empty,
@@ -313,6 +380,19 @@ pub struct HerdrAttachPlan {
     args: Vec<OsString>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZellijAttachPlan {
+    program: OsString,
+    args: Vec<OsString>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ZellijLaunchOnce {
+    program: OsString,
+    args: Vec<OsString>,
+    target_name: ZellijSessionName,
+}
+
 /// One Herdr launch-or-attach action. This constructive authority is consumed
 /// by the terminal launcher and is intentionally neither cloneable nor
 /// serializable.
@@ -340,6 +420,46 @@ impl HerdrAttachPlan {
     #[must_use]
     pub fn args(&self) -> &[OsString] {
         &self.args
+    }
+}
+
+impl ZellijAttachPlan {
+    #[must_use]
+    pub fn attach_only(program: impl Into<OsString>, args: Vec<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            args,
+        }
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &OsStr {
+        &self.program
+    }
+
+    #[must_use]
+    pub fn args(&self) -> &[OsString] {
+        &self.args
+    }
+}
+
+impl ZellijLaunchOnce {
+    #[must_use]
+    pub fn create(
+        program: impl Into<OsString>,
+        args: Vec<OsString>,
+        target_name: ZellijSessionName,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            target_name,
+        }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (OsString, Vec<OsString>, ZellijSessionName) {
+        (self.program, self.args, self.target_name)
     }
 }
 
@@ -696,12 +816,46 @@ fn parse_revision(output: &str) -> Option<String> {
 mod tests {
     use super::{
         CreateOnce, HerdrLaunchOnce, HerdrLaunchTarget, HerdrSessionName, HerdrSessionNameError,
-        HerdrSessionRecord, HerdrSessionState, SessionName, SessionNameError,
+        HerdrSessionRecord, HerdrSessionState, SessionName, SessionNameError, ZellijLaunchOnce,
+        ZellijSessionName, ZellijSessionNameError,
     };
     use static_assertions::assert_not_impl_any;
 
     assert_not_impl_any!(CreateOnce: Clone, serde::Serialize);
     assert_not_impl_any!(HerdrLaunchOnce: Clone, serde::Serialize);
+    assert_not_impl_any!(ZellijLaunchOnce: Clone, serde::Serialize);
+
+    #[test]
+    fn zellij_session_names_match_the_shipped_creation_contract() {
+        assert_eq!(
+            ZellijSessionName::parse("  review session  ")
+                .expect("valid name")
+                .as_str(),
+            "review session"
+        );
+        assert_eq!(
+            ZellijSessionName::parse(" "),
+            Err(ZellijSessionNameError::Empty)
+        );
+        assert_eq!(
+            ZellijSessionName::parse(".."),
+            Err(ZellijSessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            ZellijSessionName::parse("folder/name"),
+            Err(ZellijSessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            ZellijSessionName::parse("line\nbreak"),
+            Err(ZellijSessionNameError::ForbiddenCharacter)
+        );
+        assert_eq!(
+            ZellijSessionName::parse("--leading-option")
+                .expect("leading dashes remain valid")
+                .as_str(),
+            "--leading-option"
+        );
+    }
 
     #[test]
     fn herdr_session_names_match_the_shipped_creation_contract() {

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -9,7 +9,10 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, bounded, never, select};
 use input::{EncodedInput, KeyInput, MouseAction, MouseInput, encode_input, encode_mouse};
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
-use session::{AdmissionPlan, AttachPlan, CreateOnce, HerdrAttachPlan, HerdrLaunchOnce};
+use session::{
+    AdmissionPlan, AttachPlan, CreateOnce, HerdrAttachPlan, HerdrLaunchOnce, ZellijAttachPlan,
+    ZellijLaunchOnce,
+};
 use surface::{GridSize, PixelSize, SurfaceStore};
 
 use crate::windows_job::RelayJob;
@@ -308,6 +311,58 @@ impl TerminalWorker {
     /// cannot be established. The consumed authority is never returned.
     pub fn launch_herdr_with_metadata(
         plan: HerdrLaunchOnce,
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+    ) -> Result<Self, WorkerError> {
+        let (program, args, _target_name) = plan.into_parts();
+        Self::launch(
+            &program,
+            &args,
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+        )
+    }
+
+    /// Spawn an attach-only Zellij client with UI-derived initial dimensions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PTY, child process, or relay containment
+    /// cannot be established.
+    pub fn attach_zellij_with_metadata(
+        plan: &ZellijAttachPlan,
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+    ) -> Result<Self, WorkerError> {
+        Self::launch(
+            plan.program(),
+            plan.args(),
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+        )
+    }
+
+    /// Consume one Zellij creation authority and spawn its ordinary client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the PTY, child process, or relay containment
+    /// cannot be established. The consumed creation authority is never
+    /// returned for a retry.
+    pub fn launch_zellij_with_metadata(
+        plan: ZellijLaunchOnce,
         size: GridSize,
         resize_sequence: u64,
         pixel_size: PixelSize,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -3678,10 +3678,11 @@ impl RootView {
         let is_active = session.state.is_active();
         let can_open = session.state.can_open();
         let name = selection.session().to_owned();
-        let row_group = format!("tmux-session-actions-{host_index}-{index}");
+        let backend = session_backend_id(selection.kind());
+        let row_group = format!("{backend}-session-actions-{host_index}-{index}");
         let mut row = div()
             .id((
-                gpui::ElementId::named_usize("tree-session-host", host_index),
+                gpui::ElementId::named_usize(session_row_element_id(selection.kind()), host_index),
                 index.to_string(),
             ))
             .group(row_group.clone())
@@ -3729,7 +3730,7 @@ impl RootView {
         if !actions.is_empty() {
             row = row.child(Self::session_action_menu_button(
                 host_index,
-                format!("tmux-{index}"),
+                format!("{backend}-{index}"),
                 selection.clone(),
                 actions,
                 row_group,
@@ -4040,6 +4041,22 @@ fn herdr_session_menu_actions(
     }
     actions.extend(lifecycle.into_iter().map(SessionRowAction::Herdr));
     actions
+}
+
+const fn session_backend_id(kind: workspace::SessionKind) -> &'static str {
+    match kind {
+        workspace::SessionKind::Tmux => "tmux",
+        workspace::SessionKind::Herdr => "herdr",
+        workspace::SessionKind::Zellij => "zellij",
+    }
+}
+
+const fn session_row_element_id(kind: workspace::SessionKind) -> &'static str {
+    match kind {
+        workspace::SessionKind::Tmux => "tmux-session-host",
+        workspace::SessionKind::Herdr => "herdr-session-host",
+        workspace::SessionKind::Zellij => "zellij-session-host",
+    }
 }
 
 fn herdr_operation_label(session: &workspace::HerdrSessionItem) -> Option<&'static str> {
@@ -5147,10 +5164,10 @@ mod tests {
         input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
         kill_confirmation_title, named_key, new_session_validation, normalize_cell_width,
         queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
-        session_group_visibility, terminal_cell_at_with_offset, terminal_key_input,
-        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
-        tmux_row_actions, transitioned_presentation, tree_herdr_sessions, tree_sessions,
-        tree_zellij_sessions, workspace_window_title,
+        session_backend_id, session_group_visibility, session_row_element_id,
+        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
+        terminal_line_height, terminal_wheel_steps, tmux_row_actions, transitioned_presentation,
+        tree_herdr_sessions, tree_sessions, tree_zellij_sessions, workspace_window_title,
     };
     use model::DiagnosticKind;
     use std::sync::Arc;
@@ -5611,6 +5628,18 @@ mod tests {
         let (left, top) = session_action_menu_position(2.0, 2.0, 100.0, 80.0, 4);
         assert!((left - 4.0).abs() <= f32::EPSILON);
         assert!((top - 4.0).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn multiplexer_rows_have_backend_scoped_interaction_ids() {
+        assert_ne!(
+            session_backend_id(workspace::SessionKind::Tmux),
+            session_backend_id(workspace::SessionKind::Zellij)
+        );
+        assert_ne!(
+            session_row_element_id(workspace::SessionKind::Tmux),
+            session_row_element_id(workspace::SessionKind::Zellij)
+        );
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -324,6 +324,7 @@ struct NewSessionDraft {
 enum NewSessionKind {
     Tmux,
     Herdr,
+    Zellij,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -355,6 +356,7 @@ enum ProjectDialog {
         name: String,
         repository: String,
         path: String,
+        registration_fingerprint: String,
         submitting: bool,
         error: Option<String>,
     },
@@ -870,6 +872,7 @@ impl RootView {
             name: project.name().to_owned(),
             repository: project.repository().to_owned(),
             path: project.path().to_owned(),
+            registration_fingerprint: project.registration_fingerprint().to_owned(),
             submitting: false,
             error: None,
         });
@@ -908,11 +911,16 @@ impl RootView {
                 endpoint,
                 repository,
                 path,
+                registration_fingerprint,
                 submitting: false,
                 ..
-            }) => self
-                .workspace
-                .remove_kwt_project(host_id, endpoint, repository, path),
+            }) => self.workspace.remove_kwt_project(
+                host_id,
+                endpoint,
+                repository,
+                path,
+                registration_fingerprint,
+            ),
             _ => return,
         };
         match result {
@@ -1016,6 +1024,10 @@ impl RootView {
             NewSessionKind::Herdr => {
                 self.workspace
                     .create_herdr_session(&draft.host_id, &draft.endpoint, &draft.name)
+            }
+            NewSessionKind::Zellij => {
+                self.workspace
+                    .create_zellij_session(&draft.host_id, &draft.endpoint, &draft.name)
             }
         };
         match result {
@@ -2137,6 +2149,7 @@ impl RootView {
                                 .child(match draft.kind {
                                     NewSessionKind::Tmux => "New tmux session",
                                     NewSessionKind::Herdr => "New Herdr session",
+                                    NewSessionKind::Zellij => "New Zellij session",
                                 }),
                         )
                         .child(Self::new_session_name_input(draft, focused, cx))
@@ -2654,7 +2667,7 @@ impl RootView {
     ) -> gpui::AnyElement {
         let (id, label, color) = match action {
             SessionRowAction::Detach => ("session-action-detach", "Detach", 0x87_b9e8),
-            SessionRowAction::KillTmux => ("tmux-action-kill", "Kill", 0xd6_747a),
+            SessionRowAction::KillSession => ("session-action-kill", "Kill", 0xd6_747a),
             SessionRowAction::Herdr(HerdrRowAction::Stop) => {
                 ("herdr-action-stop", "Stop", 0xd6_747a)
             }
@@ -2682,7 +2695,7 @@ impl RootView {
                 this.session_action_menu = None;
                 match action {
                     SessionRowAction::Detach => this.detach_session(window, cx),
-                    SessionRowAction::KillTmux => this.request_session_kill(&selection, cx),
+                    SessionRowAction::KillSession => this.request_session_kill(&selection, cx),
                     SessionRowAction::Herdr(HerdrRowAction::Stop) => this.request_herdr_lifecycle(
                         &selection,
                         workspace::HerdrLifecycleAction::Stop,
@@ -2877,12 +2890,33 @@ impl RootView {
 
         let sessions = tree_sessions(host, content, retained);
         let herdr_sessions = tree_herdr_sessions(host, content, retained);
-        let groups = session_group_visibility(host, &herdr_sessions);
+        let zellij_sessions = tree_zellij_sessions(host, content, retained);
+        let groups = session_group_visibility(host, &herdr_sessions, &zellij_sessions);
         if groups.tmux {
-            host_tree = host_tree.child(Self::session_tree(host_index, host, &sessions, cx));
+            host_tree = host_tree.child(Self::session_tree(
+                host_index,
+                host,
+                &sessions,
+                "TMUX SESSIONS",
+                NewSessionKind::Tmux,
+                None,
+                cx,
+            ));
         }
         if groups.herdr {
             host_tree = host_tree.child(Self::herdr_tree(host_index, host, &herdr_sessions, cx));
+        }
+        if groups.zellij {
+            host_tree = host_tree.child(Self::session_tree(
+                host_index,
+                host,
+                &zellij_sessions,
+                "ZELLIJ SESSIONS",
+                NewSessionKind::Zellij,
+                host.zellij_diagnostic()
+                    .map(|diagnostic| diagnostic.message().to_owned()),
+                cx,
+            ));
         }
         if host.kwt_available()
             || !host.projects().is_empty()
@@ -2984,6 +3018,9 @@ impl RootView {
         host_index: usize,
         host: &HostItem,
         sessions: &[TreeSession],
+        title: &'static str,
+        create_kind: NewSessionKind,
+        diagnostic: Option<String>,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let mut tree = div().w_full().flex().flex_col().child({
@@ -2997,13 +3034,27 @@ impl RootView {
                 .text_xs()
                 .font_weight(FontWeight::SEMIBOLD)
                 .text_color(rgb(SESSION_GROUP_TEXT))
-                .child(div().flex_1().child("TMUX SESSIONS"));
-            if host.connection() == HostConnectionState::Ready {
+                .child(div().flex_1().child(title));
+            let create_available = match create_kind {
+                NewSessionKind::Tmux => true,
+                NewSessionKind::Zellij => {
+                    host.zellij_available() && host.zellij_diagnostic().is_none()
+                }
+                NewSessionKind::Herdr => false,
+            };
+            if host.connection() == HostConnectionState::Ready && create_available {
                 let host_id = host.id().to_owned();
                 let endpoint = host.endpoint().to_owned();
                 header = header.child(
                     div()
-                        .id(("create-tmux-session", host_index))
+                        .id((
+                            if create_kind == NewSessionKind::Tmux {
+                                "create-tmux-session"
+                            } else {
+                                "create-zellij-session"
+                            },
+                            host_index,
+                        ))
                         .size(px(22.0))
                         .flex()
                         .items_center()
@@ -3015,19 +3066,20 @@ impl RootView {
                         .hover(|style| style.bg(rgb(0x25_2a34)).text_color(rgb(0xd2_d7_df)))
                         .child("+")
                         .on_click(cx.listener(move |this, _, window, cx| {
-                            this.open_new_session(
-                                &host_id,
-                                &endpoint,
-                                NewSessionKind::Tmux,
-                                window,
-                                cx,
-                            );
+                            this.open_new_session(&host_id, &endpoint, create_kind, window, cx);
                         })),
                 );
             }
             header
         });
-        if sessions.is_empty() {
+        if let Some(message) = diagnostic {
+            tree = tree.child(Self::capability_diagnostic_row(
+                host_index,
+                "retry-zellij",
+                message,
+                cx,
+            ));
+        } else if sessions.is_empty() {
             tree = tree.child(
                 div()
                     .h(px(SESSION_ROW_HEIGHT))
@@ -3374,8 +3426,9 @@ impl RootView {
             header
         });
         if let Some(diagnostic) = host.herdr_diagnostic() {
-            tree = tree.child(Self::herdr_diagnostic_row(
+            tree = tree.child(Self::capability_diagnostic_row(
                 host_index,
+                "retry-herdr",
                 diagnostic.message().to_owned(),
                 cx,
             ));
@@ -3397,8 +3450,9 @@ impl RootView {
         tree.into_any_element()
     }
 
-    fn herdr_diagnostic_row(
+    fn capability_diagnostic_row(
         host_index: usize,
+        retry_id: &'static str,
         message: String,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
@@ -3423,7 +3477,7 @@ impl RootView {
             )
             .child(
                 div()
-                    .id(("retry-herdr", host_index))
+                    .id((retry_id, host_index))
                     .flex_none()
                     .cursor_pointer()
                     .text_xs()
@@ -3911,6 +3965,7 @@ struct HostTreeStatus {
 struct SessionGroupVisibility {
     tmux: bool,
     herdr: bool,
+    zellij: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3923,7 +3978,7 @@ enum HerdrRowAction {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SessionRowAction {
     Detach,
-    KillTmux,
+    KillSession,
     Herdr(HerdrRowAction),
 }
 
@@ -3970,7 +4025,7 @@ fn tmux_row_actions(active: bool, can_kill: bool) -> Vec<SessionRowAction> {
         actions.push(SessionRowAction::Detach);
     }
     if can_kill {
-        actions.push(SessionRowAction::KillTmux);
+        actions.push(SessionRowAction::KillSession);
     }
     actions
 }
@@ -3999,12 +4054,16 @@ fn herdr_operation_label(session: &workspace::HerdrSessionItem) -> Option<&'stat
 fn session_group_visibility(
     host: &HostItem,
     herdr_sessions: &[TreeHerdrSession],
+    zellij_sessions: &[TreeSession],
 ) -> SessionGroupVisibility {
     SessionGroupVisibility {
         tmux: true,
         herdr: host.herdr_available()
             || !herdr_sessions.is_empty()
             || host.herdr_diagnostic().is_some(),
+        zellij: host.zellij_available()
+            || !zellij_sessions.is_empty()
+            || host.zellij_diagnostic().is_some(),
     }
 }
 
@@ -4069,6 +4128,7 @@ fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelecti
         } => Some(match kind {
             workspace::SessionKind::Tmux => SessionSelection::new(host_id, endpoint, session),
             workspace::SessionKind::Herdr => SessionSelection::herdr(host_id, endpoint, session),
+            workspace::SessionKind::Zellij => SessionSelection::zellij(host_id, endpoint, session),
         }),
         WorkspaceContent::Shell
         | WorkspaceContent::Loading
@@ -4201,6 +4261,66 @@ fn tree_herdr_sessions(
         };
     }
     sessions
+}
+
+fn tree_zellij_sessions(
+    host: &HostItem,
+    content: &WorkspaceContent,
+    retained: &[SessionSelection],
+) -> Vec<TreeSession> {
+    let active = active_session_selection(content);
+    let active_for_host = active.as_ref().filter(|selection| {
+        selection.host_id() == host.id() && selection.kind() == workspace::SessionKind::Zellij
+    });
+    let mut selections = host
+        .zellij_sessions()
+        .iter()
+        .map(|session| {
+            (
+                SessionSelection::zellij(host.id(), host.endpoint(), session.name()),
+                true,
+            )
+        })
+        .collect::<Vec<_>>();
+    for selection in retained
+        .iter()
+        .filter(|selection| {
+            selection.host_id() == host.id() && selection.kind() == workspace::SessionKind::Zellij
+        })
+        .chain(active_for_host)
+    {
+        if !selections
+            .iter()
+            .any(|(candidate, _)| candidate == selection)
+        {
+            selections.push((selection.clone(), false));
+        }
+    }
+    let host_accepts_actions = !matches!(
+        host.connection(),
+        HostConnectionState::Disconnected | HostConnectionState::Unavailable
+    ) && host.zellij_diagnostic().is_none();
+    selections
+        .into_iter()
+        .map(|(selection, discovered)| {
+            let retained = retained.contains(&selection);
+            let is_active = active.as_ref() == Some(&selection);
+            let can_kill = discovered && host_accepts_actions;
+            let state = match (is_active, retained, host_accepts_actions, can_kill) {
+                (true, _, _, true) => TreeSessionState::ActiveKillable,
+                (true, _, _, false) => TreeSessionState::Active,
+                (false, true, _, true) => TreeSessionState::RetainedKillable,
+                (false, true, _, false) => TreeSessionState::Retained,
+                (false, false, true, _) => TreeSessionState::Fresh,
+                (false, false, false, _) => TreeSessionState::Cached,
+            };
+            TreeSession {
+                show_endpoint: selection.endpoint() != host.endpoint(),
+                selection,
+                state,
+            }
+        })
+        .collect()
 }
 
 fn kill_confirmation_title(selection: &SessionSelection) -> String {
@@ -4513,6 +4633,20 @@ fn new_session_validation(
                     "A Herdr session with this name already exists on this host. Restart it instead."
                         .to_owned()
                 })
+        }
+        NewSessionKind::Zellij => {
+            if !host.zellij_available() || host.zellij_diagnostic().is_some() {
+                return Some("Zellij is not available on this host.".to_owned());
+            }
+            let Ok(name) = workspace::ZellijSessionName::parse(&draft.name) else {
+                return Some(
+                    "Use a nonempty name without slashes or control characters.".to_owned(),
+                );
+            };
+            host.zellij_sessions()
+                .iter()
+                .any(|session| session.name() == name.as_str())
+                .then(|| "A Zellij session with this name already exists on this host.".to_owned())
         }
     }
 }
@@ -5016,7 +5150,7 @@ mod tests {
         session_group_visibility, terminal_cell_at_with_offset, terminal_key_input,
         terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
         tmux_row_actions, transitioned_presentation, tree_herdr_sessions, tree_sessions,
-        workspace_window_title,
+        tree_zellij_sessions, workspace_window_title,
     };
     use model::DiagnosticKind;
     use std::sync::Arc;
@@ -5244,6 +5378,7 @@ mod tests {
                 "project-id",
                 "project",
                 "/repos/project",
+                "project-fingerprint",
                 vec![
                     WorktreeItem::new(
                         "/repos/project",
@@ -5290,7 +5425,7 @@ mod tests {
         );
 
         assert_eq!(host_tree_status(&host), None);
-        assert!(session_group_visibility(&host, &[]).tmux);
+        assert!(session_group_visibility(&host, &[], &[]).tmux);
     }
 
     #[test]
@@ -5320,7 +5455,7 @@ mod tests {
         let rows = tree_herdr_sessions(&host, &active, &retained);
 
         assert_eq!(rows.len(), 2);
-        assert!(session_group_visibility(&host, &rows).herdr);
+        assert!(session_group_visibility(&host, &rows, &[]).herdr);
         assert_eq!(rows[0].selection.session(), "retained");
         assert!(rows[0].show_endpoint);
         assert!(rows[0].inventory.is_none());
@@ -5354,6 +5489,61 @@ mod tests {
         assert_eq!(rows[0].selection.session(), "cached");
         assert!(!rows[0].access.can_open());
         assert!(!rows[0].access.can_mutate());
+    }
+
+    #[test]
+    fn retained_and_active_zellij_sessions_survive_unavailable_inventory() {
+        let size = GridSize::new(80, 24).expect("valid grid");
+        let active = WorkspaceContent::Terminal {
+            host_id: "wsl".to_owned(),
+            endpoint: "Ubuntu".to_owned(),
+            session: "active".to_owned(),
+            kind: workspace::SessionKind::Zellij,
+            presentation_id: 1,
+            surface: Arc::new(SurfaceStore::new(SurfaceFrame::blank(1, size))),
+        };
+        let host = HostItem::wsl(
+            "Ubuntu",
+            None,
+            HostConnectionState::Unavailable,
+            Vec::new(),
+            None,
+        );
+        let retained = vec![SessionSelection::zellij(
+            "wsl",
+            "Ubuntu-Previous",
+            "retained",
+        )];
+
+        let rows = tree_zellij_sessions(&host, &active, &retained);
+
+        assert_eq!(rows.len(), 2);
+        assert!(session_group_visibility(&host, &[], &rows).zellij);
+        assert_eq!(rows[0].selection.session(), "retained");
+        assert!(rows[0].show_endpoint);
+        assert!(rows[0].state.can_open());
+        assert!(!rows[0].state.can_kill());
+        assert_eq!(rows[1].selection.session(), "active");
+        assert!(rows[1].state.is_active());
+        assert!(rows[1].state.can_open());
+        assert!(!rows[1].state.can_kill());
+    }
+
+    #[test]
+    fn failed_current_zellij_inventory_exposes_cached_rows_only() {
+        let host = HostItem::wsl("Ubuntu", None, HostConnectionState::Ready, Vec::new(), None)
+            .with_zellij_sessions(vec![workspace::SessionItem::new("cached", 0)])
+            .with_zellij_diagnostic(HostDiagnostic::new(
+                DiagnosticKind::MalformedOutput,
+                "invalid Zellij inventory",
+            ));
+
+        let rows = tree_zellij_sessions(&host, &WorkspaceContent::Shell, &[]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].selection.session(), "cached");
+        assert!(!rows[0].state.can_open());
+        assert!(!rows[0].state.can_kill());
     }
 
     #[test]
@@ -5395,7 +5585,7 @@ mod tests {
     fn active_session_menus_include_detach_without_losing_backend_lifecycle() {
         assert_eq!(
             tmux_row_actions(true, true),
-            vec![SessionRowAction::Detach, SessionRowAction::KillTmux]
+            vec![SessionRowAction::Detach, SessionRowAction::KillSession]
         );
         assert_eq!(
             herdr_session_menu_actions(true, vec![HerdrRowAction::Stop]),
@@ -5406,7 +5596,7 @@ mod tests {
         );
         assert_eq!(
             tmux_row_actions(false, true),
-            vec![SessionRowAction::KillTmux]
+            vec![SessionRowAction::KillSession]
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -10,14 +10,14 @@ use config::TerminalAppearance;
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HerdrInventory, HostError,
     HostSnapshot, KwtInventory, LiveSessionTarget, StdCommandRunner, WslConfig, WslExecutable,
-    WslHost,
+    WslHost, ZellijInventory,
 };
 pub use input::{KeyEvent, KeyInput, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey};
 use model::DiagnosticKind;
 use session::HerdrLaunchTarget;
 pub use session::{
     HerdrLifecycleAction, HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName,
-    SessionNameError,
+    SessionNameError, ZellijSessionName, ZellijSessionNameError,
 };
 use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
@@ -130,6 +130,7 @@ pub struct SessionSelection {
 pub enum SessionKind {
     Tmux,
     Herdr,
+    Zellij,
 }
 
 impl SessionSelection {
@@ -158,6 +159,20 @@ impl SessionSelection {
             endpoint: endpoint.into(),
             session: session.into(),
             kind: SessionKind::Herdr,
+        }
+    }
+
+    #[must_use]
+    pub fn zellij(
+        host_id: impl Into<String>,
+        endpoint: impl Into<String>,
+        session: impl Into<String>,
+    ) -> Self {
+        Self {
+            host_id: host_id.into(),
+            endpoint: endpoint.into(),
+            session: session.into(),
+            kind: SessionKind::Zellij,
         }
     }
 
@@ -234,6 +249,9 @@ pub struct HostItem {
     herdr_available: bool,
     herdr_sessions: Vec<HerdrSessionItem>,
     herdr_diagnostic: Option<HostDiagnostic>,
+    zellij_available: bool,
+    zellij_sessions: Vec<SessionItem>,
+    zellij_diagnostic: Option<HostDiagnostic>,
     projects: Vec<ProjectItem>,
     directory_workspaces: Vec<DirectoryWorkspaceItem>,
     kwt_state: KwtState,
@@ -254,6 +272,7 @@ pub struct ProjectItem {
     repository: String,
     name: String,
     path: String,
+    registration_fingerprint: String,
     worktrees: Vec<WorktreeItem>,
 }
 
@@ -263,12 +282,14 @@ impl ProjectItem {
         repository: impl Into<String>,
         name: impl Into<String>,
         path: impl Into<String>,
+        registration_fingerprint: impl Into<String>,
         worktrees: Vec<WorktreeItem>,
     ) -> Self {
         Self {
             repository: repository.into(),
             name: name.into(),
             path: path.into(),
+            registration_fingerprint: registration_fingerprint.into(),
             worktrees,
         }
     }
@@ -286,6 +307,11 @@ impl ProjectItem {
     #[must_use]
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    #[must_use]
+    pub fn registration_fingerprint(&self) -> &str {
+        &self.registration_fingerprint
     }
 
     #[must_use]
@@ -475,6 +501,9 @@ impl HostItem {
             herdr_available: false,
             herdr_sessions: Vec::new(),
             herdr_diagnostic: None,
+            zellij_available: false,
+            zellij_sessions: Vec::new(),
+            zellij_diagnostic: None,
             projects: Vec::new(),
             directory_workspaces: Vec::new(),
             kwt_state: KwtState::Uninitialized,
@@ -492,6 +521,19 @@ impl HostItem {
     #[must_use]
     pub fn with_herdr_diagnostic(mut self, diagnostic: HostDiagnostic) -> Self {
         self.herdr_diagnostic = Some(diagnostic);
+        self
+    }
+
+    #[must_use]
+    pub fn with_zellij_sessions(mut self, sessions: Vec<SessionItem>) -> Self {
+        self.zellij_available = true;
+        self.zellij_sessions = sessions;
+        self
+    }
+
+    #[must_use]
+    pub fn with_zellij_diagnostic(mut self, diagnostic: HostDiagnostic) -> Self {
+        self.zellij_diagnostic = Some(diagnostic);
         self
     }
 
@@ -543,6 +585,21 @@ impl HostItem {
     #[must_use]
     pub const fn herdr_diagnostic(&self) -> Option<&HostDiagnostic> {
         self.herdr_diagnostic.as_ref()
+    }
+
+    #[must_use]
+    pub const fn zellij_available(&self) -> bool {
+        self.zellij_available
+    }
+
+    #[must_use]
+    pub fn zellij_sessions(&self) -> &[SessionItem] {
+        &self.zellij_sessions
+    }
+
+    #[must_use]
+    pub const fn zellij_diagnostic(&self) -> Option<&HostDiagnostic> {
+        self.zellij_diagnostic.as_ref()
     }
 
     #[must_use]
@@ -1000,19 +1057,32 @@ struct PendingPaste {
     input: input::EncodedInput,
 }
 
-#[derive(Clone)]
-struct KillCaptureRequest {
-    selection: SessionSelection,
-    host: RuntimeHost,
-    endpoint: host::WslEndpoint,
-    runtime: host::WslRuntimeIdentity,
+enum KillCaptureRequest {
+    Tmux {
+        selection: SessionSelection,
+        host: RuntimeHost,
+        endpoint: host::WslEndpoint,
+        runtime: host::WslRuntimeIdentity,
+    },
+    Zellij(PendingKill),
 }
 
 struct PendingKill {
     generation: u64,
     selection: SessionSelection,
     host: RuntimeHost,
-    target: Arc<LiveSessionTarget>,
+    target: KillTarget,
+}
+
+#[derive(Clone)]
+enum KillTarget {
+    Tmux(Arc<LiveSessionTarget>),
+    Zellij {
+        endpoint: host::WslEndpoint,
+        runtime: host::WslRuntimeIdentity,
+        executable: String,
+        name: String,
+    },
 }
 
 #[derive(Clone)]
@@ -1238,13 +1308,17 @@ enum AttachTarget {
         session_directory: String,
         socket_path: String,
     },
+    Zellij {
+        executable: String,
+        name: String,
+    },
 }
 
 impl AttachTarget {
     fn tmux(&self) -> Option<&session::SessionIdentity> {
         match self {
             Self::Tmux(identity) => Some(identity),
-            Self::Herdr { .. } => None,
+            Self::Herdr { .. } | Self::Zellij { .. } => None,
         }
     }
 
@@ -1266,6 +1340,7 @@ impl AttachTarget {
         match self {
             Self::Tmux(_) => SessionKind::Tmux,
             Self::Herdr { .. } => SessionKind::Herdr,
+            Self::Zellij { .. } => SessionKind::Zellij,
         }
     }
 }
@@ -1289,6 +1364,17 @@ struct HerdrCreateRequest {
     term: AttachTerm,
     name: HerdrLaunchTarget,
     precondition: HerdrLaunchPrecondition,
+}
+
+#[derive(Clone)]
+struct ZellijCreateRequest {
+    host_id: String,
+    host: RuntimeHost,
+    endpoint: host::WslEndpoint,
+    runtime: host::WslRuntimeIdentity,
+    executable: String,
+    term: AttachTerm,
+    name: ZellijSessionName,
 }
 
 impl HerdrCreateRequest {
@@ -1369,6 +1455,9 @@ impl AttachRequest {
             }
             SessionKind::Herdr => {
                 SessionSelection::herdr(&self.host_id, self.endpoint.distro(), &self.name)
+            }
+            SessionKind::Zellij => {
+                SessionSelection::zellij(&self.host_id, self.endpoint.distro(), &self.name)
             }
         }
     }
@@ -1785,6 +1874,16 @@ fn refreshed_session_name<'a>(
                         && session.socket_path() == socket_path
                 })
                 .map(session::HerdrSessionRecord::name),
+            _ => None,
+        },
+        AttachTarget::Zellij { executable, name } => match snapshot.zellij() {
+            ZellijInventory::Available {
+                executable: current_executable,
+                sessions,
+            } if current_executable == executable => sessions
+                .iter()
+                .find(|session| session.name() == name)
+                .map(session::ZellijSessionRecord::name),
             _ => None,
         },
     })
@@ -2292,6 +2391,7 @@ impl Workspace {
         endpoint: &str,
         repository: &str,
         path: &str,
+        registration_fingerprint: &str,
     ) -> Result<(), WorkspaceError> {
         self.start_kwt_project_mutation(
             host_id,
@@ -2299,6 +2399,7 @@ impl Workspace {
             KwtProjectMutationRequest::Remove {
                 repository: repository.to_owned(),
                 path: path.to_owned(),
+                registration_fingerprint: registration_fingerprint.to_owned(),
             },
         )
     }
@@ -2722,6 +2823,75 @@ impl Workspace {
         self.start_herdr_launch(&request, navigation)
     }
 
+    /// Create one named Zellij session and attach its ordinary client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is invalid, Zellij or the selected host
+    /// is unavailable, another session operation is active, or the background
+    /// launch task cannot be started.
+    pub fn create_zellij_session(
+        &self,
+        host_id: &str,
+        endpoint: &str,
+        name: &str,
+    ) -> Result<(), WorkspaceError> {
+        let name = ZellijSessionName::parse(name)
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        let navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let request = capture_zellij_create_request(&self.inner, host_id, endpoint, name)?;
+        let navigation_generation = self.begin_navigation();
+        let in_flight_fallback = self.supersede_inflight_attachment()?;
+        let visible_previous = self.retain_active_presentation()?;
+        let previous = in_flight_fallback.or(visible_previous);
+        let cancellation = CancellationToken::new();
+        *self
+            .inner
+            .pending_creation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(PendingCreation {
+            navigation_generation,
+            previous,
+            cancellation: cancellation.clone(),
+            herdr_operation: None,
+        });
+        clear_terminal_notice(&self.inner);
+        set_inner_state(
+            &self.inner,
+            WorkspaceContent::Attaching {
+                host_id: request.host_id.clone(),
+                endpoint: request.endpoint.distro().to_owned(),
+                session: request.name.as_str().to_owned(),
+                kind: SessionKind::Zellij,
+            },
+        );
+        let inner = Arc::clone(&self.inner);
+        let spawn_request = request.clone();
+        if let Err(error) = thread::Builder::new()
+            .name("ghosthub-zellij-create".to_owned())
+            .spawn(move || {
+                run_zellij_create(&inner, &spawn_request, navigation_generation, &cancellation);
+            })
+        {
+            drop(navigation);
+            restore_inventory_after_creation_failure(
+                &self.inner,
+                None,
+                navigation_generation,
+                format!("start Zellij creation task: {error}"),
+            );
+            return Err(WorkspaceError::new(format!(
+                "start Zellij creation task: {error}"
+            )));
+        }
+        Ok(())
+    }
+
     /// Restart one stopped Herdr session and attach the launched client.
     ///
     /// Restart consumes the same one-shot constructive authority as creation,
@@ -3129,15 +3299,32 @@ impl Workspace {
         if herdr_removed {
             self.inner.revision.fetch_add(1, Ordering::Release);
         }
-        let request = capture_kill_request(&self.inner, selection)?;
+        let request = capture_kill_request(&self.inner, selection, generation)?;
+        if let KillCaptureRequest::Zellij(pending) = request {
+            if !publish_pending_kill(&self.inner, pending) {
+                return Err(WorkspaceError::new(
+                    "Zellij kill request was superseded before confirmation",
+                ));
+            }
+            return Ok(());
+        }
+        let KillCaptureRequest::Tmux {
+            selection,
+            host,
+            endpoint,
+            runtime,
+        } = request
+        else {
+            unreachable!("Zellij kill requests return above");
+        };
         let workspace = self.clone();
         thread::Builder::new()
             .name("ghosthub-session-kill-identity".to_owned())
             .spawn(move || {
-                let result = request.host.capture_live_session(
-                    &request.endpoint,
-                    &request.runtime,
-                    request.selection.session(),
+                let result = host.capture_live_session(
+                    &endpoint,
+                    &runtime,
+                    selection.session(),
                     &CancellationToken::new(),
                 );
                 match result {
@@ -3146,9 +3333,9 @@ impl Workspace {
                             &workspace.inner,
                             PendingKill {
                                 generation,
-                                selection: request.selection,
-                                host: request.host,
-                                target: Arc::new(target),
+                                selection,
+                                host,
+                                target: KillTarget::Tmux(Arc::new(target)),
                             },
                         );
                     }
@@ -3207,10 +3394,10 @@ impl Workspace {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
-            .ok_or_else(|| WorkspaceError::new("no tmux session kill is awaiting confirmation"))?;
+            .ok_or_else(|| WorkspaceError::new("no session kill is awaiting confirmation"))?;
         if self.inner.kill_generation.load(Ordering::Acquire) != pending.generation {
             return Err(WorkspaceError::new(
-                "tmux session kill confirmation is no longer current",
+                "session kill confirmation is no longer current",
             ));
         }
         self.inner.revision.fetch_add(1, Ordering::Release);
@@ -3219,17 +3406,44 @@ impl Workspace {
             generation: pending.generation,
             selection: pending.selection.clone(),
             host: pending.host.clone(),
-            target: Arc::clone(&pending.target),
+            target: pending.target.clone(),
         };
         if let Err(error) = thread::Builder::new()
             .name("ghosthub-session-kill".to_owned())
             .spawn(move || {
-                let result = pending
-                    .host
-                    .kill_live_session(&pending.target, &CancellationToken::new());
-                match result {
-                    Ok(()) => workspace.finish_session_kill(&pending.target),
-                    Err(error) => workspace.push_operation_error(error.to_string()),
+                let _operation = workspace
+                    .inner
+                    .session_operations
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                match &pending.target {
+                    KillTarget::Tmux(target) => {
+                        match pending
+                            .host
+                            .kill_live_session(target, &CancellationToken::new())
+                        {
+                            Ok(()) => workspace.finish_session_kill(target),
+                            Err(error) => workspace.push_operation_error(error.to_string()),
+                        }
+                    }
+                    KillTarget::Zellij {
+                        endpoint,
+                        runtime,
+                        executable,
+                        name,
+                    } => {
+                        let result = pending.host.kill_zellij_session(
+                            endpoint,
+                            runtime,
+                            executable,
+                            name,
+                            &CancellationToken::new(),
+                            || workspace.finish_zellij_presentation(endpoint, runtime, name),
+                        );
+                        if let Err(error) = result {
+                            workspace.push_operation_error(error.to_string());
+                        }
+                    }
                 }
                 let _refresh_started = workspace.refresh();
                 workspace.inner.revision.fetch_add(1, Ordering::Release);
@@ -3241,7 +3455,9 @@ impl Workspace {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(retry);
             self.inner.revision.fetch_add(1, Ordering::Release);
-            return Err(WorkspaceError::new(format!("kill tmux session: {error}")));
+            return Err(WorkspaceError::new(format!(
+                "start session kill task: {error}"
+            )));
         }
         Ok(())
     }
@@ -3445,6 +3661,48 @@ impl Workspace {
                 key.endpoint == endpoint.distro()
                     && key.runtime == *runtime
                     && key.target.tmux() == Some(identity)
+            });
+        if changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    fn finish_zellij_presentation(
+        &self,
+        endpoint: &host::WslEndpoint,
+        runtime: &host::WslRuntimeIdentity,
+        name: &str,
+    ) {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let target_matches = |target: &AttachTarget| matches!(target, AttachTarget::Zellij { name: target_name, .. } if target_name == name);
+        let active_matches = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+            .is_some_and(|active| {
+                active.request.endpoint == *endpoint
+                    && active.request.runtime == *runtime
+                    && target_matches(&active.request.target)
+            });
+        if active_matches {
+            self.detach_locked();
+        }
+        let changed = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove_matching(|key| {
+                key.endpoint == endpoint.distro()
+                    && key.runtime == *runtime
+                    && target_matches(&key.target)
             });
         if changed {
             self.inner.revision.fetch_add(1, Ordering::Release);
@@ -4365,7 +4623,7 @@ fn capture_attach_request(
     inner: &Inner,
     selection: &SessionSelection,
 ) -> Result<AttachRequest, WorkspaceError> {
-    if selection.kind() == SessionKind::Herdr {
+    if matches!(selection.kind(), SessionKind::Herdr | SessionKind::Zellij) {
         require_host_session_actions(inner, selection)?;
     }
     let selected_host = inner
@@ -4432,6 +4690,28 @@ fn capture_attach_request(
                     session.name().to_owned(),
                 )
             }
+            SessionKind::Zellij => {
+                let ZellijInventory::Available {
+                    executable,
+                    sessions,
+                } = context.snapshot.zellij()
+                else {
+                    return Err(WorkspaceError::new("Zellij is not available on this host"));
+                };
+                let session = sessions
+                    .iter()
+                    .find(|session| session.name() == selection.session())
+                    .ok_or_else(|| {
+                        WorkspaceError::new("Zellij session is not in the current inventory")
+                    })?;
+                (
+                    AttachTarget::Zellij {
+                        executable: executable.clone(),
+                        name: session.name().to_owned(),
+                    },
+                    session.name().to_owned(),
+                )
+            }
         };
         Ok(AttachRequest {
             host_id: selection.host_id().to_owned(),
@@ -4448,10 +4728,11 @@ fn capture_attach_request(
 fn capture_kill_request(
     inner: &Inner,
     selection: &SessionSelection,
+    generation: u64,
 ) -> Result<KillCaptureRequest, WorkspaceError> {
-    if selection.kind() != SessionKind::Tmux {
+    if !matches!(selection.kind(), SessionKind::Tmux | SessionKind::Zellij) {
         return Err(WorkspaceError::new(
-            "Kill Session is available only for tmux sessions",
+            "Kill Session is available only for tmux and Zellij sessions",
         ));
     }
     if inner
@@ -4473,9 +4754,10 @@ fn capture_kill_request(
             request.host_id == selection.host_id()
                 && request.endpoint.distro() == selection.endpoint()
                 && request.name == selection.session()
+                && request.target.kind() == SessionKind::Tmux
         })
     {
-        return Ok(KillCaptureRequest {
+        return Ok(KillCaptureRequest::Tmux {
             selection: selection.clone(),
             host: request.host,
             endpoint: request.endpoint,
@@ -4495,22 +4777,55 @@ fn capture_kill_request(
                 "host endpoint changed; refresh the session selection",
             ));
         }
-        if !context
-            .snapshot
-            .sessions()
-            .iter()
-            .any(|session| session.name() == selection.session())
-        {
-            return Err(WorkspaceError::new(
-                "session is not in the current inventory",
-            ));
+        match selection.kind() {
+            SessionKind::Tmux => {
+                if !context
+                    .snapshot
+                    .sessions()
+                    .iter()
+                    .any(|session| session.name() == selection.session())
+                {
+                    return Err(WorkspaceError::new(
+                        "session is not in the current inventory",
+                    ));
+                }
+                Ok(KillCaptureRequest::Tmux {
+                    selection: selection.clone(),
+                    host: context.host.clone(),
+                    endpoint: context.snapshot.endpoint().clone(),
+                    runtime: context.snapshot.runtime().clone(),
+                })
+            }
+            SessionKind::Zellij => {
+                let ZellijInventory::Available {
+                    executable,
+                    sessions,
+                } = context.snapshot.zellij()
+                else {
+                    return Err(WorkspaceError::new("Zellij is not available on this host"));
+                };
+                if !sessions
+                    .iter()
+                    .any(|session| session.name() == selection.session())
+                {
+                    return Err(WorkspaceError::new(
+                        "Zellij session is not in the current inventory",
+                    ));
+                }
+                Ok(KillCaptureRequest::Zellij(PendingKill {
+                    generation,
+                    selection: selection.clone(),
+                    host: context.host.clone(),
+                    target: KillTarget::Zellij {
+                        endpoint: context.snapshot.endpoint().clone(),
+                        runtime: context.snapshot.runtime().clone(),
+                        executable: executable.clone(),
+                        name: selection.session().to_owned(),
+                    },
+                }))
+            }
+            SessionKind::Herdr => unreachable!("Herdr was rejected above"),
         }
-        Ok(KillCaptureRequest {
-            selection: selection.clone(),
-            host: context.host.clone(),
-            endpoint: context.snapshot.endpoint().clone(),
-            runtime: context.snapshot.runtime().clone(),
-        })
     })
 }
 
@@ -4705,6 +5020,66 @@ fn capture_herdr_create_request(
     })
 }
 
+fn capture_zellij_create_request(
+    inner: &Inner,
+    host_id: &str,
+    endpoint: &str,
+    name: ZellijSessionName,
+) -> Result<ZellijCreateRequest, WorkspaceError> {
+    if inner
+        .selected_host
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_deref()
+        != Some(host_id)
+    {
+        return Err(WorkspaceError::new("host is not selected"));
+    }
+
+    require_host_session_actions(
+        inner,
+        &SessionSelection::zellij(host_id, endpoint, name.as_str()),
+    )?;
+    let host = inner
+        .host
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let context = host
+        .as_ref()
+        .ok_or_else(|| WorkspaceError::new("WSL inventory is not ready"))?;
+    context.map(|context, _inventory_generation| {
+        if context.snapshot.endpoint().distro() != endpoint {
+            return Err(WorkspaceError::new(
+                "the WSL endpoint changed; choose the host again before creating a session",
+            ));
+        }
+        let ZellijInventory::Available {
+            executable,
+            sessions,
+        } = context.snapshot.zellij()
+        else {
+            return Err(WorkspaceError::new("Zellij is not available on this host"));
+        };
+        if sessions
+            .iter()
+            .any(|session| session.name() == name.as_str())
+        {
+            return Err(WorkspaceError::new(
+                "a Zellij session with this name already exists",
+            ));
+        }
+        Ok(ZellijCreateRequest {
+            host_id: host_id.to_owned(),
+            host: context.host.clone(),
+            endpoint: context.snapshot.endpoint().clone(),
+            runtime: context.snapshot.runtime().clone(),
+            executable: executable.clone(),
+            term: context.snapshot.creation_term(),
+            name,
+        })
+    })
+}
+
 fn capture_herdr_restart_request(
     inner: &Inner,
     selection: &SessionSelection,
@@ -4774,13 +5149,21 @@ fn require_host_session_actions(
         HostConnectionState::Disconnected | HostConnectionState::Unavailable
     ) {
         return Err(WorkspaceError::new(
-            "connect the WSL host before changing a Herdr session",
+            "connect the WSL host before changing a session",
         ));
     }
-    if host.herdr_diagnostic.is_some() {
-        return Err(WorkspaceError::new(
-            "refresh Herdr inventory before changing a session",
-        ));
+    match selection.kind() {
+        SessionKind::Herdr if host.herdr_diagnostic.is_some() => {
+            return Err(WorkspaceError::new(
+                "refresh Herdr inventory before changing a session",
+            ));
+        }
+        SessionKind::Zellij if host.zellij_diagnostic.is_some() => {
+            return Err(WorkspaceError::new(
+                "refresh Zellij inventory before changing a session",
+            ));
+        }
+        SessionKind::Tmux | SessionKind::Herdr | SessionKind::Zellij => {}
     }
     Ok(())
 }
@@ -4958,6 +5341,7 @@ fn publish_discovered_host(
     let reconciliation =
         reconcile_herdr_lifecycle_fences(inner, &context.snapshot, generation, true);
     set_herdr_inventory(inner, context.snapshot.herdr());
+    set_zellij_inventory(inner, context.snapshot.zellij());
     *inner
         .host
         .lock()
@@ -5103,8 +5487,14 @@ struct KwtRefresh {
 
 #[derive(Clone)]
 enum KwtProjectMutationRequest {
-    Add { path: String },
-    Remove { repository: String, path: String },
+    Add {
+        path: String,
+    },
+    Remove {
+        repository: String,
+        path: String,
+        registration_fingerprint: String,
+    },
 }
 
 impl KwtProjectMutationRequest {
@@ -5269,17 +5659,21 @@ fn capture_kwt_project_mutation(
                     ));
                 }
             }
-            KwtProjectMutationRequest::Remove { repository, path } => {
+            KwtProjectMutationRequest::Remove {
+                repository,
+                path,
+                registration_fingerprint,
+            } => {
                 if !item.can_remove_kwt_project() {
                     return Err(WorkspaceError::new(
                         "refresh KWT inventory before removing a project",
                     ));
                 }
-                if !item
-                    .projects
-                    .iter()
-                    .any(|project| project.repository == *repository && project.path == *path)
-                {
+                if !item.projects.iter().any(|project| {
+                    project.repository == *repository
+                        && project.path == *path
+                        && project.registration_fingerprint == *registration_fingerprint
+                }) {
                     return Err(WorkspaceError::new(
                         "the selected KWT project is no longer in the current inventory",
                     ));
@@ -5333,12 +5727,15 @@ fn run_kwt_project_mutation(inner: &Arc<Inner>, task: &KwtProjectMutationTask) {
                 .register_kwt_project(&task.endpoint, &task.runtime, path, &task.cancellation)
         }
         KwtProjectMutationRequest::Remove {
-            repository, path, ..
+            repository,
+            path,
+            registration_fingerprint,
         } => task.host.remove_kwt_project(
             &task.endpoint,
             &task.runtime,
             path,
             repository,
+            registration_fingerprint,
             &task.cancellation,
         ),
     };
@@ -5423,6 +5820,7 @@ fn publish_kwt_project_mutation(
                     project.repository(),
                     project.name(),
                     project.path(),
+                    project.registration_fingerprint(),
                     worktrees,
                 ));
                 host.projects.sort_by(|left, right| {
@@ -5623,6 +6021,7 @@ fn publish_kwt_inventory(
                     project.project().repository(),
                     project.project().name(),
                     project.project().path(),
+                    project.project().registration_fingerprint(),
                     project
                         .worktrees()
                         .iter()
@@ -5920,6 +6319,84 @@ fn run_herdr_create(
     );
 }
 
+fn run_zellij_create(
+    inner: &Inner,
+    request: &ZellijCreateRequest,
+    navigation_generation: u64,
+    cancellation: &CancellationToken,
+) {
+    let _operation = inner
+        .session_operations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(inventory_publication) =
+        reserve_current_constructive_inventory(inner, navigation_generation, cancellation)
+    else {
+        return;
+    };
+    let created = create_zellij_fresh(inner, request, navigation_generation, cancellation);
+    let (worker, snapshot, session, initial_geometry) = match created {
+        Ok(created) => created,
+        Err(error) => {
+            settle_constructive_inventory(inner, inventory_publication);
+            restore_inventory_after_creation_failure(
+                inner,
+                None,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        settle_constructive_inventory(inner, inventory_publication);
+        drop(worker);
+        return;
+    }
+    let inventory_generation = match merge_constructive_inventory(
+        inner,
+        &request.host,
+        &request.endpoint,
+        &request.runtime,
+        snapshot.clone(),
+        inventory_publication,
+        "the created Zellij session",
+    ) {
+        Ok(generation) => generation,
+        Err(error) => {
+            settle_constructive_inventory(inner, inventory_publication);
+            drop(worker);
+            restore_inventory_after_creation_failure(
+                inner,
+                None,
+                navigation_generation,
+                error.to_string(),
+            );
+            return;
+        }
+    };
+    let attached = AttachRequest {
+        host_id: request.host_id.clone(),
+        host: request.host.clone(),
+        endpoint: snapshot.endpoint().clone(),
+        runtime: snapshot.runtime().clone(),
+        target: AttachTarget::Zellij {
+            executable: request.executable.clone(),
+            name: session.name().to_owned(),
+        },
+        name: session.name().to_owned(),
+        inventory_generation,
+    };
+    publish_created_presentation(
+        inner,
+        attached,
+        worker,
+        initial_geometry,
+        request.term,
+        navigation_generation,
+    );
+}
+
 fn run_herdr_lifecycle(workspace: &Workspace, pending: &PendingHerdrLifecycle) {
     let _operation = workspace
         .inner
@@ -6084,7 +6561,7 @@ fn create_herdr_fresh(
     )?;
 
     let expected_name = request.name.as_str();
-    let discovered = poll_herdr_startup(cancellation, &HERDR_STARTUP_BACKOFF, || {
+    let discovered = poll_session_startup("Zellij", cancellation, &HERDR_STARTUP_BACKOFF, || {
         if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
             return Err(WorkspaceError::new("Herdr creation was superseded"));
         }
@@ -6120,7 +6597,109 @@ fn create_herdr_fresh(
     ))
 }
 
-fn poll_herdr_startup<T>(
+fn create_zellij_fresh(
+    inner: &Inner,
+    request: &ZellijCreateRequest,
+    navigation_generation: u64,
+    cancellation: &CancellationToken,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        session::ZellijSessionRecord,
+        TerminalGeometry,
+    ),
+    WorkspaceError,
+> {
+    let before = request
+        .host
+        .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
+        .map_err(|error| WorkspaceError::new(error.to_string()))?;
+    if before.endpoint() != &request.endpoint || before.runtime() != &request.runtime {
+        return Err(WorkspaceError::new(
+            "WSL changed; refresh before creating the Zellij session",
+        ));
+    }
+    let ZellijInventory::Available {
+        executable,
+        sessions,
+    } = before.zellij()
+    else {
+        return Err(WorkspaceError::new("Zellij is not available on this host"));
+    };
+    if executable != &request.executable {
+        return Err(WorkspaceError::new(
+            "the Zellij executable changed; refresh before creating the session",
+        ));
+    }
+    if sessions
+        .iter()
+        .any(|session| session.name() == request.name.as_str())
+    {
+        return Err(WorkspaceError::new(
+            "a Zellij session with this name already exists",
+        ));
+    }
+    if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+        return Err(WorkspaceError::new("Zellij creation was superseded"));
+    }
+    let authority = request.host.zellij_launch_once(
+        before.endpoint(),
+        &request.executable,
+        request.name.clone(),
+        request.term,
+    );
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::launch_zellij_with_metadata(
+        authority,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+        default_colors(&inner.appearance),
+    )
+    .map_err(|error| WorkspaceError::new(error.to_string()))?;
+
+    let expected_name = request.name.as_str();
+    let discovered = poll_session_startup("Herdr", cancellation, &HERDR_STARTUP_BACKOFF, || {
+        if inner.navigation_generation.load(Ordering::Acquire) != navigation_generation {
+            return Err(WorkspaceError::new("Zellij creation was superseded"));
+        }
+        let snapshot = request
+            .host
+            .discover_with_cancel(&ConptyAdmissionAttacher::new(), cancellation)
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+        if snapshot.endpoint() != &request.endpoint || snapshot.runtime() != &request.runtime {
+            return Err(WorkspaceError::new(
+                "WSL changed while creating the Zellij session",
+            ));
+        }
+        let session = match snapshot.zellij() {
+            ZellijInventory::Available {
+                executable,
+                sessions,
+            } if executable == &request.executable => sessions
+                .iter()
+                .find(|session| session.name() == expected_name)
+                .cloned(),
+            _ => None,
+        };
+        Ok(session.map(|session| (snapshot, session)))
+    })?;
+    if let Some((snapshot, session)) = discovered {
+        return Ok((worker, snapshot, session, geometry));
+    }
+    drop(worker);
+    Err(WorkspaceError::new(
+        "Zellij started, but the new session did not appear in inventory; refresh before trying again",
+    ))
+}
+
+fn poll_session_startup<T>(
+    backend: &str,
     cancellation: &CancellationToken,
     delays: &[Duration],
     mut probe: impl FnMut() -> Result<Option<T>, WorkspaceError>,
@@ -6128,7 +6707,9 @@ fn poll_herdr_startup<T>(
     let mut delay_index = 0;
     loop {
         if cancellation.is_cancelled() {
-            return Err(WorkspaceError::new("Herdr startup was cancelled"));
+            return Err(WorkspaceError::new(format!(
+                "{backend} startup was cancelled"
+            )));
         }
         if let Some(value) = probe()? {
             return Ok(Some(value));
@@ -6138,7 +6719,9 @@ fn poll_herdr_startup<T>(
         };
         delay_index += 1;
         if cancellation.wait_cancelled(delay) {
-            return Err(WorkspaceError::new("Herdr startup was cancelled"));
+            return Err(WorkspaceError::new(format!(
+                "{backend} startup was cancelled"
+            )));
         }
     }
 }
@@ -6363,6 +6946,7 @@ fn create_fresh(
                 &request.runtime,
                 before.creation_term(),
                 before.herdr(),
+                before.zellij(),
                 cancellation,
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
@@ -6922,6 +7506,7 @@ fn merge_constructive_inventory(
     let inventory_state = ready_content(&snapshot);
     reconcile_herdr_lifecycle_fences(inner, &snapshot, publication_generation, false);
     set_herdr_inventory(inner, snapshot.herdr());
+    set_zellij_inventory(inner, snapshot.zellij());
     reconcile_retained_session_names(inner, &snapshot, runtime_host.socket_directory());
     *inner
         .host
@@ -6946,6 +7531,7 @@ fn publish_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: Ho
 fn set_attach_inventory(inner: &Inner, request: &AttachRequest, snapshot: HostSnapshot) {
     let inventory_state = ready_content(&snapshot);
     set_herdr_inventory(inner, snapshot.herdr());
+    set_zellij_inventory(inner, snapshot.zellij());
     reconcile_retained_session_names(inner, &snapshot, request.host.socket_directory());
     *inner
         .host
@@ -7179,6 +7765,31 @@ fn attach_fresh(
             };
             launch_fresh_herdr(inner, request, term, &fresh, &session)
         }
+        AttachTarget::Zellij { executable, name } => {
+            let ZellijInventory::Available {
+                executable: current_executable,
+                sessions,
+            } = fresh.zellij()
+            else {
+                return Err(AttachFreshError::SessionChanged {
+                    error: WorkspaceError::new("Zellij is no longer available on this host"),
+                    snapshot: Box::new(fresh),
+                });
+            };
+            let Some(session) = sessions
+                .iter()
+                .find(|session| session.name() == name && current_executable == executable)
+                .cloned()
+            else {
+                return Err(AttachFreshError::SessionChanged {
+                    error: WorkspaceError::new(
+                        "Zellij session changed since discovery; refresh and choose it again",
+                    ),
+                    snapshot: Box::new(fresh),
+                });
+            };
+            launch_fresh_zellij(inner, request, term, &fresh, &session)
+        }
     }
 }
 
@@ -7229,6 +7840,20 @@ fn attach_fresh_retained(
                 &fresh,
                 &session,
             )?
+        }
+        AttachTarget::Zellij { executable, name } => {
+            let ZellijInventory::Available {
+                executable: current_executable,
+                sessions,
+            } = fresh.zellij()
+            else {
+                unreachable!("resolved retained request has Zellij inventory");
+            };
+            let session = sessions
+                .iter()
+                .find(|session| session.name() == name && current_executable == executable)
+                .expect("resolved retained request has a matching Zellij session");
+            launch_fresh_zellij(inner, &resolved_request, AttachTerm::Xterm, &fresh, session)?
         }
     };
     Ok((worker, snapshot, resolved_request, geometry))
@@ -7369,6 +7994,35 @@ fn launch_fresh_herdr(
     Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
 }
 
+fn launch_fresh_zellij(
+    inner: &Inner,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    session: &session::ZellijSessionRecord,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
+    let AttachTarget::Zellij { executable, .. } = &request.target else {
+        unreachable!("Zellij launch requires a Zellij target");
+    };
+    let plan = request
+        .host
+        .zellij_attach_plan(fresh.endpoint(), executable, session, term);
+    let geometry = *inner
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::attach_zellij_with_metadata(
+        &plan,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
+        default_colors(&inner.appearance),
+    )
+    .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+    Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
+}
+
 fn set_terminal_notice(inner: &Inner, term: AttachTerm) {
     let notice = (term == AttachTerm::Xterm).then(|| REDUCED_COLOR_NOTICE.to_owned());
     *inner
@@ -7445,6 +8099,34 @@ fn set_herdr_inventory(inner: &Inner, inventory: &HerdrInventory) {
         }
         HerdrInventory::Failed(error) => {
             host.herdr_diagnostic = Some(HostDiagnostic::new(error.kind(), error.to_string()));
+        }
+    }
+}
+
+fn set_zellij_inventory(inner: &Inner, inventory: &ZellijInventory) {
+    let mut hosts = inner
+        .hosts
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(host) = hosts.iter_mut().find(|host| host.id == "wsl") else {
+        return;
+    };
+    match inventory {
+        ZellijInventory::Unavailable => {
+            host.zellij_available = false;
+            host.zellij_sessions.clear();
+            host.zellij_diagnostic = None;
+        }
+        ZellijInventory::Available { sessions, .. } => {
+            host.zellij_available = true;
+            host.zellij_sessions = sessions
+                .iter()
+                .map(|session| SessionItem::new(session.name(), 0))
+                .collect();
+            host.zellij_diagnostic = None;
+        }
+        ZellijInventory::Failed(error) => {
+            host.zellij_diagnostic = Some(HostDiagnostic::new(error.kind(), error.to_string()));
         }
     }
 }
@@ -10259,11 +10941,11 @@ mod tests {
             generation,
             selection: SessionSelection::new("wsl", "Ubuntu", "work"),
             host: host.clone(),
-            target: Arc::new(LiveSessionTarget::test_fixture(
+            target: KillTarget::Tmux(Arc::new(LiveSessionTarget::test_fixture(
                 &snapshot,
                 "work",
                 session::SessionIdentity::new(100, "$1", 200),
-            )),
+            ))),
         };
 
         workspace.inner.kill_generation.store(2, Ordering::Release);
@@ -11193,7 +11875,8 @@ mod tests {
         let cancellation = CancellationToken::new();
         let mut probes = 0;
 
-        let result = poll_herdr_startup(
+        let result = poll_session_startup(
+            "Herdr",
             &cancellation,
             &[Duration::ZERO; 6],
             || -> Result<Option<&'static str>, WorkspaceError> {
@@ -11250,7 +11933,43 @@ mod tests {
     }
 
     #[test]
-    fn host_refresh_keeps_cached_tmux_and_herdr_rows_visible() {
+    fn zellij_refresh_failure_preserves_cached_rows() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::shell(
+            Appearance::default(),
+            vec![HostItem::wsl(
+                "Ubuntu",
+                None,
+                HostConnectionState::Ready,
+                Vec::new(),
+                None,
+            )],
+        ));
+        set_zellij_inventory(
+            &workspace.inner,
+            &ZellijInventory::Available {
+                executable: "/opt/zellij/bin/zellij".to_owned(),
+                sessions: vec![session::ZellijSessionRecord::discovered("review")],
+            },
+        );
+        set_zellij_inventory(
+            &workspace.inner,
+            &ZellijInventory::Failed(
+                WslExecutable::from_absolute("wsl.exe").expect_err("relative path is rejected"),
+            ),
+        );
+
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        assert!(host.zellij_available());
+        assert_eq!(host.zellij_sessions()[0].name(), "review");
+        assert_eq!(
+            host.zellij_diagnostic().expect("scoped diagnostic").kind(),
+            DiagnosticKind::MalformedOutput
+        );
+    }
+
+    #[test]
+    fn host_refresh_keeps_cached_multiplexer_rows_visible() {
         let spec = WslHostSpec::available(
             WslConfig::with_distro("Ubuntu").expect("valid config"),
             WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
@@ -11268,6 +11987,8 @@ mod tests {
                 false,
                 HerdrSessionState::Running,
             )];
+            host.zellij_available = true;
+            host.zellij_sessions = vec![SessionItem::new("zellij-work", 0)];
         }
 
         begin_refresh(
@@ -11282,6 +12003,7 @@ mod tests {
         assert_eq!(host.connection(), HostConnectionState::Connecting);
         assert_eq!(host.sessions()[0].name(), "tmux-work");
         assert_eq!(host.herdr_sessions()[0].name(), "herdr-work");
+        assert_eq!(host.zellij_sessions()[0].name(), "zellij-work");
     }
 
     #[test]
@@ -11325,7 +12047,7 @@ mod tests {
             .kwt_refresh_generation
             .store(7, Ordering::Release);
         let inventory = KwtInventory::parse(
-            br#"[{"repository":"project-id","name":"project","path":"/repos/project","last_touched":null}]"#,
+            br#"[{"repository":"project-id","name":"project","path":"/repos/project","last_touched":null,"registration_fingerprint":"project-fingerprint"}]"#,
             br#"[{"path":"/repos/project","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"project-id","session_name":"project-main","tmux_socket_name":null}]"#,
             br#"[{"name":"scratch","path":"/work/scratch","session_name":"scratch","session_live":false}]"#,
         )
@@ -11412,7 +12134,7 @@ mod tests {
             .kwt_refresh_generation
             .store(7, Ordering::Release);
         let added = KwtInventory::parse(
-            br#"[{"repository":"added-id","name":"added","path":"/repos/added","last_touched":null}]"#,
+            br#"[{"repository":"added-id","name":"added","path":"/repos/added","last_touched":null,"registration_fingerprint":"added-fingerprint"}]"#,
             b"[]",
             b"[]",
         )
@@ -11491,7 +12213,7 @@ mod tests {
             .kwt_refresh_generation
             .store(2, Ordering::Release);
         let inventory = KwtInventory::parse(
-            br#"[{"repository":"project-id","name":"stale","path":"/repos/stale","last_touched":null}]"#,
+            br#"[{"repository":"project-id","name":"stale","path":"/repos/stale","last_touched":null,"registration_fingerprint":"stale-fingerprint"}]"#,
             b"[]",
             b"[]",
         )

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -1420,11 +1420,17 @@ struct PresentationKey {
 
 struct SuppressedHerdrPresentation {
     active_selection: Option<SessionSelection>,
-    retained: Option<ClosedRetainedHerdrPresentation>,
+    retained: Option<ClosedRetainedPresentation>,
     navigation_generation: u64,
 }
 
-struct ClosedRetainedHerdrPresentation {
+struct SuppressedZellijPresentation {
+    active_selection: Option<SessionSelection>,
+    retained: Option<ClosedRetainedPresentation>,
+    navigation_generation: u64,
+}
+
+struct ClosedRetainedPresentation {
     key: PresentationKey,
     attachment: ActiveAttachment<AttachRequest>,
     presentation_id: u64,
@@ -3432,16 +3438,26 @@ impl Workspace {
                         executable,
                         name,
                     } => {
+                        let mut suppressed = None;
                         let result = pending.host.kill_zellij_session(
                             endpoint,
                             runtime,
                             executable,
                             name,
                             &CancellationToken::new(),
-                            || workspace.finish_zellij_presentation(endpoint, runtime, name),
+                            || {
+                                suppressed =
+                                    workspace.close_zellij_presentations(endpoint, runtime, name);
+                            },
                         );
-                        if let Err(error) = result {
-                            workspace.push_operation_error(error.to_string());
+                        match result {
+                            Ok(()) => {
+                                workspace.finish_zellij_presentation(endpoint, runtime, name);
+                            }
+                            Err(error) => {
+                                workspace.restore_suppressed_zellij_presentation(suppressed);
+                                workspace.push_operation_error(error.to_string());
+                            }
                         }
                     }
                 }
@@ -3709,6 +3725,115 @@ impl Workspace {
         }
     }
 
+    fn close_zellij_presentations(
+        &self,
+        endpoint: &host::WslEndpoint,
+        runtime: &host::WslRuntimeIdentity,
+        name: &str,
+    ) -> Option<SuppressedZellijPresentation> {
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let navigation_generation = self.inner.navigation_generation.load(Ordering::Acquire);
+        let target_matches = |target: &AttachTarget| matches!(target, AttachTarget::Zellij { name: target_name, .. } if target_name == name);
+        let mut attachment = self
+            .inner
+            .attachment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let active_selection = attachment.active().and_then(|active| {
+            (active.request.endpoint == *endpoint
+                && active.request.runtime == *runtime
+                && target_matches(&active.request.target))
+            .then(|| active.request.selection())
+        });
+        if active_selection.is_some() {
+            attachment.invalidate();
+            self.inner
+                .worker
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .invalidate();
+            clear_pending_paste(&self.inner);
+            clear_terminal_notice(&self.inner);
+            self.restore_inventory_state();
+        }
+        drop(attachment);
+
+        let removed = self
+            .inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take_matching(|key| {
+                key.endpoint == endpoint.distro()
+                    && key.runtime == *runtime
+                    && target_matches(&key.target)
+            });
+        let changed = active_selection.is_some() || !removed.is_empty();
+        let retained = active_selection.is_none().then(|| {
+            removed
+                .into_iter()
+                .next()
+                .map(|presentation| ClosedRetainedPresentation {
+                    key: presentation.key,
+                    attachment: presentation.attachment,
+                    presentation_id: presentation.presentation_id,
+                })
+        });
+        if changed {
+            self.inner.revision.fetch_add(1, Ordering::Release);
+        }
+        (active_selection.is_some() || retained.is_some()).then_some(SuppressedZellijPresentation {
+            active_selection,
+            retained: retained.flatten(),
+            navigation_generation,
+        })
+    }
+
+    fn restore_suppressed_zellij_presentation(
+        &self,
+        suppressed: Option<SuppressedZellijPresentation>,
+    ) {
+        let Some(suppressed) = suppressed else {
+            return;
+        };
+        if let Some(retained) = suppressed.retained {
+            match reopen_closed_retained_presentation(&self.inner, retained) {
+                Ok(presentation) => {
+                    publish_restored_retained_presentation(&self.inner, presentation);
+                }
+                Err(error) => {
+                    self.push_operation_error(format!(
+                        "could not restore a retained Zellij presentation after a failed kill: {error}"
+                    ));
+                }
+            }
+        }
+        let Some(selection) = suppressed.active_selection else {
+            return;
+        };
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        let _navigation = self
+            .inner
+            .navigation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.inner.navigation_generation.load(Ordering::Acquire)
+            != suppressed.navigation_generation
+        {
+            return;
+        }
+        if let Err(error) = self.switch_session_locked(&selection) {
+            self.push_operation_error(format!(
+                "could not restore the Zellij presentation after a failed kill: {error}"
+            ));
+        }
+    }
+
     fn finish_herdr_presentation(
         &self,
         endpoint: &host::WslEndpoint,
@@ -3802,7 +3927,7 @@ impl Workspace {
             removed
                 .into_iter()
                 .next()
-                .map(|presentation| ClosedRetainedHerdrPresentation {
+                .map(|presentation| ClosedRetainedPresentation {
                     key: presentation.key,
                     attachment: presentation.attachment,
                     presentation_id: presentation.presentation_id,
@@ -3826,9 +3951,9 @@ impl Workspace {
             return;
         };
         if let Some(retained) = suppressed.retained {
-            match reopen_closed_retained_herdr_presentation(&self.inner, retained) {
+            match reopen_closed_retained_presentation(&self.inner, retained) {
                 Ok(presentation) => {
-                    publish_restored_retained_herdr_presentation(&self.inner, presentation);
+                    publish_restored_retained_presentation(&self.inner, presentation);
                 }
                 Err(error) => {
                     self.push_operation_error(format!(
@@ -7676,9 +7801,9 @@ fn restore_presentation_inventory(inner: &Inner) {
     set_inner_state(inner, state);
 }
 
-fn reopen_closed_retained_herdr_presentation(
+fn reopen_closed_retained_presentation(
     inner: &Inner,
-    mut closed: ClosedRetainedHerdrPresentation,
+    mut closed: ClosedRetainedPresentation,
 ) -> Result<RetainedPresentation<TerminalWorker>, WorkspaceError> {
     let term = closed.attachment.term;
     let (worker, _snapshot, attached_name, initial_geometry) =
@@ -7710,7 +7835,7 @@ fn reopen_closed_retained_herdr_presentation(
     })
 }
 
-fn publish_restored_retained_herdr_presentation(
+fn publish_restored_retained_presentation(
     inner: &Inner,
     presentation: RetainedPresentation<TerminalWorker>,
 ) {
@@ -8618,7 +8743,7 @@ mod tests {
         };
         let suppressed = SuppressedHerdrPresentation {
             active_selection: None,
-            retained: Some(ClosedRetainedHerdrPresentation {
+            retained: Some(ClosedRetainedPresentation {
                 key: request.presentation_key(),
                 attachment: ActiveAttachment {
                     request,
@@ -8879,6 +9004,27 @@ mod tests {
                 is_default: false,
                 session_directory: "/tmp/herdr/review".to_owned(),
                 socket_path: "/tmp/herdr/review/herdr.sock".to_owned(),
+            },
+            name: name.to_owned(),
+            inventory_generation: 1,
+        }
+    }
+
+    #[cfg(windows)]
+    fn zellij_attach_request_fixture(snapshot: &HostSnapshot, name: &str) -> AttachRequest {
+        AttachRequest {
+            host_id: "wsl".to_owned(),
+            host: WslHost::new(
+                WslConfig::with_distro("Ubuntu").expect("valid WSL config"),
+                Arc::new(StdCommandRunner) as SharedCommandRunner,
+                WslExecutable::from_absolute(r"C:\Windows\System32\wsl.exe")
+                    .expect("absolute WSL path"),
+            ),
+            endpoint: snapshot.endpoint().clone(),
+            runtime: snapshot.runtime().clone(),
+            target: AttachTarget::Zellij {
+                executable: "/usr/bin/zellij".to_owned(),
+                name: name.to_owned(),
             },
             name: name.to_owned(),
             inventory_generation: 1,
@@ -11046,6 +11192,59 @@ mod tests {
                 .target,
             AttachTarget::Tmux(active_identity)
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn zellij_kill_suppression_keeps_active_recovery_authority() {
+        let workspace = Workspace::preview(WorkspaceSnapshot::ready(
+            Appearance::default(),
+            "Ubuntu",
+            Vec::new(),
+        ));
+        let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+        let request = zellij_attach_request_fixture(&snapshot, "work");
+        workspace
+            .inner
+            .attachment
+            .lock()
+            .expect("attachment")
+            .reserve(request, AttachTerm::Xterm256Color)
+            .expect("reserve active attachment");
+        let size = GridSize::new(80, 24).expect("valid grid");
+        set_inner_state(
+            &workspace.inner,
+            WorkspaceContent::Terminal {
+                host_id: "wsl".to_owned(),
+                endpoint: "Ubuntu".to_owned(),
+                session: "work".to_owned(),
+                kind: SessionKind::Zellij,
+                presentation_id: 1,
+                surface: Arc::new(SurfaceStore::new(surface::SurfaceFrame::blank(1, size))),
+            },
+        );
+
+        let suppressed = workspace
+            .close_zellij_presentations(snapshot.endpoint(), snapshot.runtime(), "work")
+            .expect("matching presentation is recoverable");
+
+        assert_eq!(
+            suppressed.active_selection,
+            Some(SessionSelection::zellij("wsl", "Ubuntu", "work"))
+        );
+        assert!(
+            workspace
+                .inner
+                .attachment
+                .lock()
+                .expect("attachment")
+                .active()
+                .is_none()
+        );
+        assert!(matches!(
+            workspace.snapshot().content(),
+            WorkspaceContent::Ready { .. }
+        ));
     }
 
     #[test]

--- a/rust/workspace/tests/wsl_live.rs
+++ b/rust/workspace/tests/wsl_live.rs
@@ -16,6 +16,11 @@ struct IsolatedServer {
     tmpdir: String,
 }
 
+struct ZellijLiveSession {
+    executable: String,
+    name: String,
+}
+
 static WSL_LIVE: Mutex<()> = Mutex::new(());
 
 #[test]
@@ -115,6 +120,76 @@ impl IsolatedServer {
             .status()
             .expect("query isolated WSL path")
             .success()
+    }
+}
+
+impl ZellijLiveSession {
+    fn unique() -> Self {
+        let output = Command::new("wsl.exe")
+            .args(["--exec", "/bin/sh", "-lc", "command -v zellij"])
+            .output()
+            .expect("resolve Zellij in WSL");
+        assert!(
+            output.status.success(),
+            "Zellij is required for this live test: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let executable = String::from_utf8(output.stdout)
+            .expect("UTF-8 Zellij path")
+            .trim()
+            .to_owned();
+        assert!(executable.starts_with('/'), "absolute Zellij path");
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        Self {
+            executable,
+            name: format!("ghosthub-live-{:x}-{nonce:x}", std::process::id()),
+        }
+    }
+
+    fn run<I, S>(&self, args: I) -> Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut command = Command::new("wsl.exe");
+        command.args([
+            "--exec",
+            "/usr/bin/env",
+            "-u",
+            "ZELLIJ",
+            "-u",
+            "ZELLIJ_PANE_ID",
+            "-u",
+            "ZELLIJ_SESSION_NAME",
+            &self.executable,
+        ]);
+        command.args(args);
+        command.output().expect("run isolated Zellij command")
+    }
+
+    fn is_active(&self) -> bool {
+        let output = self.run(["list-sessions", "--no-formatting"]);
+        output.status.success()
+            && String::from_utf8_lossy(&output.stdout).lines().any(|line| {
+                line.strip_suffix(" (CURRENT)")
+                    .unwrap_or(line)
+                    .starts_with(&format!("{} [Created ", self.name))
+            })
+    }
+
+    fn selection(&self, workspace: &Workspace) -> SessionSelection {
+        let snapshot = workspace.snapshot();
+        let host = &snapshot.hosts()[0];
+        SessionSelection::zellij(host.id(), host.endpoint(), &self.name)
+    }
+}
+
+impl Drop for ZellijLiveSession {
+    fn drop(&mut self) {
+        let _ignored = self.run(["kill-session", "--", &self.name]);
     }
 }
 
@@ -811,6 +886,83 @@ fn detach_restores_the_inventory_revalidated_during_attachment() {
                 if sessions.iter().any(|session| session.name() == "appeared-before-attach")
         )
     });
+}
+
+#[test]
+#[ignore = "requires WSL2, tmux, and Zellij; uses a nonce-named Zellij session"]
+fn creates_detaches_reattaches_and_kills_a_zellij_session() {
+    let _serial = WSL_LIVE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let server = IsolatedServer::empty("zellij-lifecycle");
+    let zellij = ZellijLiveSession::unique();
+    let workspace = start_workspace(&server);
+
+    wait_until_with_diagnostic(
+        || {
+            workspace
+                .snapshot()
+                .hosts()
+                .first()
+                .is_some_and(workspace::HostItem::zellij_available)
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    let endpoint = workspace.snapshot().hosts()[0].endpoint().to_owned();
+    workspace
+        .create_zellij_session("wsl", &endpoint, &zellij.name)
+        .expect("start one-shot Zellij creation");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal {
+                    session,
+                    kind: workspace::SessionKind::Zellij,
+                    ..
+                } if session == &zellij.name
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    assert!(zellij.is_active(), "created Zellij session must be active");
+
+    workspace.detach();
+    wait_until_with_diagnostic(
+        || {
+            workspace.snapshot().hosts()[0]
+                .zellij_sessions()
+                .iter()
+                .any(|session| session.name() == zellij.name)
+        },
+        || workspace_diagnostic(&workspace),
+    );
+    workspace
+        .attach(&zellij.selection(&workspace))
+        .expect("reattach the active Zellij session");
+    wait_until_with_diagnostic(
+        || {
+            matches!(
+                workspace.snapshot().content(),
+                WorkspaceContent::Terminal {
+                    session,
+                    kind: workspace::SessionKind::Zellij,
+                    ..
+                } if session == &zellij.name
+            )
+        },
+        || workspace_diagnostic(&workspace),
+    );
+
+    let selection = zellij.selection(&workspace);
+    workspace
+        .request_session_kill(&selection)
+        .expect("prepare confirmed Zellij kill");
+    wait_until(|| workspace.session_kill_confirmation().is_some());
+    workspace
+        .confirm_session_kill()
+        .expect("execute confirmed Zellij kill");
+    wait_until(|| !zellij.is_active());
 }
 
 fn terminal_contains(workspace: &Workspace, expected: &str) -> bool {


### PR DESCRIPTION
- Adds Zellij beside tmux and Herdr on the automatic WSL host, so local Windows users can discover, create, attach, switch, detach, and explicitly kill Zellij sessions.
- Keeps Zellij optional and host-scoped: a missing or broken installation does not block tmux, Herdr, projects, or application startup.
- Preserves backend ownership by using ordinary Zellij clients, retaining presentations for fast switching, and requiring fresh runtime and session validation before destruction.
- Scrubs inherited Zellij routing variables so discovery and attachment cannot drift into a launcher-owned server.
- Updates the pinned KWT integration to the latest project contract and carries registration fingerprints through guarded project removal.
- Real WSL acceptance covers Zellij 0.44.3 create, render, detach, reattach, and confirmed kill; the full Rust workspace, strict Clippy, architecture/contracts, and license checks pass.