### PR TITLE
Stabilize retained tmux activation coverage

### DIFF
--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1161,9 +1161,24 @@ struct WorkspaceTmuxDiscoveryTests {
     @Test("retained tmux activation unparks before publishing the active handle")
     func retainedTmuxActivationUnparksBeforePublishingHandle() async throws {
         let environment = try setupHostEnvironment()
+        var snapshot = environment.snapshot
         let budget = LivePreviewBudget(limit: 4)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
         weak var weakModel: WorkspaceSceneModel?
         var events: [String] = []
+        let identity = TmuxSessionIdentity(
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1000"
+        )
+        snapshot.hosts[0].tmuxSessions = [.init(
+            name: "first",
+            managed: false,
+            windows: [],
+            serverPID: identity.serverPID,
+            sessionID: identity.sessionID,
+            createdAt: identity.createdAt
+        )]
         let previewCoordinator = TmuxSessionPreviewCoordinator(
             mode: .live,
             budget: budget,
@@ -1182,10 +1197,14 @@ struct WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: {
                 successfulTmuxResolution("/usr/bin/tmux")
             },
+            nativeTmuxPaneSplitter: Self.previewPaneSplitter(
+                identity: identity
+            ),
             sessionPreviewCoordinator: previewCoordinator
         )
         weakModel = model
@@ -1198,31 +1217,18 @@ struct WorkspaceTmuxDiscoveryTests {
             name: "second"
         )
         model.openBorrowedTmuxSession(first)
-        let firstHandle = try #require(
-            model.retainedBorrowedTmuxHandle(for: first)
-        )
-        model.openBorrowedTmuxSession(second)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
         let key = TmuxPreviewKey(
             hostID: first.hostID,
             name: first.name,
             socketName: first.socketName
         )
-        let identity = TmuxSessionIdentity(
-            serverPID: "101",
-            sessionID: "$1",
-            createdAt: "1000"
-        )
-        previewCoordinator.register(.init(
-            key: key,
-            surface: { nil },
-            handleID: { firstHandle.id },
-            generation: { nil },
-            identity: { identity },
-            connectionState: { .connected },
-            isActive: { weakModel?.activeBorrowedTmuxSelection == first },
-            activate: {}
-        ))
         previewCoordinator.setExpanded(true, for: key)
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxSessionIsConnected(first)
+                && !previewCoordinator.requiresIdentity(key)
+        }
+        model.openBorrowedTmuxSession(second)
 
         await waitUntilMainActor {
             events == ["park:second"]


### PR DESCRIPTION
[CI run 31750796953](https://github.com/kenn-io/ghosthub/actions/runs/31750796953) intermittently lost the retained tmux preview's fake identity after the scene model's real attachment finished connecting. The activation-order test then waited for a parking state that could no longer occur.

- Drive the test through the model-owned surface and token-bound tmux identity instead of registering a competing fake presentation.
- Wait for the attachment and preview identity to settle before navigating away.
- Preserve the original contract: a retained Live preview is unparked before its handle becomes active.

The focused test passed 100 consecutive process-level reruns; the exact 1,697-test Swift Testing CI lane and essential kwt/tmux workflows also pass.
