### PR TITLE
Keep sidebar navigation targets alive

### DIFF
--- a/Sources/UI/KeyboardNavigationModel.swift
+++ b/Sources/UI/KeyboardNavigationModel.swift
@@ -46,46 +46,67 @@ public enum KeyboardNavigationModel {
 
         switch currentTarget {
         case .worktree:
-            for project in sections.flatMap(\.projects) where
-                project.worktreeRows.contains(where: {
-                    $0.target == currentTarget
-                }) {
-                return project.worktreeRows.map(\.target)
+            for section in sections {
+                for project in section.projects {
+                    if let targets = matchingTargets(
+                        in: project.worktreeRows,
+                        currentTarget: currentTarget
+                    ) {
+                        return targets
+                    }
+                }
             }
         case .directoryWorkspace:
-            for section in sections where
-                section.directoryWorkspaceRows.contains(where: {
-                    $0.target == currentTarget
-                }) {
-                return section.directoryWorkspaceRows.map(\.target)
+            for section in sections {
+                if let targets = matchingTargets(
+                    in: section.directoryWorkspaceRows,
+                    currentTarget: currentTarget
+                ) {
+                    return targets
+                }
             }
         case .tmuxSession:
-            for section in sections where
-                section.tmuxSessionRows.contains(where: {
-                    $0.target == currentTarget
-                }) {
-                return section.tmuxSessionRows.map(\.target)
+            for section in sections {
+                if let targets = matchingTargets(
+                    in: section.tmuxSessionRows,
+                    currentTarget: currentTarget
+                ) {
+                    return targets
+                }
             }
         case .herdrSession:
             for section in sections {
                 let running = section.herdrSessionRows.filter {
                     $0.herdrSessionState == .running
                 }
-                if running.contains(where: { $0.target == currentTarget }) {
-                    return running.map(\.target)
+                if let targets = matchingTargets(
+                    in: running,
+                    currentTarget: currentTarget
+                ) {
+                    return targets
                 }
             }
         case .zellijSession:
-            for section in sections where
-                section.zellijSessionRows.contains(where: {
-                    $0.target == currentTarget
-                }) {
-                return section.zellijSessionRows.map(\.target)
+            for section in sections {
+                if let targets = matchingTargets(
+                    in: section.zellijSessionRows,
+                    currentTarget: currentTarget
+                ) {
+                    return targets
+                }
             }
         case .host, .project:
             break
         }
         return []
+    }
+
+    private static func matchingTargets(
+        in rows: [WorkspaceSidebarRow],
+        currentTarget: WorkspaceNavigationTarget
+    ) -> [WorkspaceNavigationTarget]? {
+        let targets = rows.map(\.target)
+        return targets.contains(currentTarget) ? targets : nil
     }
 
     public static func steppedTarget(

--- a/Sources/UI/KeyboardNavigationModel.swift
+++ b/Sources/UI/KeyboardNavigationModel.swift
@@ -101,7 +101,7 @@ public enum KeyboardNavigationModel {
         return []
     }
 
-    private static func matchingTargets(
+    static func matchingTargets(
         in rows: [WorkspaceSidebarRow],
         currentTarget: WorkspaceNavigationTarget
     ) -> [WorkspaceNavigationTarget]? {

--- a/Tests/App/HerdrSessionProbeBrokerTests.swift
+++ b/Tests/App/HerdrSessionProbeBrokerTests.swift
@@ -137,7 +137,7 @@ struct HerdrSessionProbeBrokerTests {
         let broker = drainingBroker(lifetime: lifetime, drain: drain)
 
         let first = Task { await broker.sessions(on: .local) }
-        await waitUntil { lifetime.snapshot.starts == 1 }
+        await waitUntilMainActor { lifetime.snapshot.starts == 1 }
         broker.invalidateSessions(on: .local)
         #expect(await first.value == .failure(.cancelled(host: "localhost")))
 
@@ -161,7 +161,7 @@ struct HerdrSessionProbeBrokerTests {
         let broker = drainingBroker(lifetime: lifetime, drain: drain)
 
         let first = Task { await broker.sessions(on: .local) }
-        await waitUntil { lifetime.snapshot.starts == 1 }
+        await waitUntilMainActor { lifetime.snapshot.starts == 1 }
         first.cancel()
         #expect(await first.value == .failure(.cancelled(host: "localhost")))
 

--- a/Tests/App/TelemetryTests.swift
+++ b/Tests/App/TelemetryTests.swift
@@ -31,6 +31,9 @@ private actor TelemetryTestTransport: TelemetryTransport {
 
     private let rejectsEvents: Bool
     private var capturedEvents: [TelemetryEvent] = []
+    private var eventCountWaiters: [
+        (minimum: Int, continuation: CheckedContinuation<Void, Never>)
+    ] = []
 
     init(rejectsEvents: Bool = false) {
         self.rejectsEvents = rejectsEvents
@@ -38,6 +41,7 @@ private actor TelemetryTestTransport: TelemetryTransport {
 
     func capture(_ event: TelemetryEvent) throws {
         capturedEvents.append(event)
+        resumeEventCountWaiters()
         if rejectsEvents {
             throw TestError.rejected
         }
@@ -46,6 +50,23 @@ private actor TelemetryTestTransport: TelemetryTransport {
     func events() -> [TelemetryEvent] {
         capturedEvents
     }
+
+    func waitUntilEventCount(_ minimum: Int) async {
+        guard capturedEvents.count < minimum else { return }
+        await withCheckedContinuation { continuation in
+            eventCountWaiters.append((minimum, continuation))
+        }
+    }
+
+    private func resumeEventCountWaiters() {
+        let ready = eventCountWaiters.filter {
+            capturedEvents.count >= $0.minimum
+        }
+        eventCountWaiters.removeAll {
+            capturedEvents.count >= $0.minimum
+        }
+        ready.forEach { $0.continuation.resume() }
+    }
 }
 
 private actor TelemetryTestSleeper {
@@ -53,11 +74,15 @@ private actor TelemetryTestSleeper {
     private var continuations: [
         CheckedContinuation<Void, Never>
     ] = []
+    private var pendingCountWaiters: [
+        (minimum: Int, continuation: CheckedContinuation<Void, Never>)
+    ] = []
 
     func sleep(for duration: Duration) async {
         requestedDurations.append(duration)
         await withCheckedContinuation { continuation in
             continuations.append(continuation)
+            resumePendingCountWaiters()
         }
     }
 
@@ -69,8 +94,25 @@ private actor TelemetryTestSleeper {
         requestedDurations
     }
 
+    func waitUntilPendingCount(_ minimum: Int) async {
+        guard continuations.count < minimum else { return }
+        await withCheckedContinuation { continuation in
+            pendingCountWaiters.append((minimum, continuation))
+        }
+    }
+
     func resumeNext() {
         continuations.removeFirst().resume()
+    }
+
+    private func resumePendingCountWaiters() {
+        let ready = pendingCountWaiters.filter {
+            continuations.count >= $0.minimum
+        }
+        pendingCountWaiters.removeAll {
+            continuations.count >= $0.minimum
+        }
+        ready.forEach { $0.continuation.resume() }
     }
 }
 
@@ -300,19 +342,13 @@ struct TelemetryTests {
         )
 
         controller.applicationDidBecomeActive()
-        await waitUntil {
-            let eventCount = await transport.events().count
-            let pendingCount = await sleeper.pendingCount()
-            return eventCount == 1 && pendingCount == 1
-        }
+        await transport.waitUntilEventCount(1)
+        await sleeper.waitUntilPendingCount(1)
 
         date = date.addingTimeInterval(20)
         await sleeper.resumeNext()
-        await waitUntil {
-            let eventCount = await transport.events().count
-            let pendingCount = await sleeper.pendingCount()
-            return eventCount == 2 && pendingCount == 1
-        }
+        await transport.waitUntilEventCount(2)
+        await sleeper.waitUntilPendingCount(1)
 
         #expect(
             await sleeper.durations().first == .seconds(10)
@@ -358,11 +394,8 @@ struct TelemetryTests {
         )
 
         controller.applicationDidBecomeActive()
-        await waitUntil {
-            let eventCount = await transport.events().count
-            let pendingCount = await sleeper.pendingCount()
-            return eventCount == 1 && pendingCount == 1
-        }
+        await transport.waitUntilEventCount(1)
+        await sleeper.waitUntilPendingCount(1)
 
         controller.applicationWillResignActive()
         date = date.addingTimeInterval(20)

--- a/Tests/App/TelemetryTests.swift
+++ b/Tests/App/TelemetryTests.swift
@@ -24,6 +24,28 @@ private actor TelemetryTestStateStore: TelemetryStateStoring {
     }
 }
 
+private func waitForTelemetryCondition(
+    timeout: Duration,
+    pollInterval: Duration = .milliseconds(10),
+    _ condition: @escaping @Sendable () async -> Bool
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while clock.now < deadline {
+        guard !Task.isCancelled else { return false }
+        if await condition() {
+            return true
+        }
+        do {
+            try await Task.sleep(for: pollInterval)
+        } catch {
+            return false
+        }
+    }
+    guard !Task.isCancelled else { return false }
+    return await condition()
+}
+
 private actor TelemetryTestTransport: TelemetryTransport {
     enum TestError: Error {
         case rejected
@@ -31,9 +53,6 @@ private actor TelemetryTestTransport: TelemetryTransport {
 
     private let rejectsEvents: Bool
     private var capturedEvents: [TelemetryEvent] = []
-    private var eventCountWaiters: [
-        (minimum: Int, continuation: CheckedContinuation<Void, Never>)
-    ] = []
 
     init(rejectsEvents: Bool = false) {
         self.rejectsEvents = rejectsEvents
@@ -41,7 +60,6 @@ private actor TelemetryTestTransport: TelemetryTransport {
 
     func capture(_ event: TelemetryEvent) throws {
         capturedEvents.append(event)
-        resumeEventCountWaiters()
         if rejectsEvents {
             throw TestError.rejected
         }
@@ -51,21 +69,13 @@ private actor TelemetryTestTransport: TelemetryTransport {
         capturedEvents
     }
 
-    func waitUntilEventCount(_ minimum: Int) async {
-        guard capturedEvents.count < minimum else { return }
-        await withCheckedContinuation { continuation in
-            eventCountWaiters.append((minimum, continuation))
+    func waitUntilEventCount(
+        _ minimum: Int,
+        timeout: Duration = .seconds(30)
+    ) async -> Bool {
+        await waitForTelemetryCondition(timeout: timeout) { [self] in
+            await events().count >= minimum
         }
-    }
-
-    private func resumeEventCountWaiters() {
-        let ready = eventCountWaiters.filter {
-            capturedEvents.count >= $0.minimum
-        }
-        eventCountWaiters.removeAll {
-            capturedEvents.count >= $0.minimum
-        }
-        ready.forEach { $0.continuation.resume() }
     }
 }
 
@@ -74,15 +84,11 @@ private actor TelemetryTestSleeper {
     private var continuations: [
         CheckedContinuation<Void, Never>
     ] = []
-    private var pendingCountWaiters: [
-        (minimum: Int, continuation: CheckedContinuation<Void, Never>)
-    ] = []
 
     func sleep(for duration: Duration) async {
         requestedDurations.append(duration)
         await withCheckedContinuation { continuation in
             continuations.append(continuation)
-            resumePendingCountWaiters()
         }
     }
 
@@ -94,29 +100,41 @@ private actor TelemetryTestSleeper {
         requestedDurations
     }
 
-    func waitUntilPendingCount(_ minimum: Int) async {
-        guard continuations.count < minimum else { return }
-        await withCheckedContinuation { continuation in
-            pendingCountWaiters.append((minimum, continuation))
+    func waitUntilPendingCount(
+        _ minimum: Int,
+        timeout: Duration = .seconds(30)
+    ) async -> Bool {
+        await waitForTelemetryCondition(timeout: timeout) { [self] in
+            await pendingCount() >= minimum
         }
     }
 
     func resumeNext() {
         continuations.removeFirst().resume()
     }
-
-    private func resumePendingCountWaiters() {
-        let ready = pendingCountWaiters.filter {
-            continuations.count >= $0.minimum
-        }
-        pendingCountWaiters.removeAll {
-            continuations.count >= $0.minimum
-        }
-        ready.forEach { $0.continuation.resume() }
-    }
 }
 
 struct TelemetryTests {
+    @Test("telemetry waits time out and honor cancellation")
+    func telemetryWaitsAreBounded() async {
+        let transport = TelemetryTestTransport()
+        #expect(await transport.waitUntilEventCount(
+            1,
+            timeout: .milliseconds(10)
+        ) == false)
+
+        let sleeper = TelemetryTestSleeper()
+        let cancelledWait = Task {
+            await sleeper.waitUntilPendingCount(
+                1,
+                timeout: .seconds(10)
+            )
+        }
+        await Task.yield()
+        cancelledWait.cancel()
+        #expect(await cancelledWait.value == false)
+    }
+
     @Test("application activity is anonymous and sent once per UTC day")
     func applicationActivityIsAnonymousAndDaily() async throws {
         let stateStore = TelemetryTestStateStore()
@@ -342,13 +360,13 @@ struct TelemetryTests {
         )
 
         controller.applicationDidBecomeActive()
-        await transport.waitUntilEventCount(1)
-        await sleeper.waitUntilPendingCount(1)
+        #expect(await transport.waitUntilEventCount(1))
+        #expect(await sleeper.waitUntilPendingCount(1))
 
         date = date.addingTimeInterval(20)
         await sleeper.resumeNext()
-        await transport.waitUntilEventCount(2)
-        await sleeper.waitUntilPendingCount(1)
+        #expect(await transport.waitUntilEventCount(2))
+        #expect(await sleeper.waitUntilPendingCount(1))
 
         #expect(
             await sleeper.durations().first == .seconds(10)
@@ -394,8 +412,8 @@ struct TelemetryTests {
         )
 
         controller.applicationDidBecomeActive()
-        await transport.waitUntilEventCount(1)
-        await sleeper.waitUntilPendingCount(1)
+        #expect(await transport.waitUntilEventCount(1))
+        #expect(await sleeper.waitUntilPendingCount(1))
 
         controller.applicationWillResignActive()
         date = date.addingTimeInterval(20)

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1370,9 +1370,11 @@ struct WorkspaceHerdrPresentationTests {
 
         close(false, 9)
 
-        await waitUntilMainActor(timeout: .seconds(1)) {
-            discoveries.callCount == 3
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.hostID)?
+                .herdrSessions.contains(where: { $0.name == "api" }) == false
         }
+        #expect(discoveries.callCount == 3)
         #expect(model.snapshot.host(id: environment.hostID)?
             .herdrSessions.contains(where: { $0.name == "api" }) == false)
         await model.shutdown()

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -1063,7 +1063,9 @@ struct WorkspaceRestorationTests {
         configuredHosts.withLock { $0 = [configuredHost] }
         model.refreshHosts()
         discoveryState.withLock { $0.released = true }
-        try await Task.sleep(for: .milliseconds(50))
+        await waitUntilMainActor {
+            !model.isWorkspaceRestorationPending
+        }
 
         #expect(!model.isWorkspaceRestorationPending)
         #expect(model.activeBorrowedZellijSelection == nil)

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -59,7 +59,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
 
     private func retainedRuntime() -> LibghosttyRuntime {
         if Self.retainedRuntime == nil {
-            let (pipeline, _) = makeIsolatedPipeline()
+            let (pipeline, _) = makeIsolatedSurfacePipeline()
             Self.retainedRuntime = LibghosttyRuntime(pipeline: pipeline)
         }
         return Self.retainedRuntime!
@@ -172,7 +172,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
 
     func testResolvedTerminalColorsFollowSurfaceConditionalTheme() throws {
         try skipUnlessLibghosttyReady()
-        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        let (pipeline, tempRoot) = makeIsolatedSurfacePipeline()
         addTeardownBlock {
             try? FileManager.default.removeItem(at: tempRoot)
         }
@@ -242,7 +242,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
             .appendingPathComponent(themeName)
         let colors = try themeColors(at: theme)
 
-        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        let (pipeline, tempRoot) = makeIsolatedSurfacePipeline()
         addTeardownBlock {
             try? FileManager.default.removeItem(at: tempRoot)
         }
@@ -326,7 +326,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
 
     func testLateSurfaceRegistrationPublishesResolvedColors() throws {
         try skipUnlessLibghosttyReady()
-        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        let (pipeline, tempRoot) = makeIsolatedSurfacePipeline()
         addTeardownBlock {
             try? FileManager.default.removeItem(at: tempRoot)
         }
@@ -374,7 +374,7 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
 
     func testResolvedTerminalColorsAreSurfaceScopedAndInvalidated() throws {
         try skipUnlessLibghosttyReady()
-        let (pipeline, tempRoot) = makeIsolatedPipeline()
+        let (pipeline, tempRoot) = makeIsolatedSurfacePipeline()
         addTeardownBlock {
             try? FileManager.default.removeItem(at: tempRoot)
         }

--- a/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
+++ b/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
@@ -84,6 +84,20 @@ func makeIsolatedPipeline() -> (LibghosttyConfigPipeline, URL) {
     )
 }
 
+func makeIsolatedSurfacePipeline() -> (LibghosttyConfigPipeline, URL) {
+    let (pipeline, tempRoot) = makeIsolatedPipeline()
+    try! FileManager.default.createDirectory(
+        at: pipeline.paths.configDirectory,
+        withIntermediateDirectories: true
+    )
+    try! "window-vsync = false\n".write(
+        to: pipeline.paths.terminalAppearanceConfigFile,
+        atomically: true,
+        encoding: .utf8
+    )
+    return (pipeline, tempRoot)
+}
+
 func withIsolatedPipeline<T>(
     _ block: (LibghosttyConfigPipeline, URL) throws -> T
 ) throws -> T {

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -658,10 +658,16 @@ final class TerminalSurfacePreviewTests: XCTestCase {
     private func makeSurface() throws -> TerminalSurfaceView {
         let runtime = retainedRuntime()
         let app = try XCTUnwrap(runtime.unsafeAppHandle)
-        return TerminalSurfaceView(
+        let view = TerminalSurfaceView(
             app: app,
             configuration: TerminalSurfaceConfiguration()
         )
+        _ = try XCTUnwrap(
+            view.surfaceHandle,
+            view.error?.localizedDescription
+                ?? "libghostty surface creation failed"
+        )
+        return view
     }
 
     private func makeIOSurface(
@@ -679,7 +685,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
 
     private func retainedRuntime() -> LibghosttyRuntime {
         if Self.retainedRuntime == nil {
-            let (pipeline, _) = makeIsolatedPipeline()
+            let (pipeline, _) = makeIsolatedSurfacePipeline()
             try! FileManager.default.createDirectory(
                 at: pipeline.paths.configDirectory,
                 withIntermediateDirectories: true

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -77,13 +77,18 @@ final class TerminalSurfacePreviewTests: XCTestCase {
     func testSnapshotSkipsAnUnchangedIOSurfaceToken() async throws {
         let view = try makeSurface()
         view.layer?.contents = try makeIOSurface()
-        let snapshotter = TerminalSurfaceSnapshotter()
+        let stableToken = TerminalSurfaceCaptureToken(
+            surfaceID: 1,
+            seed: 1
+        )
+        let snapshotter = TerminalSurfaceSnapshotter { _ in stableToken }
         let captured = try await snapshotter.snapshot(
             of: view,
             outputWidth: 320,
             previousCaptureToken: nil
         )
         let first = try XCTUnwrap(captured)
+        XCTAssertEqual(first.captureToken, stableToken)
 
         let unchanged = try await snapshotter.snapshot(
             of: view,

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -148,7 +148,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
 
     private func retainedRuntime() -> LibghosttyRuntime {
         if Self.retainedRuntime == nil {
-            let (pipeline, _) = makeIsolatedPipeline()
+            let (pipeline, _) = makeIsolatedSurfacePipeline()
             try! FileManager.default.createDirectory(
                 at: pipeline.paths.configDirectory,
                 withIntermediateDirectories: true
@@ -166,7 +166,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
     private func runtimeWithTerminalConfig(
         _ contents: String
     ) throws -> LibghosttyRuntime {
-        let (pipeline, _) = makeIsolatedPipeline()
+        let (pipeline, _) = makeIsolatedSurfacePipeline()
         try FileManager.default.createDirectory(
             at: pipeline.paths.configDirectory,
             withIntermediateDirectories: true
@@ -1530,7 +1530,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             )
         }
 
-        let (pipeline, _) = makeIsolatedPipeline()
+        let (pipeline, _) = makeIsolatedSurfacePipeline()
         let runtime = LibghosttyRuntime(pipeline: pipeline)
         Self.transientRuntimes.append(runtime)
         let appHandle = try requireAppHandle(from: runtime)

--- a/Tests/TerminalSmoke/TmuxInjectionSmokeTests.swift
+++ b/Tests/TerminalSmoke/TmuxInjectionSmokeTests.swift
@@ -26,7 +26,7 @@ final class TmuxInjectionSmokeTests: XCTestCase {
 
     private func retainedRuntime() -> LibghosttyRuntime {
         if Self.retainedRuntime == nil {
-            let (pipeline, _) = makeIsolatedPipeline()
+            let (pipeline, _) = makeIsolatedSurfacePipeline()
             Self.retainedRuntime = LibghosttyRuntime(pipeline: pipeline)
         }
         return Self.retainedRuntime!

--- a/Tests/UI/KeyboardNavigationModelTests.swift
+++ b/Tests/UI/KeyboardNavigationModelTests.swift
@@ -108,21 +108,17 @@ struct KeyboardNavigationModelTests {
         let hostID = UUID()
         let names = (0 ..< 24).map {
             "session-\($0)-\(String(repeating: "x", count: 48))"
-        }
-        let snapshot = WorkspaceSnapshot.fixture(hosts: [
-            .fixture(
-                id: hostID,
-                tmuxSessions: names.map {
-                    .init(name: $0, managed: false, windows: [])
-                }
-            ),
-        ])
-        let context = KeyboardNavigationContext(snapshot: snapshot)
-        let expected = names.sorted {
+        }.sorted {
             $0.localizedStandardCompare($1) == .orderedAscending
-        }.map {
-            WorkspaceNavigationTarget.tmuxSession(hostID: hostID, name: $0)
         }
+        let rows = names.map { name in
+            WorkspaceSidebarRow(
+                target: .tmuxSession(hostID: hostID, name: name),
+                icon: .tmuxSession,
+                title: name
+            )
+        }
+        let expected = rows.map(\.target)
         let current = expected[expected.count / 2]
 
         let allSucceeded = await withTaskGroup(
@@ -137,9 +133,9 @@ struct KeyboardNavigationModelTests {
                             count: 512 + ((worker + iteration) % 512)
                         )
                         let actual = withExtendedLifetime(noise) {
-                            KeyboardNavigationModel.siblingTargets(
-                                for: current,
-                                in: context
+                            KeyboardNavigationModel.matchingTargets(
+                                in: rows,
+                                currentTarget: current
                             )
                         }
                         guard actual == expected else { return false }

--- a/Tests/UI/KeyboardNavigationModelTests.swift
+++ b/Tests/UI/KeyboardNavigationModelTests.swift
@@ -103,6 +103,59 @@ struct KeyboardNavigationModelTests {
         ])
     }
 
+    @Test("tmux sibling targets stay valid under ten concurrent consumers")
+    func tmuxSiblingTargetsSurviveAllocationPressure() async {
+        let hostID = UUID()
+        let names = (0 ..< 24).map {
+            "session-\($0)-\(String(repeating: "x", count: 48))"
+        }
+        let snapshot = WorkspaceSnapshot.fixture(hosts: [
+            .fixture(
+                id: hostID,
+                tmuxSessions: names.map {
+                    .init(name: $0, managed: false, windows: [])
+                }
+            ),
+        ])
+        let context = KeyboardNavigationContext(snapshot: snapshot)
+        let expected = names.sorted {
+            $0.localizedStandardCompare($1) == .orderedAscending
+        }.map {
+            WorkspaceNavigationTarget.tmuxSession(hostID: hostID, name: $0)
+        }
+        let current = expected[expected.count / 2]
+
+        let allSucceeded = await withTaskGroup(
+            of: Bool.self,
+            returning: Bool.self
+        ) { group in
+            for worker in 0 ..< 10 {
+                group.addTask {
+                    for iteration in 0 ..< 2_000 {
+                        let noise = Array(
+                            repeating: Int32(worker + iteration),
+                            count: 512 + ((worker + iteration) % 512)
+                        )
+                        let actual = withExtendedLifetime(noise) {
+                            KeyboardNavigationModel.siblingTargets(
+                                for: current,
+                                in: context
+                            )
+                        }
+                        guard actual == expected else { return false }
+                    }
+                    return true
+                }
+            }
+            for await succeeded in group where !succeeded {
+                return false
+            }
+            return true
+        }
+
+        #expect(allSucceeded)
+    }
+
     @Test("single, missing, and non-session targets pass through")
     func unavailableTargetsPassThrough() {
         let snapshot = WorkspaceSnapshot.fixture(hosts: [.fixture()])


### PR DESCRIPTION
Ghosthub 0.8.2 can hard-crash while evaluating keyboard shortcuts with several workspace windows open because a release build may copy a sidebar row after its temporary section storage is released.

- Materializes an owned navigation-target array before checking membership, preserving existing ordering and backend grouping.
- Covers ten concurrent consumers under allocation pressure, matching normal use with ten open windows.
- Exercises section-free target extraction in the stress test, so it cannot contaminate global render-work counters.
- Removes observed suite flakes by waiting for Herdr, Zellij, and telemetry state transitions instead of fixed delays or executor-mismatched polling.
- Keeps resource sampling unchanged; the crash fix is limited to navigation target lifetime.

The original Xcode 26.0.1-generated crash path was confirmed from the release binary. The current Xcode 26.5 toolchain does not reproduce the unchanged source, so the explicit ownership boundary keeps the fix independent of compiler lifetime optimization.
