### PR TITLE
Keep managed KWT inventory on the pinned revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,12 +155,13 @@ jobs:
 
       - name: Build pinned kwt helper
         shell: bash
-        working-directory: .release-inputs/kwt-source
         run: |
           kwt_binary="$RUNNER_TEMP/kwt"
-          go build -trimpath \
-            -ldflags "-s -w -X go.kenn.io/kwt/internal/cmd.version=$KWT_REF" \
-            -o "$kwt_binary" ./cmd/kwt
+          tools/build_pinned_kwt.sh \
+            "https://github.com/$KWT_REPOSITORY.git" \
+            "$KWT_REF" \
+            "$GITHUB_WORKSPACE/.release-inputs/kwt-source" \
+            "$kwt_binary"
           kwt_archs="$(lipo -archs "$kwt_binary")"
           if [[ "$kwt_archs" != "arm64" ]]; then
             echo "Embedded kwt must be an arm64 Mach-O; found: $kwt_archs" >&2
@@ -170,9 +171,6 @@ jobs:
           kwt_reported="$("$kwt_binary" version)"
           echo "$kwt_reported"
           kwt_version="$(printf '%s\n' "$kwt_reported" | sed -n '1s/^kwt version //p')"
-          # Go's VCS stamping usually supplies the revision here and outranks
-          # the -X value; -X covers the case where stamping is unavailable.
-          # Either way the helper must name the revision it was built from.
           if [[ "$kwt_reported" != *"$KWT_REF"* ]]; then
             echo "Embedded kwt does not report the pinned revision $KWT_REF:" >&2
             echo "$kwt_reported" >&2

