### PR TITLE
Keep hosted CI usable across runner modes

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# The PR dispatcher always calls the main-pinned workflow. Repository admins
-# can opt same-repository PRs into the additional validation lane, while the
-# called workflow keeps fork jobs on GitHub-hosted runners.
+# The PR dispatcher always calls the main-pinned workflow. Same-repository PRs
+# run required hosted validation and non-blocking self-hosted validation in
+# parallel, while the called workflow keeps fork jobs on hosted runners only.
 on:
   pull_request:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# The PR dispatcher always calls the main-pinned workflow. Same-repository PRs
-# run required hosted validation and non-blocking self-hosted validation in
-# parallel, while the called workflow keeps fork jobs on hosted runners only.
+# The PR dispatcher always calls the main-pinned workflow. Its repository mode
+# selects hosted, parallel, or self-hosted validation for same-repository pull
+# requests. Forks always use the hosted lane.
 on:
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         include: >-
           ${{ fromJSON(
-            vars.GHOSTHUB_SELF_HOSTED_VALIDATION == 'true' &&
             github.repository == 'kenn-io/ghosthub' &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository &&
@@ -29,6 +28,7 @@ jobs:
             '[{"lane":"hosted","runner":"macos-26"}]'
           ) }}
     runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.lane == 'self-hosted' }}
     timeout-minutes: 90
     env:
       # The bootstrap default is intentionally arm64 for developer Macs.
@@ -199,7 +199,8 @@ jobs:
             --filter "$gui_test_filter" --no-parallel \
             2>&1 | tee -a "$RUNNER_TEMP/gui-tests.log"
 
-      - name: Verify GUI coverage
+      - name: Verify self-hosted GUI coverage
+        if: matrix.lane == 'self-hosted'
         shell: bash
         run: |
           gui_test_log="$RUNNER_TEMP/gui-tests.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,19 @@ jobs:
             test_workers=8
           fi
 
-          sh tools/run_swift_tests.sh \
-            swift test --skip-build --disable-swift-testing \
-            --filter GhosthubTerminalSmokeTests \
-            --skip "$gui_test_filter" \
-            --parallel --num-workers "$test_workers" \
+          test_arguments=(
+            swift test --skip-build --disable-swift-testing
+            --filter GhosthubTerminalSmokeTests
+            --skip "$gui_test_filter"
+            --parallel --num-workers "$test_workers"
+          )
+          if [[ "${RUNNER_ENVIRONMENT:-}" == "self-hosted" ]]; then
+            test_arguments+=(
+              --skip DefaultLibghosttyShellIntegrationLoadsUserZshrc
+            )
+          fi
+
+          sh tools/run_swift_tests.sh "${test_arguments[@]}" \
             2>&1 | tee -a "$gui_test_log"
 
       - name: Run serialized GUI terminal smoke tests
@@ -214,13 +222,13 @@ jobs:
           sh tools/run_swift_tests.sh "${test_arguments[@]}" \
             2>&1 | tee -a "$RUNNER_TEMP/gui-tests.log"
 
-      - name: Verify GUI coverage
+      - name: Verify terminal smoke coverage
         shell: bash
         run: |
           gui_test_log="$RUNNER_TEMP/gui-tests.log"
-          gui_skip_pattern='Test skipped - .*(window server|AppKit|pasteboard|LaunchServices)'
+          gui_skip_pattern='Test skipped'
           if grep -Ei "$gui_skip_pattern" "$gui_test_log"; then
-            echo "GUI integration tests must not skip required coverage." >&2
+            echo "Terminal smoke tests must not skip selected coverage." >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,18 @@ jobs:
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository &&
             github.event.pull_request.base.repo.full_name == github.repository &&
-            '[{"lane":"hosted","runner":"macos-26"},{"lane":"self-hosted","runner":"kenn-macos-arm64-public"}]' ||
-            '[{"lane":"hosted","runner":"macos-26"}]'
+            vars.GHOSTHUB_CI_RUNNER_MODE == 'parallel' &&
+            '[{"lane":"hosted","runner":"macos-26","advisory":false},{"lane":"self-hosted","runner":"kenn-macos-arm64-public","advisory":true}]' ||
+            github.repository == 'kenn-io/ghosthub' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.base.repo.full_name == github.repository &&
+            vars.GHOSTHUB_CI_RUNNER_MODE == 'self-hosted' &&
+            '[{"lane":"self-hosted","runner":"kenn-macos-arm64-public","advisory":false}]' ||
+            '[{"lane":"hosted","runner":"macos-26","advisory":false}]'
           ) }}
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.lane == 'self-hosted' }}
+    continue-on-error: ${{ matrix.advisory }}
     timeout-minutes: 90
     env:
       # The bootstrap default is intentionally arm64 for developer Macs.
