### PR TITLE
Fix worktree sibling keyboard navigation

### DIFF
--- a/Sources/App/MenuCommands.swift
+++ b/Sources/App/MenuCommands.swift
@@ -26,7 +26,8 @@ struct MenuActionContext {
         ApplicationShortcutMenuModel.keyboardBinding(
             settingsStore.shortcutPreferences.resolved[action],
             for: action,
-            sceneIsFocused: sceneModel?.isFocusedWindow == true,
+            sceneIsFocused:
+            sceneModel?.acceptsApplicationShortcutKeyEvents == true,
             hasAttachedSheet: sceneHasAttachedSheet,
             actionIsAvailable: actionIsAvailable
         )?.swiftUI
@@ -43,7 +44,8 @@ struct MenuActionContext {
         return ApplicationShortcutMenuModel.keyboardBinding(
             splitBinding,
             for: action,
-            sceneIsFocused: sceneModel?.isFocusedWindow == true,
+            sceneIsFocused:
+            sceneModel?.acceptsApplicationShortcutKeyEvents == true,
             hasAttachedSheet: sceneHasAttachedSheet,
             actionIsAvailable: sceneModel?.canSplitActivePane == true
         )?.swiftUI

--- a/Sources/App/WorkspaceSceneModel+Selection.swift
+++ b/Sources/App/WorkspaceSceneModel+Selection.swift
@@ -51,7 +51,8 @@ extension WorkspaceSceneModel {
         _ action: ApplicationShortcutAction,
         invocation: ApplicationShortcutInvocation = .keyEvent
     ) -> Bool {
-        guard invocation == .menu || isFocusedWindow else { return false }
+        guard invocation == .menu || acceptsApplicationShortcutKeyEvents
+        else { return false }
         if ApplicationShortcutMenuModel.menuOwnedActions.contains(action),
            hasAttachedApplicationSheet {
             return false

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1082,6 +1082,9 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
     weak var workspaceWindow: NSWindow?
+    var acceptsApplicationShortcutKeyEvents: Bool {
+        workspaceWindow?.isKeyWindow ?? isFocusedWindow
+    }
     @Published var selection: WorkspaceSelection {
         didSet {
             syncTerminalConfig()

--- a/Tests/App/WorkspaceApplicationShortcutTests.swift
+++ b/Tests/App/WorkspaceApplicationShortcutTests.swift
@@ -7,6 +7,12 @@ import GhosthubWorkspace
 import Testing
 @testable import GhosthubApp
 
+private final class ShortcutFocusWindow: NSWindow {
+    var keyState = false
+
+    override var isKeyWindow: Bool { keyState }
+}
+
 @Suite("Workspace application shortcuts", .serialized)
 @MainActor
 struct WorkspaceApplicationShortcutTests {
@@ -69,6 +75,79 @@ struct WorkspaceApplicationShortcutTests {
         #expect(model.performApplicationShortcut(.nextSibling))
         #expect(model.selection.selectedWorktreeID == second.id)
         #expect(model.performApplicationShortcut(.previousSibling))
+        #expect(model.selection.selectedWorktreeID == first.id)
+        await model.shutdown()
+    }
+
+    @Test("sibling shortcuts use the live workspace window focus")
+    func siblingShortcutsUseLiveWindowFocus() async throws {
+        let host = HostSummary.fixture()
+        let project = ProjectSummary.fixture(hostID: host.id)
+        let first = WorktreeSummary.fixture(
+            hostID: host.id, projectID: project.id, name: "first"
+        )
+        let second = WorktreeSummary.fixture(
+            hostID: host.id, projectID: project.id, name: "second"
+        )
+        let model = try makeModel(
+            database: .inMemory(), localHostID: host.id,
+            snapshot: WorkspaceSnapshot(
+                hosts: [host], projects: [project],
+                worktrees: [first, second]
+            )
+        )
+        model.selection = .init(
+            selectedHostID: host.id,
+            selectedProjectID: project.id,
+            selectedWorktreeID: first.id
+        )
+        let window = ShortcutFocusWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        model.workspaceWindow = window
+        let monitor = ShortcutMonitor(
+            shortcuts: { ApplicationShortcutCatalog.compiledDefaults },
+            perform: { action in
+                model.performApplicationShortcut(action)
+            }
+        )
+        let next = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+        let previous = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+
+        window.keyState = true
+        #expect(monitor.processForTesting(next) == nil)
+        #expect(model.selection.selectedWorktreeID == second.id)
+        #expect(monitor.processForTesting(previous) == nil)
+        #expect(model.selection.selectedWorktreeID == first.id)
+
+        window.keyState = false
+        model.isFocusedWindow = true
+        #expect(monitor.processForTesting(next) === next)
         #expect(model.selection.selectedWorktreeID == first.id)
         await model.shutdown()
     }
@@ -235,12 +314,13 @@ struct WorkspaceApplicationShortcutTests {
             snapshot: environment.snapshot
         )
         model.isFocusedWindow = true
-        let window = NSWindow(
+        let window = ShortcutFocusWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled],
             backing: .buffered,
             defer: false
         )
+        window.keyState = true
         let sheet = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
             styleMask: [.titled],


### PR DESCRIPTION
Control-Tab and Control-Shift-Tab could do nothing when SwiftUI's cached window-focus state lagged behind AppKit. This makes the attached workspace window's actual key status authoritative, so sibling navigation follows the active Ghosthub window and background windows cannot handle the same shortcut.

- Covers forward and reverse navigation through the real shortcut-monitor event path.
- Keeps the cached focus fallback only for scene models that are not yet attached to a window.
- Leaves native macOS tab shortcuts, terminal input, and pass-through behavior unchanged.
