### PR TITLE
Keep session recovery alive when a terminal surface cannot be created

### DIFF
--- a/Sources/App/DisplayAvailability.swift
+++ b/Sources/App/DisplayAvailability.swift
@@ -1,0 +1,32 @@
+import Foundation
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+
+/// How many displays macOS currently reports as active.
+///
+/// With the lid shut and no external display attached the count is zero. Nothing
+/// can render, and CoreVideo refuses to build the display link libghostty's
+/// renderer needs for vsync ("invalid display count (0)"), so
+/// `ghostty_surface_new` fails. Attaching in that window therefore cannot
+/// succeed, and Ghosthub waits for a display instead of burning a reconnect on
+/// it.
+///
+/// This reads the same quantity CoreVideo itself measures rather than
+/// `NSScreen.screens`, so the check matches the precondition that actually
+/// fails.
+enum DisplayAvailability {
+    static func activeCount() -> Int {
+        #if canImport(CoreGraphics)
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success else {
+            // An unreadable display list must never strand a session. Report a
+            // display so the attach proceeds and reports its own real failure.
+            return 1
+        }
+        return Int(count)
+        #else
+        return 1
+        #endif
+    }
+}

--- a/Sources/App/NativeHerdrSessionCoordinator.swift
+++ b/Sources/App/NativeHerdrSessionCoordinator.swift
@@ -16,6 +16,9 @@ enum BorrowedHerdrAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// The terminal surface could not be created. Transient — no display was
+    /// available to render it — so recovery keeps trying instead of latching.
+    case surfaceUnavailable
 }
 
 private struct NativeHerdrSessionKey: Hashable {
@@ -369,7 +372,12 @@ final class NativeHerdrSessionCoordinator {
             return nil
         }
         if let error = surface.launchError {
-            failSurfaceLaunch(handle, reason: error.localizedDescription)
+            failSurfaceLaunch(
+                handle,
+                reason: error.localizedDescription,
+                closure: surface.launchFailureIsRetryable
+                    ? .surfaceUnavailable : .launchFailed
+            )
             return nil
         }
         surface.blocksClipboardReads = attachment.host.isRemote
@@ -405,10 +413,17 @@ final class NativeHerdrSessionCoordinator {
 
     private func failSurfaceLaunch(
         _ handle: BorrowedHerdrSessionHandle,
-        reason: String
+        reason: String,
+        closure: BorrowedHerdrAttachmentClosure = .launchFailed
     ) {
+        AppLogger.shared.error(
+            "herdr surface launch failed: \(reason) "
+                + "retryable=\(closure == .surfaceUnavailable) "
+                + "activeDisplays=\(DisplayAvailability.activeCount())",
+            context: "herdr"
+        )
         cancelPaneSplits(handleID: handle.id)
-        attachmentClosures[handle.id] = .launchFailed
+        attachmentClosures[handle.id] = closure
         remoteExitStatusStore.remove(
             attachments.removeValue(forKey: handle.id)?.remoteExitStatusURL
         )

--- a/Sources/App/NativeSessionAttachmentSupport.swift
+++ b/Sources/App/NativeSessionAttachmentSupport.swift
@@ -12,6 +12,9 @@ protocol NativeSessionPaneSurfacing: AnyObject {
     var paneSplitErrorMessage: String? { get set }
     var hasEffectiveKeyboardFocus: Bool { get }
     var launchError: Error? { get }
+    /// True when `launchError` describes a transient condition that a later
+    /// attach can recover from, rather than a rejected launch.
+    var launchFailureIsRetryable: Bool { get }
     var childExitCode: UInt32? { get }
     func registerSurfaceCloseObserver(
         id: UUID,
@@ -31,6 +34,8 @@ extension NativeSessionPaneSurfacing {
     }
 
     var hasEffectiveKeyboardFocus: Bool { false }
+
+    var launchFailureIsRetryable: Bool { false }
 }
 
 extension TerminalSurfaceView: NativeSessionPaneSurfacing {

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -31,6 +31,9 @@ enum BorrowedTmuxAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// The terminal surface could not be created. Transient — no display was
+    /// available to render it — so recovery keeps trying instead of latching.
+    case surfaceUnavailable
 }
 
 private struct NativeTmuxSessionKey: Hashable {
@@ -517,7 +520,12 @@ final class NativeTmuxSessionCoordinator {
             return nil
         }
         if let error = surface.launchError {
-            failSurfaceLaunch(handle, reason: error.localizedDescription)
+            failSurfaceLaunch(
+                handle,
+                reason: error.localizedDescription,
+                closure: surface.launchFailureIsRetryable
+                    ? .surfaceUnavailable : .launchFailed
+            )
             return nil
         }
         if isFirstLaunch, appliesPresentationStyle,
@@ -789,10 +797,17 @@ final class NativeTmuxSessionCoordinator {
 
     private func failSurfaceLaunch(
         _ handle: BorrowedTmuxSessionHandle,
-        reason: String
+        reason: String,
+        closure: BorrowedTmuxAttachmentClosure = .launchFailed
     ) {
+        AppLogger.shared.error(
+            "tmux surface launch failed: \(reason) "
+                + "retryable=\(closure == .surfaceUnavailable) "
+                + "activeDisplays=\(DisplayAvailability.activeCount())",
+            context: "tmux"
+        )
         cancelPaneSplits(handleID: handle.id)
-        attachmentClosures[handle.id] = .launchFailed
+        attachmentClosures[handle.id] = closure
         remoteExitStatusStore.remove(
             attachments.removeValue(forKey: handle.id)?.remoteExitStatusURL
         )

--- a/Sources/App/NativeZellijSessionCoordinator.swift
+++ b/Sources/App/NativeZellijSessionCoordinator.swift
@@ -16,6 +16,9 @@ enum BorrowedZellijAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// The terminal surface could not be created. Transient — no display was
+    /// available to render it — so recovery keeps trying instead of latching.
+    case surfaceUnavailable
 }
 
 private struct NativeZellijSessionKey: Hashable {
@@ -298,7 +301,12 @@ final class NativeZellijSessionCoordinator {
             return nil
         }
         if let error = surface.launchError {
-            failSurfaceLaunch(handle, reason: error.localizedDescription)
+            failSurfaceLaunch(
+                handle,
+                reason: error.localizedDescription,
+                closure: surface.launchFailureIsRetryable
+                    ? .surfaceUnavailable : .launchFailed
+            )
             return nil
         }
         surface.blocksClipboardReads = attachment.host.isRemote
@@ -326,9 +334,16 @@ final class NativeZellijSessionCoordinator {
 
     private func failSurfaceLaunch(
         _ handle: BorrowedZellijSessionHandle,
-        reason: String
+        reason: String,
+        closure: BorrowedZellijAttachmentClosure = .launchFailed
     ) {
-        attachmentClosures[handle.id] = .launchFailed
+        AppLogger.shared.error(
+            "zellij surface launch failed: \(reason) "
+                + "retryable=\(closure == .surfaceUnavailable) "
+                + "activeDisplays=\(DisplayAvailability.activeCount())",
+            context: "zellij"
+        )
+        attachmentClosures[handle.id] = closure
         remoteExitStatusStore.remove(
             attachments.removeValue(forKey: handle.id)?.remoteExitStatusURL
         )

--- a/Sources/App/WorkspaceSceneModel+Subscriptions.swift
+++ b/Sources/App/WorkspaceSceneModel+Subscriptions.swift
@@ -36,6 +36,21 @@ extension WorkspaceSceneModel {
         #endif
     }
 
+    /// Displays coming or going changes whether an attach can succeed at all,
+    /// so a session waiting on one retries the moment the lid opens.
+    func subscribeDisplayAvailability() {
+        #if canImport(AppKit)
+        screenParametersCancellable = NotificationCenter.default
+            .publisher(
+                for: NSApplication.didChangeScreenParametersNotification
+            )
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.handleDisplayParametersChanged()
+            }
+        #endif
+    }
+
     func handleApplicationDidBecomeActiveForResourceMonitoring() {
         isAppActive = true
         tmuxSessionPreviewCoordinator.applicationDidBecomeActive()

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -848,6 +848,14 @@ final class WorkspaceSceneModel: ObservableObject {
     var herdrReconnectSupervisorIsRunning: Bool {
         herdrReconnectSupervisor.isRunning
     }
+
+    /// tmux supervisors are per presentation, so unlike Herdr and Zellij this
+    /// reports whether any retained presentation is still recovering.
+    var anyTmuxReconnectSupervisorIsRunning: Bool {
+        retainedTmuxPresentations.values.contains {
+            $0.reconnectSupervisor.isRunning
+        }
+    }
     @Published private(set) var sessionConnectionRecoveryRequest:
         SessionConnectionRecoveryRequest?
     private enum RemoteTmuxEstablishmentPhase: Equatable {
@@ -861,6 +869,10 @@ final class WorkspaceSceneModel: ObservableObject {
         var host: CommandHost
         var phase: RemoteTmuxEstablishmentPhase
         var surfaceExitCode: UInt32?
+        /// The previous attempt could not create a terminal surface, so no
+        /// client ever ran and there is no exit code to inspect. Recovery is
+        /// still legitimate: the transport failure that started it stands.
+        var surfaceLaunchFailed = false
     }
     private struct TmuxPresentationKey: Hashable {
         var hostID: UUID
@@ -1196,6 +1208,9 @@ final class WorkspaceSceneModel: ObservableObject {
     private let tmuxSessionStyler: TmuxSessionStyling
     private let tmuxPresentationStyleProvider:
         (UInt?) -> TmuxPresentationStyle?
+    /// Displays macOS currently reports as active. Zero means nothing can be
+    /// rendered, so an attach cannot succeed; see `DisplayAvailability`.
+    private let activeDisplayCount: @Sendable () -> Int
     private let sshHostProbeRunner: SSHHostProbeRunner
     private let sshAuthenticationCoordinator: SSHAuthenticationCoordinator
     private let sshAuthenticationScopeID = UUID()
@@ -1268,6 +1283,7 @@ final class WorkspaceSceneModel: ObservableObject {
     var childExitCancellable: AnyCancellable?
     var appDidBecomeActiveCancellable: AnyCancellable?
     var appDidResignActiveCancellable: AnyCancellable?
+    var screenParametersCancellable: AnyCancellable?
     var shortcutMonitor: ShortcutMonitor?
     var openTerminalSurfaceCount: Int {
         terminalCoordinator.surfaceEntries().reduce(into: 0) { count, entry in
@@ -1365,6 +1381,9 @@ final class WorkspaceSceneModel: ObservableObject {
         @escaping (UInt?) -> TmuxPresentationStyle? = { _ in nil },
         appliesTmuxPresentationStyleToExistingSessionsProvider:
         @escaping () -> Bool = { false },
+        activeDisplayCount: @escaping @Sendable () -> Int = {
+            DisplayAvailability.activeCount()
+        },
         kwtInventoryLoader: @escaping KwtInventoryLoader = { host in
             try await KwtInventoryClient().load(from: host)
         },
@@ -1709,6 +1728,7 @@ final class WorkspaceSceneModel: ObservableObject {
         self.tmuxSessionStyler = tmuxSessionStyler
         self.tmuxPresentationStyleProvider =
             tmuxPresentationStyleProvider
+        self.activeDisplayCount = activeDisplayCount
         self.sshHostProbeRunner = sshHostProbeRunner
         self.sshAuthenticationCoordinator = sshAuthenticationCoordinator
         self.createdSessionDiscoveryDelays =
@@ -2073,6 +2093,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 activityController.startOutputFlushLoop()
                 subscribeChildExitEvents()
                 subscribeAppActivity()
+                subscribeDisplayAvailability()
                 activityController
                     .refreshWorkspaceResourceSummary()
                 installShortcutMonitor()
@@ -2125,6 +2146,7 @@ final class WorkspaceSceneModel: ObservableObject {
         childExitCancellable?.cancel()
         appDidBecomeActiveCancellable?.cancel()
         appDidResignActiveCancellable?.cancel()
+        screenParametersCancellable?.cancel()
         shortcutMonitor?.uninstall()
         // Nil out controller backings so their deinits run now,
         // cancelling detached tasks that could fire closures
@@ -9713,6 +9735,21 @@ final class WorkspaceSceneModel: ObservableObject {
         if case .disconnected = state,
            presentation.recoveryState != nil,
            nativeTmuxSessionCoordinator.attachmentClosure(handle)
+           == .surfaceUnavailable,
+           var context = presentation.reconnectContext,
+           context.handleID == handle.id {
+            // The surface could not be created, which is transient. The
+            // supervisor already stopped when it handed off this relaunch, so
+            // re-arm it; its first act is the display check, so it backs off
+            // rather than spinning on a relaunch that cannot succeed yet.
+            context.surfaceLaunchFailed = true
+            presentation.reconnectContext = context
+            startTmuxReconnect(presentation, context: context)
+            return
+        }
+        if case .disconnected = state,
+           presentation.recoveryState != nil,
+           nativeTmuxSessionCoordinator.attachmentClosure(handle)
            == .launchFailed {
             cancelTmuxReconnect(presentation)
             return
@@ -9845,6 +9882,15 @@ final class WorkspaceSceneModel: ObservableObject {
             context.surfaceExitCode = code
             activeHerdrReconnectContext = context
             startHerdrReconnect(context)
+        case .surfaceUnavailable:
+            // Transient: see the tmux path in nativeTmuxStateChanged.
+            guard let context = activeHerdrReconnectContext,
+                  context.handleID == handle.id
+            else {
+                cancelHerdrReconnect()
+                return
+            }
+            startHerdrReconnect(context)
         case .launchFailed, nil:
             cancelHerdrReconnect()
         }
@@ -9916,6 +9962,17 @@ final class WorkspaceSceneModel: ObservableObject {
                 context.surfaceExitCode = code
                 activeZellijReconnectContext = context
                 startZellijReconnect(context)
+            case .surfaceUnavailable:
+                // Transient: see the tmux path in nativeTmuxStateChanged.
+                guard let context = activeZellijReconnectContext,
+                      context.handleID == handle.id
+                else {
+                    zellijReconnectSupervisor.cancel()
+                    activeBorrowedZellijRecoveryState = nil
+                    scheduleZellijSessionDiscovery()
+                    return
+                }
+                startZellijReconnect(context)
             case .launchFailed, nil:
                 if let selection = pendingCreatedZellijSessions
                     .removeValue(forKey: handle.id) {
@@ -9960,6 +10017,7 @@ final class WorkspaceSceneModel: ObservableObject {
         guard activeZellijReconnectContext == context,
               activeBorrowedZellijHandle?.id == context.handleID
         else { return .stop }
+        guard canAttachToDisplay else { return .retry }
         guard let connection = context.connection else {
             stopZellijReconnect(
                 "The SSH connection changed while Ghosthub was checking the Zellij session. Reopen it to use the current connection."
@@ -10328,6 +10386,7 @@ final class WorkspaceSceneModel: ObservableObject {
         guard activeHerdrReconnectContext == context,
               activeBorrowedHerdrHandle?.id == context.handleID
         else { return .stop }
+        guard canAttachToDisplay else { return .retry }
         let probe = await validatedHerdrSessionProbe(
             named: context.selection.name,
             on: context.host
@@ -10504,6 +10563,35 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    /// Whether an attach can succeed right now.
+    ///
+    /// libghostty's renderer needs an active display to build the vsync display
+    /// link it creates with every surface, so attaching with none — lid shut, no
+    /// external monitor — always fails. Holding instead of attempting keeps the
+    /// supervisor's backoff intact and stops Ghosthub waking SSH on every dark
+    /// wake while the lid is closed. `subscribeDisplayAvailability()` retries
+    /// the moment a display comes back.
+    private var canAttachToDisplay: Bool {
+        activeDisplayCount() > 0
+    }
+
+    /// Resumes recovery as soon as a display comes back, so a session held by
+    /// `canAttachToDisplay` attaches on lid open instead of waiting out the
+    /// supervisor's remaining delay.
+    func handleDisplayParametersChanged() {
+        guard canAttachToDisplay else { return }
+        for presentation in retainedTmuxPresentations.values
+            where presentation.reconnectSupervisor.isRunning {
+            presentation.reconnectSupervisor.reconnectNow()
+        }
+        if herdrReconnectSupervisor.isRunning {
+            herdrReconnectSupervisor.reconnectNow()
+        }
+        if zellijReconnectSupervisor.isRunning {
+            zellijReconnectSupervisor.reconnectNow()
+        }
+    }
+
     private func attemptTmuxReconnect(
         _ presentation: RetainedTmuxPresentation,
         context: TmuxReconnectContext
@@ -10513,6 +10601,7 @@ final class WorkspaceSceneModel: ObservableObject {
               retainedTmuxPresentation(for: presentation.handle)
               === presentation
         else { return .stop }
+        guard canAttachToDisplay else { return .retry }
         let outcome = await tmuxProbeOutcome(
             for: presentation,
             context: context
@@ -10618,7 +10707,9 @@ final class WorkspaceSceneModel: ObservableObject {
         else { return .stop }
         switch outcome {
         case .present:
-            guard context.surfaceExitCode == 255 else {
+            guard context.surfaceExitCode == 255
+                || context.surfaceLaunchFailed
+            else {
                 stopTmuxReconnectWithUnableToAttach(
                     presentation,
                     "The remote tmux client exited before it could attach."

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -807,6 +807,10 @@ final class WorkspaceSceneModel: ObservableObject {
         var host: CommandHost
         var connection: SSHConnectionArgumentsSnapshot?
         var surfaceExitCode: UInt32?
+        /// The previous attempt could not create a terminal surface, so no
+        /// client ever ran and there is no exit code to inspect. Recovery is
+        /// still legitimate: the transport failure that started it stands.
+        var surfaceLaunchFailed = false
 
         static func == (
             lhs: ActiveZellijReconnectContext,
@@ -817,6 +821,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 && lhs.host == rhs.host
                 && lhs.connection?.cacheKey == rhs.connection?.cacheKey
                 && lhs.surfaceExitCode == rhs.surfaceExitCode
+                && lhs.surfaceLaunchFailed == rhs.surfaceLaunchFailed
         }
     }
     private var activeZellijReconnectContext: ActiveZellijReconnectContext?
@@ -947,6 +952,10 @@ final class WorkspaceSceneModel: ObservableObject {
         var handleID: UUID
         var host: CommandHost
         var surfaceExitCode: UInt32?
+        /// The previous attempt could not create a terminal surface, so no
+        /// client ever ran and there is no exit code to inspect. Recovery is
+        /// still legitimate: the transport failure that started it stands.
+        var surfaceLaunchFailed = false
     }
     private var activeHerdrReconnectContext: ActiveHerdrReconnectContext?
     @Published private(set) var isWorkspaceRestorationPending = false
@@ -9856,6 +9865,19 @@ final class WorkspaceSceneModel: ObservableObject {
             activeHerdrReconnectContext?.surfaceExitCode = nil
             return
         }
+        // Checked before `hasLaunched`: a surface that failed to be created
+        // never launched, so the guard below would drop this transient failure
+        // and the session would latch. See the tmux path.
+        if case .disconnected = state,
+           nativeHerdrSessionCoordinator.attachmentClosure(handle)
+           == .surfaceUnavailable,
+           var context = activeHerdrReconnectContext,
+           context.handleID == handle.id {
+            context.surfaceLaunchFailed = true
+            activeHerdrReconnectContext = context
+            startHerdrReconnect(context)
+            return
+        }
         guard case .disconnected = state,
               nativeHerdrSessionCoordinator.hasLaunched(handle)
         else { return }
@@ -9883,14 +9905,9 @@ final class WorkspaceSceneModel: ObservableObject {
             activeHerdrReconnectContext = context
             startHerdrReconnect(context)
         case .surfaceUnavailable:
-            // Transient: see the tmux path in nativeTmuxStateChanged.
-            guard let context = activeHerdrReconnectContext,
-                  context.handleID == handle.id
-            else {
-                cancelHerdrReconnect()
-                return
-            }
-            startHerdrReconnect(context)
+            // Recoverable failures are re-armed above, before `hasLaunched`.
+            // Reaching here means no matching reconnect context survives.
+            cancelHerdrReconnect()
         case .launchFailed, nil:
             cancelHerdrReconnect()
         }
@@ -9921,6 +9938,18 @@ final class WorkspaceSceneModel: ObservableObject {
             sessionConnectionRecoveryRequest = nil
             scheduleZellijSessionDiscovery()
         case .disconnected:
+            // Checked before `hasLaunched`: a surface that failed to be created
+            // never launched, so the guard below would drop this transient
+            // failure and the session would latch. See the tmux path.
+            if nativeZellijSessionCoordinator.attachmentClosure(handle)
+                == .surfaceUnavailable,
+                var context = activeZellijReconnectContext,
+                context.handleID == handle.id {
+                context.surfaceLaunchFailed = true
+                activeZellijReconnectContext = context
+                startZellijReconnect(context)
+                return
+            }
             guard nativeZellijSessionCoordinator.hasLaunched(handle) else {
                 if let selection = pendingCreatedZellijSessions
                     .removeValue(forKey: handle.id) {
@@ -9963,16 +9992,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 activeZellijReconnectContext = context
                 startZellijReconnect(context)
             case .surfaceUnavailable:
-                // Transient: see the tmux path in nativeTmuxStateChanged.
-                guard let context = activeZellijReconnectContext,
-                      context.handleID == handle.id
-                else {
-                    zellijReconnectSupervisor.cancel()
-                    activeBorrowedZellijRecoveryState = nil
-                    scheduleZellijSessionDiscovery()
-                    return
-                }
-                startZellijReconnect(context)
+                // Recoverable failures are re-armed above, before
+                // `hasLaunched`. Reaching here means no matching reconnect
+                // context survives.
+                fallthrough
             case .launchFailed, nil:
                 if let selection = pendingCreatedZellijSessions
                     .removeValue(forKey: handle.id) {
@@ -10131,7 +10154,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 scheduleZellijSessionDiscovery()
                 return .stop
             }
-            guard context.surfaceExitCode == 255 else {
+            guard context.surfaceExitCode == 255
+                || context.surfaceLaunchFailed
+            else {
                 stopZellijReconnect(
                     "The remote Zellij client exited before it could attach."
                 )
@@ -10424,7 +10449,9 @@ final class WorkspaceSceneModel: ObservableObject {
             // SSH reserves 255 for transport failure, but a client could also choose it.
             // The accepted ambiguity self-corrects because every retry first probes the
             // exact running Herdr session and stops when that session is absent.
-            guard context.surfaceExitCode == 255 else {
+            guard context.surfaceExitCode == 255
+                || context.surfaceLaunchFailed
+            else {
                 stopHerdrReconnectWithUnableToAttach(
                     "The remote Herdr client exited before it could attach."
                 )

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -9870,28 +9870,26 @@ final class WorkspaceSceneModel: ObservableObject {
             activeHerdrReconnectContext?.surfaceLaunchFailed = false
             return
         }
-        // Checked before `hasLaunched`: a surface that failed to be created
-        // never launched, so the guard below would drop this transient failure
-        // and the session would latch. See the tmux path.
-        if case .disconnected = state,
-           nativeHerdrSessionCoordinator.attachmentClosure(handle)
-           == .surfaceUnavailable,
-           var context = activeHerdrReconnectContext,
-           context.handleID == handle.id {
-            context.surfaceLaunchFailed = true
-            activeHerdrReconnectContext = context
-            startHerdrReconnect(context)
-            return
-        }
-        guard case .disconnected = state,
-              nativeHerdrSessionCoordinator.hasLaunched(handle)
-        else { return }
+        guard case .disconnected = state else { return }
         if suppressedHerdrStops.values.contains(where: {
             $0.selection.hostID == handle.hostID
                 && $0.selection.name == handle.name
         }) {
             return
         }
+        // Checked before `hasLaunched`: a surface that failed to be created
+        // never launched, so the guard below would drop this transient failure
+        // and the session would latch. See the tmux path.
+        if nativeHerdrSessionCoordinator.attachmentClosure(handle)
+            == .surfaceUnavailable,
+            var context = activeHerdrReconnectContext,
+            context.handleID == handle.id {
+            context.surfaceLaunchFailed = true
+            activeHerdrReconnectContext = context
+            startHerdrReconnect(context)
+            return
+        }
+        guard nativeHerdrSessionCoordinator.hasLaunched(handle) else { return }
         switch nativeHerdrSessionCoordinator.attachmentClosure(handle) {
         case .detached:
             cancelHerdrReconnect()

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -9724,6 +9724,10 @@ final class WorkspaceSceneModel: ObservableObject {
             presentation.recoveryRequest = nil
             if presentation.reconnectContext?.handleID == handle.id {
                 presentation.reconnectContext?.surfaceExitCode = nil
+                // Belt and braces: relaunch already rebuilds the context, but
+                // clearing here keeps "only the attempt that failed may skip
+                // the exit-code check" true regardless of that path.
+                presentation.reconnectContext?.surfaceLaunchFailed = false
                 startEstablishmentConfirmationIfNeeded(
                     presentation: presentation
                 )
@@ -9863,6 +9867,7 @@ final class WorkspaceSceneModel: ObservableObject {
             activeBorrowedHerdrRecoveryState = nil
             sessionConnectionRecoveryRequest = nil
             activeHerdrReconnectContext?.surfaceExitCode = nil
+            activeHerdrReconnectContext?.surfaceLaunchFailed = false
             return
         }
         // Checked before `hasLaunched`: a surface that failed to be created
@@ -9933,6 +9938,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 context.connection = nativeZellijSessionCoordinator
                     .attachmentConnectionSnapshot(handle)
                 context.surfaceExitCode = nil
+                context.surfaceLaunchFailed = false
                 activeZellijReconnectContext = context
             }
             sessionConnectionRecoveryRequest = nil

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -10762,7 +10762,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 publishActiveState(for: presentation)
                 return .stop
             }
-            guard context.surfaceExitCode == 255 else {
+            guard context.surfaceExitCode == 255
+                || (context.phase == .establishingWorkspace
+                    && context.surfaceLaunchFailed)
+            else {
                 stopTmuxReconnectWithUnableToAttach(
                     presentation,
                     "The remote workspace could not be established."

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -103,6 +103,22 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         }
     }
 
+    /// True when this surface failed because libghostty could not create it.
+    ///
+    /// That failure is transient: the renderer needs an active display to build
+    /// its vsync display link, so creation fails whenever no display is
+    /// available (lid shut, no external monitor) and succeeds again once one is.
+    /// Callers use this to keep recovering instead of latching.
+    public var launchFailureIsRetryable: Bool {
+        guard let terminalError = error as? TerminalSurfaceError else {
+            return false
+        }
+        if case .surfaceCreationFailed = terminalError {
+            return true
+        }
+        return false
+    }
+
     // MARK: - Internal State
 
     @Published public private(set) var focused: Bool = false
@@ -1844,7 +1860,7 @@ enum TerminalSurfaceError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .surfaceCreationFailed:
-            return "ghostty_surface_new returned nil"
+            return "Ghosthub could not create the terminal surface."
         case let .surfaceClosed(processAlive):
             return processAlive
                 ? "Surface closed while process is still running"

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -103,18 +103,19 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         }
     }
 
-    /// True when this surface failed because libghostty could not create it.
+    /// True when libghostty could not create this surface with no active display.
     ///
-    /// That failure is transient: the renderer needs an active display to build
-    /// its vsync display link, so creation fails whenever no display is
-    /// available (lid shut, no external monitor) and succeeds again once one is.
-    /// Callers use this to keep recovering instead of latching.
+    /// That specific failure is transient: the renderer needs an active display
+    /// to build its vsync display link. Other creation failures may persist, so
+    /// callers must not keep recovering from them indefinitely.
     public var launchFailureIsRetryable: Bool {
         guard let terminalError = error as? TerminalSurfaceError else {
             return false
         }
-        if case .surfaceCreationFailed = terminalError {
-            return true
+        if case let .surfaceCreationFailed(activeDisplayCount) = terminalError {
+            return DisplayAvailability.surfaceCreationFailureIsRetryable(
+                activeDisplayCount: activeDisplayCount
+            )
         }
         return false
     }
@@ -303,7 +304,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             ghostty_surface_new(app, &config)
         }
         guard let surfaceHandle else {
-            error = TerminalSurfaceError.surfaceCreationFailed
+            error = TerminalSurfaceError.surfaceCreationFailed(
+                activeDisplayCount: DisplayAvailability.activeCount()
+            )
             return
         }
         surface = surfaceHandle
@@ -1854,7 +1857,7 @@ private extension TerminalSurfaceView {
 // MARK: - Error
 
 enum TerminalSurfaceError: LocalizedError {
-    case surfaceCreationFailed
+    case surfaceCreationFailed(activeDisplayCount: Int)
     case surfaceClosed(processAlive: Bool)
 
     var errorDescription: String? {

--- a/Sources/TerminalSupport/DisplayAvailability.swift
+++ b/Sources/TerminalSupport/DisplayAvailability.swift
@@ -15,8 +15,8 @@ import CoreGraphics
 /// This reads the same quantity CoreVideo itself measures rather than
 /// `NSScreen.screens`, so the check matches the precondition that actually
 /// fails.
-enum DisplayAvailability {
-    static func activeCount() -> Int {
+public enum DisplayAvailability {
+    public static func activeCount() -> Int {
         #if canImport(CoreGraphics)
         var count: UInt32 = 0
         guard CGGetActiveDisplayList(0, nil, &count) == .success else {
@@ -28,5 +28,11 @@ enum DisplayAvailability {
         #else
         return 1
         #endif
+    }
+
+    public static func surfaceCreationFailureIsRetryable(
+        activeDisplayCount: Int
+    ) -> Bool {
+        activeDisplayCount == 0
     }
 }

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -26,7 +26,7 @@ enum TerminalFontZoomCommand: Equatable, Sendable {
 }
 
 enum TerminalSurfaceError: LocalizedError {
-    case surfaceCreationFailed
+    case surfaceCreationFailed(activeDisplayCount: Int)
     case surfaceClosed(processAlive: Bool)
 
     var errorDescription: String? {
@@ -78,8 +78,10 @@ public final class TerminalSurfaceView: ObservableObject {
         guard let terminalError = error as? TerminalSurfaceError else {
             return false
         }
-        if case .surfaceCreationFailed = terminalError {
-            return true
+        if case let .surfaceCreationFailed(activeDisplayCount) = terminalError {
+            return DisplayAvailability.surfaceCreationFailureIsRetryable(
+                activeDisplayCount: activeDisplayCount
+            )
         }
         return false
     }

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -73,6 +73,17 @@ public final class TerminalSurfaceView: ObservableObject {
     @Published public var error: Error?
     public internal(set) var childExitCode: UInt32?
 
+    /// Mirrors `TerminalSurfaceView.launchFailureIsRetryable`.
+    public var launchFailureIsRetryable: Bool {
+        guard let terminalError = error as? TerminalSurfaceError else {
+            return false
+        }
+        if case .surfaceCreationFailed = terminalError {
+            return true
+        }
+        return false
+    }
+
     public var suppressAutoFocus: Bool = false
     public var onFocusChange: ((Bool) -> Void)?
     public var onPrimaryInteraction: (() -> Void)?

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -616,8 +616,10 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     var paneSplitErrorMessage: String?
     var hasEffectiveKeyboardFocus = false
     var paneSplitShortcutHandler: ((TerminalPaneSplitShortcut) -> Void)?
-    let launchError: Error?
-    let launchFailureIsRetryable: Bool
+    /// Mutable so a test can fail one attach and let the next succeed, which is
+    /// how a transient surface failure behaves in practice.
+    var launchError: Error?
+    var launchFailureIsRetryable: Bool
     private var closeOnRegistrationCode: UInt32?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -329,6 +329,7 @@ func makeModel(
     @escaping (UInt?) -> TmuxPresentationStyle? = { _ in nil },
     appliesTmuxPresentationStyleToExistingSessionsProvider:
     @escaping () -> Bool = { false },
+    activeDisplayCount: @escaping @Sendable () -> Int = { 1 },
     kwtInventoryLoader: @escaping WorkspaceSceneModel.KwtInventoryLoader = {
         host in
         try await KwtInventoryClient().load(from: host)
@@ -503,6 +504,7 @@ func makeModel(
         tmuxPresentationStyleProvider: tmuxPresentationStyleProvider,
         appliesTmuxPresentationStyleToExistingSessionsProvider:
         appliesTmuxPresentationStyleToExistingSessionsProvider,
+        activeDisplayCount: activeDisplayCount,
         kwtInventoryLoader: kwtInventoryLoader,
         kwtRemoteProvisioner: kwtRemoteProvisioner,
         kwtWorktreeCreator: kwtWorktreeCreator,
@@ -578,10 +580,12 @@ final class RecordingNativeSessionSurfaceStore: NativeSessionSurfaceStoring {
 
     init(
         launchError: Error? = nil,
+        launchFailureIsRetryable: Bool = false,
         closeOnRegistrationCode: UInt32? = nil
     ) {
         surface = RecordingNativeSessionPaneSurface(
             launchError: launchError,
+            launchFailureIsRetryable: launchFailureIsRetryable,
             closeOnRegistrationCode: closeOnRegistrationCode
         )
     }
@@ -613,15 +617,18 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     var hasEffectiveKeyboardFocus = false
     var paneSplitShortcutHandler: ((TerminalPaneSplitShortcut) -> Void)?
     let launchError: Error?
+    let launchFailureIsRetryable: Bool
     private var closeOnRegistrationCode: UInt32?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
 
     init(
         launchError: Error? = nil,
+        launchFailureIsRetryable: Bool = false,
         closeOnRegistrationCode: UInt32? = nil
     ) {
         self.launchError = launchError
+        self.launchFailureIsRetryable = launchFailureIsRetryable
         self.closeOnRegistrationCode = closeOnRegistrationCode
     }
 

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1425,6 +1425,47 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("no active display holds Herdr recovery without probing the host")
+    func zeroDisplaysHoldsHerdrRecovery() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let displays = Mutex(1)
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in
+                probes.withLock { $0 += 1 }
+                return .present
+            },
+            activeDisplayCount: { displays.withLock { $0 } }
+        )
+        let herdr = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+        try await model.openBorrowedHerdrSession(herdr)
+        await launchHerdrSurface(model, store: store)
+        probes.withLock { $0 = 0 }
+
+        displays.withLock { $0 = 0 }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor { model.herdrReconnectSupervisorIsRunning }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(store.requestedKeys.count == 1)
+        #expect(probes.withLock { $0 } == 0)
+        #expect(model.herdrReconnectSupervisorIsRunning)
+
+        displays.withLock { $0 = 1 }
+        model.handleDisplayParametersChanged()
+        await waitUntilMainActor { store.requestedKeys.count == 2 }
+
+        #expect(model.activeBorrowedHerdrSelection == herdr)
+        await model.shutdown()
+    }
+
     @Test("reconnect rejects SSH route drift after its exact probe")
     func remoteTransportRecoveryRejectsRouteDrift() async throws {
         let environment = try remoteEnvironment()
@@ -1682,6 +1723,7 @@ struct WorkspaceHerdrPresentationTests {
         paneSplitCapabilityProvider: @escaping NativeHerdrSessionCoordinator
             .PaneSplitCapabilityProvider = { _, _, _, _ in .success(nil) },
         paneSplitter: HerdrPaneSplitter = HerdrPaneSplitter(),
+        activeDisplayCount: @escaping @Sendable () -> Int = { 1 },
         createdSessionDiscoveryDelays: [Duration] = [
             .milliseconds(500),
             .seconds(1),
@@ -1706,6 +1748,7 @@ struct WorkspaceHerdrPresentationTests {
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },
+            activeDisplayCount: activeDisplayCount,
             herdrLifecycleCoordinator: coordinator,
             herdrSSHConnectionSnapshotProvider:
             sshConnectionSnapshotProvider,

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1425,6 +1425,44 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("retryable Herdr surface failure keeps recovering instead of latching")
+    func retryableHerdrSurfaceFailureKeepsRecovering() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in .present }
+        )
+        let herdr = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+        try await model.openBorrowedHerdrSession(herdr)
+        await launchHerdrSurface(model, store: store)
+
+        // Displays vanished between the gate and surface creation. Recovery
+        // must re-arm each time rather than latching after the first failure,
+        // so attempts keep accumulating.
+        store.surface.launchError = HerdrSurfaceLaunchTestError.rejected
+        store.surface.launchFailureIsRetryable = true
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            store.requestedKeys.count >= 3
+        }
+
+        store.surface.launchError = nil
+        store.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            model.activeBorrowedHerdrSelection == herdr
+                && !model.herdrReconnectSupervisorIsRunning
+        }
+
+        #expect(model.activeBorrowedHerdrSelection == herdr)
+        await model.shutdown()
+    }
+
     @Test("no active display holds Herdr recovery without probing the host")
     func zeroDisplaysHoldsHerdrRecovery() async throws {
         let environment = try remoteEnvironment()
@@ -1787,4 +1825,10 @@ final class HerdrDiscoveryQueue: @unchecked Sendable {
         callCount += 1
         return results.isEmpty ? .unavailable : results.removeFirst()
     }
+}
+
+private enum HerdrSurfaceLaunchTestError: LocalizedError {
+    case rejected
+
+    var errorDescription: String? { "Surface launch rejected" }
 }

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1215,6 +1215,47 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("confirmed Herdr stop suppresses delayed surface recovery")
+    func confirmedStopSuppressesDelayedSurfaceRecovery() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = HerdrSessionLifecycleCoordinator()
+        let probes = Mutex(0)
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in
+                probes.withLock { $0 += 1 }
+                return .present
+            },
+            coordinator: coordinator
+        )
+        let selection = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+        let key = HerdrSessionLifecycleCoordinator.Key(
+            hostID: selection.hostID,
+            sessionName: selection.name
+        )
+        try await model.openBorrowedHerdrSession(selection)
+        await launchHerdrSurface(model, store: store)
+        let probeCountBeforeStop = probes.withLock { $0 }
+
+        let operation = try #require(coordinator.begin(.stop, key: key))
+        coordinator.willStop(operation)
+        store.surface.launchError = HerdrSurfaceLaunchTestError.rejected
+        store.surface.launchFailureIsRetryable = true
+
+        model.prepareActiveBorrowedHerdrSurface()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(probes.withLock { $0 } == probeCountBeforeStop)
+        #expect(!model.herdrReconnectSupervisorIsRunning)
+        coordinator.finish(operation, outcome: .succeeded)
+        await model.shutdown()
+    }
+
     @Test("manual retry probes the exact running session before attaching")
     func manualRetryRequiresRunningSession() async throws {
         let environment = try environment()

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1463,6 +1463,47 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("recovered Herdr surface failure does not excuse a later exit")
+    func recoveredHerdrSurfaceFailureDoesNotExcuseLaterExit() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in .present }
+        )
+        let herdr = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+        try await model.openBorrowedHerdrSession(herdr)
+        await launchHerdrSurface(model, store: store)
+
+        // A transient surface failure, then a successful reconnect.
+        store.surface.launchError = HerdrSurfaceLaunchTestError.rejected
+        store.surface.launchFailureIsRetryable = true
+        store.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            store.requestedKeys.count >= 2
+        }
+        store.surface.launchError = nil
+        store.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            !model.herdrReconnectSupervisorIsRunning
+                && model.activeBorrowedHerdrSelection == herdr
+        }
+        let recoveredCount = store.requestedKeys.count
+
+        // A normal client exit is not a transport failure and must not inherit
+        // the earlier transient failure's licence to retry.
+        store.surface.closeObservers.values.first?(false, 0)
+        try await Task.sleep(for: .milliseconds(150))
+
+        #expect(store.requestedKeys.count == recoveredCount)
+        #expect(!model.herdrReconnectSupervisorIsRunning)
+        await model.shutdown()
+    }
+
     @Test("no active display holds Herdr recovery without probing the host")
     func zeroDisplaysHoldsHerdrRecovery() async throws {
         let environment = try remoteEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -4218,6 +4218,61 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("recovered surface failure does not excuse a later normal exit")
+    func recoveredSurfaceFailureDoesNotExcuseLaterNormalExit() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remoteSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(remoteSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        // A transient surface failure, then a successful reconnect.
+        surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected
+        surfaceStore.surface.launchFailureIsRetryable = true
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor { surfaceStore.requestCount == 2 }
+        surfaceStore.surface.launchError = nil
+        surfaceStore.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+        let recoveredRequestCount = surfaceStore.requestCount
+
+        // The client now exits normally. That is not a transport failure, so
+        // it must be reported rather than retried: the earlier transient
+        // failure cannot keep excusing later exits.
+        surfaceStore.surface.closeObservers.values.first?(false, 0)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(surfaceStore.requestCount == recoveredRequestCount)
+        #expect(model.activeBorrowedTmuxRecoveryState?.isReconnecting != true)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("inactive retained presentation continues automatic recovery")
     func inactivePresentationContinuesAutomaticRecovery() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1,6 +1,7 @@
 import GhosthubTransport
 import Combine
 import Foundation
+import Synchronization
 import GhosthubSettings
 import GhosthubTerminal
 import GhosthubTmux
@@ -4097,6 +4098,122 @@ struct WorkspaceTmuxDiscoveryTests {
         #expect(
             surfaceStore.lastConfiguration?.command?.contains("'open'") == false
         )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("no active display holds recovery without probing the host")
+    func zeroDisplaysHoldsRecoveryUntilDisplayReturns() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let displays = Mutex(1)
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            activeDisplayCount: { displays.withLock { $0 } },
+            tmuxSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remoteSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(remoteSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        probes.withLock { $0 = 0 }
+
+        // The lid closes, then the transport dies: recovery must hold rather
+        // than burn its one attempt on a surface that cannot be created.
+        displays.withLock { $0 = 0 }
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(surfaceStore.requestCount == 1)
+        #expect(probes.withLock { $0 } == 0)
+        #expect(model.anyTmuxReconnectSupervisorIsRunning)
+
+        // The lid opens.
+        displays.withLock { $0 = 1 }
+        model.handleDisplayParametersChanged()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("retryable surface failure keeps recovering instead of latching")
+    func retryableSurfaceFailureKeepsRecovering() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let remoteSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(remoteSelection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        // Displays vanished between the gate and surface creation, so the
+        // relaunch fails transiently. Recovery must re-arm, not latch.
+        surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected
+        surfaceStore.surface.launchFailureIsRetryable = true
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor { surfaceStore.requestCount == 2 }
+
+        // Not latched: recovery stays armed. `isRunning` is deliberately not
+        // asserted — a tmux supervisor stops each time it hands off a relaunch,
+        // so it is false at arbitrary moments while recovery is still healthy.
+        #expect(model.activeBorrowedTmuxRecoveryState?.isReconnecting == true)
+
+        surfaceStore.surface.launchError = nil
+        surfaceStore.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
         await model.shutdown()
     }
 
@@ -9788,6 +9905,7 @@ private struct SceneModelRootHarness: View {
 private final class SceneTmuxPaneSurfaceStub: NativeSessionPaneSurfacing {
     var blocksClipboardReads = false
     var launchError: Error?
+    var launchFailureIsRetryable = false
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
     private(set) var lastObserverID: UUID?

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -4677,6 +4677,58 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("retryable surface failure relaunches an absent workspace")
+    func retryableSurfaceFailureRelaunchesAbsentWorkspace() async throws {
+        let environment = try setupRemoteEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionName = "kwt-ghosthub-main"
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxReconnectIntervals: [.seconds(10)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected
+        surfaceStore.surface.launchFailureIsRetryable = true
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
+        }
+        model.reconnectActiveTmuxSessionNow()
+        await waitUntilMainActor { surfaceStore.requestCount == 2 }
+
+        surfaceStore.surface.launchError = nil
+        surfaceStore.surface.launchFailureIsRetryable = false
+        model.reconnectActiveTmuxSessionNow()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 3
+                || model.activeBorrowedTmuxRecoveryState == nil
+        }
+
+        #expect(surfaceStore.requestCount == 3)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == true
+        )
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("resolver timeout remains retryable")
     func resolverTimeoutRemainsRetryable() async throws {
         let discoveries = TmuxDiscoveryResultQueue([

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -1654,6 +1654,70 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("recovered Zellij surface failure does not excuse a later exit")
+    func recoveredZellijSurfaceFailureDoesNotExcuseLaterExit() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+
+        // A transient surface failure, then a successful reconnect.
+        store.surface.launchError = ZellijSurfaceLaunchTestError.rejected
+        store.surface.launchFailureIsRetryable = true
+        store.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            store.requestedConfigurations.count >= 2
+        }
+        store.surface.launchError = nil
+        store.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            !model.zellijReconnectSupervisorIsRunning
+                && model.activeBorrowedZellijSelection == selection
+        }
+        let recoveredCount = store.requestedConfigurations.count
+
+        // A normal client exit is not a transport failure and must not inherit
+        // the earlier transient failure's licence to retry.
+        store.surface.closeObservers.values.first?(false, 0)
+        try await Task.sleep(for: .milliseconds(150))
+
+        #expect(store.requestedConfigurations.count == recoveredCount)
+        #expect(!model.zellijReconnectSupervisorIsRunning)
+        await model.shutdown()
+    }
+
     @Test("no active display holds Zellij recovery without probing the host")
     func zeroDisplaysHoldsZellijRecovery() async throws {
         let database = try WorkspaceDatabase.inMemory()

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -1593,6 +1593,73 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("no active display holds Zellij recovery without probing the host")
+    func zeroDisplaysHoldsZellijRecovery() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let probes = Mutex(0)
+        let displays = Mutex(1)
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            activeDisplayCount: { displays.withLock { $0 } },
+            zellijSessionDiscovery: { _ in
+                probes.withLock { $0 += 1 }
+                return .available(["api"])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            model.activeBorrowedZellijSelection == selection
+                && store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+        probes.withLock { $0 = 0 }
+
+        displays.withLock { $0 = 0 }
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        await waitUntilMainActor { model.zellijReconnectSupervisorIsRunning }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(store.requestedConfigurations.count == 1)
+        #expect(probes.withLock { $0 } == 0)
+        #expect(model.zellijReconnectSupervisorIsRunning)
+
+        displays.withLock { $0 = 1 }
+        model.handleDisplayParametersChanged()
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 2
+        }
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        await model.shutdown()
+    }
+
     @Test("confirmed kill suppresses reconnect in another scene")
     func confirmedKillSuppressesPeerReconnect() async throws {
         let host = HostSummary(

--- a/Tests/App/WorkspaceZellijTests.swift
+++ b/Tests/App/WorkspaceZellijTests.swift
@@ -1593,6 +1593,67 @@ struct WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("retryable Zellij surface failure keeps recovering instead of latching")
+    func retryableZellijSurfaceFailureKeepsRecovering() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            zellijSessionDiscovery: { _ in .available(["api"]) },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor {
+            store.requestedConfigurations.count == 1
+                && !store.surface.closeObservers.isEmpty
+        }
+
+        // Displays vanished between the gate and surface creation. Recovery
+        // must re-arm each time rather than latching after the first failure,
+        // so attempts keep accumulating.
+        store.surface.launchError = ZellijSurfaceLaunchTestError.rejected
+        store.surface.launchFailureIsRetryable = true
+        let close = try #require(store.surface.closeObservers.values.first)
+        close(false, 255)
+        try await Task.sleep(for: .milliseconds(300))
+        #expect(store.requestedConfigurations.count >= 3)
+        #expect(model.zellijReconnectSupervisorIsRunning)
+
+        store.surface.launchError = nil
+        store.surface.launchFailureIsRetryable = false
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            model.activeBorrowedZellijSelection == selection
+                && !model.zellijReconnectSupervisorIsRunning
+        }
+
+        #expect(model.activeBorrowedZellijSelection == selection)
+        await model.shutdown()
+    }
+
     @Test("no active display holds Zellij recovery without probing the host")
     func zeroDisplaysHoldsZellijRecovery() async throws {
         let database = try WorkspaceDatabase.inMemory()
@@ -3624,4 +3685,10 @@ struct WorkspaceZellijTests {
             WorkspaceSnapshot(hosts: [host], projects: [], worktrees: [])
         )
     }
+}
+
+private enum ZellijSurfaceLaunchTestError: LocalizedError {
+    case rejected
+
+    var errorDescription: String? { "Surface launch rejected" }
 }

--- a/Tests/TerminalSupport/DisplayAvailabilityTests.swift
+++ b/Tests/TerminalSupport/DisplayAvailabilityTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import GhosthubTerminalSupport
+
+@Suite("Display availability")
+struct DisplayAvailabilityTests {
+    @Test(
+        "surface creation failure is retryable only with no active display",
+        arguments: [
+            (activeDisplayCount: 0, expected: true),
+            (activeDisplayCount: 1, expected: false),
+            (activeDisplayCount: 2, expected: false),
+        ]
+    )
+    func surfaceCreationFailureRetryability(
+        activeDisplayCount: Int,
+        expected: Bool
+    ) {
+        #expect(
+            DisplayAvailability.surfaceCreationFailureIsRetryable(
+                activeDisplayCount: activeDisplayCount
+            ) == expected
+        )
+    }
+}


### PR DESCRIPTION
Closes #131.

When macOS wakes with no active display, the bundled libghostty cannot create a terminal surface. The remote tmux, Herdr, or Zellij session may still be healthy, but Ghosthub previously treated the local surface failure as permanent and stopped automatic recovery. The user then saw “Unable to attach” until choosing Retry.

- Waits for an active display before probing a remote host. This preserves the existing retry schedule and avoids repeated SSH traffic during lid-closed dark wakes.
- Wakes the existing retry supervisor as soon as macOS reports a display change.
- Treats a surface-creation failure as retryable only when the active display count captured at failure is zero. Other renderer, configuration, and resource failures remain normal launch failures.
- Re-arms tmux, Herdr, and Zellij recovery when that transient failure interrupts a relaunch. A client that never started has no exit code, so recovery records the surface failure separately and clears it after a successful connection.
- If a remote tmux session is still absent, repeats only safe workspace establishment. Ghosthub never automatically replays a launch-profile command.
- Keeps a confirmed Herdr Stop authoritative if a delayed surface callback arrives.
- Logs the real surface-launch failure instead of showing libghostty’s misleading `OutOfMemory` label.

[ghostty-org/ghostty@a177ba9](https://github.com/ghostty-org/ghostty/commit/a177ba90af18d5df91b2b5cb8dddc0a55905c37f) makes the macOS display link optional and should remove this specific zero-display trigger once Ghosthub adopts a release containing it. That change is not in Ghosthub’s current bundled libghostty, so this PR keeps recovery correct today without waiting for the dependency and toolchain upgrade.

Out of scope: changing the existing `surfaceExitCode == 255` policy for clients that actually launch and then exit because of a signal.
