### PR TITLE
Add an activation work gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
       - name: Build Swift tests
         run: swift build --build-tests
 
+      # Runs before the long test lanes so a window-switch render
+      # regression fails the build in seconds with a legible step name.
+      - name: Run activation work gate
+        run: >-
+          sh tools/run_swift_tests.sh
+          swift test --skip-build --disable-xctest
+          --filter ActivationWorkGateTests
+
       - name: Run terminal smoke tests
         # Most AppKit/PTY tests are isolated by fixture, so parallel workers
         # shorten the runner exposure window without saturating hosted Macs.

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,12 @@ test-kwt-contract: ensure-kwt ensure-tmux
 		sh tools/run_with_timeout.sh 600 sh tools/run_swift_tests.sh \
 			$(SWIFT) test --filter PinnedKwtContractTests
 
+# Bounds the render work a key-window switch may trigger; catches
+# focus-driven view invalidation regressions in seconds.
+test-activation-gate:
+	@sh tools/run_swift_tests.sh $(SWIFT) test \
+		--disable-xctest --filter ActivationWorkGateTests
+
 # Essential workflow smoke for kwt inventory and ordinary tmux attachment.
 test-essential-workflows: test-kwt-contract
 	@set -euo pipefail; \

--- a/Sources/UI/RenderWorkCounters.swift
+++ b/Sources/UI/RenderWorkCounters.swift
@@ -1,23 +1,46 @@
+import os
+
 /// Render-path work counters behind the activation work gate
 /// (`ActivationWorkGateTests`). Key-window switches must stay cheap, so the