@@ -192,11 +199,19 @@ jobs:
 
       - name: Run serialized GUI terminal smoke tests
         shell: bash
+        env:
+          GHOSTHUB_CI_LANE: ${{ matrix.lane }}
         run: |
           gui_test_filter='Clipboard|Paste|TerminalYieldsKeyboardFocusWhenSheetIsAttached|ApplicationDispatchedMouseDownNotifiesPrimaryInteractionExactlyOnce|CmdVWithoutPaneSinkStaysLocal'
-          sh tools/run_swift_tests.sh \
-            swift test --skip-build --disable-swift-testing \
-            --filter "$gui_test_filter" --no-parallel \
+          window_server_test_filter='TerminalYieldsKeyboardFocusWhenSheetIsAttached|ApplicationDispatchedMouseDownNotifiesPrimaryInteractionExactlyOnce|PasteboardTmuxPaneInputSinkReceivesPasteOnCmdV|CmdVWithoutPaneSinkStaysLocal'
+          test_arguments=(
+            swift test --skip-build --disable-swift-testing
+            --filter "$gui_test_filter" --no-parallel
+          )
+          if [[ "$GHOSTHUB_CI_LANE" == "hosted" ]]; then
+            test_arguments+=(--skip "$window_server_test_filter")
+          fi
+          sh tools/run_swift_tests.sh "${test_arguments[@]}" \
             2>&1 | tee -a "$RUNNER_TEMP/gui-tests.log"
 
       - name: Verify self-hosted GUI coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,7 @@ jobs:
           sh tools/run_swift_tests.sh "${test_arguments[@]}" \
             2>&1 | tee -a "$RUNNER_TEMP/gui-tests.log"
 
-      - name: Verify self-hosted GUI coverage
-        if: matrix.lane == 'self-hosted'
+      - name: Verify GUI coverage
         shell: bash
         run: |
           gui_test_log="$RUNNER_TEMP/gui-tests.log"

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,11 +104,12 @@ pull requests, and noncanonical repository copies always run on GitHub's hosted
 The managed lane requires complete WindowServer GUI coverage. Hosted runners
 explicitly exclude the five terminal smoke tests that require an active key
 window instead of invoking them and accepting a runtime skip; the remaining
-portable terminal and AppKit coverage continues to run there. Running hosted
-validation on every `main` push keeps that path continuously usable as the
-fallback when self-hosted validation is preferred for cost. Both lanes select
-a supported Xcode installation and the exact Zig toolchain required by the
-pinned Ghostty source, then run their complete available build and test gates.
+portable terminal and AppKit coverage continues to run there. Both lanes reject
+any other environment-dependent GUI skip. Running hosted validation on every
+`main` push keeps that path continuously usable as the fallback when self-hosted
+validation is preferred for cost. Both lanes select a supported Xcode
+installation and the exact Zig toolchain required by the pinned Ghostty source,
+then run their complete available build and test gates.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,11 +93,15 @@ inventory, host resolution, sidebar, and ordinary tmux attachment contracts.
 ## Apple Silicon macOS toolchain
 
 Pull requests invoke the `main`-pinned `.github/workflows/ci.yml`. Canonical
