### PR TITLE
Require wrapped ownership for real tmux tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,10 @@ parent's checklist.
 
 - Run `make format` before committing Swift changes. CI runs
   `make format-check` and fails on drift.
-- Run Swift tests with `swift test` or targeted `xcodebuild test`.
+- Run Swift tests with `make swift-test` or targeted `xcodebuild test`.
+- Tests that start a real tmux server must use `TestTmuxServer` and run under
+  `tools/run_swift_tests.sh`; command-construction-only and Zellij tests do not
+  need that fixture.
 - Run Python tests with `make python-test`.
 
 ## Naming
@@ -221,7 +224,7 @@ If you touch terminal startup, shell environment, config layering, embedded libg
 
 - `make test-libghostty-bootstrap`
 - `make python-test`
-- `swift test`
+- `make swift-test`
 - `make build`
 
 If the change is specifically about interactive shell behavior, also verify the existing smoke coverage around:

--- a/Package.swift
+++ b/Package.swift
@@ -323,6 +323,7 @@ targets.append(
         dependencies: [
             "GhosthubTransport",
             "GhosthubTmux",
+            "GhosthubTestSupport",
         ],
         path: "Tests/Tmux"
     )

--- a/Tests/App/PinnedKwtContractTests.swift
+++ b/Tests/App/PinnedKwtContractTests.swift
@@ -242,28 +242,12 @@ struct PinnedKwtContractTests {
         )
         #expect(primary.tmuxSocketName == nil)
         let tmuxPath = try TmuxBinaryResolver().resolveTmuxPath().get()
-        let startSession = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", "default",
-                "new-session", "-d", "-s", primary.sessionName,
-            ],
-            timeout: 10
+        let tmuxServer = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .productContract(name: "default")
         )
-        try #require(
-            startSession.status == 0,
-            Comment(rawValue: startSession.stderr)
-        )
-        defer {
-            _ = AccountCommandRunner.runProcess(
-                executable: tmuxPath,
-                arguments: [
-                    "-L", "default", "kill-session",
-                    "-t", "=\(primary.sessionName):",
-                ],
-                timeout: 10
-            )
-        }
+        defer { tmuxServer.stop() }
+        try tmuxServer.createSession(primary.sessionName)
         _ = try await registry.unregister(
             projectPath: registeredProject.project.path,
             expectedRepository: registeredProject.project.repository,
@@ -387,23 +371,11 @@ struct PinnedKwtContractTests {
         var expectedRepository = registered.repository
         var preservedProvenance: (url: URL, data: Data)?
         var protectedSession: (
+            server: TestTmuxServer,
             tmux: String,
-            socket: String,
             session: String
         )?
-        defer {
-            if let protectedSession {
-                _ = AccountCommandRunner.runProcess(
-                    executable: protectedSession.tmux,
-                    arguments: [
-                        "-L", protectedSession.socket,
-                        "kill-session", "-t",
-                        "=\(protectedSession.session):",
-                    ],
-                    timeout: 10
-                )
-            }
-        }
+        defer { protectedSession?.server.stop() }
         if guardCase == .repositoryMismatch {
             expectedRepository = "github.com/acme/replacement"
         } else {
@@ -459,19 +431,12 @@ struct PinnedKwtContractTests {
                     String(format: "%02x", $0)
                 }.joined()
                 let tmux = try TmuxBinaryResolver().resolveTmuxPath().get()
-                let startSession = AccountCommandRunner.runProcess(
-                    executable: tmux,
-                    arguments: [
-                        "-f", "/dev/null", "-L", socket,
-                        "new-session", "-d", "-s", session,
-                    ],
-                    timeout: 10
+                let server = try TestTmuxServer(
+                    tmuxPath: tmux,
+                    socket: .productContract(name: socket)
                 )
-                try #require(
-                    startSession.status == 0,
-                    Comment(rawValue: startSession.stderr)
-                )
-                protectedSession = (tmux, socket, session)
+                try server.createSession(session)
+                protectedSession = (server, tmux, session)
             }
         }
 
@@ -523,7 +488,7 @@ struct PinnedKwtContractTests {
             let liveSession = AccountCommandRunner.runProcess(
                 executable: protectedSession.tmux,
                 arguments: [
-                    "-L", protectedSession.socket,
+                    "-L", protectedSession.server.socketName,
                     "has-session", "-t", "=\(protectedSession.session):",
                 ],
                 timeout: 10

--- a/Tests/App/TestTmuxServerTests.swift
+++ b/Tests/App/TestTmuxServerTests.swift
@@ -1,0 +1,164 @@
+import Darwin
+import Foundation
+import GhosthubTestSupport
+import Testing
+
+@Suite("test tmux server boundary")
+struct TestTmuxServerTests {
+    @Test("wrapper identity is required before deriving a socket")
+    func missingRunIdentityFails() {
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "GHOSTHUB_TEST_TMUX_RUN_ID")
+
+        #expect(throws: TestTmuxServerError.self) {
+            _ = try TestTmuxServer.runOwnedSocketName(
+                purpose: "fixture",
+                environment: environment
+            )
+        }
+    }
+
+    @Test("wrapper identity must be six alphanumeric characters")
+    func malformedRunIdentityFails() {
+        var environment = ProcessInfo.processInfo.environment
+        environment["GHOSTHUB_TEST_TMUX_RUN_ID"] = "bad-id"
+
+        #expect(throws: TestTmuxServerError.self) {
+            _ = try TestTmuxServer.runOwnedSocketName(
+                purpose: "fixture",
+                environment: environment
+            )
+        }
+    }
+
+    @Test("wrapper directory must match the run identity")
+    func mismatchedRunDirectoryFails() {
+        var environment = ProcessInfo.processInfo.environment
+        environment["GHOSTHUB_TEST_TMUX_RUN_ID"] = "ABC123"
+        environment["TMUX_TMPDIR"] = "/tmp/not-a-ghosthub-test-run"
+
+        #expect(throws: TestTmuxServerError.self) {
+            _ = try TestTmuxServer.runOwnedSocketName(
+                purpose: "fixture",
+                environment: environment
+            )
+        }
+    }
+
+    @Test("run-owned sockets include the wrapper identity")
+    func derivesRunOwnedSocketName() throws {
+        let environment = try wrapperEnvironment()
+        let runID = try #require(
+            environment["GHOSTHUB_TEST_TMUX_RUN_ID"]
+        )
+
+        let name = try TestTmuxServer.runOwnedSocketName(
+            purpose: "fixture",
+            environment: environment
+        )
+
+        #expect(name == "ghosthub-fixture-\(runID)")
+    }
+
+    @Test("product sockets resolve beneath the wrapper directory")
+    func derivesProtectedSocketPath() throws {
+        let environment = try wrapperEnvironment()
+        let tmuxDirectory = try #require(environment["TMUX_TMPDIR"])
+        let server = try TestTmuxServer(
+            tmuxPath: "/usr/bin/false",
+            socket: .productContract(name: "default"),
+            environment: environment
+        )
+
+        #expect(
+            server.socketPath
+                == "\(tmuxDirectory)/tmux-\(getuid())/default"
+        )
+    }
+
+    @Test("a real server is removed by whole-server teardown")
+    func stopsRealServer() throws {
+        let tmuxPath = try #require(findTmux())
+        let environment = try wrapperEnvironment()
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "fixture"),
+            environment: environment
+        )
+        try server.createSession("owned")
+
+        #expect(tmuxStatus(tmuxPath, server, ["has-session", "-t", "=owned:"]) == 0)
+        server.stop()
+        #expect(tmuxStatus(tmuxPath, server, ["has-session", "-t", "=owned:"]) != 0)
+    }
+
+    @Test("a protected exact socket remains reachable by its product name")
+    func productSocketUsesPrivateNamedPath() throws {
+        let tmuxPath = try #require(findTmux())
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .productContract(name: "kwt-pr-0123456789abcdef")
+        )
+        try server.createSession("protected")
+
+        #expect(
+            tmuxNamedStatus(
+                tmuxPath,
+                server.socketName,
+                ["has-session", "-t", "=protected:"]
+            ) == 0
+        )
+        server.stop()
+        #expect(
+            tmuxNamedStatus(
+                tmuxPath,
+                server.socketName,
+                ["has-session", "-t", "=protected:"]
+            ) != 0
+        )
+    }
+
+    private func wrapperEnvironment() throws -> [String: String] {
+        let environment = ProcessInfo.processInfo.environment
+        _ = try #require(environment["GHOSTHUB_TEST_TMUX_RUN_ID"])
+        _ = try #require(environment["TMUX_TMPDIR"])
+        return environment
+    }
+
+    private func findTmux() -> String? {
+        ProcessInfo.processInfo.environment["PATH"]?
+            .split(separator: ":")
+            .map { String($0) + "/tmux" }
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    private func tmuxStatus(
+        _ tmuxPath: String,
+        _ server: TestTmuxServer,
+        _ arguments: [String]
+    ) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tmuxPath)
+        process.arguments = server.connectionArguments + arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    private func tmuxNamedStatus(
+        _ tmuxPath: String,
+        _ socketName: String,
+        _ arguments: [String]
+    ) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tmuxPath)
+        process.arguments = ["-L", socketName] + arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+}

