### PR TITLE
Accept appcasts emitted by pinned Sparkle

### DIFF
--- a/Tests/test_generate_nightly_update_appcast.py
+++ b/Tests/test_generate_nightly_update_appcast.py
@@ -124,11 +124,11 @@ assert notes.is_file()
 (release_root / "captured-release-notes.md").write_text(notes.read_text())
 (release_root / "appcast.xml").write_text(
     '<?xml version="1.0"?>'
-    '<rss xmlns:sparkle="https://sparkle-project.org/xml-namespaces/sparkle">'
-    '<channel><item><enclosure url="'
+    '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">'
+    '<channel><item><sparkle:version>123</sparkle:version><enclosure url="'
     + prefix
     + archive.name
-    + '" sparkle:version="123" sparkle:edSignature="signed" />'
+    + '" sparkle:edSignature="signed" />'
     '</item></channel></rss>'
     '<!-- sparkle-signatures: edSignature: signed-feed -->'
 )

--- a/Tests/test_generate_update_appcast.py
+++ b/Tests/test_generate_update_appcast.py
@@ -109,11 +109,11 @@ assert notes.is_file()
 (release_root / "captured-release-notes.md").write_text(notes.read_text())
 (release_root / "appcast.xml").write_text(
     '<?xml version="1.0"?>'
-    '<rss xmlns:sparkle="https://sparkle-project.org/xml-namespaces/sparkle">'
-    '<channel><item><enclosure url="'
+    '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">'
+    '<channel><item><sparkle:version>123</sparkle:version><enclosure url="'
     + prefix
     + archive.name
-    + '" sparkle:version="123" sparkle:edSignature="signed" />'
+    + '" sparkle:edSignature="signed" />'
     '</item></channel></rss>'
     '<!-- sparkle-signatures: edSignature: signed-feed -->'
 )
@@ -197,9 +197,10 @@ def test_verifies_appcast_enclosure_against_the_built_app(tmp_path):
     )
     appcast.write_text(
         '<?xml version="1.0"?>'
-        '<rss xmlns:sparkle="https://sparkle-project.org/'
-        'xml-namespaces/sparkle"><channel><item><enclosure '
-        f'url="{expected_url}" sparkle:version="123" '
+        '<rss xmlns:sparkle="http://www.andymatuschak.org/'
+        'xml-namespaces/sparkle"><channel><item>'
+        '<sparkle:version>123</sparkle:version><enclosure '
+        f'url="{expected_url}" '
         'sparkle:edSignature="signed" /></item></channel></rss>',
         encoding="utf-8",
     )
@@ -208,34 +209,38 @@ def test_verifies_appcast_enclosure_against_the_built_app(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("enclosure", "message"),
+    ("version", "enclosure", "message"),
     [
         (
+            "123",
             'url="https://nightly-downloads.ghosthub.ai/wrong.dmg" '
-            'sparkle:version="123" sparkle:edSignature="signed"',
+            'sparkle:edSignature="signed"',
             "URL",
         ),
         (
+            "122",
             'url="https://nightly-downloads.ghosthub.ai/build.dmg" '
-            'sparkle:version="122" sparkle:edSignature="signed"',
+            'sparkle:edSignature="signed"',
             "CFBundleVersion",
         ),
         (
-            'url="https://nightly-downloads.ghosthub.ai/build.dmg" '
-            'sparkle:version="123"',
+            "123",
+            'url="https://nightly-downloads.ghosthub.ai/build.dmg"',
             "signature",
         ),
         (
+            "123",
             'url="https://nightly-downloads.ghosthub.ai/build.dmg" '
-            'sparkle:version="123" sparkle:edSignature="signed" />'
+            'sparkle:edSignature="signed" />'
             '<enclosure url="https://nightly-downloads.ghosthub.ai/other.dmg" '
-            'sparkle:version="123" sparkle:edSignature="signed"',
+            'sparkle:edSignature="signed"',
             "exactly one",
         ),
     ],
 )
 def test_rejects_appcast_that_does_not_name_the_built_artifact(
     tmp_path,
+    version,
     enclosure,
     message,
 ):