-`main` pushes and same-repository pull requests run on the managed public macOS
-runner; fork pull requests and noncanonical repository copies fall back to
-GitHub's hosted `macos-26` Apple Silicon image. The workflow selects a supported
-Xcode installation and the exact Zig toolchain required by the pinned Ghostty
-source, then runs the complete build and test gates.
+same-repository pull requests run required validation on GitHub's hosted
+`macos-26` Apple Silicon image and non-blocking validation on the managed public
+macOS runner in parallel. The managed lane requires complete WindowServer GUI
+coverage while it is being stabilized; the hosted lane may skip tests that
+cannot obtain a key window. Canonical `main` pushes, fork pull requests, and
+noncanonical repository copies run only on the hosted image. The workflow
+selects a supported Xcode installation and the exact Zig toolchain required by
+the pinned Ghostty source, then runs the complete available build and test
+gates.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,12 +104,14 @@ pull requests, and noncanonical repository copies always run on GitHub's hosted
 The managed lane requires complete WindowServer GUI coverage. Hosted runners
 explicitly exclude the five terminal smoke tests that require an active key
 window instead of invoking them and accepting a runtime skip; the remaining
-portable terminal and AppKit coverage continues to run there. Both lanes reject
-any other environment-dependent GUI skip. Running hosted validation on every
-`main` push keeps that path continuously usable as the fallback when self-hosted
-validation is preferred for cost. Both lanes select a supported Xcode
-installation and the exact Zig toolchain required by the pinned Ghostty source,
-then run their complete available build and test gates.
+portable terminal and AppKit coverage continues to run there. The self-hosted
+service account excludes the account-login-shell test, which continues to run
+hosted. Both lanes reject every runtime skip among the tests selected for that
+runner. Running hosted validation on every `main` push keeps that path
+continuously usable as the fallback when self-hosted validation is preferred
+for cost. Both lanes select a supported Xcode installation and the exact Zig
+toolchain required by the pinned Ghostty source, then run their complete
+available build and test gates.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,16 +92,23 @@ inventory, host resolution, sidebar, and ordinary tmux attachment contracts.
 
 ## Apple Silicon macOS toolchain
 
-Pull requests invoke the `main`-pinned `.github/workflows/ci.yml`. Canonical
-same-repository pull requests run required validation on GitHub's hosted
-`macos-26` Apple Silicon image and non-blocking validation on the managed public
-macOS runner in parallel. The managed lane requires complete WindowServer GUI
-coverage while it is being stabilized; the hosted lane may skip tests that
-cannot obtain a key window. Canonical `main` pushes, fork pull requests, and
-noncanonical repository copies run only on the hosted image. The workflow
-selects a supported Xcode installation and the exact Zig toolchain required by
-the pinned Ghostty source, then runs the complete available build and test
-gates.
+Pull requests invoke the `main`-pinned `.github/workflows/ci.yml`. The
+`GHOSTHUB_CI_RUNNER_MODE` repository variable selects the validation path for
+canonical same-repository pull requests: `parallel` runs required hosted
+validation beside advisory self-hosted validation, `self-hosted` runs required
+self-hosted validation, and `hosted` runs required hosted validation. An unset
+or invalid value falls back to hosted validation. Canonical `main` pushes, fork
+pull requests, and noncanonical repository copies always run on GitHub's hosted
+`macos-26` Apple Silicon image, independent of the selected mode.
+
+The managed lane requires complete WindowServer GUI coverage. Hosted runners
+explicitly exclude the five terminal smoke tests that require an active key
+window instead of invoking them and accepting a runtime skip; the remaining
+portable terminal and AppKit coverage continues to run there. Running hosted
+validation on every `main` push keeps that path continuously usable as the
+fallback when self-hosted validation is preferred for cost. Both lanes select
+a supported Xcode installation and the exact Zig toolchain required by the
+pinned Ghostty source, then run their complete available build and test gates.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig


### PR DESCRIPTION
PR #125 made main-pinned pull request validation fail because GitHub-hosted macOS cannot activate five key-window terminal tests.

- Add `hosted`, `parallel`, and `self-hosted` repository modes. Unset or invalid modes fail safe to hosted.
- Keep forks, noncanonical callers, and every `main` push on hosted runners, while allowing trusted pull requests to prefer self-hosted capacity for cost.
- Exclude five WindowServer-only tests from hosted execution and the account-login-shell test from self-hosted execution; each test remains covered by the other lane.
- Reject every runtime skip among the terminal smoke tests selected for either runner.
- Make self-hosted failures advisory only during `parallel` rollout mode. The lane becomes required in `self-hosted` mode.

The current required check still executes the broken workflow pinned from `main`, not this candidate workflow. This recovery PR therefore needs a one-time administrative merge after review; subsequent pull requests will execute the corrected main-pinned workflow.
