### PR TITLE
Require zero GUI skips in macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,13 @@ jobs:
       - name: Run terminal smoke tests
         # Most AppKit/PTY tests are isolated by fixture, so parallel workers
         # shorten the runner exposure window without saturating hosted Macs.
-        # Keep tests marked Pasteboard out of this lane because they mutate
-        # NSPasteboard.general, which is shared across worker processes.
+        # Keep tests that mutate NSPasteboard.general or require the key
+        # application window in the serialized GUI lane below.
         shell: bash
         run: |
-          windowserver_log="$RUNNER_TEMP/windowserver-tests.log"
-          : > "$windowserver_log"
+          gui_test_log="$RUNNER_TEMP/gui-tests.log"
+          gui_test_filter='Clipboard|Paste|TerminalYieldsKeyboardFocusWhenSheetIsAttached|ApplicationDispatchedMouseDownNotifiesPrimaryInteractionExactlyOnce|CmdVWithoutPaneSinkStaysLocal'
+          : > "$gui_test_log"
           test_workers=2
           if [[ "${RUNNER_ENVIRONMENT:-}" == "self-hosted" ]]; then
             test_workers=8
@@ -185,27 +186,26 @@ jobs:
           sh tools/run_swift_tests.sh \
             swift test --skip-build --disable-swift-testing \
             --filter GhosthubTerminalSmokeTests \
-            --skip 'Clipboard|Paste' \
+            --skip "$gui_test_filter" \
             --parallel --num-workers "$test_workers" \
-            2>&1 | tee -a "$windowserver_log"
+            2>&1 | tee -a "$gui_test_log"
 
-      - name: Run pasteboard terminal smoke tests
+      - name: Run serialized GUI terminal smoke tests
         shell: bash
         run: |
+          gui_test_filter='Clipboard|Paste|TerminalYieldsKeyboardFocusWhenSheetIsAttached|ApplicationDispatchedMouseDownNotifiesPrimaryInteractionExactlyOnce|CmdVWithoutPaneSinkStaysLocal'
           sh tools/run_swift_tests.sh \
             swift test --skip-build --disable-swift-testing \
-            --filter 'Clipboard|Paste' --no-parallel \
-            2>&1 | tee -a "$RUNNER_TEMP/windowserver-tests.log"
+            --filter "$gui_test_filter" --no-parallel \
+            2>&1 | tee -a "$RUNNER_TEMP/gui-tests.log"
 
-      - name: Verify WindowServer coverage
+      - name: Verify GUI coverage
         shell: bash
         run: |
-          windowserver_log="$RUNNER_TEMP/windowserver-tests.log"
-          skip_count="$(grep -c \
-            'Test skipped - Test requires window server' \
-            "$windowserver_log" || true)"
-          if [[ "$skip_count" -ne 2 ]]; then
-            echo "Expected 2 WindowServer skips; found $skip_count." >&2
+          gui_test_log="$RUNNER_TEMP/gui-tests.log"
+          gui_skip_pattern='Test skipped - .*(window server|AppKit|pasteboard|LaunchServices)'
+          if grep -Ei "$gui_skip_pattern" "$gui_test_log"; then
+            echo "GUI integration tests must not skip required coverage." >&2
             exit 1
           fi
 

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -312,7 +312,8 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
     private func makeTestWindow(
         contentView: NSView,
         size: CGSize = CGSize(width: 960, height: 640),
-        settleDelay: TimeInterval = 0.25
+        settleDelay: TimeInterval = 0.25,
+        requiresActiveApplication: Bool = false
     ) -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(origin: .zero, size: size),
@@ -321,7 +322,18 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             defer: false
         )
         window.contentView = contentView
+        if requiresActiveApplication {
+            NSApplication.shared.setActivationPolicy(.regular)
+            NSApplication.shared.unhide(nil)
+            window.orderFrontRegardless()
+        }
         window.makeKeyAndOrderFront(nil)
+        if requiresActiveApplication {
+            NSRunningApplication.current.activate(
+                options: [.activateAllWindows]
+            )
+        }
+        window.displayIfNeeded()
         waitUntil(timeout: 1.0) { window.isKeyWindow }
         RunLoop.main.run(
             until: Date().addingTimeInterval(settleDelay)
@@ -331,10 +343,14 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
 
     private func hostInWindow(
         _ view: TerminalSurfaceView,
-        size: CGSize = CGSize(width: 960, height: 640)
+        size: CGSize = CGSize(width: 960, height: 640),
+        requiresActiveApplication: Bool = false
     ) -> NSWindow {
         let window = makeTestWindow(
-            contentView: view, size: size, settleDelay: 0.1
+            contentView: view,
+            size: size,
+            settleDelay: 0.1,
+            requiresActiveApplication: requiresActiveApplication
         )
         window.makeFirstResponder(view)
         view.focusDidChange(true)
@@ -994,7 +1010,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             app: appHandle,
             configuration: TerminalSurfaceConfiguration()
         )
-        let window = hostInWindow(view)
+        let window = hostInWindow(view, requiresActiveApplication: true)
         waitUntil(timeout: 2.0) {
             view.window === window
                 && view.focused
@@ -1161,7 +1177,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             app: appHandle,
             configuration: TerminalSurfaceConfiguration()
         )
-        let window = hostInWindow(view)
+        let window = hostInWindow(view, requiresActiveApplication: true)
         guard window.isKeyWindow else {
             throw XCTSkip(
                 "Test requires window server - skipping in headless environment"
@@ -2419,7 +2435,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         var pastedData: [Data] = []
         view.tmuxPaneInputSink = { sunkData.append($0) }
         view.tmuxPanePasteSink = { pastedData.append($0) }
-        let window = hostInWindow(view)
+        let window = hostInWindow(view, requiresActiveApplication: true)
         waitUntil(timeout: 2.0) {
             view.window === window && view.focused && window.isKeyWindow
         }
@@ -2470,7 +2486,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         var pastedData: [Data] = []
         view.tmuxPaneInputSink = { sunkData.append($0) }
         view.tmuxPanePasteSink = { pastedData.append($0) }
-        let window = hostInWindow(view)
+        let window = hostInWindow(view, requiresActiveApplication: true)
         waitUntil(timeout: 2.0) {
             view.window === window && view.focused && window.isKeyWindow
         }
@@ -2511,7 +2527,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             app: appHandle,
             configuration: TerminalSurfaceConfiguration()
         )
-        let window = hostInWindow(view)
+        let window = hostInWindow(view, requiresActiveApplication: true)
         waitUntil(timeout: 2.0) {
             view.window === window && view.focused && window.isKeyWindow
         }


### PR DESCRIPTION
The trusted macOS rollout requires hosted and self-hosted lanes to exercise the same GUI coverage, but hosted CI currently treats two application-dispatched paste tests as expected skips.

- Activates the XCTest application only for tests that require a key window.
- Serializes key-window and pasteboard tests so parallel workers cannot compete for WindowServer focus.
- Fails either lane when WindowServer, AppKit, pasteboard, or LaunchServices coverage is skipped.
- Keeps hosted CI on every caller and leaves trusted execution opt-in, main-pinned, and unavailable to forks.

Local app and smoke-target builds pass. The hosted pull request run is the authoritative GUI check because an actively used desktop session can refuse foreground activation by an XCTest process.
