### PR TITLE
Prevent quit confirmation from blocking Ghosthub

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -149,6 +149,7 @@ struct GhosthubApp: App {
                         settingsStore.confirmBeforeQuitting
                     )
                 }
+                appDelegate.bindQuitRequests(from: terminalRuntime)
                 updateController.configureRelaunch(
                     prepareRelaunch: {
                         let states = WindowRegistry.shared

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -1,29 +1,7 @@
 #if canImport(AppKit)
 import AppKit
+import GhosthubTerminal
 import GhosthubWorkspace
-
-@MainActor
-private func presentApplicationAlert(
-    _ alert: NSAlert
-) -> NSApplication.ModalResponse {
-    guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
-        return alert.runModal()
-    }
-
-    var response: NSApplication.ModalResponse?
-    alert.beginSheetModal(for: window) { modalResponse in
-        response = modalResponse
-    }
-
-    while response == nil {
-        _ = RunLoop.current.run(
-            mode: .default,
-            before: Date(timeIntervalSinceNow: 0.01)
-        )
-    }
-
-    return response ?? .abort
-}
 
 @MainActor
 private func presentApplicationAlertAsync(
@@ -31,7 +9,9 @@ private func presentApplicationAlertAsync(
     completion: @escaping (NSApplication.ModalResponse) -> Void
 ) {
     guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
-        completion(alert.runModal())
+        DispatchQueue.main.async {
+            completion(alert.runModal())
+        }
         return
     }
 
@@ -102,8 +82,6 @@ final class ApplicationDelegate: NSObject,
     NSApplicationDelegate {
     let sshAuthenticationCoordinator = SSHAuthenticationCoordinator()
 
-    var confirmTermination: () -> Bool
-
     var requestTerminationConfirmation: (
         (@escaping (Bool) -> Void) -> Void
     )?
@@ -114,6 +92,12 @@ final class ApplicationDelegate: NSObject,
         NSApplication.shared.terminate(nil)
     }
 
+    var replyToApplicationShouldTerminate: (Bool) -> Void = { confirmed in
+        NSApplication.shared.reply(
+            toApplicationShouldTerminate: confirmed
+        )
+    }
+
     var openWorkspaceWindow: (WorkspaceWindowState) -> Void = { _ in }
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
@@ -121,10 +105,11 @@ final class ApplicationDelegate: NSObject,
     private var restoredWorkspaceWindowCount: Int?
     private(set) var terminationConfirmed = false
     private(set) var terminationConfirmationPending = false
+    private var pendingTerminationDecisions: [(Bool) -> Void] = []
+    private var applicationTerminationRequestPending = false
     private var updaterTerminationAuthorized = false
 
     override init() {
-        confirmTermination = { false }
         super.init()
         NotificationCenter.default.addObserver(
             self,
@@ -132,11 +117,6 @@ final class ApplicationDelegate: NSObject,
             name: NSApplication.didFinishRestoringWindowsNotification,
             object: nil
         )
-        confirmTermination = { [weak self] in
-            guard let self else { return false }
-            return presentApplicationAlert(makeTerminationAlert())
-                == .alertFirstButtonReturn
-        }
     }
 
     deinit {
@@ -256,33 +236,35 @@ final class ApplicationDelegate: NSObject,
         return state
     }
 
-    @discardableResult
-    func prepareUserInitiatedTermination(
-        forceConfirmation: Bool = false
-    ) -> Bool {
-        if terminationConfirmed {
-            return true
-        }
-        guard forceConfirmation || needsConfirmQuit() else {
-            terminationConfirmed = true
-            return true
-        }
-        guard confirmTermination() else {
-            return false
-        }
-        terminationConfirmed = true
-        return true
-    }
-
     func requestUserInitiatedTermination(
         forceConfirmation: Bool = false,
         onConfirm: @escaping () -> Void
+    ) {
+        requestTerminationDecision(
+            forceConfirmation: forceConfirmation
+        ) { confirmed in
+            guard confirmed else { return }
+            onConfirm()
+        }
+    }
+
+    private func requestTerminationDecision(
+        forceConfirmation: Bool = false,
+        onDecision: @escaping (Bool) -> Void
     ) {
         if terminationConfirmed {
             AppLogger.shared.info(
                 "quit: already confirmed, terminating"
             )
-            onConfirm()
+            onDecision(true)
+            return
+        }
+
+        if terminationConfirmationPending {
+            AppLogger.shared.info(
+                "quit: joining pending confirmation"
+            )
+            pendingTerminationDecisions.append(onDecision)
             return
         }
 
@@ -297,40 +279,53 @@ final class ApplicationDelegate: NSObject,
 
         guard forceConfirmation || needs else {
             terminationConfirmed = true
-            onConfirm()
-            return
-        }
-        guard !terminationConfirmationPending else {
-            AppLogger.shared.info(
-                "quit: confirmation already pending"
-            )
+            onDecision(true)
             return
         }
         terminationConfirmationPending = true
+        pendingTerminationDecisions = [onDecision]
+
+        let finish: (Bool) -> Void = { [weak self] confirmed in
+            guard let self else { return }
+            terminationConfirmationPending = false
+            let decisions = pendingTerminationDecisions
+            pendingTerminationDecisions.removeAll()
+            if confirmed {
+                terminationConfirmed = true
+            }
+            decisions.forEach { $0(confirmed) }
+        }
 
         if let requestTerminationConfirmation {
-            requestTerminationConfirmation { [weak self] confirmed in
-                guard let self else { return }
-                terminationConfirmationPending = false
-                guard confirmed else { return }
-                terminationConfirmed = true
-                onConfirm()
-            }
+            requestTerminationConfirmation(finish)
             return
         }
 
-        presentApplicationAlertAsync(makeTerminationAlert()) { [weak self] response in
-            guard let self else { return }
-            terminationConfirmationPending = false
-            guard response == .alertFirstButtonReturn else { return }
-            terminationConfirmed = true
-            onConfirm()
+        presentApplicationAlertAsync(makeTerminationAlert()) { response in
+            finish(response == .alertFirstButtonReturn)
         }
     }
 
     func requestApplicationTermination() {
-        requestUserInitiatedTermination { [weak self] in
-            self?.terminateApplication()
+        guard !applicationTerminationRequestPending else {
+            AppLogger.shared.info(
+                "quit: application termination already requested"
+            )
+            return
+        }
+        applicationTerminationRequestPending = true
+        requestTerminationDecision { [weak self] confirmed in
+            guard let self else { return }
+            applicationTerminationRequestPending = false
+            if confirmed {
+                terminateApplication()
+            }
+        }
+    }
+
+    func bindQuitRequests(from source: ApplicationQuitRequestSource) {
+        source.quitRequestHandler = { [weak self] in
+            self?.requestApplicationTermination()
         }
     }
 
@@ -357,11 +352,17 @@ final class ApplicationDelegate: NSObject,
         if terminationConfirmed {
             return .terminateNow
         }
+        guard needsConfirmQuit() else {
+            terminationConfirmed = true
+            return .terminateNow
+        }
         // Shutdown, restart, logout, and ordinary quit requests intentionally
         // use the same confirmation gate. Only Sparkle receives the narrow
         // one-shot authorization above after the user accepts its relaunch.
-        return prepareUserInitiatedTermination()
-            ? .terminateNow : .terminateCancel
+        requestTerminationDecision { [weak self] confirmed in
+            self?.replyToApplicationShouldTerminate(confirmed)
+        }
+        return .terminateLater
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -87,7 +87,13 @@ private final class ResolvedColorGenerationTracker: @unchecked Sendable {
 }
 
 @MainActor
-public final class LibghosttyRuntime: ObservableObject {
+public protocol ApplicationQuitRequestSource: AnyObject {
+    var quitRequestHandler: (() -> Void)? { get set }
+}
+
+@MainActor
+public final class LibghosttyRuntime: ObservableObject,
+    ApplicationQuitRequestSource {
     private struct ResolvedColorEntry {
         let colors: TerminalResolvedColors
         let generation: ResolvedColorCallbackGeneration
@@ -129,6 +135,7 @@ public final class LibghosttyRuntime: ObservableObject {
 
     public let runtimeState: LibghosttyRuntimeState
     public let renderTracker = SurfaceRenderTracker()
+    public var quitRequestHandler: (() -> Void)?
 
     private let configReloadNoticeSubject =
         PassthroughSubject<LibghosttyConfigReloadNotice?, Never>()
@@ -177,6 +184,11 @@ public final class LibghosttyRuntime: ObservableObject {
         forSurfaceIdentity identity: UInt
     ) -> TerminalResolvedColors? {
         resolvedTerminalColorsBySurface[identity]
+    }
+
+    func requestQuit() {
+        runtimeState.recordAction(.quit)
+        quitRequestHandler?()
     }
 
     var unsafeAppHandle: ghostty_app_t? {
@@ -741,8 +753,7 @@ public final class LibghosttyRuntime: ObservableObject {
         case GHOSTTY_ACTION_QUIT:
             DispatchQueue.main.async {
                 let state = runtime(from: userdataValue)
-                state.runtimeState.recordAction(.quit)
-                NSApplication.shared.terminate(nil)
+                state.requestQuit()
             }
             return true
 

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -5,6 +5,7 @@ import GhosthubWorkspace
 import XCTest
 import UserNotifications
 @testable import GhosthubApp
+@testable import GhosthubTerminal
 
 // MARK: - Test Fixtures
 
@@ -103,7 +104,6 @@ extension ApplicationDelegate {
     ) -> ApplicationDelegate {
         let delegate = ApplicationDelegate()
         delegate.needsConfirmQuit = { needsConfirmQuit }
-        delegate.confirmTermination = { confirmTerminationResult }
         delegate.requestTerminationConfirmation = { completion in
             completion(confirmTerminationResult)
         }
@@ -115,6 +115,14 @@ extension ApplicationDelegate {
 
 @MainActor
 final class ApplicationDelegateTests: XCTestCase {
+    private final class QuitRequestSource: ApplicationQuitRequestSource {
+        var quitRequestHandler: (() -> Void)?
+
+        func requestQuit() {
+            quitRequestHandler?()
+        }
+    }
+
     private class CloseSpyWindow: NSWindow {
         private(set) var closeCallCount = 0
 
@@ -341,22 +349,54 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertTrue(soundPlayer.playedSounds.isEmpty)
     }
 
-    func testApplicationShouldTerminateHonorsConfirmation() {
-        let confirmDelegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: true
-        )
-        XCTAssertEqual(
-            confirmDelegate.applicationShouldTerminate(NSApplication.shared),
-            .terminateNow
-        )
+    func testApplicationShouldTerminateRepliesAfterAsyncConfirmation() {
+        let delegate = ApplicationDelegate()
+        var confirmation: ((Bool) -> Void)?
+        var replies: [Bool] = []
+        delegate.requestTerminationConfirmation = { callback in
+            confirmation = callback
+        }
+        delegate.replyToApplicationShouldTerminate = { confirmed in
+            replies.append(confirmed)
+        }
 
-        let cancelDelegate = ApplicationDelegate.forTesting(
-            confirmTerminationResult: false
-        )
         XCTAssertEqual(
-            cancelDelegate.applicationShouldTerminate(NSApplication.shared),
-            .terminateCancel
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateLater
         )
+        XCTAssertTrue(delegate.terminationConfirmationPending)
+        XCTAssertTrue(replies.isEmpty)
+
+        confirmation?(true)
+
+        XCTAssertEqual(replies, [true])
+        XCTAssertTrue(delegate.terminationConfirmed)
+        XCTAssertFalse(delegate.terminationConfirmationPending)
+    }
+
+    func testApplicationShouldTerminateRepliesAfterAsyncCancellation() {
+        let delegate = ApplicationDelegate()
+        var confirmation: ((Bool) -> Void)?
+        var replies: [Bool] = []
+        delegate.requestTerminationConfirmation = { callback in
+            confirmation = callback
+        }
+        delegate.replyToApplicationShouldTerminate = { confirmed in
+            replies.append(confirmed)
+        }
+
+        XCTAssertEqual(
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateLater
+        )
+        XCTAssertTrue(delegate.terminationConfirmationPending)
+        XCTAssertTrue(replies.isEmpty)
+
+        confirmation?(false)
+
+        XCTAssertEqual(replies, [false])
+        XCTAssertFalse(delegate.terminationConfirmed)
+        XCTAssertFalse(delegate.terminationConfirmationPending)
     }
 
     func testUpdaterAuthorizationBypassesExactlyOneTerminationGate() {
@@ -372,7 +412,7 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertFalse(delegate.terminationConfirmed)
         XCTAssertEqual(
             delegate.applicationShouldTerminate(NSApplication.shared),
-            .terminateCancel
+            .terminateLater
         )
     }
 
@@ -385,7 +425,7 @@ final class ApplicationDelegateTests: XCTestCase {
 
         XCTAssertEqual(
             delegate.applicationShouldTerminate(NSApplication.shared),
-            .terminateCancel
+            .terminateLater
         )
     }
 
@@ -398,50 +438,6 @@ final class ApplicationDelegateTests: XCTestCase {
             delegate.applicationShouldTerminate(NSApplication.shared),
             .terminateNow
         )
-    }
-
-    func testPrepareUserInitiatedTerminationHonorsConfirmation() {
-        let delegate = ApplicationDelegate()
-
-        delegate.confirmTermination = { false }
-        XCTAssertFalse(delegate.prepareUserInitiatedTermination())
-        XCTAssertFalse(delegate.terminationConfirmed)
-
-        delegate.confirmTermination = { true }
-        XCTAssertTrue(delegate.prepareUserInitiatedTermination())
-        XCTAssertTrue(delegate.terminationConfirmed)
-    }
-
-    func testPrepareUserInitiatedTerminationSkipsPromptWhenSafe() {
-        let delegate = ApplicationDelegate()
-        delegate.needsConfirmQuit = { false }
-
-        var confirmCalled = false
-        delegate.confirmTermination = {
-            confirmCalled = true
-            return false
-        }
-
-        XCTAssertTrue(delegate.prepareUserInitiatedTermination())
-        XCTAssertFalse(confirmCalled)
-        XCTAssertTrue(delegate.terminationConfirmed)
-    }
-
-    func testPrepareUserInitiatedTerminationCanForceConfirmationWhenSafe() {
-        let delegate = ApplicationDelegate()
-        delegate.needsConfirmQuit = { false }
-
-        var confirmCallCount = 0
-        delegate.confirmTermination = {
-            confirmCallCount += 1
-            return true
-        }
-
-        XCTAssertTrue(
-            delegate.prepareUserInitiatedTermination(forceConfirmation: true)
-        )
-        XCTAssertEqual(confirmCallCount, 1)
-        XCTAssertTrue(delegate.terminationConfirmed)
     }
 
     func testRequestUserInitiatedTerminationForcesAsyncConfirmationWhenSafe() {
@@ -508,9 +504,63 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertTrue(delegate.terminationConfirmed)
     }
 
+    func testAppKitTerminationJoinsPendingApplicationConfirmation() {
+        let delegate = ApplicationDelegate()
+        var completion: ((Bool) -> Void)?
+        var terminationRequests = 0
+        var replies: [Bool] = []
+        delegate.requestTerminationConfirmation = { callback in
+            completion = callback
+        }
+        delegate.terminateApplication = {
+            terminationRequests += 1
+        }
+        delegate.replyToApplicationShouldTerminate = { confirmed in
+            replies.append(confirmed)
+        }
+
+        delegate.requestApplicationTermination()
+        XCTAssertEqual(
+            delegate.applicationShouldTerminate(NSApplication.shared),
+            .terminateLater
+        )
+
+        completion?(true)
+
+        XCTAssertEqual(terminationRequests, 1)
+        XCTAssertEqual(replies, [true])
+        XCTAssertTrue(delegate.terminationConfirmed)
+        XCTAssertFalse(delegate.terminationConfirmationPending)
+    }
+
+    func testBoundTerminalQuitUsesAsyncApplicationCoordinator() {
+        let source = QuitRequestSource()
+        let delegate = ApplicationDelegate()
+        var confirmation: ((Bool) -> Void)?
+        var confirmationRequests = 0
+        var terminationRequests = 0
+        delegate.requestTerminationConfirmation = { callback in
+            confirmationRequests += 1
+            confirmation = callback
+        }
+        delegate.terminateApplication = {
+            terminationRequests += 1
+        }
+        delegate.bindQuitRequests(from: source)
+
+        source.requestQuit()
+
+        XCTAssertEqual(confirmationRequests, 1)
+        XCTAssertEqual(terminationRequests, 0)
+
+        confirmation?(true)
+
+        XCTAssertEqual(terminationRequests, 1)
+        XCTAssertTrue(delegate.terminationConfirmed)
+    }
+
     func testApplicationDoesNotTerminateAfterLastWindowCloses() {
         let delegate = ApplicationDelegate.forTesting()
-        XCTAssertTrue(delegate.prepareUserInitiatedTermination())
 
         XCTAssertFalse(
             delegate.applicationShouldTerminateAfterLastWindowClosed(

--- a/Tests/Terminal/LibghosttyRuntimeStateTests.swift
+++ b/Tests/Terminal/LibghosttyRuntimeStateTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import Testing
+@testable import GhosthubTerminal
 @testable import GhosthubTerminalSupport
 
 @MainActor
@@ -13,5 +15,32 @@ struct LibghosttySurfaceRuntimeCallbacksTests {
 
         #expect(spy.recordedClipboardLocation == .selection)
         #expect(spy.recordedCloseProcessAlive == true)
+    }
+}
+
+@MainActor
+@Suite("Libghostty application actions", .serialized)
+struct LibghosttyApplicationActionTests {
+    @Test("semantic quit invokes the configured application handler")
+    func semanticQuitInvokesConfiguredApplicationHandler() {
+        let configRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: configRoot) }
+        let runtime = LibghosttyRuntime(
+            pipeline: LibghosttyConfigPipeline(
+                paths: LibghosttyConfigPaths(
+                    configDirectory: configRoot
+                )
+            )
+        )
+        var quitRequests = 0
+        runtime.quitRequestHandler = {
+            quitRequests += 1
+        }
+
+        runtime.requestQuit()
+
+        #expect(runtime.runtimeState.lastAction == .quit)
+        #expect(quitRequests == 1)
     }
 }


### PR DESCRIPTION
Command-Q could block Ghosthub's main thread while the quit confirmation sheet was open, leaving the app beachballed and forcing users to terminate it without a chance to preserve work.

- Return `.terminateLater` for AppKit quit requests and reply only after asynchronous confirmation.
- Route libghostty semantic quit actions through the same application coordinator as the Quit menu.
- Coalesce duplicate requests and deliver one decision to overlapping AppKit, menu, and terminal requests.
- Preserve the existing confirmation preference and Sparkle's one-shot relaunch authorization.

This changes only quit coordination; terminal sessions remain detached rather than killed.