@@ -245,8 +250,9 @@ def test_rejects_appcast_that_does_not_name_the_built_artifact(
     appcast = tmp_path / "appcast.xml"
     expected_url = "https://nightly-downloads.ghosthub.ai/build.dmg"
     appcast.write_text(
-        '<rss xmlns:sparkle="https://sparkle-project.org/'
-        'xml-namespaces/sparkle"><channel><item><enclosure '
+        '<rss xmlns:sparkle="http://www.andymatuschak.org/'
+        'xml-namespaces/sparkle"><channel><item>'
+        f'<sparkle:version>{version}</sparkle:version><enclosure '
         f'{enclosure} /></item></channel></rss>',
         encoding="utf-8",
     )
@@ -454,6 +460,12 @@ def test_pinned_generate_appcast_accepts_the_standard_seed_export(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    appcast = (tmp_path / "appcast.xml").read_text()
+    appcast_path = tmp_path / "appcast.xml"
+    appcast = appcast_path.read_text()
     assert "sparkle:edSignature=" in appcast
     assert "<!-- sparkle-signatures:" in appcast
+    verify_appcast(
+        appcast_path,
+        app / "Contents/Info.plist",
+        archive.name,
+    )

--- a/Tests/test_nightly_channel.py
+++ b/Tests/test_nightly_channel.py
@@ -85,9 +85,10 @@ def appcast_data(
         else ""
     )
     content = (
-        '<rss xmlns:sparkle="https://sparkle-project.org/'
-        'xml-namespaces/sparkle"><channel><item><enclosure '
-        f'url="{url}" sparkle:version="{build}"{signature_attribute} />'
+        '<rss xmlns:sparkle="http://www.andymatuschak.org/'
+        'xml-namespaces/sparkle"><channel><item>'
+        f'<sparkle:version>{build}</sparkle:version><enclosure '
+        f'url="{url}"{signature_attribute} />'
         '</item></channel></rss>'
     ).encode()
     if not include_feed_signature:
@@ -143,29 +144,32 @@ def test_manifest_rejects_invalid_published_metadata(field, value):
         signed_appcast(b"<rss><channel /></rss>"),
         signed_appcast(
             (
-                '<rss xmlns:sparkle="https://sparkle-project.org/'
+                '<rss xmlns:sparkle="http://www.andymatuschak.org/'
                 'xml-namespaces/sparkle"><channel><item>'
+                '<sparkle:version>1</sparkle:version>'
                 '<enclosure url="https://example.test/one.dmg" '
-                f'sparkle:version="1" sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
+                f'sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
                 '<enclosure url="https://example.test/two.dmg" '
-                f'sparkle:version="2" sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
-                "</item></channel></rss>"
-            ).encode()
-        ),
-        signed_appcast(
-            (
-                '<rss xmlns:sparkle="https://sparkle-project.org/'
-                'xml-namespaces/sparkle"><channel><item><enclosure '
-                'url="http://example.test/build.dmg" sparkle:version="1" '
                 f'sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
                 "</item></channel></rss>"
             ).encode()
         ),
         signed_appcast(
             (
-                '<rss xmlns:sparkle="https://sparkle-project.org/'
-                'xml-namespaces/sparkle"><channel><item><enclosure '
-                'url="https://example.test/build.dmg" sparkle:version="zero" '
+                '<rss xmlns:sparkle="http://www.andymatuschak.org/'
+                'xml-namespaces/sparkle"><channel><item>'
+                '<sparkle:version>1</sparkle:version><enclosure '
+                'url="http://example.test/build.dmg" '
+                f'sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
+                "</item></channel></rss>"
+            ).encode()
+        ),
+        signed_appcast(
+            (
+                '<rss xmlns:sparkle="http://www.andymatuschak.org/'
+                'xml-namespaces/sparkle"><channel><item>'
+                '<sparkle:version>zero</sparkle:version><enclosure '
+                'url="https://example.test/build.dmg" '
                 f'sparkle:edSignature="{ARCHIVE_SIGNATURE}" />'
                 "</item></channel></rss>"
             ).encode()

--- a/tools/nightly_channel.py
+++ b/tools/nightly_channel.py
@@ -21,7 +21,7 @@ from urllib.request import urlopen
 from xml.etree import ElementTree
 
 
-SPARKLE_NAMESPACE = "https://sparkle-project.org/xml-namespaces/sparkle"
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
 DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
 ASCII_NUMBER_RE = re.compile(r"[0-9]+\Z")
@@ -258,16 +258,21 @@ class AppcastPointer:
             root = ElementTree.fromstring(content)
         except ElementTree.ParseError as error:
             raise ValueError("appcast is not valid XML") from error
-        enclosures = root.findall(".//enclosure")
+        items = root.findall(".//item")
+        enclosures = [
+            (item, enclosure)
+            for item in items
+            for enclosure in item.findall("enclosure")
+        ]
         if len(enclosures) != 1:
             raise ValueError("appcast must contain exactly one enclosure")
-        enclosure = enclosures[0]
+        item, enclosure = enclosures[0]
         dmg_url = require_https_url("appcast enclosure URL", enclosure.get("url"))
         require_ed25519_signature(
             "appcast enclosure signature",
             enclosure.get(f"{{{SPARKLE_NAMESPACE}}}edSignature"),
         )
-        raw_build = enclosure.get(f"{{{SPARKLE_NAMESPACE}}}version")
+        raw_build = item.findtext(f"{{{SPARKLE_NAMESPACE}}}version")
         try:
             build = int(raw_build) if raw_build is not None else 0
         except ValueError as error:

--- a/tools/verify_update_appcast.py
+++ b/tools/verify_update_appcast.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from xml.etree import ElementTree
 
 
-SPARKLE_NAMESPACE = "https://sparkle-project.org/xml-namespaces/sparkle"
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 
 
 def verify_appcast(
@@ -26,16 +26,22 @@ def verify_appcast(
         raise ValueError("app CFBundleVersion must be a string or integer")
     app_build = str(app_build_value)
 
-    enclosures = ElementTree.parse(appcast_path).findall(".//enclosure")
+    root = ElementTree.parse(appcast_path)
+    items = root.findall(".//item")
+    enclosures = [
+        (item, enclosure)
+        for item in items
+        for enclosure in item.findall("enclosure")
+    ]
     if len(enclosures) != 1:
         raise ValueError("appcast must contain exactly one enclosure")
-    enclosure = enclosures[0]
+    item, enclosure = enclosures[0]
     if enclosure.get("url") != expected_url:
         raise ValueError("appcast enclosure URL does not match the artifact")
     signature = enclosure.get(f"{{{SPARKLE_NAMESPACE}}}edSignature")
     if not signature:
         raise ValueError("appcast enclosure is missing its Sparkle signature")
-    if enclosure.get(f"{{{SPARKLE_NAMESPACE}}}version") != app_build:
+    if item.findtext(f"{{{SPARKLE_NAMESPACE}}}version") != app_build:
         raise ValueError("appcast version does not match CFBundleVersion")
 
 


### PR DESCRIPTION
The first live nightly reached notarization but publication stopped because Ghosthub expected a different appcast shape than pinned Sparkle 2.9.4 emits.

- Read the archive signature from Sparkle's runtime namespace and the build number from the item-level version element in both candidate verification and channel eligibility.
- Make controlled fixtures match the generated feed and exercise the boundary with an appcast produced by the real pinned Sparkle tool.
- Leave signing, notarization, release publication, and stable-channel isolation unchanged.