-/// gate bounds how much counted work a switch may trigger. Counting stays
-/// compiled into release builds so the gate exercises the shipping code
-/// path; the storage is `nonisolated(unsafe)` because every counted call
-/// site runs on the main thread during view updates.
+/// gate bounds how much counted work a switch may trigger. Counting is
+/// opt-in: outside an explicit recording window every count call is a
+/// single flag check, so unrelated test suites exercising these views can
+/// neither race the gate nor pollute its counts, and release builds keep
+/// the shipping code path the gate measures.
 enum RenderWorkCounters {
-    private(set) nonisolated(unsafe) static var rootBodyEvaluations = 0
-    private(set) nonisolated(unsafe) static var sidebarSectionComputations = 0
+    struct Counts {
+        var rootBodyEvaluations = 0
+        var sidebarSectionComputations = 0
+        fileprivate var isRecording = false
+    }
+
+    private static let state = OSAllocatedUnfairLock(
+        initialState: Counts()
+    )
 
     static func countRootBodyEvaluation() {
-        rootBodyEvaluations += 1
+        state.withLock {
+            guard $0.isRecording else { return }
+            $0.rootBodyEvaluations += 1
+        }
     }
 
     static func countSidebarSectionComputation() {
-        sidebarSectionComputations += 1
+        state.withLock {
+            guard $0.isRecording else { return }
+            $0.sidebarSectionComputations += 1
+        }
     }
 
-    static func reset() {
-        rootBodyEvaluations = 0
-        sidebarSectionComputations = 0
+    static func beginRecording() {
+        state.withLock { $0 = Counts(isRecording: true) }
+    }
+
+    static func endRecording() -> Counts {
+        state.withLock {
+            let counts = $0
+            $0 = Counts()
+            return counts
+        }
     }
 }

--- a/Sources/UI/RenderWorkCounters.swift
+++ b/Sources/UI/RenderWorkCounters.swift
@@ -1,0 +1,23 @@
+/// Render-path work counters behind the activation work gate
+/// (`ActivationWorkGateTests`). Key-window switches must stay cheap, so the
+/// gate bounds how much counted work a switch may trigger. Counting stays
+/// compiled into release builds so the gate exercises the shipping code
+/// path; the storage is `nonisolated(unsafe)` because every counted call
+/// site runs on the main thread during view updates.
+enum RenderWorkCounters {
+    private(set) nonisolated(unsafe) static var rootBodyEvaluations = 0
+    private(set) nonisolated(unsafe) static var sidebarSectionComputations = 0
+
+    static func countRootBodyEvaluation() {
+        rootBodyEvaluations += 1
+    }
+
+    static func countSidebarSectionComputation() {
+        sidebarSectionComputations += 1
+    }
+
+    static func reset() {
+        rootBodyEvaluations = 0
+        sidebarSectionComputations = 0
+    }
+}

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -119,6 +119,7 @@ public struct RootView: View {
         display.activeZellijSession
     }
     public var body: some View {
+        let _ = RenderWorkCounters.countRootBodyEvaluation()
         contentWithNotifications
             .onAppear {
                 reviewSessionConnectionRequestIfNeeded()

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -466,6 +466,7 @@ public enum WorkspaceSidebarModel {
         herdrSessionOrderRawValue: String = "",
         zellijSessionOrderRawValue: String = ""
     ) -> [WorkspaceSidebarSection] {
+        RenderWorkCounters.countSidebarSectionComputation()
         let worktreeOrder = WorkspaceSidebarOrder(
             rawValue: worktreeOrderRawValue
         )

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -1,0 +1,245 @@
+import AppKit
+import GhosthubSettings
+import GhosthubTerminalSupport
+import GhosthubWorkspace
+import SwiftUI
+import Testing
+@testable import GhosthubUI
+
+/// Activation work gate: bounds the render work a key-window switch may
+/// trigger, so regressions that route focus changes through broad view
+/// invalidation (the 0.8.0 window-switch lag class) fail CI immediately.
+///
+/// The harness hosts two real `RootView` windows and flips the
+/// `controlActiveState` environment between them, which is the mechanism
+/// AppKit uses to deliver key-window changes to SwiftUI content. Driving it
+/// directly keeps the gate deterministic on headless CI runners, where real
+/// key-window transitions are not reliable. App-scene invalidation (e.g.
+/// focused-value reads on the `App` itself) happens above any hostable
+/// view, so it stays outside this gate's reach.
+@MainActor
+struct ActivationWorkGateTests {
+    /// Budgets are a ratchet at 2x the measured baseline: 10 switches cost
+    /// 20 root body evaluations (one per window per switch) and 40 sidebar
+    /// section computations (two call sites per root evaluation until the
+    /// sections result is memoized; kata 4rqt). Lower the budgets when
+    /// render work shrinks; never raise them without profiling why the
+    /// work grew.
+    private enum Budget {
+        static let switches = 10
+        static let rootBodyEvaluations = 40
+        static let sidebarSectionComputations = 80
+    }
+
+    @Test("key-window switching stays within the render work budget")
+    func keyWindowSwitchingStaysWithinRenderWorkBudget() {
+        let gate = GateEnvironment()
+        defer { gate.close() }
+
+        RenderWorkCounters.reset()
+        for index in 0 ..< Budget.switches {
+            gate.activateWindow(index.isMultiple(of: 2) ? 1 : 0)
+        }
+
+        #expect(
+            RenderWorkCounters.rootBodyEvaluations
+                <= Budget.rootBodyEvaluations
+        )
+        #expect(
+            RenderWorkCounters.sidebarSectionComputations
+                <= Budget.sidebarSectionComputations
+        )
+    }
+
+    @Test("gate counters register render work")
+    func gateCountersRegisterRenderWork() {
+        let gate = GateEnvironment()
+        defer { gate.close() }
+
+        RenderWorkCounters.reset()
+        gate.activateWindow(1)
+
+        #expect(RenderWorkCounters.rootBodyEvaluations > 0)
+
+        RenderWorkCounters.reset()
+        _ = WorkspaceSidebarModel.sections(in: gate.snapshot)
+        #expect(RenderWorkCounters.sidebarSectionComputations == 1)
+    }
+}
+
+// MARK: - Harness
+
+@MainActor
+private final class GateEnvironment {
+    let snapshot: WorkspaceSnapshot
+
+    private let windowModels: [GateWindowModel]
+    private let windows: [NSWindow]
+    private let hostingViews: [NSHostingView<GateHarness>]
+    private let settingsStore: SettingsStore
+    private let tempRoot: URL
+    private let defaults: UserDefaults
+    private let defaultsSuiteName: String
+    private let sidebarToggleTarget = NSObject()
+
+    init() {
+        let sessionNames = ["alpha", "beta", "gamma", "delta"]
+        let environment = makeWorkspaceEnvironment(
+            hostConfig: { host in
+                host.tmuxSessions = sessionNames.map {
+                    TmuxSessionSummary(
+                        name: $0,
+                        managed: false,
+                        windows: []
+                    )
+                }
+            },
+            worktrees: [
+                { $0.name = "main"
+                    $0.branch = "main" },
+                { $0.name = "feature-a"
+                    $0.branch = "feature-a" },
+                { $0.name = "feature-b"
+                    $0.branch = "feature-b" },
+            ]
+        )
+        snapshot = environment.snapshot
+
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: tempRoot,
+            withIntermediateDirectories: true
+        )
+        defaultsSuiteName = "ActivationWorkGate-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        settingsStore = SettingsStore(
+            configPipeline: LibghosttyConfigPipeline(
+                paths: LibghosttyConfigPaths(
+                    configDirectory: tempRoot.appendingPathComponent(
+                        ".config",
+                        isDirectory: true
+                    )
+                )
+            ),
+            userDefaults: defaults
+        )
+
+        var models: [GateWindowModel] = []
+        var hostingViews: [NSHostingView<GateHarness>] = []
+        var windows: [NSWindow] = []
+        for index in 0 ..< 2 {
+            let model = GateWindowModel(
+                snapshot: environment.snapshot,
+                selection: environment.selection,
+                activeSession: WorkspaceTmuxSessionSelection(
+                    hostID: environment.host.id,
+                    name: sessionNames[index]
+                ),
+                isActive: index == 0
+            )
+            let hostingView = NSHostingView(
+                rootView: GateHarness(
+                    model: model,
+                    settingsStore: settingsStore,
+                    defaults: defaults,
+                    sidebarToggleTarget: sidebarToggleTarget
+                )
+            )
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1000, height: 700),
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = hostingView
+            window.orderFront(nil)
+            models.append(model)
+            hostingViews.append(hostingView)
+            windows.append(window)
+        }
+        windowModels = models
+        self.hostingViews = hostingViews
+        self.windows = windows
+        settle()
+    }
+
+    func activateWindow(_ index: Int) {
+        for (modelIndex, model) in windowModels.enumerated() {
+            model.isActive = modelIndex == index
+        }
+        settle()
+    }
+
+    func close() {
+        for window in windows {
+            window.orderOut(nil)
+        }
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    private func settle(for duration: TimeInterval = 0.05) {
+        for hostingView in hostingViews {
+            hostingView.layoutSubtreeIfNeeded()
+        }
+        RunLoop.main.run(until: Date().addingTimeInterval(duration))
+        for hostingView in hostingViews {
+            hostingView.layoutSubtreeIfNeeded()
+        }
+    }
+}
+
+@MainActor
+private final class GateWindowModel: ObservableObject {
+    let snapshot: WorkspaceSnapshot
+    @Published var selection: WorkspaceSelection
+    @Published var activeSession: WorkspaceTmuxSessionSelection?
+    @Published var columnVisibility: NavigationSplitViewVisibility = .all
+    @Published var isCommandPalettePresented = false
+    @Published var isActive: Bool
+
+    init(
+        snapshot: WorkspaceSnapshot,
+        selection: WorkspaceSelection,
+        activeSession: WorkspaceTmuxSessionSelection,
+        isActive: Bool
+    ) {
+        self.snapshot = snapshot
+        self.selection = selection
+        self.activeSession = activeSession
+        self.isActive = isActive
+    }
+}
+
+private struct GateHarness: View {
+    @ObservedObject var model: GateWindowModel
+    let settingsStore: SettingsStore
+    let defaults: UserDefaults
+    let sidebarToggleTarget: AnyObject
+
+    var body: some View {
+        RootView(
+            display: WorkspaceDisplayState(
+                snapshot: model.snapshot,
+                activeTmuxSession: model.activeSession
+            ),
+            content: ContentBuilders(
+                tmuxSessionContentBuilder: { _, _, _, _ in
+                    AnyView(Color.clear)
+                }
+            ),
+            sidebarToggleTarget: sidebarToggleTarget,
+            settingsStore: settingsStore,
+            selection: $model.selection,
+            columnVisibility: $model.columnVisibility,
+            isCommandPalettePresented: $model.isCommandPalettePresented
+        )
+        .defaultAppStorage(defaults)
+        .environment(
+            \.controlActiveState,
+            model.isActive ? .key : .inactive
+        )
+    }
+}

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -17,6 +17,7 @@ import Testing
 /// key-window transitions are not reliable. App-scene invalidation (e.g.
 /// focused-value reads on the `App` itself) happens above any hostable
 /// view, so it stays outside this gate's reach.
