### PR TITLE
Use project and worktree names in native tabs

### DIFF
--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -532,7 +532,7 @@ final class CompactWorkspaceTitlebarController {
                 Image(systemName: sessionTitle.icon.systemImageName)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
-                Text(sessionTitle.sessionName)
+                Text(sessionTitle.displayName)
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/UI/SessionTitlebarPresentation.swift
+++ b/Sources/UI/SessionTitlebarPresentation.swift
@@ -2,22 +2,22 @@ import Foundation
 import GhosthubWorkspace
 
 public struct SessionTitlebarPresentation: Equatable, Sendable {
-    public let sessionName: String
+    public let displayName: String
     public let hostname: String
     public let icon: WorkspaceSidebarRowIcon
 
     public init(
-        sessionName: String,
+        displayName: String,
         hostname: String,
         icon: WorkspaceSidebarRowIcon
     ) {
-        self.sessionName = sessionName
+        self.displayName = displayName
         self.hostname = hostname
         self.icon = icon
     }
 
     public var title: String {
-        "\(sessionName) · \(hostname)"
+        "\(displayName) · \(hostname)"
     }
 
     public static func resolve(
@@ -37,7 +37,7 @@ public struct SessionTitlebarPresentation: Equatable, Sendable {
         if let activeZellijSession,
            let host = snapshot.host(id: activeZellijSession.hostID) {
             return SessionTitlebarPresentation(
-                sessionName: activeZellijSession.name,
+                displayName: activeZellijSession.name,
                 hostname: hostname(for: host),
                 icon: .zellijSession
             )
@@ -71,7 +71,10 @@ public struct SessionTitlebarPresentation: Equatable, Sendable {
         }
 
         return SessionTitlebarPresentation(
-            sessionName: activeSession.name,
+            displayName: tmuxDisplayName(
+                activeSession: activeSession,
+                in: snapshot
+            ),
             hostname: hostname(for: host),
             icon: icon
         )
@@ -85,10 +88,24 @@ public struct SessionTitlebarPresentation: Equatable, Sendable {
               let host = snapshot.host(id: activeHerdrSession.hostID)
         else { return nil }
         return SessionTitlebarPresentation(
-            sessionName: activeHerdrSession.name,
+            displayName: activeHerdrSession.name,
             hostname: hostname(for: host),
             icon: .herdrSession
         )
+    }
+
+    private static func tmuxDisplayName(
+        activeSession: WorkspaceTmuxSessionSelection,
+        in snapshot: WorkspaceSnapshot
+    ) -> String {
+        guard let worktreeID = activeSession.worktreeID,
+              let worktree = snapshot.worktree(id: worktreeID),
+              let worktreeName = nonempty(worktree.name)
+        else { return activeSession.name }
+        guard let project = snapshot.project(id: worktree.projectID),
+              let projectName = nonempty(project.name)
+        else { return worktreeName }
+        return "\(projectName) / \(worktreeName)"
     }
 
     private static func hostname(for host: HostSummary) -> String {

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -776,7 +776,7 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertEqual(forwardingDelegate.resizeCount, 1)
     }
 
-    func testCompactTitlebarKeepsSessionIdentity() {
+    func testCompactTitlebarUsesDisplayName() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .resizable],
@@ -788,7 +788,7 @@ final class ApplicationDelegateTests: XCTestCase {
             isSidebarVisible: true,
             canCreateWorktree: true,
             sessionTitle: SessionTitlebarPresentation(
-                sessionName: "docbank",
+                displayName: "ghosthub / feature/api",
                 hostname: "studio-mac",
                 icon: .tmuxSession
             ),
@@ -801,7 +801,10 @@ final class ApplicationDelegateTests: XCTestCase {
         controller.install(on: window)
 
         XCTAssertNil(window.toolbar)
-        XCTAssertEqual(window.title, "docbank · studio-mac")
+        XCTAssertEqual(
+            window.title,
+            "ghosthub / feature/api · studio-mac"
+        )
         XCTAssertEqual(window.titleVisibility, .hidden)
     }
 

--- a/Tests/UI/SessionTitlebarPresentationTests.swift
+++ b/Tests/UI/SessionTitlebarPresentationTests.swift
@@ -32,14 +32,14 @@ struct SessionTitlebarPresentationTests {
         #expect(presentation?.icon.systemImageName == "terminal")
     }
 
-    @Test("workspace session reuses linked-worktree sidebar icon")
+    @Test("workspace session shows project and worktree names")
     func linkedWorktreeSession() {
         let hostID = UUID()
         let projectID = UUID()
         let worktree = WorktreeSummary.fixture(
             hostID: hostID,
             projectID: projectID,
-            name: "feature"
+            name: "feature/api"
         )
         let snapshot = WorkspaceSnapshot.fixture(
             hosts: [
@@ -47,23 +47,29 @@ struct SessionTitlebarPresentationTests {
                     id: hostID,
                     name: "Build Box",
                     kind: .remote,
-                    sshDestination: "wesm@build.example:2222"
+                    sshDestination: "builder@build.example:2222"
                 ),
             ],
-            projects: [.fixture(id: projectID, hostID: hostID)],
+            projects: [
+                .fixture(
+                    id: projectID,
+                    hostID: hostID,
+                    name: "ghosthub"
+                ),
+            ],
             worktrees: [worktree]
         )
 
         let presentation = SessionTitlebarPresentation.resolve(
             activeSession: WorkspaceTmuxSessionSelection(
                 hostID: hostID,
-                name: "kwt-feature",
+                name: "kwt-wt-ghosthub-feature-api-deadbeef",
                 worktreeID: worktree.id
             ),
             in: snapshot
         )
 
-        #expect(presentation?.title == "kwt-feature · build.example")
+        #expect(presentation?.title == "ghosthub / feature/api · build.example")
         #expect(presentation?.icon == .worktree)
     }
 
@@ -86,7 +92,13 @@ struct SessionTitlebarPresentationTests {
         host.remoteHostname = "builder.internal"
         let snapshot = WorkspaceSnapshot.fixture(
             hosts: [host],
-            projects: [.fixture(id: projectID, hostID: hostID)],
+            projects: [
+                .fixture(
+                    id: projectID,
+                    hostID: hostID,
+                    name: "ghosthub"
+                ),
+            ],
             worktrees: [worktree]
         )
 
@@ -99,8 +111,45 @@ struct SessionTitlebarPresentationTests {
             in: snapshot
         )
 
-        #expect(presentation?.title == "kwt-main · builder.internal")
+        #expect(presentation?.title == "ghosthub / main · builder.internal")
         #expect(presentation?.icon == .primaryWorktree)
+    }
+
+    @Test("workspace title falls back without parsing its session name")
+    func workspaceTitleFallbacks() {
+        let hostID = UUID()
+        let worktree = WorktreeSummary.fixture(
+            hostID: hostID,
+            projectID: UUID(),
+            name: "feature/api"
+        )
+        let snapshot = WorkspaceSnapshot.fixture(
+            hosts: [.fixture(id: hostID, name: "studio-mac")],
+            worktrees: [worktree]
+        )
+
+        let projectless = SessionTitlebarPresentation.resolve(
+            activeSession: WorkspaceTmuxSessionSelection(
+                hostID: hostID,
+                name: "kwt-wt-ghosthub-feature-api-deadbeef",
+                worktreeID: worktree.id
+            ),
+            in: snapshot
+        )
+        #expect(projectless?.title == "feature/api · studio-mac")
+
+        let missingWorktree = SessionTitlebarPresentation.resolve(
+            activeSession: WorkspaceTmuxSessionSelection(
+                hostID: hostID,
+                name: "kwt-wt-ghosthub-feature-api-deadbeef",
+                worktreeID: UUID()
+            ),
+            in: snapshot
+        )
+        #expect(
+            missingWorktree?.title
+                == "kwt-wt-ghosthub-feature-api-deadbeef · studio-mac"
+        )
     }
 
     @Test("missing active session or host has no title")

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -318,6 +318,14 @@ capture_state guide-terminal.png
 dismiss_sheet
 fi
 
+expected_window_title() {
+  case "$1" in
+    fix-reconnect-backoff) printf '%s\n' 'ghosthub / fix-reconnect-backoff' ;;
+    add-session-filters) printf '%s\n' 'agentsview / add-session-filters' ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
 prepare_command_window() {
   local query="$1" create="${2:-true}" select="${3:-palette}"
   if [[ "$create" == "true" ]]; then
@@ -352,7 +360,7 @@ prepare_command_window() {
     palette "$query"
   fi
   sleep 3
-  demo_input expect-window-title "$query"
+  demo_input expect-window-title "$(expected_window_title "$query")"
   demo_input hide-sidebar
 }
 
@@ -388,7 +396,7 @@ prepare_command_tab() {
   sleep 1
   palette "$query"
   sleep 3
-  demo_input expect-window-title "$query"
+  demo_input expect-window-title "$(expected_window_title "$query")"
   demo_input hide-sidebar
 }
 

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -72,7 +72,9 @@ under **Tmux Sessions**.
 
 Select the project's primary checkout or any linked worktree in the sidebar.
 Kwt supplies the exact canonical tmux session name. Ghosthub creates or repairs
-that session when necessary and then attaches an ordinary tmux client.
+that session when necessary and then attaches an ordinary tmux client. The
+native window tab and titlebar show the project and worktree names instead of
+that internal session name.
 A status glyph on the worktree row indicates when current discovery confirms
 its tmux session is live, including while Ghosthub is detached. Cached sessions
 do not remain marked live while the host is unreachable.


### PR DESCRIPTION
KWT's exact tmux session name is useful for attachment, but it is noisy in native window chrome.

- shows `project / worktree · host` for KWT worktree tabs and titlebars
- keeps standalone tmux, directory workspace, Herdr, and Zellij labels unchanged
- falls back to the worktree or exact session name when inventory metadata is incomplete, without parsing identity
- leaves attachment, restoration, kill, activity, and reconciliation on exact KWT values
- updates the website guide and its deterministic native-tabs screenshot

![Native tabs showing project and worktree names](https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets/guide-native-tabs.png)