--- a/Tests/test_build_pinned_kwt.py
+++ b/Tests/test_build_pinned_kwt.py
@@ -278,7 +278,7 @@ fi
     )
     assert (
         output.with_suffix(".revision").read_text()
-        == f"{second_revision} identity=3"
+        == f"{second_revision} identity=4"
     )
     assert second_revision in subprocess.run(
         [output, "--version"],
@@ -403,9 +403,11 @@ def test_rejects_helper_without_complete_daemon_identity(
     assert not output.with_suffix(".revision").exists()
 
 
-def test_stamps_pinned_source_identity_for_daemon_replacement(
+def identity_fixture(
     tmp_path: Path,
-) -> None:
+    *,
+    omit_linux_revision_time: bool = False,
+) -> tuple[Path, str]:
     repository = tmp_path / "repository"
     repository.mkdir()
     subprocess.run(["git", "init", "-q", repository], check=True)
@@ -428,7 +430,6 @@ import \"os\"
 
 var version = \"dev\"
 var commit = \"none\"
-var revisionTime = \"\"
 
 func Execute() {
     _ = json.NewEncoder(os.Stdout).Encode(map[string]string{
@@ -439,6 +440,30 @@ func Execute() {
 }
 """
     )
+    if omit_linux_revision_time:
+        (command.parent / "revision_time_default.go").write_text(
+            """//go:build !linux
+
+package cmd
+
+var revisionTime = ""
+"""
+        )
+        (command.parent / "revision_time_linux.go").write_text(
+            """//go:build linux
+
+package cmd
+
+const revisionTime = ""
+"""
+        )
+    else:
+        (command.parent / "revision_time.go").write_text(
+            """package cmd
+
+var revisionTime = ""
+"""
+        )
     main = repository / "cmd" / "kwt" / "main.go"
     main.parent.mkdir(parents=True)
     main.write_text(
@@ -466,6 +491,13 @@ func main() { cmd.Execute() }
         capture_output=True,
         text=True,
     ).stdout.strip()
+    return repository, revision
+
+
+def test_stamps_pinned_source_identity_for_daemon_replacement(
+    tmp_path: Path,
+) -> None:
+    repository, revision = identity_fixture(tmp_path)
     output = tmp_path / "output" / "kwt"
 
     result = subprocess.run(
@@ -496,3 +528,31 @@ func main() { cmd.Execute() }
         "revision": revision,
         "revision_time": "2026-08-13T18:42:17Z",
     }
+
+
+def test_rejects_target_that_omits_an_identity_symbol(tmp_path: Path) -> None:
+    repository, revision = identity_fixture(
+        tmp_path,
+        omit_linux_revision_time=True,
+    )
+    output = tmp_path / "output" / "kwt"
+
+    result = subprocess.run(
+        [
+            "bash",
+            "tools/build_pinned_kwt.sh",
+            str(repository),
+            revision,
+            str(tmp_path / "source"),
+            str(output),
+            "linux",
+            "arm64",
+        ],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert not output.exists()
+    assert not output.with_suffix(".revision").exists()

--- a/Tests/test_build_pinned_kwt.py
+++ b/Tests/test_build_pinned_kwt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import stat
@@ -72,7 +73,11 @@ revision=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -ldflags)
-      revision="${2##*=}"
+      for value in $2; do
+        case "$value" in
+          go.kenn.io/kwt/internal/cmd.version=*) revision="${value#*=}" ;;
+        esac
+      done
       shift 2
       ;;
     -o)
@@ -242,7 +247,10 @@ fi
         ).stdout
         == ""
     )
-    assert output.with_suffix(".revision").read_text() == second_revision
+    assert (
+        output.with_suffix(".revision").read_text()
+        == f"{second_revision} identity=2"
+    )
     assert second_revision in subprocess.run(
         [output, "--version"],
         check=True,
@@ -295,3 +303,130 @@ exec "{real_git}" "$@"
         assert result.returncode == 0, result.stderr
 
     assert fetch_log.read_text().splitlines() == ["fetch"]
+
+
+def test_rebuilds_helper_from_legacy_identity_stamp(tmp_path: Path) -> None:
+    repository, revision, _, fake_bin = bootstrap_fixture(tmp_path)
+    output = tmp_path / "output" / "kwt"
+    output.parent.mkdir()
+    stale_helper = (
+        "#!/bin/sh\n"
+        f"printf 'kwt version {revision}\\n'\n"
+        "# missing daemon build identity\n"
+    )
+    output.write_text(stale_helper)
+    output.chmod(output.stat().st_mode | stat.S_IXUSR)
+    output.with_suffix(".revision").write_text(revision)
+
+    result = subprocess.run(
+        [
+            "bash",
+            "tools/build_pinned_kwt.sh",
+            str(repository),
+            revision,
+            str(tmp_path / "source"),
+            str(output),
+        ],
+        cwd=Path(__file__).parents[1],
+        env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text() != stale_helper
+
+
+def test_stamps_pinned_source_identity_for_daemon_replacement(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q", repository], check=True)
+    subprocess.run(
+        ["git", "-C", repository, "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", repository, "config", "user.name", "Test"],
+        check=True,
+    )
+    (repository / "go.mod").write_text("module go.kenn.io/kwt\n\ngo 1.25\n")
+    command = repository / "internal" / "cmd" / "root.go"
+    command.parent.mkdir(parents=True)
+    command.write_text(
+        """package cmd
+
+import \"encoding/json\"
+import \"os\"
+
+var version = \"dev\"
+var commit = \"none\"
+var revisionTime = \"\"
+
+func Execute() {
+    _ = json.NewEncoder(os.Stdout).Encode(map[string]string{
+        \"version\": version,
+        \"revision\": commit,
+        \"revision_time\": revisionTime,
+    })
+}
+"""
+    )
+    main = repository / "cmd" / "kwt" / "main.go"
+    main.parent.mkdir(parents=True)
+    main.write_text(
+        """package main
+
+import \"go.kenn.io/kwt/internal/cmd\"
+
+func main() { cmd.Execute() }
+"""
+    )
+    subprocess.run(["git", "-C", repository, "add", "."], check=True)
+    commit_environment = {
+        **os.environ,
+        "GIT_AUTHOR_DATE": "2026-08-13T18:42:17Z",
+        "GIT_COMMITTER_DATE": "2026-08-13T18:42:17Z",
+    }
+    subprocess.run(
+        ["git", "-C", repository, "commit", "-qm", "fixture"],
+        check=True,
+        env=commit_environment,
+    )
+    revision = subprocess.run(
+        ["git", "-C", repository, "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    output = tmp_path / "output" / "kwt"
+
+    result = subprocess.run(
+        [
+            "bash",
+            "tools/build_pinned_kwt.sh",
+            str(repository),
+            revision,
+            str(tmp_path / "source"),
+            str(output),
+        ],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    identity = json.loads(
+        subprocess.run(
+            [output, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+    assert identity == {
+        "version": revision,
+        "revision": revision,
+        "revision_time": "2026-08-13T18:42:17Z",
+    }

--- a/Tests/test_build_pinned_kwt.py
+++ b/Tests/test_build_pinned_kwt.py
@@ -8,6 +8,8 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 
 def bootstrap_fixture(tmp_path: Path) -> tuple[Path, str, str, Path]:
     repository = tmp_path / "repository"
@@ -69,13 +71,19 @@ if [ "$#" -eq 3 ] && [ "$1" = "version" ] && [ "$2" = "-m" ]; then
   exit 0
 fi
 output=
-revision=
+version=
+commit=
+revision_time=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -ldflags)
       for value in $2; do
         case "$value" in
-          go.kenn.io/kwt/internal/cmd.version=*) revision="${value#*=}" ;;
+          go.kenn.io/kwt/internal/cmd.version=*) version="${value#*=}" ;;
+          go.kenn.io/kwt/internal/cmd.commit=*) commit="${value#*=}" ;;
+          go.kenn.io/kwt/internal/cmd.revisionTime=*)
+            revision_time="${value#*=}"
+            ;;
         esac
       done
       shift 2
@@ -89,7 +97,28 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
-printf '#!/bin/sh\\nprintf "kwt version %%s\\\\n" "%s"\\n' "$revision" >"$output"
+case "${FAKE_KWT_IDENTITY_OMISSION:-}" in
+  version) version=dev ;;
+  revision) commit=none ;;
+  revision_time) revision_time= ;;
+esac
+cat >"$output" <<EOF
+#!/bin/sh
+case "\\$*" in
+  "--version")
+    printf 'kwt version %s\\n' "$version"
+    ;;
+  "daemon start"|"daemon stop")
+    exit 0
+    ;;
+  "daemon status --json")
+    printf '%s\\n' '{"service":"kwt","state":"ready","home":"/tmp/fake-kwt","endpoint":"127.0.0.1:1","pid":1,"version":"$version","revision":"$commit","revision_time":"$revision_time","schema_major":1,"schema_version":"1.6.0","capabilities":[],"started_at":"2026-08-13T18:42:17Z","uptime_seconds":0,"active_work":0,"active_leases":0}'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
 chmod +x "$output"
 """
     )
@@ -249,7 +278,7 @@ fi
     )
     assert (
         output.with_suffix(".revision").read_text()
-        == f"{second_revision} identity=2"
+        == f"{second_revision} identity=3"
     )
     assert second_revision in subprocess.run(
         [output, "--version"],
@@ -335,6 +364,43 @@ def test_rebuilds_helper_from_legacy_identity_stamp(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert output.read_text() != stale_helper
+
+
+@pytest.mark.parametrize("targeted", [False, True])
+@pytest.mark.parametrize("omission", ["version", "revision", "revision_time"])
+def test_rejects_helper_without_complete_daemon_identity(
+    tmp_path: Path,
+    omission: str,
+    targeted: bool,
+) -> None:
+    repository, revision, _, fake_bin = bootstrap_fixture(tmp_path)
+    output = tmp_path / "output" / "kwt"
+    command = [
+        "bash",
+        "tools/build_pinned_kwt.sh",
+        str(repository),
+        revision,
+        str(tmp_path / "source"),
+        str(output),
+    ]
+    if targeted:
+        command.extend(["darwin", "arm64"])
+
+    result = subprocess.run(
+        command,
+        cwd=Path(__file__).parents[1],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "FAKE_KWT_IDENTITY_OMISSION": omission,
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert not output.exists()
+    assert not output.with_suffix(".revision").exists()
 
 
 def test_stamps_pinned_source_identity_for_daemon_replacement(

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,8 +28,11 @@ caches `KWT_REF` under `.build`, then stages that exact helper into the debug
 app. A developer can override the repository, revision, source directory, or
 binary path deliberately, but the default never embeds the system kwt.
 `bootstrap-kwt-variants` cross-compiles the complete remote matrix from the
-same pin. Before either debug or release packaging, every variant is checked
-for its expected Mach-O/ELF/PE architecture and embedded pinned revision.
+same pin. Each cross-compile retains its Go symbol table but omits debug
+information, then inspects that actual Mach-O, ELF, or PE artifact for the
+exact pinned version, revision, and revision timestamp before caching it.
+Before either debug or release packaging, every variant is also checked for
+its expected architecture and embedded pinned revision.
 
 Packaging also stages libghostty's own emitted resources: the bundled Ghostty
 theme corpus and shell integration at `Contents/Resources/ghostty`, and the

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,8 +70,10 @@ remote matrix pin is recorded independently as
 cannot change the managed remote path. The revision is also included in GitHub
 release notes. Release CI checks out that revision under
 `.release-inputs/kwt-source` and passes the checkout as `KWT_SOURCE_DIR` when
-building the remote variant matrix; the repository slug used by
-`actions/checkout` is never passed to `git clone`. Release CI records the
+building the remote variant matrix. It builds the local release helper through
+`tools/build_pinned_kwt.sh`, so the helper must pass the same explicit identity
+stamping and isolated daemon validation before signing. The repository slug
+used by `actions/checkout` is never passed to `git clone`. Release CI records the
 helper it built from the pin; a local build against a substituted
 `KWT_BINARY_PATH` is recorded as `unpinned` rather than inheriting the pin. Kwt
 is part of Ghosthub's signed code, but Ghosthub invokes only its CLI and never

--- a/tools/build_pinned_kwt.sh
+++ b/tools/build_pinned_kwt.sh
@@ -29,9 +29,10 @@ if [[ $# -eq 6 ]]; then
   goarch="$6"
 fi
 stamp="${output}.revision"
-stamp_value="$revision"
+build_identity_schema=2
+stamp_value="${revision} identity=${build_identity_schema}"
 if [[ "$targeted" == true ]]; then
-  stamp_value="${revision} ${goos}/${goarch}"
+  stamp_value="${revision} ${goos}/${goarch} identity=${build_identity_schema}"
 fi
 
 # The stamp records intent; only the binary can say which revision it is.
@@ -119,18 +120,28 @@ else
 fi
 
 mkdir -p "$(dirname "$output")"
+kwt_revision_time="$(
+  TZ=UTC git -C "$source_dir" show -s \
+    --date=format-local:'%Y-%m-%dT%H:%M:%SZ' \
+    --format='%cd' \
+    "$revision"
+)"
+kwt_build_ldflags="-s -w"
+kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.version=${revision}"
+kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.commit=${revision}"
+kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.revisionTime=${kwt_revision_time}"
 (
   cd "$source_dir"
   if [[ "$targeted" == true ]]; then
     CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build \
       -trimpath \
-      -ldflags "-s -w -X go.kenn.io/kwt/internal/cmd.version=${revision}" \
+      -ldflags "$kwt_build_ldflags" \
       -o "$output" \
       cmd/kwt/main.go
   else
     CGO_ENABLED=0 go build \
       -trimpath \
-      -ldflags "-s -w -X go.kenn.io/kwt/internal/cmd.version=${revision}" \
+      -ldflags "$kwt_build_ldflags" \
       -o "$output" \
       cmd/kwt/main.go
   fi

--- a/tools/build_pinned_kwt.sh
+++ b/tools/build_pinned_kwt.sh
@@ -29,7 +29,7 @@ if [[ $# -eq 6 ]]; then
   goarch="$6"
 fi
 stamp="${output}.revision"
-build_identity_schema=2
+build_identity_schema=3
 stamp_value="${revision} identity=${build_identity_schema}"
 if [[ "$targeted" == true ]]; then
   stamp_value="${revision} ${goos}/${goarch} identity=${build_identity_schema}"
@@ -39,6 +39,57 @@ fi
 reported_version() {
   "$output" --version 2>&1 || true
 }
+
+validate_native_identity() (
+  helper="$1"
+  validation_prefix="${2:-$helper}"
+  validation_root="$(mktemp -d "${validation_prefix}.identity.XXXXXX")"
+  validation_home="${validation_root}/home"
+  validation_kwt_home="${validation_root}/kwt-home"
+  validation_config_home="${validation_root}/config"
+  mkdir -p \
+    "$validation_home" \
+    "$validation_kwt_home" \
+    "$validation_config_home"
+
+  run_isolated_helper() {
+    HOME="$validation_home" \
+      KWT_HOME="$validation_kwt_home" \
+      XDG_CONFIG_HOME="$validation_config_home" \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_SYSTEM=/dev/null \
+      "$helper" "$@"
+  }
+  daemon_started=false
+  cleanup_validation() {
+    if [[ "$daemon_started" == true ]]; then
+      run_isolated_helper daemon stop >/dev/null 2>&1 || return
+      daemon_started=false
+    fi
+    find "$validation_root" -depth -delete
+  }
+  trap cleanup_validation EXIT
+
+  daemon_started=true
+  run_isolated_helper daemon start >/dev/null
+  identity="$(run_isolated_helper daemon status --json)"
+  if [[ "$identity" != *'"version":"'"$revision"'"'* ]] \
+    || [[ "$identity" != *'"revision":"'"$revision"'"'* ]] \
+    || [[ "$identity" != *'"revision_time":"'"$kwt_revision_time"'"'* ]]; then
+    printf 'Built kwt daemon reports an incomplete pinned identity.\n' >&2
+    printf 'Expected version and revision %s at %s; received %s.\n' \
+      "$revision" "$kwt_revision_time" "${identity:-no daemon status}" >&2
+    return 1
+  fi
+
+  if ! run_isolated_helper daemon stop >/dev/null 2>&1; then
+    printf 'Built kwt validation daemon could not be stopped.\n' >&2
+    return 1
+  fi
+  daemon_started=false
+  find "$validation_root" -depth -delete
+  trap - EXIT
+)
 
 target_metadata_matches() {
   [[ "$targeted" == true && -f "$output" ]] || return 1
@@ -130,41 +181,65 @@ kwt_build_ldflags="-s -w"
 kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.version=${revision}"
 kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.commit=${revision}"
 kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.revisionTime=${kwt_revision_time}"
-(
+build_helper() (
+  helper_output="$1"
+  helper_goos="${2:-}"
+  helper_goarch="${3:-}"
   cd "$source_dir"
-  if [[ "$targeted" == true ]]; then
-    CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build \
+  if [[ -n "$helper_goos" && -n "$helper_goarch" ]]; then
+    CGO_ENABLED=0 GOOS="$helper_goos" GOARCH="$helper_goarch" go build \
       -trimpath \
       -ldflags "$kwt_build_ldflags" \
-      -o "$output" \
+      -o "$helper_output" \
       cmd/kwt/main.go
   else
     CGO_ENABLED=0 go build \
       -trimpath \
       -ldflags "$kwt_build_ldflags" \
-      -o "$output" \
+      -o "$helper_output" \
       cmd/kwt/main.go
   fi
 )
 
-# The linker silently ignores -X for a symbol it cannot find, so an unstamped
-# native binary is the only evidence that kwt has moved its version variable.
-# Every cross-compiled variant uses the same source and linker symbol.
+if [[ "$targeted" == true ]]; then
+  build_helper "$output" "$goos" "$goarch"
+else
+  build_helper "$output"
+fi
+
+# The linker silently ignores -X for a symbol it cannot find. Exercise the
+# native helper's isolated daemon interface before asserting that the cache
+# contains the full replacement identity. Cross-compiled variants first build
+# a native probe from the same source and linker flags, then retain their
+# format-specific validation.
 if [[ "$targeted" == false ]]; then
   chmod 0755 "$output"
-  version_output="$(reported_version)"
-  if [[ "$version_output" != *"$revision"* ]]; then
-    printf 'Built kwt reports %s instead of the pinned revision %s.\n' \
-      "${version_output:-no version output}" "$revision" >&2
-    printf 'Update the -X version symbol in %s to match kwt.\n' "$0" >&2
-    rm -f "$output"
+  if ! validate_native_identity "$output"; then
+    rm -f "$output" "$stamp"
     exit 1
   fi
-elif ! target_metadata_matches; then
-  printf 'Built kwt does not match %s/%s at revision %s.\n' \
-    "$goos" "$goarch" "$revision" >&2
-  rm -f "$output"
-  exit 1
+else
+  if ! target_metadata_matches; then
+    printf 'Built kwt does not match %s/%s at revision %s.\n' \
+      "$goos" "$goarch" "$revision" >&2
+    rm -f "$output" "$stamp"
+    exit 1
+  fi
+
+  native_probe_root="$(mktemp -d "${output}.native.XXXXXX")"
+  native_probe="${native_probe_root}/kwt"
+  cleanup_native_probe() {
+    find "$native_probe_root" -depth -delete
+  }
+  trap cleanup_native_probe EXIT
+  build_helper "$native_probe"
+  chmod 0755 "$native_probe"
+  if ! validate_native_identity "$native_probe" "$output"; then
+    rm -f "$output" "$stamp"
+    exit 1
+  fi
+  cleanup_native_probe
+  trap - EXIT
 fi
 
 printf '%s' "$stamp_value" >"$stamp"

--- a/tools/build_pinned_kwt.sh
+++ b/tools/build_pinned_kwt.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+project_root="$(dirname "$script_dir")"
+
 locked=false
 if [[ $# -eq 5 && "$5" == "--locked" ]]; then
   locked=true
@@ -29,7 +32,7 @@ if [[ $# -eq 6 ]]; then
   goarch="$6"
 fi
 stamp="${output}.revision"
-build_identity_schema=3
+build_identity_schema=4
 stamp_value="${revision} identity=${build_identity_schema}"
 if [[ "$targeted" == true ]]; then
   stamp_value="${revision} ${goos}/${goarch} identity=${build_identity_schema}"
@@ -129,6 +132,12 @@ command -v go >/dev/null || {
   printf 'Go is required to build the pinned kwt helper.\n' >&2
   exit 1
 }
+if [[ "$targeted" == true ]]; then
+  command -v uv >/dev/null || {
+    printf 'uv is required to validate cross-compiled kwt helpers.\n' >&2
+    exit 1
+  }
+fi
 
 if [[ -e "$source_dir" && ! -d "$source_dir/.git" ]]; then
   printf '%s exists but is not a Git checkout; refusing to replace it.\n' \
@@ -177,10 +186,9 @@ kwt_revision_time="$(
     --format='%cd' \
     "$revision"
 )"
-kwt_build_ldflags="-s -w"
-kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.version=${revision}"
-kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.commit=${revision}"
-kwt_build_ldflags+=" -X go.kenn.io/kwt/internal/cmd.revisionTime=${kwt_revision_time}"
+kwt_identity_ldflags="-X go.kenn.io/kwt/internal/cmd.version=${revision}"
+kwt_identity_ldflags+=" -X go.kenn.io/kwt/internal/cmd.commit=${revision}"
+kwt_identity_ldflags+=" -X go.kenn.io/kwt/internal/cmd.revisionTime=${kwt_revision_time}"
 build_helper() (
   helper_output="$1"
   helper_goos="${2:-}"
@@ -189,13 +197,13 @@ build_helper() (
   if [[ -n "$helper_goos" && -n "$helper_goarch" ]]; then
     CGO_ENABLED=0 GOOS="$helper_goos" GOARCH="$helper_goarch" go build \
       -trimpath \
-      -ldflags "$kwt_build_ldflags" \
+      -ldflags "-w ${kwt_identity_ldflags}" \
       -o "$helper_output" \
       cmd/kwt/main.go
   else
     CGO_ENABLED=0 go build \
       -trimpath \
-      -ldflags "$kwt_build_ldflags" \
+      -ldflags "-s -w ${kwt_identity_ldflags}" \
       -o "$helper_output" \
       cmd/kwt/main.go
   fi
@@ -207,11 +215,10 @@ else
   build_helper "$output"
 fi
 
-# The linker silently ignores -X for a symbol it cannot find. Exercise the
-# native helper's isolated daemon interface before asserting that the cache
-# contains the full replacement identity. Cross-compiled variants first build
-# a native probe from the same source and linker flags, then retain their
-# format-specific validation.
+# The linker silently ignores -X for a symbol it cannot find. Exercise native
+# helpers through their isolated daemon interface. Cross-compiled helpers keep
+# their Go symbol table (but not DWARF) so all three exact identity values can
+# be inspected in the artifact that will run on the remote host.
 if [[ "$targeted" == false ]]; then
   chmod 0755 "$output"
   if ! validate_native_identity "$output"; then
@@ -226,20 +233,16 @@ else
     exit 1
   fi
 
-  native_probe_root="$(mktemp -d "${output}.native.XXXXXX")"
-  native_probe="${native_probe_root}/kwt"
-  cleanup_native_probe() {
-    find "$native_probe_root" -depth -delete
-  }
-  trap cleanup_native_probe EXIT
-  build_helper "$native_probe"
-  chmod 0755 "$native_probe"
-  if ! validate_native_identity "$native_probe" "$output"; then
+  if ! uv --directory "$project_root" run --frozen python \
+    "$script_dir/validate_kwt_identity.py" \
+    --binary "$output" \
+    --version "$revision" \
+    --revision "$revision" \
+    --revision-time "$kwt_revision_time"; then
+    printf 'Built kwt does not contain the complete pinned identity.\n' >&2
     rm -f "$output" "$stamp"
     exit 1
   fi
-  cleanup_native_probe
-  trap - EXIT
 fi
 
 printf '%s' "$stamp_value" >"$stamp"

--- a/tools/validate_kwt_identity.py
+++ b/tools/validate_kwt_identity.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+
+IDENTITY_SYMBOLS = {
+    "version": "go.kenn.io/kwt/internal/cmd.version",
+    "revision": "go.kenn.io/kwt/internal/cmd.commit",
+    "revision_time": "go.kenn.io/kwt/internal/cmd.revisionTime",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate identity globals in a cross-compiled kwt helper."
+    )
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--revision-time", required=True)
+    return parser.parse_args()
+
+
+def symbol_addresses(path: Path) -> dict[str, int]:
+    result = subprocess.run(
+        ["go", "tool", "nm", "-size", "-type", path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "symbol table is unavailable"
+        raise ValueError(f"could not inspect {path}: {detail}")
+
+    wanted = set(IDENTITY_SYMBOLS.values())
+    addresses: dict[str, int] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) >= 4 and fields[-1] in wanted:
+            addresses[fields[-1]] = int(fields[0], 16)
+    return addresses
+
+
+def file_offset(contents: bytes, address: int) -> int:
+    if contents.startswith(b"\x7fELF"):
+        return elf_file_offset(contents, address)
+    if contents.startswith(b"\xcf\xfa\xed\xfe"):
+        return macho_file_offset(contents, address)
+    if contents.startswith(b"MZ"):
+        return pe_file_offset(contents, address)
+    raise ValueError("helper is not a supported 64-bit executable")
+
+
+def elf_file_offset(contents: bytes, address: int) -> int:
+    if len(contents) < 64 or contents[4:6] != b"\x02\x01":
+        raise ValueError("helper is not a 64-bit little-endian ELF executable")
+    program_offset = struct.unpack_from("<Q", contents, 32)[0]
+    program_size = struct.unpack_from("<H", contents, 54)[0]
+    program_count = struct.unpack_from("<H", contents, 56)[0]
+    for index in range(program_count):
+        offset = program_offset + index * program_size
+        if offset + 56 > len(contents):
+            break
+        segment_type = struct.unpack_from("<I", contents, offset)[0]
+        segment_file_offset = struct.unpack_from("<Q", contents, offset + 8)[0]
+        virtual_address = struct.unpack_from("<Q", contents, offset + 16)[0]
+        file_size = struct.unpack_from("<Q", contents, offset + 32)[0]
+        if (
+            segment_type == 1
+            and virtual_address <= address < virtual_address + file_size
+        ):
+            return segment_file_offset + address - virtual_address
+    raise ValueError(f"address 0x{address:x} is not backed by the ELF file")
+
+
+def macho_file_offset(contents: bytes, address: int) -> int:
+    if len(contents) < 32:
+        raise ValueError("helper has a truncated Mach-O header")
+    command_count = struct.unpack_from("<I", contents, 16)[0]
+    offset = 32
+    for _ in range(command_count):
+        if offset + 8 > len(contents):
+            break
+        command, command_size = struct.unpack_from("<II", contents, offset)
+        if command_size < 8 or offset + command_size > len(contents):
+            break
+        if command == 0x19 and command_size >= 72:
+            virtual_address = struct.unpack_from("<Q", contents, offset + 24)[0]
+            file_size = struct.unpack_from("<Q", contents, offset + 48)[0]
+            segment_file_offset = struct.unpack_from(
+                "<Q", contents, offset + 40
+            )[0]
+            if virtual_address <= address < virtual_address + file_size:
+                return segment_file_offset + address - virtual_address
+        offset += command_size
+    raise ValueError(f"address 0x{address:x} is not backed by the Mach-O file")
+
+
+def pe_file_offset(contents: bytes, address: int) -> int:
+    if len(contents) < 64:
+        raise ValueError("helper has a truncated PE header")
+    pe_offset = struct.unpack_from("<I", contents, 0x3C)[0]
+    if (
+        pe_offset + 24 > len(contents)
+        or contents[pe_offset : pe_offset + 4] != b"PE\0\0"
+    ):
+        raise ValueError("helper has an invalid PE header")
+    section_count = struct.unpack_from("<H", contents, pe_offset + 6)[0]
+    optional_size = struct.unpack_from("<H", contents, pe_offset + 20)[0]
+    optional_offset = pe_offset + 24
+    if (
+        optional_offset + optional_size > len(contents)
+        or optional_size < 32
+        or struct.unpack_from("<H", contents, optional_offset)[0] != 0x20B
+    ):
+        raise ValueError("helper is not a 64-bit PE executable")
+    image_base = struct.unpack_from("<Q", contents, optional_offset + 24)[0]
+    relative_address = address - image_base if address >= image_base else address
+    section_offset = optional_offset + optional_size
+    for index in range(section_count):
+        offset = section_offset + index * 40
+        if offset + 40 > len(contents):
+            break
+        virtual_address = struct.unpack_from("<I", contents, offset + 12)[0]
+        raw_size = struct.unpack_from("<I", contents, offset + 16)[0]
+        raw_offset = struct.unpack_from("<I", contents, offset + 20)[0]
+        if virtual_address <= relative_address < virtual_address + raw_size:
+            return raw_offset + relative_address - virtual_address
+    raise ValueError(f"address 0x{address:x} is not backed by the PE file")
+
+
+def go_string(contents: bytes, address: int) -> str:
+    header_offset = file_offset(contents, address)
+    if header_offset + 16 > len(contents):
+        raise ValueError(f"Go string header at 0x{address:x} is truncated")
+    data_address, length = struct.unpack_from("<QQ", contents, header_offset)
+    if length > 4096:
+        raise ValueError(f"Go string at 0x{address:x} has invalid length {length}")
+    data_offset = file_offset(contents, data_address)
+    if data_offset + length > len(contents):
+        raise ValueError(f"Go string data at 0x{data_address:x} is truncated")
+    try:
+        return contents[data_offset : data_offset + length].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"Go string at 0x{address:x} is not UTF-8") from error
+
+
+def validate_identity(path: Path, expected: dict[str, str]) -> None:
+    try:
+        contents = path.read_bytes()
+    except FileNotFoundError as error:
+        raise ValueError(f"kwt helper is missing: {path}") from error
+    addresses = symbol_addresses(path)
+    for field, symbol in IDENTITY_SYMBOLS.items():
+        if symbol not in addresses:
+            raise ValueError(f"{path} does not contain identity symbol {symbol}")
+        actual = go_string(contents, addresses[symbol])
+        if actual != expected[field]:
+            raise ValueError(
+                f"{path} has {field} {actual!r}; expected {expected[field]!r}"
+            )
+
+
+def main() -> int:
+    arguments = parse_args()
+    try:
+        validate_identity(
+            arguments.binary,
+            {
+                "version": arguments.version,
+                "revision": arguments.revision,
+                "revision_time": arguments.revision_time,
+            },
+        )
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Ghosthub could connect to a remote host yet reject its project inventory when an older PATH-installed KWT daemon remained active. Managed helpers advertised only a display version, so KWT could not determine that Ghosthub's revision-pinned helper was newer; the older daemon could then omit the registration fingerprint Ghosthub requires.

- Stamp the version, source commit, and UTC revision time into native and managed remote helpers so KWT replaces stale daemons.
- Exercise native identity through an isolated daemon, and inspect all three exact values in each actual cross-compiled Mach-O, ELF, or PE helper before trusting its cache stamp.
- Build the signed release helper through that same validated native path instead of a separate release-only Go command.
- Invalidate helpers cached with the incomplete identity and rebuild every supported target variant.
- Keep registration fingerprint validation strict; this adds no app-side compatibility path.

An isolated old-daemon reproduction now replaces the daemon and returns fingerprinted inventory. A fresh six-target build passed exact artifact inspection, along with the KWT-essential workflows, Python and bootstrap suites, release bundle tests, workflow lint, and app build.