+@Suite(.serialized)
 @MainActor
 struct ActivationWorkGateTests {
     /// Budgets are a ratchet at 2x the measured baseline: 10 switches cost
@@ -36,17 +37,17 @@ struct ActivationWorkGateTests {
         let gate = GateEnvironment()
         defer { gate.close() }
 
-        RenderWorkCounters.reset()
+        RenderWorkCounters.beginRecording()
         for index in 0 ..< Budget.switches {
             gate.activateWindow(index.isMultiple(of: 2) ? 1 : 0)
         }
+        let counts = RenderWorkCounters.endRecording()
 
         #expect(
-            RenderWorkCounters.rootBodyEvaluations
-                <= Budget.rootBodyEvaluations
+            counts.rootBodyEvaluations <= Budget.rootBodyEvaluations
         )
         #expect(
-            RenderWorkCounters.sidebarSectionComputations
+            counts.sidebarSectionComputations
                 <= Budget.sidebarSectionComputations
         )
     }
@@ -56,14 +57,15 @@ struct ActivationWorkGateTests {
         let gate = GateEnvironment()
         defer { gate.close() }
 
-        RenderWorkCounters.reset()
+        RenderWorkCounters.beginRecording()
         gate.activateWindow(1)
+        #expect(RenderWorkCounters.endRecording().rootBodyEvaluations > 0)
 
-        #expect(RenderWorkCounters.rootBodyEvaluations > 0)
-
-        RenderWorkCounters.reset()
+        RenderWorkCounters.beginRecording()
         _ = WorkspaceSidebarModel.sections(in: gate.snapshot)
-        #expect(RenderWorkCounters.sidebarSectionComputations == 1)
+        #expect(
+            RenderWorkCounters.endRecording().sidebarSectionComputations == 1
+        )
     }
 }
 

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -20,16 +20,19 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ActivationWorkGateTests {
-    /// Budgets are a ratchet at 2x the measured baseline: 10 switches cost
-    /// 20 root body evaluations (one per window per switch) and 40 sidebar
-    /// section computations (two call sites per root evaluation until the
-    /// sections result is memoized; kata 4rqt). Lower the budgets when
-    /// render work shrinks; never raise them without profiling why the
-    /// work grew.
+    /// Budgets are a ratchet at the measured baseline plus 30%: 10 switches
+    /// cost exactly 20 root body evaluations (one per window per switch)
+    /// and 40 sidebar section computations (two call sites per root
+    /// evaluation until the sections result is memoized; kata 4rqt). The
+    /// headroom absorbs a stray framework re-evaluation, while any new
+    /// per-switch invalidation source adds at least one root evaluation
+    /// per switch (+10 and +20 here) and trips the gate. Lower the budgets
+    /// when render work shrinks; never raise them without profiling why
+    /// the work grew.
     private enum Budget {
         static let switches = 10
-        static let rootBodyEvaluations = 40
-        static let sidebarSectionComputations = 80
+        static let rootBodyEvaluations = 26
+        static let sidebarSectionComputations = 52
     }
 
     @Test("key-window switching stays within the render work budget")

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -23,7 +23,7 @@ struct ActivationWorkGateTests {
     /// Budgets are a ratchet at the measured baseline plus 30%: 10 switches
     /// cost exactly 20 root body evaluations (one per window per switch)
     /// and 40 sidebar section computations (two call sites per root
-    /// evaluation until the sections result is memoized; kata 4rqt). The
+    /// evaluation until the sections result is memoized). The
     /// headroom absorbs a stray framework re-evaluation, while any new
     /// per-switch invalidation source adds at least one root evaluation
     /// per switch (+10 and +20 here) and trips the gate. Lower the budgets


### PR DESCRIPTION
The 0.8.0 window-switch lag (#107) and the earlier activation-inventory regression (#100) were both caught only by hand profiling. This adds a CI gate that catches that regression class automatically, in seconds.

- Counts work instead of timing it: wall-clock thresholds on shared runners are either too loose to catch a 100-200ms regression or too flaky to trust, while work counts are exactly reproducible (identical across repeated runs).
- Two counters ship in the real render path: RootView body evaluations and WorkspaceSidebarModel.sections computations. A two-window harness hosting real RootViews drives controlActiveState flips, the mechanism AppKit uses to deliver key-window changes, so the gate stays deterministic on headless runners.
- Budgets ratchet at the measured baseline plus 30% (baseline: exactly 2 root evaluations and 4 section computations per switch), tight enough that a single added per-switch invalidation source trips the gate. The #107 class multiplied per-switch work by at least 4x, so it would trip both budgets. A companion test asserts the counters register work, so removing an increment cannot silently green the gate.
- The CI step runs right after the test build, before the long lanes, so a regression fails fast under a legible step name; the gate also runs again inside the existing Swift Testing lane, a few redundant seconds.
- Known blind spot: App-scene invalidation (the exact #107 mechanism) happens above any hostable view and cannot run in-process; the gate bounds the per-switch view-tree work that made it expensive. The sections baseline halves once the sections result is memoized, at which point the budget ratchets down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
