### PR TITLE
Fix/bundle libghostty themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,6 @@ test, and documentation-only changes are omitted.
   correct presentation if removal fails or the worktree moved concurrently.
 - Sidebar transitions resize the terminal smoothly without repeated terminal
   grid reflow.
-||||||| base
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ test, and documentation-only changes are omitted.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ghostty's built-in color schemes now ship with Ghosthub, so `theme =
+  Catppuccin Macchiato` and every other bundled name resolves without first
+  copying theme files into `~/.config/ghostty/themes`. Bundled shell
+  integration and the `xterm-ghostty` terminfo database ship alongside them.
+
 ## [0.8.2] - 2026-08-11
 
 ### Fixed
@@ -97,6 +104,7 @@ test, and documentation-only changes are omitted.
   correct presentation if removal fails or the worktree moved concurrently.
 - Sidebar transitions resize the terminal smoothly without repeated terminal
   grid reflow.
+||||||| base
 
 ## [0.6.0] - 2026-08-04
 

--- a/LICENSES/THIRD-PARTY-NOTICES.md
+++ b/LICENSES/THIRD-PARTY-NOTICES.md
@@ -34,6 +34,12 @@ revisions and is copied verbatim into `Ghosthub.app/Contents/Resources/Licenses`
 | uucode and generated Unicode data | `uucode-MIT.txt`, `uucode-Bjoern-Hoehrmann-MIT.txt`, `Unicode-Data.txt` |
 | Symbols Nerd Font | `Symbols-Nerd-Font-MIT.txt` |
 | JetBrains Mono | `JetBrains-Mono-OFL-1.1.txt` |
+| iTerm2-Color-Schemes theme corpus | `iTerm2-Color-Schemes-MIT.txt` |
+
+The bundled Ghostty themes are the iTerm2-Color-Schemes collection, which
+Ghosthub redistributes unmodified. That collection is MIT licensed; the
+copyright and license for each individual theme belong to that theme's
+author, as stated in `iTerm2-Color-Schemes-MIT.txt`.
 
 Portions of this software are copyright © 2023 The FreeType Project
 (www.freetype.org). All rights reserved.

--- a/LICENSES/iTerm2-Color-Schemes-MIT.txt
+++ b/LICENSES/iTerm2-Color-Schemes-MIT.txt
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2011 to Present Mark Badolato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This license covers the iTerm-Color-Schemes repository collection of themes. 
+
+The copyright/license for each individual theme belongs to the author of that theme.

--- a/LICENSES/iTerm2-Color-Schemes-MIT.txt
+++ b/LICENSES/iTerm2-Color-Schemes-MIT.txt
@@ -20,6 +20,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-This license covers the iTerm-Color-Schemes repository collection of themes. 
+This license covers the iTerm-Color-Schemes repository collection of themes.
 
 The copyright/license for each individual theme belongs to the author of that theme.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ LIBGHOSTTY_GIT ?=
 LIBGHOSTTY_XCRUN ?=
 LIBGHOSTTY_XCFRAMEWORK_TARGET ?= aarch64
 LIBGHOSTTY_OPTIMIZE ?= Debug
+# Themes, shell integration, and terminfo staged by the libghostty bootstrap.
+# Bundles copy this tree into Contents/Resources.
+LIBGHOSTTY_SHARE_DIR ?= $(abspath .build/libghostty/share)
 DIST_ROOT ?= dist
 DEBUG_ROOT ?= $(DIST_ROOT)/debug
 RELEASE_ROOT ?= $(DIST_ROOT)/release
@@ -366,6 +369,7 @@ debug-app: ensure-kwt ensure-kwt-variants bootstrap-libghostty
 		--app-license-path "$(APP_LICENSE_PATH)" \
 		--kwt-binary "$$kwt_bin" \
 		--kwt-variants-dir "$(KWT_VARIANTS_DIR)" \
+		--libghostty-share-dir "$(LIBGHOSTTY_SHARE_DIR)" \
 		--third-party-licenses-dir "$(THIRD_PARTY_LICENSES_DIR)" \
 		--copyright "$(APP_COPYRIGHT)" \
 		--kwt-version "$(KWT_VERSION)" \
@@ -399,6 +403,7 @@ release-app: ensure-kwt ensure-kwt-variants build-release
 		--app-license-path "$(APP_LICENSE_PATH)" \
 		--kwt-binary "$$kwt_bin" \
 		--kwt-variants-dir "$(KWT_VARIANTS_DIR)" \
+		--libghostty-share-dir "$(LIBGHOSTTY_SHARE_DIR)" \
 		--third-party-licenses-dir "$(THIRD_PARTY_LICENSES_DIR)" \
 		--copyright "$(APP_COPYRIGHT)" \
 		--kwt-version "$(KWT_VERSION)" \

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let libghosttyBuildRoot = packageRoot.appendingPathComponent(".build/libghostty"
 let vendorMetadataPath = packageRoot.appendingPathComponent("Vendor/ghostty.version.json")
 let libghosttyManifestPath = libghosttyBuildRoot.appendingPathComponent("manifest.json")
 /// Increment whenever Ghosthub's libghostty patch surface changes.
-let requiredLibghosttyBootstrapVersion = 22
+let requiredLibghosttyBootstrapVersion = 23
 
 func loadJSONDictionary(at url: URL) -> [String: Any]? {
     guard let data = try? Data(contentsOf: url),

--- a/Sources/TerminalSupport/LibghosttyEmbeddedResourcesLocator.swift
+++ b/Sources/TerminalSupport/LibghosttyEmbeddedResourcesLocator.swift
@@ -1,44 +1,65 @@
 import Foundation
 
 public enum LibghosttyEmbeddedResourcesLocator {
-    private static let relativeResourcePath = [
-        ".build",
-        "libghostty",
-        "source",
-        "zig-out",
-        "share",
-        "ghostty",
+    /// A place the emitted libghostty `share` tree can live, relative to a
+    /// candidate root. The compiled terminfo entry is the sentinel proving
+    /// the tree is a real resource bundle rather than a same-named directory.
+    private struct Layout {
+        let resources: [String]
+        let terminfoSentinel: [String]
+
+        init(prefix: [String]) {
+            resources = prefix + ["ghostty"]
+            terminfoSentinel = prefix + ["terminfo", "78", "xterm-ghostty"]
+        }
+    }
+
+    private static let layouts = [
+        // Repo-local staged bootstrap artifacts.
+        Layout(prefix: [".build", "libghostty", "share"]),
+        // Packaged Ghosthub.app bundle.
+        Layout(prefix: ["Contents", "Resources"]),
     ]
 
-    private static let relativeTerminfoSentinel = [
-        ".build",
-        "libghostty",
-        "source",
-        "zig-out",
-        "share",
-        "terminfo",
-        "78",
-        "xterm-ghostty",
-    ]
-
+    /// Points `GHOSTTY_RESOURCES_DIR` at Ghosthub's own resources.
+    ///
+    /// Ghostty exports this variable into every shell it runs, so launching
+    /// Ghosthub from a Ghostty terminal otherwise inherits Ghostty.app's
+    /// themes and shell integration — and a release libghostty trusts the
+    /// variable ahead of its own executable-path discovery. Ghosthub's
+    /// resources therefore override an inherited value, and an inherited
+    /// value is used only when Ghosthub has no resources of its own.
     public static func configureEnvironmentIfNeeded(
         executablePath: String = ProcessInfo.processInfo.arguments.first ?? "",
         currentDirectoryPath: String = FileManager.default.currentDirectoryPath
     ) -> URL? {
-        if let existing = ProcessInfo.processInfo.environment["GHOSTTY_RESOURCES_DIR"],
-           !existing.isEmpty {
-            return URL(fileURLWithPath: existing, isDirectory: true)
-        }
-
-        guard let resourcesURL = resolveResourcesDirectory(
+        guard let resourcesURL = effectiveResourcesDirectory(
             executablePath: executablePath,
-            currentDirectoryPath: currentDirectoryPath
-        ) else {
-            return nil
-        }
+            currentDirectoryPath: currentDirectoryPath,
+            inheritedResourcesPath: ProcessInfo.processInfo
+                .environment["GHOSTTY_RESOURCES_DIR"]
+        ) else { return nil }
 
         setenv("GHOSTTY_RESOURCES_DIR", resourcesURL.path, 1)
         return resourcesURL
+    }
+
+    static func effectiveResourcesDirectory(
+        executablePath: String,
+        currentDirectoryPath: String,
+        inheritedResourcesPath: String?
+    ) -> URL? {
+        if let resourcesURL = resolveResourcesDirectory(
+            executablePath: executablePath,
+            currentDirectoryPath: currentDirectoryPath
+        ) {
+            return resourcesURL
+        }
+
+        guard let inheritedResourcesPath, !inheritedResourcesPath.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: inheritedResourcesPath, isDirectory: true)
     }
 
     static func resolveResourcesDirectory(
@@ -51,12 +72,14 @@ public enum LibghosttyEmbeddedResourcesLocator {
         )
 
         for root in roots {
-            let resourcesURL = root.appendingPathComponents(relativeResourcePath)
-            let terminfoURL = root.appendingPathComponents(relativeTerminfoSentinel)
-            guard FileManager.default.fileExists(atPath: resourcesURL.path),
-                  FileManager.default.fileExists(atPath: terminfoURL.path)
-            else { continue }
-            return resourcesURL
+            for layout in layouts {
+                let resourcesURL = root.appendingPathComponents(layout.resources)
+                let terminfoURL = root.appendingPathComponents(layout.terminfoSentinel)
+                guard FileManager.default.fileExists(atPath: resourcesURL.path),
+                      FileManager.default.fileExists(atPath: terminfoURL.path)
+                else { continue }
+                return resourcesURL
+            }
         }
 
         return nil

--- a/Tests/Terminal/LibghosttyEmbeddedResourcesLocatorTests.swift
+++ b/Tests/Terminal/LibghosttyEmbeddedResourcesLocatorTests.swift
@@ -4,10 +4,11 @@ import Testing
 
 struct LibghosttyEmbeddedResourcesLocatorTests {
     private func assertResolvesToLayoutResources(
+        share: MockLibghosttyLayout.SharePrefix = .repoLocalBootstrap,
         executablePath: (MockLibghosttyLayout) -> String,
         currentDirectoryPath: (MockLibghosttyLayout) -> String
     ) throws {
-        let layout = try MockLibghosttyLayout.create()
+        let layout = try MockLibghosttyLayout.create(share: share)
 
         let resolved =
             LibghosttyEmbeddedResourcesLocator.resolveResourcesDirectory(
@@ -39,5 +40,74 @@ struct LibghosttyEmbeddedResourcesLocatorTests {
             },
             currentDirectoryPath: { $0.root.path }
         )
+    }
+
+    @Test("resolveResourcesDirectory finds the packaged app bundle layout")
+    func resolveResourcesDirectoryFindsPackagedAppBundleLayout() throws {
+        try assertResolvesToLayoutResources(
+            share: .packagedAppBundle,
+            executablePath: { layout in
+                layout.root.appendingPathComponent(
+                    "Contents/MacOS/Ghosthub",
+                    isDirectory: false
+                ).path
+            },
+            currentDirectoryPath: { _ in "/tmp" }
+        )
+    }
+
+    @Test("Ghosthub's own resources override an inherited Ghostty.app path")
+    func ownResourcesOverrideInheritedGhosttyPath() throws {
+        let layout = try MockLibghosttyLayout.create(share: .packagedAppBundle)
+
+        let resolved = LibghosttyEmbeddedResourcesLocator
+            .effectiveResourcesDirectory(
+                executablePath: layout.root.appendingPathComponent(
+                    "Contents/MacOS/Ghosthub",
+                    isDirectory: false
+                ).path,
+                currentDirectoryPath: "/tmp",
+                inheritedResourcesPath:
+                "/Applications/Ghostty.app/Contents/Resources/ghostty"
+            )
+
+        #expect(resolved == layout.resources)
+    }
+
+    @Test("an inherited path is used only when Ghosthub ships no resources")
+    func inheritedPathIsUsedOnlyWithoutOwnResources() {
+        let inherited = "/Applications/Ghostty.app/Contents/Resources/ghostty"
+
+        let resolved = LibghosttyEmbeddedResourcesLocator
+            .effectiveResourcesDirectory(
+                executablePath: "/Applications/Ghosthub.app/Contents/MacOS/Ghosthub",
+                currentDirectoryPath: "/tmp",
+                inheritedResourcesPath: inherited
+            )
+
+        #expect(resolved == URL(fileURLWithPath: inherited, isDirectory: true))
+    }
+
+    @Test("resolveResourcesDirectory ignores a layout without compiled terminfo")
+    func resolveResourcesDirectoryIgnoresLayoutWithoutTerminfo() throws {
+        let layout = try MockLibghosttyLayout.create(share: .packagedAppBundle)
+        try FileManager.default.removeItem(
+            at: layout.root.appendingPathComponent(
+                "Contents/Resources/terminfo",
+                isDirectory: true
+            )
+        )
+
+        let resolved =
+            LibghosttyEmbeddedResourcesLocator.resolveResourcesDirectory(
+                executablePath: layout.root
+                    .appendingPathComponent(
+                        "Contents/MacOS/Ghosthub",
+                        isDirectory: false
+                    ).path,
+                currentDirectoryPath: "/tmp"
+            )
+
+        #expect(resolved == nil)
     }
 }

--- a/Tests/Terminal/TerminalFixtures.swift
+++ b/Tests/Terminal/TerminalFixtures.swift
@@ -36,23 +36,27 @@ extension LibghosttySurfaceRuntimeCallbacks {
 // MARK: - Mock Libghostty Layout
 
 struct MockLibghosttyLayout {
+    /// Where the emitted libghostty `share` tree sits under the layout root.
+    enum SharePrefix: String {
+        case repoLocalBootstrap = ".build/libghostty/share"
+        case packagedAppBundle = "Contents/Resources"
+    }
+
     let root: URL
     let resources: URL
     let tempDir: TempDirectoryFixture
 
-    static func create() throws -> MockLibghosttyLayout {
+    static func create(
+        share: SharePrefix = .repoLocalBootstrap
+    ) throws -> MockLibghosttyLayout {
         let tempDir = try TempDirectoryFixture()
         let root = tempDir.url
-        let resources = root
-            .appendingPathComponent(
-                ".build/libghostty/source/zig-out/share/ghostty",
-                isDirectory: true
-            )
-        let terminfo = root
-            .appendingPathComponent(
-                ".build/libghostty/source/zig-out/share/terminfo/78",
-                isDirectory: true
-            )
+        let shareRoot = root
+            .appendingPathComponent(share.rawValue, isDirectory: true)
+        let resources = shareRoot
+            .appendingPathComponent("ghostty", isDirectory: true)
+        let terminfo = shareRoot
+            .appendingPathComponent("terminfo/78", isDirectory: true)
 
         try FileManager.default.createDirectory(
             at: resources,

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -230,6 +230,83 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         }
     }
 
+    func testBundledGhosttyThemeResolvesByName() throws {
+        try skipUnlessLibghosttyReady()
+        let resources = try XCTUnwrap(
+            LibghosttyEmbeddedResourcesLocator.configureEnvironmentIfNeeded(),
+            "The emitted libghostty resources must be discoverable"
+        )
+        let themeName = "Catppuccin Macchiato"
+        let theme = resources
+            .appendingPathComponent("themes", isDirectory: true)
+            .appendingPathComponent(themeName)
+        let colors = try themeColors(at: theme)
+
+        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try FileManager.default.createDirectory(
+            at: pipeline.paths.configDirectory,
+            withIntermediateDirectories: true
+        )
+        try "theme = \(themeName)\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtime = LibghosttyRuntime(pipeline: pipeline)
+        Self.retainedConditionalThemeRuntimes.append(runtime)
+
+        XCTAssertEqual(runtime.phase, .ready)
+        XCTAssertFalse(
+            runtime.diagnostics.contains { $0.contains(themeName) },
+            """
+            A bundled theme name must resolve against the shipped corpus, \
+            not report tried paths: \(runtime.diagnostics)
+            """
+        )
+
+        let coordinator = TerminalSurfaceCoordinator(runtime: runtime)
+        Self.retainedConditionalThemeCoordinators.append(coordinator)
+        let view = try XCTUnwrap(coordinator.surface(
+            for: SurfaceKey.fixture(leafID: UUID()),
+            configuration: TerminalSurfaceConfiguration()
+        ))
+        view.appearance = NSAppearance(named: .aqua)
+        let window = hostInWindow(view)
+        Self.retainedConditionalThemeWindows.append(window)
+        let identity = try XCTUnwrap(view.surfaceIdentity)
+
+        waitUntil {
+            runtime.resolvedTerminalColors(
+                forSurfaceIdentity: identity
+            ) == colors
+        }
+    }
+
+    /// The bundled corpus is upstream data, so read the expected colors from
+    /// the theme itself rather than pinning its palette in the test.
+    private func themeColors(at url: URL) throws -> TerminalResolvedColors {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        func value(of key: String) throws -> String {
+            let line = try XCTUnwrap(
+                contents.split(separator: "\n").first {
+                    $0.hasPrefix("\(key) = ")
+                },
+                "\(url.lastPathComponent) should declare \(key)"
+            )
+            return line
+                .dropFirst("\(key) = ".count)
+                .trimmingCharacters(in: .whitespaces)
+                .uppercased()
+        }
+        return TerminalResolvedColors(
+            foreground: try value(of: "foreground"),
+            background: try value(of: "background")
+        )
+    }
+
     func testLateSurfaceRegistrationPublishesResolvedColors() throws {
         try skipUnlessLibghosttyReady()
         let (pipeline, tempRoot) = makeIsolatedPipeline()

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -278,11 +278,25 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         Self.retainedConditionalThemeWindows.append(window)
         let identity = try XCTUnwrap(view.surfaceIdentity)
 
-        waitUntil {
-            runtime.resolvedTerminalColors(
+        var resolved: TerminalResolvedColors?
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            resolved = runtime.resolvedTerminalColors(
                 forSurfaceIdentity: identity
-            ) == colors
+            )
+            if resolved == colors {
+                break
+            }
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
         }
+
+        // Asserted rather than waited on, so a corpus whose colors stop
+        // matching reports both values instead of only a timeout.
+        XCTAssertEqual(
+            resolved,
+            colors,
+            "\(themeName) should resolve to its own declared colors"
+        )
     }
 
     /// The bundled corpus is upstream data, so read the expected colors from
@@ -296,10 +310,13 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
                 },
                 "\(url.lastPathComponent) should declare \(key)"
             )
-            return line
+            let value = line
                 .dropFirst("\(key) = ".count)
                 .trimmingCharacters(in: .whitespaces)
                 .uppercased()
+            // Themes may write a hex color with or without the leading "#";
+            // resolved colors always carry it.
+            return value.hasPrefix("#") ? value : "#\(value)"
         }
         return TerminalResolvedColors(
             foreground: try value(of: "foreground"),

--- a/Tests/test_assemble_app_bundle.py
+++ b/Tests/test_assemble_app_bundle.py
@@ -1,5 +1,6 @@
 import importlib.util
 import plistlib
+import shutil
 import stat
 import sys
 from pathlib import Path
@@ -44,6 +45,25 @@ def make_executable(path: Path, contents: str = "#!/bin/sh\nexit 0\n") -> Path:
     path.write_text(contents, encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
     return path
+
+
+def make_libghostty_share_dir(tmp_path: Path) -> Path:
+    share_dir = tmp_path / "libghostty-share"
+    themes = share_dir / "ghostty" / "themes"
+    themes.mkdir(parents=True)
+    (themes / "Catppuccin Macchiato").write_text(
+        "background = 24273a\n", encoding="utf-8"
+    )
+    shell_integration = share_dir / "ghostty" / "shell-integration" / "zsh"
+    shell_integration.mkdir(parents=True)
+    (shell_integration / "ghostty-integration").write_text(
+        "# integration\n", encoding="utf-8"
+    )
+    terminfo = share_dir / "terminfo" / "78"
+    terminfo.mkdir(parents=True)
+    (terminfo / "xterm-ghostty").write_bytes(b"terminfo")
+    (terminfo / "xterm-ghostty-alias").symlink_to("xterm-ghostty")
+    return share_dir
 
 
 def make_release_inputs(
@@ -132,6 +152,7 @@ def test_release_license_inventory_covers_compiled_dependencies():
         "Unicode-Data.txt",
         "Symbols-Nerd-Font-MIT.txt",
         "JetBrains-Mono-OFL-1.1.txt",
+        "iTerm2-Color-Schemes-MIT.txt",
         "kwt-Apache-2.0.txt",
         "kwt-NOTICE.txt",
         "fantastty-MIT.txt",
@@ -184,6 +205,7 @@ def test_assemble_app_bundle_stages_icon_and_binary(tmp_path):
         app_license_path=app_license,
         kwt_binary=kwt_binary,
         kwt_variants_dir=kwt_variants_dir,
+        libghostty_share_dir=make_libghostty_share_dir(tmp_path),
         third_party_licenses_dir=licenses_dir,
         copyright=COPYRIGHT_NOTICE,
         kwt_version="0.1.0",
@@ -229,6 +251,17 @@ def test_assemble_app_bundle_stages_icon_and_binary(tmp_path):
     assert (
         app_root / "Contents" / "Resources" / "Ghosthub.icns"
     ).read_bytes() == b"icns"
+    # libghostty finds these by climbing from the bundled executable, so the
+    # emitted names and their position under Resources are the contract.
+    resources = app_root / "Contents" / "Resources"
+    assert (
+        resources / "ghostty" / "themes" / "Catppuccin Macchiato"
+    ).read_text() == "background = 24273a\n"
+    assert (
+        resources / "ghostty" / "shell-integration" / "zsh" / "ghostty-integration"
+    ).is_file()
+    assert (resources / "terminfo" / "78" / "xterm-ghostty").is_file()
+    assert (resources / "terminfo" / "78" / "xterm-ghostty-alias").is_symlink()
     assert {path.name for path in app_root.iterdir()} == {"Contents"}
     assert (
         app_root
@@ -299,6 +332,7 @@ def test_release_info_plist_contains_update_configuration(tmp_path):
         app_license_path=app_license,
         kwt_binary=kwt_binary,
         kwt_variants_dir=kwt_variants_dir,
+        libghostty_share_dir=make_libghostty_share_dir(tmp_path),
         third_party_licenses_dir=licenses_dir,
         copyright=COPYRIGHT_NOTICE,
         kwt_version="0.1.0",
@@ -368,6 +402,7 @@ def test_assemble_app_bundle_replaces_existing_bundle_contents(tmp_path):
         app_license_path=app_license,
         kwt_binary=kwt_binary,
         kwt_variants_dir=kwt_variants_dir,
+        libghostty_share_dir=make_libghostty_share_dir(tmp_path),
         third_party_licenses_dir=licenses_dir,
         copyright=COPYRIGHT_NOTICE,
         kwt_version="0.1.0",
@@ -379,3 +414,72 @@ def test_assemble_app_bundle_replaces_existing_bundle_contents(tmp_path):
     assert (
         app_root / "Contents" / "Resources" / "Ghosthub.icns"
     ).read_bytes() == b"new-icon"
+
+
+def remove_theme_corpus(share_dir: Path) -> None:
+    shutil.rmtree(share_dir / "ghostty" / "themes")
+
+
+def empty_theme_corpus(share_dir: Path) -> None:
+    for theme in (share_dir / "ghostty" / "themes").iterdir():
+        theme.unlink()
+
+
+def replace_theme_corpus_with_a_file(share_dir: Path) -> None:
+    themes = share_dir / "ghostty" / "themes"
+    shutil.rmtree(themes)
+    themes.write_text("not a directory\n", encoding="utf-8")
+
+
+def replace_terminfo_sentinel_with_a_directory(share_dir: Path) -> None:
+    sentinel = share_dir / "terminfo" / "78" / "xterm-ghostty"
+    sentinel.unlink()
+    sentinel.mkdir()
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        remove_theme_corpus,
+        empty_theme_corpus,
+        replace_theme_corpus_with_a_file,
+        replace_terminfo_sentinel_with_a_directory,
+    ],
+)
+def test_assemble_app_bundle_rejects_an_unusable_share_dir(tmp_path, corrupt):
+    assemble = load_module()
+    source_bin_dir = tmp_path / "bin"
+    app_binary = make_executable(source_bin_dir / "Ghosthub")
+    app_root = tmp_path / "Ghosthub.app"
+    icon_path = tmp_path / "Ghosthub.icns"
+    icon_path.write_bytes(b"icns")
+    app_license, kwt_binary, kwt_variants_dir, licenses_dir = make_release_inputs(
+        tmp_path,
+        source_bin_dir,
+    )
+    share_dir = make_libghostty_share_dir(tmp_path)
+    corrupt(share_dir)
+
+    with pytest.raises(ValueError, match="libghostty share directory"):
+        assemble.assemble_app_bundle(
+            source_bin_dir=source_bin_dir,
+            app_binary=app_binary,
+            app_root=app_root,
+            bundle_id="com.ghosthub",
+            display_name="Ghosthub",
+            version="0.1.0",
+            build_version="123",
+            min_macos="14.0",
+            icon_path=icon_path,
+            app_license_path=app_license,
+            kwt_binary=kwt_binary,
+            kwt_variants_dir=kwt_variants_dir,
+            libghostty_share_dir=share_dir,
+            third_party_licenses_dir=licenses_dir,
+            copyright=COPYRIGHT_NOTICE,
+            kwt_version="0.1.0",
+            kwt_source_revision="abc123",
+            remote_kwt_source_revision="def456",
+        )
+
+    assert not app_root.exists()

--- a/Tests/test_libghostty_bootstrap.py
+++ b/Tests/test_libghostty_bootstrap.py
@@ -73,7 +73,7 @@ def test_render_build_command_uses_repo_bootstrap_flags(
         "-Dapp-runtime=none",
         "-Demit-xcframework=true",
         "-Demit-macos-app=false",
-        "-Demit-themes=false",
+        "-Demit-themes=true",
         "-Di18n=false",
         "-Dsentry=false",
         "-Doptimize=Debug",
@@ -268,6 +268,7 @@ def test_artifact_state_flags_archive_missing_ghostty_api(tmp_path: Path) -> Non
     artifacts.header_path.parent.mkdir(parents=True)
     artifacts.header_path.write_text("// header\n")
     artifacts.modulemap_path.write_text("module GhosttyKit {}\n")
+    _write_share_tree(artifacts.share_path)
     metadata = bootstrap.VendorMetadata(
         source="https://example.com/ghostty.git",
         tag="v0.0.0",
@@ -1365,6 +1366,121 @@ def test_artifact_state_reports_stale_manifest(
     )
 
 
+def test_artifact_state_reports_pruned_resources_despite_current_manifest(
+    repo: Repo,
+) -> None:
+    # A manifest flag cannot tell a variant that still has its resources from
+    # one whose share tree was pruned, so the tree itself is the check.
+    _write_artifacts(repo.paths.cached_artifacts, repo.metadata)
+    assert (
+        bootstrap.artifact_state_message(
+            repo.paths.cached_artifacts, repo.metadata, "native", "Debug"
+        )
+        is None
+    )
+    shutil.rmtree(repo.paths.cached_artifacts.share_path)
+
+    message = bootstrap.artifact_state_message(
+        repo.paths.cached_artifacts,
+        repo.metadata,
+        "native",
+        "Debug",
+    )
+
+    assert message is not None
+    assert "libghostty resources are incomplete" in message
+
+
+def test_artifact_state_reports_a_missing_theme_corpus(repo: Repo) -> None:
+    _write_artifacts(repo.paths.cached_artifacts, repo.metadata)
+    shutil.rmtree(
+        repo.paths.cached_artifacts.share_path.joinpath(
+            *bootstrap.THEMES_RELATIVE_PATH
+        )
+    )
+
+    message = bootstrap.artifact_state_message(
+        repo.paths.cached_artifacts,
+        repo.metadata,
+        "native",
+        "Debug",
+    )
+
+    assert message is not None
+    assert "theme corpus" in message
+
+
+def test_share_tree_problem_accepts_a_complete_tree(tmp_path: Path) -> None:
+    assert bootstrap.share_tree_problem(_write_share_tree(tmp_path)) is None
+
+
+def _empty_theme_corpus(share_root: Path) -> None:
+    for theme in share_root.joinpath(*bootstrap.THEMES_RELATIVE_PATH).iterdir():
+        theme.unlink()
+
+
+def _replace_theme_corpus_with_a_file(share_root: Path) -> None:
+    themes = share_root.joinpath(*bootstrap.THEMES_RELATIVE_PATH)
+    shutil.rmtree(themes)
+    themes.write_text("not a directory\n")
+
+
+def _replace_terminfo_sentinel_with_a_directory(share_root: Path) -> None:
+    terminfo = share_root.joinpath(*bootstrap.TERMINFO_RELATIVE_PATH)
+    terminfo.unlink()
+    terminfo.mkdir()
+
+
+@pytest.mark.parametrize(
+    ("corrupt", "reason"),
+    [
+        pytest.param(_empty_theme_corpus, "empty", id="empty-themes"),
+        pytest.param(
+            _replace_theme_corpus_with_a_file, "missing", id="themes-not-a-directory"
+        ),
+        pytest.param(
+            _replace_terminfo_sentinel_with_a_directory,
+            "terminfo",
+            id="terminfo-not-a-file",
+        ),
+    ],
+)
+def test_share_tree_problem_rejects_an_unusable_tree(
+    tmp_path: Path,
+    corrupt: Callable[[Path], None],
+    reason: str,
+) -> None:
+    # Existence alone is not enough: an empty corpus resolves no theme name,
+    # and the terminfo sentinel is what libghostty matches when it climbs.
+    share_root = _write_share_tree(tmp_path)
+    corrupt(share_root)
+
+    problem = bootstrap.share_tree_problem(share_root)
+
+    assert problem is not None
+    assert reason in problem
+
+
+def test_ensure_emitted_resources_accepts_a_complete_build(repo: Repo) -> None:
+    _write_share_tree(
+        Path(repo.paths.source_checkout_root, *bootstrap.EMITTED_SHARE_RELATIVE_PATH)
+    )
+
+    bootstrap.ensure_emitted_resources(repo.paths)
+
+
+def test_ensure_emitted_resources_rejects_an_incomplete_build(repo: Repo) -> None:
+    share_root = _write_share_tree(
+        Path(repo.paths.source_checkout_root, *bootstrap.EMITTED_SHARE_RELATIVE_PATH)
+    )
+    shutil.rmtree(share_root.joinpath(*bootstrap.THEMES_RELATIVE_PATH))
+
+    with pytest.raises(bootstrap.BootstrapError) as raised:
+        bootstrap.ensure_emitted_resources(repo.paths)
+
+    assert "iTerm2-Color-Schemes" in str(raised.value)
+
+
 def test_ensure_source_checkout_initializes_local_cache_and_fetches_pinned_commit(
     repo: Repo,
 ) -> None:
@@ -1783,10 +1899,24 @@ def _write_artifacts(
 
     artifacts.root.mkdir(parents=True, exist_ok=True)
     artifacts.xcframework_path.mkdir(parents=True)
+    _write_share_tree(artifacts.share_path)
     artifacts.header_path.parent.mkdir(parents=True, exist_ok=True)
     artifacts.header_path.write_text("// header\n")
     artifacts.modulemap_path.write_text("module GhosttyKit {}\n")
     artifacts.manifest_path.write_text(json.dumps(manifest))
+
+
+def _write_share_tree(share_root: Path) -> Path:
+    themes = share_root.joinpath(*bootstrap.THEMES_RELATIVE_PATH)
+    themes.mkdir(parents=True)
+    (themes / "Catppuccin Macchiato").write_text("background = #24273a\n")
+    share_root.joinpath(*bootstrap.SHELL_INTEGRATION_RELATIVE_PATH).mkdir(
+        parents=True
+    )
+    terminfo = share_root.joinpath(*bootstrap.TERMINFO_RELATIVE_PATH)
+    terminfo.parent.mkdir(parents=True)
+    terminfo.write_bytes(b"")
+    return share_root
 
 
 def _create_repo_layout(repo_root: Path) -> bootstrap.VendorMetadata:

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,10 +31,19 @@ binary path deliberately, but the default never embeds the system kwt.
 same pin. Before either debug or release packaging, every variant is checked
 for its expected Mach-O/ELF/PE architecture and embedded pinned revision.
 
+Packaging also stages libghostty's own emitted resources: the bundled Ghostty
+theme corpus and shell integration at `Contents/Resources/ghostty`, and the
+compiled `xterm-ghostty` terminfo database at `Contents/Resources/terminfo`.
+libghostty locates them by climbing from the running executable and matching
+compiled terminfo, so both trees must keep those exact names and positions.
+Assembly fails rather than shipping a bundle whose themes would silently
+resolve only against a user's `~/.config/ghostty/themes`.
+
 Every packaged app also carries Ghosthub's AGPL-3.0 license and all notices in
 the repository's `LICENSES` directory under `Contents/Resources/Licenses`.
 `LICENSES/THIRD-PARTY-NOTICES.md` is the audited inventory for GRDB, Sparkle,
-and the components compiled into libghostty. Embedded libghostty is built with
+the components compiled into libghostty, and the resources the bundle
+redistributes verbatim, including the iTerm2-Color-Schemes theme corpus. Embedded libghostty is built with
 internationalization disabled, so its otherwise static GNU libintl/gettext
 dependency is not part of Ghosthub's app binary or release obligations.
 

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -610,6 +610,12 @@ session model and die with the app process.
 - Keep a modest client-local minimum text contrast so inherited ANSI colors
   remain legible on light and dark backgrounds without rewriting shared tmux
   styles. Preserve an explicit user-configured value.
+- Ship libghostty's emitted `share` tree with every build. The bootstrap emits
+  the bundled theme corpus, shell integration, and compiled terminfo; app
+  bundles stage `ghostty/` and `terminfo/` into `Contents/Resources`, and
+  Ghosthub points `GHOSTTY_RESOURCES_DIR` at whichever layout it finds.
+  Without it `theme = <name>` resolves only against a user's own
+  `~/.config/ghostty/themes`.
 - Keep the generated base config independent of tmux themes. Built-in Tmux
   Theme colors or libghostty's effective Follow ghostty.conf colors are applied
   at session creation, through the explicit shared-session override, or by the

--- a/tools/assemble_app_bundle.py
+++ b/tools/assemble_app_bundle.py
@@ -12,6 +12,7 @@ TOOLS_DIR = Path(__file__).resolve().parent
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
+from libghostty_bootstrap import share_tree_problem
 from stage_release_app_bundles import stage_bundles
 
 
@@ -19,6 +20,20 @@ SPARKLE_FEED_URL = (
     "https://github.com/kenn-io/ghosthub/releases/latest/download/appcast.xml"
 )
 SPARKLE_PUBLIC_ED_KEY = "MKL5y44upnEoZrnm3VLLDocsBTD+3DgnH161eEQPhMQ="
+
+# libghostty locates its resources by climbing from the running executable and
+# looking for compiled terminfo beside them, so both trees must land directly
+# under Contents/Resources with their emitted names. Without `ghostty/themes`
+# every `theme = <name>` resolves only against ~/.config/ghostty/themes.
+LIBGHOSTTY_RESOURCE_TREES = ("ghostty", "terminfo")
+
+
+def resolve_libghostty_resource_trees(share_dir: Path) -> dict[str, Path]:
+    """Validate the emitted libghostty `share` tree before staging it."""
+    problem = share_tree_problem(share_dir)
+    if problem is not None:
+        raise ValueError(f"libghostty share directory is incomplete: {problem}")
+    return {name: share_dir / name for name in LIBGHOSTTY_RESOURCE_TREES}
 
 
 def parse_args() -> argparse.Namespace:
@@ -38,6 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--app-license-path", required=True, type=Path)
     parser.add_argument("--kwt-binary", required=True, type=Path)
     parser.add_argument("--kwt-variants-dir", required=True, type=Path)
+    parser.add_argument("--libghostty-share-dir", required=True, type=Path)
     parser.add_argument(
         "--third-party-licenses-dir", required=True, type=Path
     )
@@ -67,6 +83,7 @@ def assemble_app_bundle(
     app_license_path: Path,
     kwt_binary: Path,
     kwt_variants_dir: Path,
+    libghostty_share_dir: Path,
     third_party_licenses_dir: Path,
     copyright: str,
     kwt_version: str,
@@ -97,6 +114,9 @@ def assemble_app_bundle(
             "kwt variants directory is incomplete: "
             + ", ".join(missing_remote_helpers)
         )
+    libghostty_resource_trees = resolve_libghostty_resource_trees(
+        libghostty_share_dir
+    )
     third_party_license_paths = sorted(
         path for path in third_party_licenses_dir.iterdir() if path.is_file()
     )
@@ -140,6 +160,11 @@ def assemble_app_bundle(
         # them non-executable avoids treating foreign ELF and Mach-O payloads
         # as nested app code; the remote installer applies mode 0755.
         destination.chmod(0o644)
+
+    for name, source in libghostty_resource_trees.items():
+        # tic can emit terminfo aliases as symlinks, so preserve links rather
+        # than fanning them out into duplicate sealed resources.
+        shutil.copytree(source, resources_dir / name, symlinks=True)
 
     sparkle_framework = source_bin_dir / "Sparkle.framework"
     if not sparkle_framework.is_dir():
@@ -218,6 +243,7 @@ def main() -> int:
         app_license_path=args.app_license_path,
         kwt_binary=args.kwt_binary,
         kwt_variants_dir=args.kwt_variants_dir,
+        libghostty_share_dir=args.libghostty_share_dir,
         third_party_licenses_dir=args.third_party_licenses_dir,
         copyright=args.copyright,
         kwt_version=args.kwt_version,

--- a/tools/libghostty_bootstrap.py
+++ b/tools/libghostty_bootstrap.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-GHOSTHUB_BOOTSTRAP_VERSION = 22
+GHOSTHUB_BOOTSTRAP_VERSION = 23
 GHOSTHUB_GHOSTTY_BUNDLE_ID = "com.ghosthub"
 GHOSTHUB_TERM_PROGRAM = "ghosthub"
 SOURCE_FETCH_ATTEMPTS = 3
@@ -24,6 +24,40 @@ SOURCE_FETCH_RETRY_DELAY_SECONDS = 5.0
 
 class BootstrapError(RuntimeError):
     pass
+
+
+# libghostty resolves themes, shell integration, and terminfo from a `share`
+# tree it locates by climbing from the running executable. `zig build` emits
+# that tree next to the xcframework; it is then staged as a first-class
+# artifact that both the repo-local dev layout and app bundles read.
+EMITTED_SHARE_RELATIVE_PATH = ("zig-out", "share")
+THEMES_RELATIVE_PATH = ("ghostty", "themes")
+SHELL_INTEGRATION_RELATIVE_PATH = ("ghostty", "shell-integration")
+TERMINFO_RELATIVE_PATH = ("terminfo", "78", "xterm-ghostty")
+
+
+def share_tree_problem(share_root: Path) -> str | None:
+    """Describe why a `share` tree cannot serve libghostty, if it cannot.
+
+    Existence alone is not enough: an empty theme directory resolves no
+    theme names at all, and the terminfo sentinel is what libghostty
+    matches when it climbs for a resources directory.
+    """
+    themes = share_root.joinpath(*THEMES_RELATIVE_PATH)
+    if not themes.is_dir():
+        return f"the bundled theme corpus at {themes} is missing"
+    if not any(themes.iterdir()):
+        return f"the bundled theme corpus at {themes} is empty"
+
+    shell_integration = share_root.joinpath(*SHELL_INTEGRATION_RELATIVE_PATH)
+    if not shell_integration.is_dir():
+        return f"{shell_integration} is missing"
+
+    terminfo = share_root.joinpath(*TERMINFO_RELATIVE_PATH)
+    if not terminfo.is_file():
+        return f"the compiled terminfo entry at {terminfo} is missing"
+
+    return None
 
 
 @dataclass(frozen=True)
@@ -54,6 +88,7 @@ class VendorMetadata:
 class ArtifactPaths:
     root: Path
     xcframework_path: Path
+    share_path: Path
     header_path: Path
     modulemap_path: Path
     manifest_path: Path
@@ -64,6 +99,7 @@ class ArtifactPaths:
         return cls(
             root=root,
             xcframework_path=root / "GhosttyKit.xcframework",
+            share_path=root / "share",
             header_path=include_root / "ghostty.h",
             modulemap_path=include_root / "module.modulemap",
             manifest_path=root / "manifest.json",
@@ -119,7 +155,10 @@ def render_build_command(
         "-Dapp-runtime=none",
         "-Demit-xcframework=true",
         "-Demit-macos-app=false",
-        "-Demit-themes=false",
+        # The bundled iTerm2 theme corpus is the source for `theme = <name>`.
+        # Without it libghostty resolves only user themes under
+        # ~/.config/ghostty/themes.
+        "-Demit-themes=true",
         "-Di18n=false",
         "-Dsentry=false",
         f"-Doptimize={optimize}",
@@ -1481,6 +1520,15 @@ def artifact_state_message(
             "libghostty artifacts were built with different Ghosthub isolation settings. "
             "Re-run `python3 tools/bootstrap_libghostty.py`."
         )
+    # Checked as a tree rather than a manifest flag: artifacts built before
+    # themes were emitted and artifacts whose resources were later pruned are
+    # equally unusable, and only the tree itself distinguishes them.
+    share_problem = share_tree_problem(artifacts.share_path)
+    if share_problem is not None:
+        return (
+            f"libghostty resources are incomplete: {share_problem}. "
+            "Re-run `python3 tools/bootstrap_libghostty.py`."
+        )
 
     # A current manifest can still cover a broken archive: a strict
     # libtool that drops misaligned members produces a fat lib without
@@ -1613,8 +1661,26 @@ def repair_fat_archives(paths: BootstrapPaths) -> None:
             )
 
 
+def ensure_emitted_resources(paths: BootstrapPaths) -> None:
+    """Fail the bootstrap when the build did not emit a usable share tree.
+
+    The theme corpus is a lazy Zig dependency, so a build can otherwise
+    succeed while silently omitting it, and every `theme = <name>` lookup
+    then falls through to the user theme directory.
+    """
+    share_root = Path(paths.source_checkout_root, *EMITTED_SHARE_RELATIVE_PATH)
+    problem = share_tree_problem(share_root)
+    if problem is not None:
+        raise BootstrapError(
+            f"The Ghostty build emitted an unusable resources tree: {problem}. "
+            "Verify network access to the pinned iTerm2-Color-Schemes "
+            "dependency and rerun `python3 tools/bootstrap_libghostty.py`."
+        )
+
+
 def copy_outputs(paths: BootstrapPaths) -> None:
     source_xcframework = paths.source_checkout_root / "macos" / "GhosttyKit.xcframework"
+    source_share = Path(paths.source_checkout_root, *EMITTED_SHARE_RELATIVE_PATH)
     source_header = paths.source_checkout_root / "include" / "ghostty.h"
     source_modulemap = paths.source_checkout_root / "include" / "module.modulemap"
     artifacts = paths.cached_artifacts
@@ -1631,6 +1697,11 @@ def copy_outputs(paths: BootstrapPaths) -> None:
     if artifacts.xcframework_path.exists():
         shutil.rmtree(artifacts.xcframework_path)
     shutil.copytree(source_xcframework, artifacts.xcframework_path)
+    # Cache the resources alongside the library so a pruned or re-cleaned
+    # source checkout cannot leave a "ready" variant without themes.
+    if artifacts.share_path.exists():
+        shutil.rmtree(artifacts.share_path)
+    shutil.copytree(source_share, artifacts.share_path, symlinks=True)
     shutil.copy2(source_header, artifacts.header_path)
     shutil.copy2(source_modulemap, artifacts.modulemap_path)
 
@@ -1645,6 +1716,7 @@ def sync_cached_artifacts_to_staged(paths: BootstrapPaths) -> None:
     (staged.root / "include").mkdir(parents=True, exist_ok=True)
 
     shutil.copytree(cached.xcframework_path, staged.xcframework_path)
+    shutil.copytree(cached.share_path, staged.share_path, symlinks=True)
     shutil.copy2(cached.header_path, staged.header_path)
     shutil.copy2(cached.modulemap_path, staged.modulemap_path)
     shutil.copy2(cached.manifest_path, staged.manifest_path)
@@ -1736,6 +1808,7 @@ def bootstrap(
                 "Metal Toolchain (`xcodebuild -downloadComponent MetalToolchain`)."
             ) from error
         repair_fat_archives(paths)
+        ensure_emitted_resources(paths)
         copy_outputs(paths)
         write_manifest(paths, metadata, zig_version, xcframework_target, optimize)
         rebuilt_variant = True

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -23,6 +23,18 @@ configuration does not affect Ghosthub.
 Ghosthub reloads terminal configuration after the file changes. Use
 ++shift+cmd+comma++ to request a reload immediately.
 
+## Terminal themes
+
+Ghostty's built-in color schemes ship with Ghosthub, so `theme` accepts any of
+their names directly:
+
+```text
+theme = Catppuccin Macchiato
+```
+
+Conditional light and dark themes, and paths to your own theme files, work the
+same way.
+
 ## Shell startup
 
 For local shells, Ghosthub preserves libghostty's normal macOS login-shell and


### PR DESCRIPTION
Ghostty's built-in color schemes now ship with Ghosthub, so `theme = Catppuccin Macchiato` and every other bundled name resolves without first copying theme files into `~/.config/ghostty/themes`. Bundled shell integration and the `xterm-ghostty` terminfo database ship alongside them.

Fixes #112 