### PR TITLE
Keep light tmux sessions legible

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,14 @@ The file uses
 [Ghostty's configuration format](https://ghostty.org/docs/config/reference),
 but remains independent of Ghostty.app configuration and state. Ghosthub
 reloads the active configuration when the base file, an included file, or a
-project override changes. The **Tmux Theme** setting supplies colors for new
-sessions created by Ghosthub. Existing sessions keep their own appearance by
-default; **Apply theme to shared tmux sessions** explicitly applies the
-selected colors before future attachments. Use **Session → Apply Theme to
-Current Session** to update only the connected active session immediately.
+project override changes. Ghosthub's generated config enforces a modest local
+text-contrast floor so ANSI colors remain legible on light and dark terminal
+backgrounds without changing shared tmux styles. The **Tmux Theme** setting
+supplies colors for new sessions created by Ghosthub. Existing sessions keep
+their own appearance by default; **Apply theme to shared tmux sessions**
+explicitly applies the selected colors before future attachments. Use
+**Session → Apply Theme to Current Session** to update only the connected
+active session immediately.
 Both choices update the session's existing windows and chrome for every
 attached terminal. Quit confirmation is on by default and can be disabled in
 Terminal Settings; closing the final workspace leaves Ghosthub running, while

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -579,11 +579,7 @@ public final class SettingsStore: ObservableObject {
                 with: managedBlock
             )
 
-            try contents.write(
-                to: terminalConfigFile,
-                atomically: true,
-                encoding: .utf8
-            )
+            try configPipeline.writeGlobalConfig(contents)
             lastErrorMessage = nil
         } catch {
             lastErrorMessage = error.localizedDescription

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -289,6 +289,8 @@ public struct LibghosttyConfigPipeline {
             updated.append("\n")
         }
         updated.append("\n")
+        // libghostty loads recursive config-file entries after the root file,
+        // so included user values still override these root-level fallbacks.
         for setting in missingDefaults {
             updated.append("\(setting.key) = \(setting.value)\n")
         }

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -203,6 +203,29 @@ public struct LibghosttyConfigPipeline {
         self.fileManager = fileManager
     }
 
+    public func writeGlobalConfig(_ contents: String) throws {
+        let configFile = paths.globalConfigFile
+        let writeTarget: URL
+        if let destination = try? fileManager.destinationOfSymbolicLink(
+            atPath: configFile.path
+        ) {
+            let target = if destination.hasPrefix("/") {
+                URL(fileURLWithPath: destination)
+            } else {
+                configFile.deletingLastPathComponent()
+                    .appendingPathComponent(destination)
+            }
+            writeTarget = target.resolvingSymlinksInPath()
+        } else {
+            writeTarget = configFile
+        }
+        try contents.write(
+            to: writeTarget,
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
     @discardableResult
     public func prepareGlobalConfig() throws -> Bool {
         let configFile = paths.globalConfigFile
@@ -225,11 +248,7 @@ public struct LibghosttyConfigPipeline {
         }
 
         do {
-            try Self.defaultGlobalConfigContents.write(
-                to: configFile,
-                atomically: true,
-                encoding: .utf8
-            )
+            try writeGlobalConfig(Self.defaultGlobalConfigContents)
         } catch {
             throw LibghosttyConfigPipelineError.writeDefaultConfig(
                 configFile,
@@ -274,17 +293,7 @@ public struct LibghosttyConfigPipeline {
             updated.append("\(setting.key) = \(setting.value)\n")
         }
 
-        let writeTarget: URL
-        if (try? fileManager.destinationOfSymbolicLink(
-            atPath: configFile.path
-        )) != nil {
-            writeTarget = configFile.resolvingSymlinksInPath()
-        } else {
-            writeTarget = configFile
-        }
-        try? updated.write(
-            to: writeTarget, atomically: true, encoding: .utf8
-        )
+        try? writeGlobalConfig(updated)
     }
 
     private func configContainsKey(

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -274,8 +274,16 @@ public struct LibghosttyConfigPipeline {
             updated.append("\(setting.key) = \(setting.value)\n")
         }
 
+        let writeTarget: URL
+        if (try? fileManager.destinationOfSymbolicLink(
+            atPath: configFile.path
+        )) != nil {
+            writeTarget = configFile.resolvingSymlinksInPath()
+        } else {
+            writeTarget = configFile
+        }
         try? updated.write(
-            to: configFile, atomically: true, encoding: .utf8
+            to: writeTarget, atomically: true, encoding: .utf8
         )
     }
 

--- a/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
+++ b/Sources/TerminalSupport/LibghosttyConfigPipeline.swift
@@ -181,6 +181,7 @@ public struct LibghosttyConfigPipeline {
     scrollback-limit = 50000000
     term = xterm-256color
     cursor-style = block
+    minimum-contrast = 3
     mouse-hide-while-typing = true
     copy-on-select = clipboard
     macos-option-as-alt = true
@@ -252,6 +253,7 @@ public struct LibghosttyConfigPipeline {
         let defaults: [(key: String, value: String)] = [
             ("scrollback-limit", "50000000"),
             ("term", "xterm-256color"),
+            ("minimum-contrast", "3"),
             ("macos-option-as-alt", "true"),
             ("shell-integration", "detect"),
         ]

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -167,6 +167,50 @@ final class SettingsStoreTests {
         )
     }
 
+    @Test("startup preserves a symlinked terminal config")
+    func startupPreservesSymlinkedTerminalConfig() throws {
+        let managedDirectory = tempRoot.appendingPathComponent(
+            "managed-config",
+            isDirectory: true
+        )
+        let managedConfig = managedDirectory.appendingPathComponent(
+            "ghostty.conf",
+            isDirectory: false
+        )
+        try FileManager.default.createDirectory(
+            at: managedDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try LibghosttyConfigPipeline.defaultGlobalConfigContents.write(
+            to: managedConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createSymbolicLink(
+            at: paths.globalConfigFile,
+            withDestinationURL: managedConfig
+        )
+
+        _ = makeSUT()
+
+        let destination = try? FileManager.default
+            .destinationOfSymbolicLink(
+                atPath: paths.globalConfigFile.path
+            )
+        #expect(destination == managedConfig.path)
+        let managedContents = try String(
+            contentsOf: managedConfig,
+            encoding: .utf8
+        )
+        #expect(managedContents.contains(
+            "# >>> Ghosthub managed terminal settings >>>"
+        ))
+    }
+
     @Test("startup uses defaults and reports invalid shortcut config")
     func invalidStartupShortcutConfigUsesDefaults() throws {
         try writeAppConfig(toml: """

--- a/Tests/Terminal/LibghosttyConfigPipelineTests.swift
+++ b/Tests/Terminal/LibghosttyConfigPipelineTests.swift
@@ -192,6 +192,45 @@ struct LibghosttyConfigPipelineTests {
         ])
     }
 
+    @Test("loadPlan preserves a symlinked global config while backfilling")
+    func loadPlanPreservesSymlinkedGlobalConfigWhileBackfilling() throws {
+        let fixture = try ConfigPipelineFixture.create()
+        let managedDirectory = fixture.tempRoot.appendingPathComponent(
+            "managed-config",
+            isDirectory: true
+        )
+        let managedConfig = managedDirectory.appendingPathComponent(
+            "ghostty.conf",
+            isDirectory: false
+        )
+        try FileManager.default.createDirectory(
+            at: managedDirectory,
+            withIntermediateDirectories: true
+        )
+        try "font-family = Berkeley Mono\n".write(
+            to: managedConfig,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createSymbolicLink(
+            at: fixture.paths.globalConfigFile,
+            withDestinationURL: managedConfig
+        )
+
+        _ = try fixture.pipeline.loadPlan()
+
+        let destination = try? FileManager.default
+            .destinationOfSymbolicLink(
+                atPath: fixture.paths.globalConfigFile.path
+            )
+        #expect(destination == managedConfig.path)
+        let managedContents = try String(
+            contentsOf: managedConfig,
+            encoding: .utf8
+        )
+        #expect(managedContents.contains("minimum-contrast = 3"))
+    }
+
     @Test("loadPlan preserves existing scrollback-limit in Ghosthub-generated config")
     func loadPlanPreservesScrollbackInGeneratedConfig() throws {
         let fixture = try ConfigPipelineFixture.create()

--- a/Tests/Terminal/LibghosttyConfigPipelineTests.swift
+++ b/Tests/Terminal/LibghosttyConfigPipelineTests.swift
@@ -31,6 +31,7 @@ struct LibghosttyConfigPipelineTests {
             "term = xterm-256color",
             "cursor-style = block",
             "copy-on-select = clipboard",
+            "minimum-contrast = 3",
             "macos-option-as-alt = true",
             "shell-integration = detect",
         ], omits: [
@@ -183,6 +184,7 @@ struct LibghosttyConfigPipelineTests {
         expectConfig(contents, contains: [
             "scrollback-limit = 50000000",
             "term = xterm-256color",
+            "minimum-contrast = 3",
             "macos-option-as-alt = true",
             "shell-integration = detect",
         ], omits: [

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1012,6 +1012,49 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         XCTAssertEqual(runtime.diagnostics, [])
     }
 
+    func testNewOptionalIncludeOverridesBackfilledMinimumContrast() throws {
+        try skipUnlessLibghosttyReady()
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        let included = pipeline.paths.configDirectory
+            .appendingPathComponent("contrast.conf")
+        try "config-file = ?contrast.conf\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        _ = try pipeline.prepareGlobalConfig()
+
+        try "minimum-contrast = 7\n".write(
+            to: included,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runtime = LibghosttyRuntime(pipeline: pipeline)
+        XCTAssertEqual(runtime.phase, .ready)
+        let config = try XCTUnwrap(runtime.unsafeConfigHandle)
+
+        var contrast: Double = 0
+        let key = "minimum-contrast"
+        XCTAssertTrue(key.withCString { pointer in
+            ghostty_config_get(
+                config,
+                &contrast,
+                pointer,
+                UInt(key.utf8.count)
+            )
+        })
+        XCTAssertEqual(contrast, 7)
+    }
+
     func testPasteboardTypeMappingPreservesMimeSpecificTypes() {
         XCTAssertEqual(
             LibghosttyRuntime.pasteboardType(forMIMEType: "text/plain"),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -562,6 +562,12 @@ callback, including the active conditional light or dark theme. Until a surface
 has delivered that state, no effective Follow ghostty.conf tmux style is
 available.
 
+The generated Ghosthub terminal config sets libghostty's minimum text contrast
+to 3 so dark-oriented ANSI palettes remain legible when an existing session
+uses a light background. This is a client-local rendering constraint and does
+not modify tmux options or the colors seen by another attached client. An
+explicit user value in `ghostty.conf` remains authoritative.
+
 Existing sessions retain their own appearance by default; Ghosthub neither
 places a client-local palette over them nor changes their tmux options. The
 persistent shared-session override applies the selected effective style on

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -607,6 +607,9 @@ session model and die with the app process.
 - Keep `TERM_PROGRAM=ghosthub`.
 - Do not leak launcher-terminal `EDITOR` or `VISUAL` into embedded shells.
 - Keep Ghosthub terminal config at `~/.config/ghosthub/ghostty.conf`.
+- Keep a modest client-local minimum text contrast so inherited ANSI colors
+  remain legible on light and dark backgrounds without rewriting shared tmux
+  styles. Preserve an explicit user-configured value.
 - Keep the generated base config independent of tmux themes. Built-in Tmux
   Theme colors or libghostty's effective Follow ghostty.conf colors are applied
   at session creation, through the explicit shared-session override, or by the

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -49,6 +49,11 @@ session's existing windows and tmux chrome for all attached clients.
 To style future attachments to shared sessions automatically, enable **Apply
 theme to shared tmux sessions** in Settings. This is an explicit opt-in.
 
+Ghosthub also applies a modest client-local text-contrast floor so inherited
+ANSI colors remain legible on light and dark backgrounds without changing the
+shared tmux theme. An explicit `minimum-contrast` value in `ghostty.conf`
+remains authoritative.
+
 Theme application is not available for the Console Panel or native Windows
 sessions.
 


### PR DESCRIPTION
Pre-existing tmux sessions can legitimately supply a light background while programs continue using libghostty’s dark-oriented default ANSI palette. That combination made prompts and status output nearly unreadable in Ghosthub.

Set a modest client-local minimum contrast of 3 in Ghosthub’s generated terminal config and backfill it when absent, while preserving explicit user values. This keeps ANSI text legible without changing shared tmux options or affecting colors seen by other attached clients.

Validated with the 46-test libghostty bootstrap suite, 132 Python tests, the full 959-test Swift suite including terminal smoke coverage, formatting, and make build.