--- a/Tests/App/TestTmuxServerTests.swift
+++ b/Tests/App/TestTmuxServerTests.swift
@@ -152,7 +152,7 @@ struct TestTmuxServerTests {
         let server = try TestTmuxServer(
             tmuxPath: "/test/tmux",
             socket: .runOwned(purpose: "runner"),
-            commandRunner: { _, arguments, _ in
+            commandRunner: { _, arguments, _, _ in
                 recorder.record(arguments)
                 return TestTmuxCommandOutput(status: 0, stderr: "")
             }
@@ -165,6 +165,39 @@ struct TestTmuxServerTests {
         #expect(calls.count == 2)
         #expect(calls.first?.contains("new-session") == true)
         #expect(calls.last?.suffix(1) == ["kill-server"])
+    }
+
+    @Test("the default runner uses the validated fixture environment")
+    func defaultRunnerUsesValidatedEnvironment() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ghosthub-tmux-environment-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tmux = directory.appendingPathComponent("tmux")
+        try """
+        #!/bin/sh
+        test "$GHOSTHUB_TEST_ENVIRONMENT_SENTINEL" = fixture
+        """.write(to: tmux, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tmux.path
+        )
+        var environment = try wrapperEnvironment()
+        environment["GHOSTHUB_TEST_ENVIRONMENT_SENTINEL"] = "fixture"
+        let server = try TestTmuxServer(
+            tmuxPath: tmux.path,
+            socket: .runOwned(purpose: "environment"),
+            environment: environment
+        )
+
+        try server.createSession("owned")
+        server.stop()
     }
 
     private func wrapperEnvironment() throws -> [String: String] {

--- a/Tests/App/TestTmuxServerTests.swift
+++ b/Tests/App/TestTmuxServerTests.swift
@@ -3,6 +3,28 @@ import Foundation
 import GhosthubTestSupport
 import Testing
 
+private func findTestTmux() -> String? {
+    ProcessInfo.processInfo.environment["PATH"]?
+        .split(separator: ":")
+        .map { String($0) + "/tmux" }
+        .first { FileManager.default.isExecutableFile(atPath: $0) }
+}
+
+private final class TestTmuxCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var arguments: [[String]] = []
+
+    func record(_ arguments: [String]) {
+        lock.withLock {
+            self.arguments.append(arguments)
+        }
+    }
+
+    func snapshot() -> [[String]] {
+        lock.withLock { arguments }
+    }
+}
+
 @Suite("test tmux server boundary")
 struct TestTmuxServerTests {
     @Test("wrapper identity is required before deriving a socket")
@@ -76,9 +98,12 @@ struct TestTmuxServerTests {
         )
     }
 
-    @Test("a real server is removed by whole-server teardown")
+    @Test(
+        "a real server is removed by whole-server teardown",
+        .enabled(if: findTestTmux() != nil, "tmux is unavailable")
+    )
     func stopsRealServer() throws {
-        let tmuxPath = try #require(findTmux())
+        let tmuxPath = try #require(findTestTmux())
         let environment = try wrapperEnvironment()
         let server = try TestTmuxServer(
             tmuxPath: tmuxPath,
@@ -92,9 +117,12 @@ struct TestTmuxServerTests {
         #expect(tmuxStatus(tmuxPath, server, ["has-session", "-t", "=owned:"]) != 0)
     }
 
-    @Test("a protected exact socket remains reachable by its product name")
+    @Test(
+        "a protected exact socket remains reachable by its product name",
+        .enabled(if: findTestTmux() != nil, "tmux is unavailable")
+    )
     func productSocketUsesPrivateNamedPath() throws {
-        let tmuxPath = try #require(findTmux())
+        let tmuxPath = try #require(findTestTmux())
         let server = try TestTmuxServer(
             tmuxPath: tmuxPath,
             socket: .productContract(name: "kwt-pr-0123456789abcdef")
@@ -118,18 +146,32 @@ struct TestTmuxServerTests {
         )
     }
 
+    @Test("an injected runner owns server creation and teardown")
+    func injectedRunnerOwnsLifecycle() throws {
+        let recorder = TestTmuxCommandRecorder()
+        let server = try TestTmuxServer(
+            tmuxPath: "/test/tmux",
+            socket: .runOwned(purpose: "runner"),
+            commandRunner: { _, arguments, _ in
+                recorder.record(arguments)
+                return TestTmuxCommandOutput(status: 0, stderr: "")
+            }
+        )
+
+        try server.createSession("owned")
+        server.stop()
+
+        let calls = recorder.snapshot()
+        #expect(calls.count == 2)
+        #expect(calls.first?.contains("new-session") == true)
+        #expect(calls.last?.suffix(1) == ["kill-server"])
+    }
+
     private func wrapperEnvironment() throws -> [String: String] {
         let environment = ProcessInfo.processInfo.environment
         _ = try #require(environment["GHOSTHUB_TEST_TMUX_RUN_ID"])
         _ = try #require(environment["TMUX_TMPDIR"])
         return environment
-    }
-
-    private func findTmux() -> String? {
-        ProcessInfo.processInfo.environment["PATH"]?
-            .split(separator: ":")
-            .map { String($0) + "/tmux" }
-            .first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     private func tmuxStatus(

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -113,16 +113,76 @@ private final class TestTmuxClient {
 private func makeTestTmuxServer(
     tmuxPath: String,
     purpose: String,
-    sessions: [String]
+    sessions: [String],
+    commandRunner: TestTmuxServer.CommandRunner? = nil
 ) throws -> TestTmuxServer {
     let server = try TestTmuxServer(
         tmuxPath: tmuxPath,
-        socket: .runOwned(purpose: purpose)
+        socket: .runOwned(purpose: purpose),
+        commandRunner: commandRunner
     )
     for session in sessions {
         try server.createSession(session)
     }
     return server
+}
+
+private struct TestTmuxLoginShell: Sendable {
+    let shell: String
+    let tmuxDirectory: String
+
+    init(shell: String) throws {
+        self.shell = shell
+        tmuxDirectory = try #require(
+            ProcessInfo.processInfo.environment["TMUX_TMPDIR"]
+        )
+    }
+
+    func run(
+        command: String,
+        timeout: TimeInterval,
+        captureStandardError: Bool = false
+    ) -> (status: Int32, stdout: String) {
+        AccountCommandRunner.runLoginShell(
+            shell: shell,
+            command: "export TMUX_TMPDIR="
+                + shellQuotedCommandArgument(tmuxDirectory)
+                + "; " + command,
+            timeout: timeout,
+            captureStandardError: captureStandardError
+        )
+    }
+
+    func commandRunner() -> TestTmuxServer.CommandRunner {
+        { executable, arguments, timeout in
+            let command = ([executable] + arguments)
+                .map(shellQuotedCommandArgument)
+                .joined(separator: " ")
+            let result = run(
+                command: command,
+                timeout: timeout,
+                captureStandardError: true
+            )
+            return TestTmuxCommandOutput(
+                status: result.status,
+                stderr: result.stdout
+            )
+        }
+    }
+
+    func paneRunner() -> TmuxPaneSplitter.Runner {
+        { host, _, command in
+            guard host == .local else {
+                return (127, "test login-shell runner only supports localhost")
+            }
+            let result = run(
+                command: command,
+                timeout: 15,
+                captureStandardError: true
+            )
+            return (result.status, result.stdout)
+        }
+    }
 }
 
 private func nativePaneSplitsAreAvailable(_ tmuxPath: String) -> Bool {
@@ -580,15 +640,51 @@ struct TmuxPaneSplitterTests {
         guard case let .success(tmuxPath) =
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ghosthub-login-tmux-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let profileTmuxDirectory = directory
+            .appendingPathComponent("profile-tmux", isDirectory: true).path
+        let shell = directory.appendingPathComponent("login-shell")
+        try """
+        #!/bin/sh
+        export TMUX_TMPDIR=\(shellQuotedCommandArgument(profileTmuxDirectory))
+        exec /bin/sh "$@"
+        """.write(to: shell, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shell.path
+        )
+        let rawLoginEnvironment = AccountCommandRunner.runLoginShell(
+            shell: shell.path,
+            command: "/usr/bin/printenv TMUX_TMPDIR",
+            timeout: 5
+        )
+        #expect(
+            rawLoginEnvironment.stdout
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                == profileTmuxDirectory
+        )
+        let tmuxLoginShell = try TestTmuxLoginShell(shell: shell.path)
+        let commandRunner = tmuxLoginShell.commandRunner()
         let targetServer = try makeTestTmuxServer(
             tmuxPath: tmuxPath,
             purpose: "target",
-            sessions: ["inherited-target"]
+            sessions: ["inherited-target"],
+            commandRunner: commandRunner
         )
         let launcherServer = try makeTestTmuxServer(
             tmuxPath: tmuxPath,
             purpose: "launcher",
-            sessions: ["launcher"]
+            sessions: ["launcher"],
+            commandRunner: commandRunner
         )
         let targetSocketName = targetServer.socketName
         let launcherSocketName = launcherServer.socketName
@@ -604,8 +700,7 @@ struct TmuxPaneSplitterTests {
             "client-attached",
             "rename-session -t =inherited-target: inherited-renamed",
         ].map(shellQuotedCommandArgument).joined(separator: " ")
-        #expect(AccountCommandRunner.runLoginShell(
-            shell: "/bin/sh",
+        #expect(tmuxLoginShell.run(
             command: renameHook,
             timeout: 5
         ).status == 0)
@@ -613,8 +708,7 @@ struct TmuxPaneSplitterTests {
             tmuxPath, "-L", launcherSocketName, "display-message", "-p",
             "#{socket_path}\t#{pid}",
         ].map(shellQuotedCommandArgument).joined(separator: " ")
-        let launcherFields = AccountCommandRunner.runLoginShell(
-            shell: "/bin/sh",
+        let launcherFields = tmuxLoginShell.run(
             command: launcherIdentity,
             timeout: 5
         ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -656,8 +750,7 @@ struct TmuxPaneSplitterTests {
             "=inherited-renamed:",
             "#{pid}\t#{session_id}\t#{session_created}",
         ].map(shellQuotedCommandArgument).joined(separator: " ")
-        let targetIdentityResult = AccountCommandRunner.runLoginShell(
-            shell: "/bin/sh",
+        let targetIdentityResult = tmuxLoginShell.run(
             command: targetIdentity,
             timeout: 5
         )
@@ -665,7 +758,9 @@ struct TmuxPaneSplitterTests {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: "\t")
 
-        let client = try await TmuxPaneSplitter().clientIdentity(
+        let client = try await TmuxPaneSplitter(
+            runner: tmuxLoginShell.paneRunner()
+        ).clientIdentity(
             target: TmuxPaneSplitTarget(
                 host: .local,
                 tmuxPath: tmuxPath,

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GhosthubTerminalSupport
+import GhosthubTestSupport
 import GhosthubTmux
 import GhosthubTransport
 import Testing
@@ -109,15 +110,19 @@ private final class TestTmuxClient {
     }
 }
 
-private func stopTestTmuxServer(tmuxPath: String, socketName: String) {
-    _ = AccountCommandRunner.runProcess(
-        executable: tmuxPath,
-        arguments: [
-            "-L", socketName,
-            "kill-session", "-a", ";", "kill-session",
-        ],
-        timeout: 5
+private func makeTestTmuxServer(
+    tmuxPath: String,
+    purpose: String,
+    sessions: [String]
+) throws -> TestTmuxServer {
+    let server = try TestTmuxServer(
+        tmuxPath: tmuxPath,
+        socket: .runOwned(purpose: purpose)
     )
+    for session in sessions {
+        try server.createSession(session)
+    }
+    return server
 }
 
 private func nativePaneSplitsAreAvailable(_ tmuxPath: String) -> Bool {
@@ -161,22 +166,13 @@ struct TmuxPaneSplitterTests {
             return
         }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let socketName = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ].map { "ghosthub-split-\($0)" }
-            ?? "ghosthub-split-\(UUID().uuidString.lowercased())"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "customized",
-            ],
-            timeout: 5
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "split",
+            sessions: ["customized"]
         )
-        #expect(created.status == 0)
+        defer { server.stop() }
+        let socketName = server.socketName
         let customized = AccountCommandRunner.runProcess(
             executable: tmuxPath,
             arguments: [
@@ -290,24 +286,13 @@ struct TmuxPaneSplitterTests {
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
-        let socketName = "ghosthub-concurrent-hooks-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        for sessionName in ["concurrent-a", "concurrent-b"] {
-            let created = AccountCommandRunner.runProcess(
-                executable: tmuxPath,
-                arguments: [
-                    "-f", "/dev/null", "-L", socketName,
-                    "new-session", "-d", "-s", sessionName,
-                ],
-                timeout: 5
-            )
-            #expect(created.status == 0)
-        }
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "concurrent-hooks",
+            sessions: ["concurrent-a", "concurrent-b"]
+        )
+        defer { server.stop() }
+        let socketName = server.socketName
 
         let firstToken = UUID().uuidString.lowercased()
         let secondToken = UUID().uuidString.lowercased()
@@ -444,22 +429,13 @@ struct TmuxPaneSplitterTests {
         guard case let .success(tmuxPath) =
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.lowercased().prefix(8))
-        let socketName = "ghosthub-token-race-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "token-race",
-            ],
-            timeout: 5
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "token-race",
+            sessions: ["token-race"]
         )
-        #expect(created.status == 0)
+        defer { server.stop() }
+        let socketName = server.socketName
 
         let token = UUID().uuidString.lowercased()
         let target = TmuxPaneSplitTarget(
@@ -510,22 +486,13 @@ struct TmuxPaneSplitterTests {
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.lowercased().prefix(8))
-        let socketName = "ghosthub-slow-split-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "slow",
-            ],
-            timeout: 5
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "slow-split",
+            sessions: ["slow"]
         )
-        #expect(created.status == 0)
+        defer { server.stop() }
+        let socketName = server.socketName
 
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -613,40 +580,23 @@ struct TmuxPaneSplitterTests {
         guard case let .success(tmuxPath) =
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.lowercased().prefix(8))
-        let targetSocketName = "gh-target-\(runID)"
-        let launcherSocketName = "gh-launcher-\(runID)"
+        let targetServer = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "target",
+            sessions: ["inherited-target"]
+        )
+        let launcherServer = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "launcher",
+            sessions: ["launcher"]
+        )
+        let targetSocketName = targetServer.socketName
+        let launcherSocketName = launcherServer.socketName
         let token = UUID().uuidString.lowercased()
         let tokenPath = try testClientTokenPath(token)
-        let targetCreate = [
-            tmuxPath, "-f", "/dev/null", "-L", targetSocketName,
-            "new-session", "-d", "-s", "inherited-target",
-        ].map(shellQuotedCommandArgument).joined(separator: " ")
-        let launcherCreate = [
-            tmuxPath, "-f", "/dev/null", "-L", launcherSocketName,
-            "new-session", "-d", "-s", "launcher",
-        ].map(shellQuotedCommandArgument).joined(separator: " ")
-        #expect(AccountCommandRunner.runLoginShell(
-            shell: "/bin/sh",
-            command: targetCreate,
-            timeout: 5
-        ).status == 0)
-        #expect(AccountCommandRunner.runLoginShell(
-            shell: "/bin/sh",
-            command: launcherCreate,
-            timeout: 5
-        ).status == 0)
         defer {
-            stopTestTmuxServer(
-                tmuxPath: tmuxPath,
-                socketName: targetSocketName
-            )
-            stopTestTmuxServer(
-                tmuxPath: tmuxPath,
-                socketName: launcherSocketName
-            )
+            targetServer.stop()
+            launcherServer.stop()
             try? FileManager.default.removeItem(at: tokenPath)
         }
         let renameHook = [
@@ -905,22 +855,13 @@ struct TmuxPaneSplitterTests {
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
-        let socketName = "ghosthub-client-identity-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "identity",
-            ],
-            timeout: 5
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "client-identity",
+            sessions: ["identity"]
         )
-        #expect(created.status == 0)
+        defer { server.stop() }
+        let socketName = server.socketName
         let originalToken = UUID().uuidString.lowercased()
         let replacementToken = UUID().uuidString.lowercased()
         let original = try TestTmuxClient(
@@ -996,13 +937,13 @@ struct TmuxPaneSplitterTests {
             return
         }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
-        let socketName = "ghosthub-replacement-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "replacement",
+            sessions: ["replaceable"]
+        )
+        defer { server.stop() }
+        let socketName = server.socketName
         let target = TmuxPaneSplitTarget(
             host: .local,
             tmuxPath: tmuxPath,
@@ -1011,15 +952,6 @@ struct TmuxPaneSplitterTests {
             sshConnectionArguments: [],
             clientToken: UUID().uuidString.lowercased()
         )
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "replaceable",
-            ],
-            timeout: 5
-        )
-        #expect(created.status == 0)
         let clientProcess = try TestTmuxClient(
             tmuxPath: tmuxPath,
             socketName: socketName,
@@ -1037,15 +969,7 @@ struct TmuxPaneSplitterTests {
             arguments: ["-L", socketName, "kill-session", "-t", "replaceable"],
             timeout: 5
         )
-        let replacement = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "replaceable",
-            ],
-            timeout: 5
-        )
-        #expect(replacement.status == 0)
+        try server.createSession("replaceable")
 
         var guardedTarget = target
         guardedTarget.expectedIdentity = client?.sessionIdentity
@@ -1073,24 +997,13 @@ struct TmuxPaneSplitterTests {
             TmuxBinaryResolver().resolveTmuxPath()
         else { return }
         guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
-        let runID = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ] ?? String(UUID().uuidString.prefix(8)).lowercased()
-        let socketName = "ghosthub-client-switch-\(runID)"
-        defer {
-            stopTestTmuxServer(tmuxPath: tmuxPath, socketName: socketName)
-        }
-        for session in ["original", "visible"] {
-            let created = AccountCommandRunner.runProcess(
-                executable: tmuxPath,
-                arguments: [
-                    "-f", "/dev/null", "-L", socketName,
-                    "new-session", "-d", "-s", session,
-                ],
-                timeout: 5
-            )
-            #expect(created.status == 0)
-        }
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "client-switch",
+            sessions: ["original", "visible"]
+        )
+        defer { server.stop() }
+        let socketName = server.socketName
         let target = TmuxPaneSplitTarget(
             host: .local,
             tmuxPath: tmuxPath,

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -114,11 +114,13 @@ private func makeTestTmuxServer(
     tmuxPath: String,
     purpose: String,
     sessions: [String],
+    environment: [String: String] = ProcessInfo.processInfo.environment,
     commandRunner: TestTmuxServer.CommandRunner? = nil
 ) throws -> TestTmuxServer {
     let server = try TestTmuxServer(
         tmuxPath: tmuxPath,
         socket: .runOwned(purpose: purpose),
+        environment: environment,
         commandRunner: commandRunner
     )
     for session in sessions {
@@ -129,39 +131,43 @@ private func makeTestTmuxServer(
 
 private struct TestTmuxLoginShell: Sendable {
     let shell: String
-    let tmuxDirectory: String
+    let environment: [String: String]
 
-    init(shell: String) throws {
+    init(shell: String, environment: [String: String]) throws {
         self.shell = shell
-        tmuxDirectory = try #require(
-            ProcessInfo.processInfo.environment["TMUX_TMPDIR"]
-        )
+        self.environment = environment
+        _ = try #require(environment["TMUX_TMPDIR"])
     }
 
     func run(
         command: String,
         timeout: TimeInterval,
-        captureStandardError: Bool = false
+        captureStandardError: Bool = false,
+        environment: [String: String]? = nil
     ) -> (status: Int32, stdout: String) {
-        AccountCommandRunner.runLoginShell(
+        let environment = environment ?? self.environment
+        let tmuxDirectory = environment["TMUX_TMPDIR"] ?? ""
+        return AccountCommandRunner.runLoginShell(
             shell: shell,
             command: "export TMUX_TMPDIR="
                 + shellQuotedCommandArgument(tmuxDirectory)
                 + "; " + command,
             timeout: timeout,
-            captureStandardError: captureStandardError
+            captureStandardError: captureStandardError,
+            environmentOverrides: ["TMUX_TMPDIR": tmuxDirectory]
         )
     }
 
     func commandRunner() -> TestTmuxServer.CommandRunner {
-        { executable, arguments, timeout in
+        { executable, arguments, timeout, environment in
             let command = ([executable] + arguments)
                 .map(shellQuotedCommandArgument)
                 .joined(separator: " ")
             let result = run(
                 command: command,
                 timeout: timeout,
-                captureStandardError: true
+                captureStandardError: true,
+                environment: environment
             )
             return TestTmuxCommandOutput(
                 status: result.status,
@@ -672,18 +678,24 @@ struct TmuxPaneSplitterTests {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 == profileTmuxDirectory
         )
-        let tmuxLoginShell = try TestTmuxLoginShell(shell: shell.path)
+        let fixtureEnvironment = ProcessInfo.processInfo.environment
+        let tmuxLoginShell = try TestTmuxLoginShell(
+            shell: shell.path,
+            environment: fixtureEnvironment
+        )
         let commandRunner = tmuxLoginShell.commandRunner()
         let targetServer = try makeTestTmuxServer(
             tmuxPath: tmuxPath,
             purpose: "target",
             sessions: ["inherited-target"],
+            environment: fixtureEnvironment,
             commandRunner: commandRunner
         )
         let launcherServer = try makeTestTmuxServer(
             tmuxPath: tmuxPath,
             purpose: "launcher",
             sessions: ["launcher"],
+            environment: fixtureEnvironment,
             commandRunner: commandRunner
         )
         let targetSocketName = targetServer.socketName

--- a/Tests/App/TmuxSessionKillerTests.swift
+++ b/Tests/App/TmuxSessionKillerTests.swift
@@ -1,5 +1,6 @@
 import GhosthubTransport
 import Foundation
+import GhosthubTestSupport
 import GhosthubTmux
 import GhosthubUI
 import Testing
@@ -14,38 +15,15 @@ struct TmuxSessionKillerTests {
         else {
             return
         }
-        let socketName = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ].map { "ghosthub-kill-\($0)" }
-            ?? "ghosthub-kill-\(UUID().uuidString.lowercased())"
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "kill")
+        )
+        defer { server.stop() }
+        let socketName = server.socketName
         let sessionName = "same-name"
-        defer {
-            _ = AccountCommandRunner.runProcess(
-                executable: tmuxPath,
-                arguments: [
-                    "-L", socketName,
-                    "kill-session", "-a", ";", "kill-session",
-                ],
-                timeout: 5
-            )
-        }
-        let anchor = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", "anchor",
-            ],
-            timeout: 5
-        )
-        #expect(anchor.status == 0)
-        let initial = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-L", socketName, "new-session", "-d", "-s", sessionName,
-            ],
-            timeout: 5
-        )
-        #expect(initial.status == 0)
+        try server.createSession("anchor")
+        try server.createSession(sessionName)
 
         let killer = TmuxSessionKiller(
             pathResolver: { _ in .success(tmuxPath) }
@@ -74,14 +52,7 @@ struct TmuxSessionKillerTests {
         )
         #expect(absent.status != 0)
 
-        let replacement = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-L", socketName, "new-session", "-d", "-s", sessionName,
-            ],
-            timeout: 5
-        )
-        #expect(replacement.status == 0)
+        try server.createSession(sessionName)
         await #expect {
             try await killer.kill(
                 selection,

--- a/Tests/App/TmuxSessionStylerTests.swift
+++ b/Tests/App/TmuxSessionStylerTests.swift
@@ -1,5 +1,6 @@
 import GhosthubTransport
 import Foundation
+import GhosthubTestSupport
 import GhosthubTmux
 import GhosthubUI
 import Testing
@@ -172,30 +173,14 @@ struct TmuxSessionStylerTests {
         else {
             return
         }
-        let socketName = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ].map { "ghosthub-style-\($0)" }
-            ?? "ghosthub-style-\(UUID().uuidString.lowercased())"
-        let sessionName = "review"
-        defer {
-            _ = AccountCommandRunner.runProcess(
-                executable: tmuxPath,
-                arguments: [
-                    "-L", socketName,
-                    "kill-session", "-a", ";", "kill-session",
-                ],
-                timeout: 5
-            )
-        }
-        let created = AccountCommandRunner.runProcess(
-            executable: tmuxPath,
-            arguments: [
-                "-f", "/dev/null", "-L", socketName,
-                "new-session", "-d", "-s", sessionName,
-            ],
-            timeout: 5
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "style")
         )
-        try #require(created.status == 0)
+        defer { server.stop() }
+        let socketName = server.socketName
+        let sessionName = "review"
+        try server.createSession(sessionName)
 
         let identity = try await TmuxSessionKiller(
             pathResolver: { _ in .success(tmuxPath) }

--- a/Tests/TestSupport/TestTmuxServer.swift
+++ b/Tests/TestSupport/TestTmuxServer.swift
@@ -33,7 +33,8 @@ public final class TestTmuxServer: @unchecked Sendable {
     public typealias CommandRunner = @Sendable (
         _ executable: String,
         _ arguments: [String],
-        _ timeout: TimeInterval
+        _ timeout: TimeInterval,
+        _ environment: [String: String]
     ) throws -> TestTmuxCommandOutput
 
     public enum SocketKind: Sendable {
@@ -47,6 +48,7 @@ public final class TestTmuxServer: @unchecked Sendable {
 
     private let tmuxPath: String
     private let commandRunner: CommandRunner
+    private let environment: [String: String]
     private let lock = NSLock()
     private var stopped = false
 
@@ -59,6 +61,7 @@ public final class TestTmuxServer: @unchecked Sendable {
         let context = try Self.wrapperContext(environment: environment)
         self.tmuxPath = tmuxPath
         self.commandRunner = commandRunner ?? Self.run
+        self.environment = environment
 
         switch socket {
         case let .runOwned(purpose):
@@ -112,7 +115,7 @@ public final class TestTmuxServer: @unchecked Sendable {
         if let command {
             arguments.append(command)
         }
-        let result = try commandRunner(tmuxPath, arguments, 10)
+        let result = try commandRunner(tmuxPath, arguments, 10, environment)
         guard result.status == 0 else {
             throw TestTmuxServerError.commandFailed(
                 arguments: arguments,
@@ -135,7 +138,8 @@ public final class TestTmuxServer: @unchecked Sendable {
         _ = try? commandRunner(
             tmuxPath,
             connectionArguments + ["kill-server"],
-            5
+            5,
+            environment
         )
     }
 
@@ -257,13 +261,15 @@ public final class TestTmuxServer: @unchecked Sendable {
     private static func run(
         executable: String,
         arguments: [String],
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        environment: [String: String]
     ) throws -> TestTmuxCommandOutput {
         let process = Process()
         let stderr = Pipe()
         let completed = DispatchSemaphore(value: 0)
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
+        process.environment = environment
         process.standardOutput = FileHandle.nullDevice
         process.standardError = stderr
         process.terminationHandler = { _ in completed.signal() }

--- a/Tests/TestSupport/TestTmuxServer.swift
+++ b/Tests/TestSupport/TestTmuxServer.swift
@@ -1,0 +1,277 @@
+import Darwin
+import Foundation
+
+public enum TestTmuxServerError: Error, CustomStringConvertible, Sendable {
+    case invalidEnvironment(String)
+    case invalidSocket(String)
+    case commandFailed(arguments: [String], status: Int32, stderr: String)
+    case commandTimedOut(arguments: [String])
+
+    public var description: String {
+        switch self {
+        case let .invalidEnvironment(message), let .invalidSocket(message):
+            message
+        case let .commandFailed(arguments, status, stderr):
+            "tmux \(arguments.joined(separator: " ")) exited \(status): \(stderr)"
+        case let .commandTimedOut(arguments):
+            "tmux \(arguments.joined(separator: " ")) timed out"
+        }
+    }
+}
+
+public final class TestTmuxServer: @unchecked Sendable {
+    public enum SocketKind: Sendable {
+        case runOwned(purpose: String)
+        case productContract(name: String)
+    }
+
+    public let socketName: String
+    public let socketPath: String?
+    public let connectionArguments: [String]
+
+    private let tmuxPath: String
+    private let lock = NSLock()
+    private var stopped = false
+
+    public init(
+        tmuxPath: String,
+        socket: SocketKind,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        let context = try Self.wrapperContext(environment: environment)
+        self.tmuxPath = tmuxPath
+
+        switch socket {
+        case let .runOwned(purpose):
+            socketName = try Self.runOwnedSocketName(
+                purpose: purpose,
+                context: context
+            )
+            socketPath = nil
+            connectionArguments = ["-L", socketName]
+        case let .productContract(name):
+            try Self.validateSocketComponent(name, label: "product socket name")
+            socketName = name
+            let socketDirectory = URL(fileURLWithPath: context.tmuxDirectory)
+                .appendingPathComponent("tmux-\(getuid())", isDirectory: true)
+                .path
+            try Self.prepareSocketDirectory(socketDirectory)
+            let path = URL(fileURLWithPath: socketDirectory)
+                .appendingPathComponent(name, isDirectory: false).path
+            guard path.hasPrefix(context.tmuxDirectory + "/") else {
+                throw TestTmuxServerError.invalidSocket(
+                    "product socket escaped the private tmux directory"
+                )
+            }
+            socketPath = path
+            connectionArguments = ["-S", path]
+        }
+    }
+
+    deinit {
+        stop()
+    }
+
+    public static func runOwnedSocketName(
+        purpose: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> String {
+        try runOwnedSocketName(
+            purpose: purpose,
+            context: wrapperContext(environment: environment)
+        )
+    }
+
+    public func createSession(
+        _ name: String,
+        command: String? = nil
+    ) throws {
+        try Self.validateSocketComponent(name, label: "session name")
+        var arguments = ["-f", "/dev/null"]
+            + connectionArguments
+            + ["new-session", "-d", "-s", name]
+        if let command {
+            arguments.append(command)
+        }
+        let result = try Self.run(
+            executable: tmuxPath,
+            arguments: arguments,
+            timeout: 10
+        )
+        guard result.status == 0 else {
+            throw TestTmuxServerError.commandFailed(
+                arguments: arguments,
+                status: result.status,
+                stderr: result.stderr
+            )
+        }
+        lock.withLock {
+            stopped = false
+        }
+    }
+
+    public func stop() {
+        let shouldStop = lock.withLock {
+            guard !stopped else { return false }
+            stopped = true
+            return true
+        }
+        guard shouldStop else { return }
+        _ = try? Self.run(
+            executable: tmuxPath,
+            arguments: connectionArguments + ["kill-server"],
+            timeout: 5
+        )
+    }
+
+    private struct WrapperContext {
+        let runID: String
+        let tmuxDirectory: String
+    }
+
+    private struct ProcessResult {
+        let status: Int32
+        let stderr: String
+    }
+
+    private static func wrapperContext(
+        environment: [String: String]
+    ) throws -> WrapperContext {
+        guard let runID = environment["GHOSTHUB_TEST_TMUX_RUN_ID"],
+              runID.count == 6,
+              runID.unicodeScalars.allSatisfy({
+                  CharacterSet.alphanumerics.contains($0) && $0.isASCII
+              })
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "real tmux tests require a six-character alphanumeric "
+                    + "GHOSTHUB_TEST_TMUX_RUN_ID from make swift-test"
+            )
+        }
+        guard let tmuxDirectory = environment["TMUX_TMPDIR"],
+              tmuxDirectory.first == "/"
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "real tmux tests require an absolute TMUX_TMPDIR from make swift-test"
+            )
+        }
+        let expectedPrefix = "/tmp/ghosthub-\(getuid())/tmux-tests/run."
+        let components = tmuxDirectory.split(separator: "/")
+        guard tmuxDirectory.hasPrefix(expectedPrefix),
+              components.count == 4,
+              components[1] == "ghosthub-\(getuid())",
+              components[2] == "tmux-tests"
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "TMUX_TMPDIR is outside the standardized Ghosthub test root"
+            )
+        }
+        let runComponents = components[3].split(separator: ".")
+        guard runComponents.count == 3,
+              runComponents[0] == "run",
+              (Int32(runComponents[1]) ?? 0) > 0,
+              runComponents[2] == Substring(runID)
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "TMUX_TMPDIR does not match GHOSTHUB_TEST_TMUX_RUN_ID"
+            )
+        }
+
+        var statBuffer = stat()
+        guard lstat(tmuxDirectory, &statBuffer) == 0,
+              statBuffer.st_uid == getuid(),
+              statBuffer.st_mode & S_IFMT == S_IFDIR,
+              statBuffer.st_mode & 0o777 == 0o700
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "TMUX_TMPDIR must be an owned mode-0700 directory"
+            )
+        }
+        return WrapperContext(runID: runID, tmuxDirectory: tmuxDirectory)
+    }
+
+    private static func runOwnedSocketName(
+        purpose: String,
+        context: WrapperContext
+    ) throws -> String {
+        try validateSocketComponent(purpose, label: "socket purpose")
+        guard purpose.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" })
+        else {
+            throw TestTmuxServerError.invalidSocket(
+                "socket purpose must contain only letters, numbers, and hyphens"
+            )
+        }
+        return "ghosthub-\(purpose)-\(context.runID)"
+    }
+
+    private static func validateSocketComponent(
+        _ value: String,
+        label: String
+    ) throws {
+        guard !value.isEmpty,
+              value != ".",
+              value != "..",
+              !value.contains("/"),
+              !value.contains("\\"),
+              !value.contains("\0")
+        else {
+            throw TestTmuxServerError.invalidSocket("invalid \(label)")
+        }
+    }
+
+    private static func prepareSocketDirectory(_ path: String) throws {
+        do {
+            try FileManager.default.createDirectory(
+                atPath: path,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch {
+            guard FileManager.default.fileExists(atPath: path) else {
+                throw error
+            }
+            // A sibling fixture in the same wrapped run may already own it.
+        }
+        var statBuffer = stat()
+        guard lstat(path, &statBuffer) == 0,
+              statBuffer.st_uid == getuid(),
+              statBuffer.st_mode & S_IFMT == S_IFDIR,
+              statBuffer.st_mode & 0o777 == 0o700
+        else {
+            throw TestTmuxServerError.invalidEnvironment(
+                "private tmux socket directory must be owned and mode 0700"
+            )
+        }
+    }
+
+    private static func run(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        let process = Process()
+        let stderr = Pipe()
+        let completed = DispatchSemaphore(value: 0)
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderr
+        process.terminationHandler = { _ in completed.signal() }
+        try process.run()
+
+        if completed.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            if completed.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                process.waitUntilExit()
+            }
+            throw TestTmuxServerError.commandTimedOut(arguments: arguments)
+        }
+        let data = stderr.fileHandleForReading.readDataToEndOfFile()
+        return ProcessResult(
+            status: process.terminationStatus,
+            stderr: String(decoding: data, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+}

--- a/Tests/TestSupport/TestTmuxServer.swift
+++ b/Tests/TestSupport/TestTmuxServer.swift
@@ -19,7 +19,23 @@ public enum TestTmuxServerError: Error, CustomStringConvertible, Sendable {
     }
 }
 
+public struct TestTmuxCommandOutput: Sendable {
+    public let status: Int32
+    public let stderr: String
+
+    public init(status: Int32, stderr: String) {
+        self.status = status
+        self.stderr = stderr
+    }
+}
+
 public final class TestTmuxServer: @unchecked Sendable {
+    public typealias CommandRunner = @Sendable (
+        _ executable: String,
+        _ arguments: [String],
+        _ timeout: TimeInterval
+    ) throws -> TestTmuxCommandOutput
+
     public enum SocketKind: Sendable {
         case runOwned(purpose: String)
         case productContract(name: String)
@@ -30,16 +46,19 @@ public final class TestTmuxServer: @unchecked Sendable {
     public let connectionArguments: [String]
 
     private let tmuxPath: String
+    private let commandRunner: CommandRunner
     private let lock = NSLock()
     private var stopped = false
 
     public init(
         tmuxPath: String,
         socket: SocketKind,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        commandRunner: CommandRunner? = nil
     ) throws {
         let context = try Self.wrapperContext(environment: environment)
         self.tmuxPath = tmuxPath
+        self.commandRunner = commandRunner ?? Self.run
 
         switch socket {
         case let .runOwned(purpose):
@@ -93,11 +112,7 @@ public final class TestTmuxServer: @unchecked Sendable {
         if let command {
             arguments.append(command)
         }
-        let result = try Self.run(
-            executable: tmuxPath,
-            arguments: arguments,
-            timeout: 10
-        )
+        let result = try commandRunner(tmuxPath, arguments, 10)
         guard result.status == 0 else {
             throw TestTmuxServerError.commandFailed(
                 arguments: arguments,
@@ -117,21 +132,16 @@ public final class TestTmuxServer: @unchecked Sendable {
             return true
         }
         guard shouldStop else { return }
-        _ = try? Self.run(
-            executable: tmuxPath,
-            arguments: connectionArguments + ["kill-server"],
-            timeout: 5
+        _ = try? commandRunner(
+            tmuxPath,
+            connectionArguments + ["kill-server"],
+            5
         )
     }
 
     private struct WrapperContext {
         let runID: String
         let tmuxDirectory: String
-    }
-
-    private struct ProcessResult {
-        let status: Int32
-        let stderr: String
     }
 
     private static func wrapperContext(
@@ -248,7 +258,7 @@ public final class TestTmuxServer: @unchecked Sendable {
         executable: String,
         arguments: [String],
         timeout: TimeInterval
-    ) throws -> ProcessResult {
+    ) throws -> TestTmuxCommandOutput {
         let process = Process()
         let stderr = Pipe()
         let completed = DispatchSemaphore(value: 0)
@@ -268,7 +278,7 @@ public final class TestTmuxServer: @unchecked Sendable {
             throw TestTmuxServerError.commandTimedOut(arguments: arguments)
         }
         let data = stderr.fileHandleForReading.readDataToEndOfFile()
-        return ProcessResult(
+        return TestTmuxCommandOutput(
             status: process.terminationStatus,
             stderr: String(decoding: data, as: UTF8.self)
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -1,6 +1,7 @@
 import GhosthubTransport
 import Darwin
 import Foundation
+import GhosthubTestSupport
 import Testing
 @testable import GhosthubTmux
 
@@ -475,22 +476,12 @@ struct TmuxAttachmentInfoTests {
         let kwt = directory.appendingPathComponent("kwt")
         let config = directory.appendingPathComponent("tmux.conf")
         let marker = directory.appendingPathComponent("session-ran")
-        let socketName = ProcessInfo.processInfo.environment[
-            "GHOSTHUB_TEST_TMUX_RUN_ID"
-        ].map { "ghosthub-test-\($0)" }
-            ?? "ghosthub-test-\(UUID().uuidString.lowercased())"
-        defer {
-            let cleanup = Process()
-            cleanup.executableURL = URL(fileURLWithPath: tmuxPath)
-            cleanup.arguments = [
-                "-L", socketName,
-                "kill-session", "-a", ";", "kill-session",
-            ]
-            cleanup.standardOutput = FileHandle.nullDevice
-            cleanup.standardError = FileHandle.nullDevice
-            try? cleanup.run()
-            cleanup.waitUntilExit()
-        }
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "attachment")
+        )
+        defer { server.stop() }
+        let socketName = server.socketName
         try """
         set-option -g destroy-unattached on
         """.write(to: config, atomically: true, encoding: .utf8)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,7 +58,7 @@ prepared kwt executable.
 
 ```bash
 make swift-warning-check
-swift test
+make swift-test
 make python-test
 make docs-build
 ```

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -658,6 +658,6 @@ handling, or remote terminal changes, run:
 ```bash
 make test-libghostty-bootstrap
 make python-test
-swift test
+make swift-test
 make build
 ```


### PR DESCRIPTION
Some Swift tests could fall back to a random tmux socket name when the repository wrapper was absent. An interrupted run could then strand pseudoterminals. The default-socket contract fixture could also reach the user's tmux server when TMUX_TMPDIR was unset.

All real tmux fixtures now validate the wrapper identity before server startup and use one owner for whole-server teardown. The load-bearing default and protected pull-request socket names remain unchanged, but they resolve to exact private sockets under the wrapper run directory. A bare test invocation fails before it allocates a pseudoterminal.

The essential workflow gate passed through its existing single retry after an unrelated registration-fingerprint timing test produced the same timestamp on its first attempt.

<details>
<summary>Validation</summary>

- All 85 affected tmux tests pass, including the private named-socket contract.
- All 142 Python tests, formatting checks, essential workflows, and the app build pass.
- An unwrapped fixture run fails without creating a tmux process or socket.

</details>