### PR TITLE
Make terminal mouse interactions reliable

### DIFF
--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -742,7 +742,7 @@ public final class LibghosttyRuntime: ObservableObject,
         }
     }
 
-    fileprivate nonisolated static func handleAction(
+    nonisolated static func handleAction(
         app: ghostty_app_t?,
         target: ghostty_target_s,
         action: ghostty_action_s

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -115,6 +115,9 @@ public final class LibghosttyRuntime: ObservableObject,
     }
 
     static let osc52ClipboardWriteMIME = "application/x-ghosthub-osc52"
+    static var urlOpener: (URL) -> Bool = { url in
+        NSWorkspace.shared.open(url)
+    }
 
     public static let shared = LibghosttyRuntime(
         pipeline: LibghosttyConfigPipeline(
@@ -838,10 +841,7 @@ public final class LibghosttyRuntime: ObservableObject,
             return true
 
         case GHOSTTY_ACTION_OPEN_URL:
-            let openURLAction = action.action.open_url
-            DispatchQueue.main.async {
-                Self.openURL(openURLAction)
-            }
+            handleOpenURL(action.action.open_url)
             return true
 
         case GHOSTTY_ACTION_NEW_SPLIT:
@@ -1246,9 +1246,22 @@ public final class LibghosttyRuntime: ObservableObject,
         )
     }
 
-    @MainActor
-    private static func openURL(_ value: ghostty_action_open_url_s) {
-        let rawURL = String(cString: value.url)
+    nonisolated static func handleOpenURL(
+        _ value: ghostty_action_open_url_s
+    ) {
+        let rawURL = String(
+            decoding: UnsafeRawBufferPointer(
+                start: value.url,
+                count: Int(value.len)
+            ),
+            as: UTF8.self
+        )
+        DispatchQueue.main.async {
+            openURL(rawURL)
+        }
+    }
+
+    private static func openURL(_ rawURL: String) {
         let url: URL
         if let candidate = URL(string: rawURL), candidate.scheme != nil {
             url = candidate
@@ -1256,7 +1269,7 @@ public final class LibghosttyRuntime: ObservableObject,
             url = URL(fileURLWithPath: rawURL)
         }
 
-        NSWorkspace.shared.open(url)
+        _ = urlOpener(url)
     }
 }
 

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -5,6 +5,7 @@ import GhosttyKit
 protocol TerminalMouseEventDelegate: AnyObject {
     var surfaceHandle: ghostty_surface_t? { get }
     var prevPressureStage: Int { get set }
+    var bounds: NSRect { get }
     var frame: NSRect { get }
     func ensureFirstResponder()
     func convert(_ point: NSPoint, from view: NSView?) -> NSPoint
@@ -149,25 +150,16 @@ struct TerminalMouseEventHandler {
         )
     }
 
-    func handleMouseDragged(_ event: NSEvent) {
-        sendPointerPosition(
-            event.locationInWindow,
-            modifiers: event.modifierFlags
-        )
+    mutating func handleMouseDragged(_ event: NSEvent) {
+        handleDraggedPointer(event)
     }
 
-    func handleRightMouseDragged(_ event: NSEvent) {
-        sendPointerPosition(
-            event.locationInWindow,
-            modifiers: event.modifierFlags
-        )
+    mutating func handleRightMouseDragged(_ event: NSEvent) {
+        handleDraggedPointer(event)
     }
 
-    func handleOtherMouseDragged(_ event: NSEvent) {
-        sendPointerPosition(
-            event.locationInWindow,
-            modifiers: event.modifierFlags
-        )
+    mutating func handleOtherMouseDragged(_ event: NSEvent) {
+        handleDraggedPointer(event)
     }
 
     func handleScrollWheel(_ event: NSEvent) {
@@ -241,6 +233,20 @@ struct TerminalMouseEventHandler {
         _ button: ghostty_input_mouse_button_e
     ) {
         pressedButtons.removeAll { $0.button.rawValue == button.rawValue }
+    }
+
+    private mutating func handleDraggedPointer(_ event: NSEvent) {
+        if let delegate {
+            let position = delegate.convert(event.locationInWindow, from: nil)
+            pointerIsInside = delegate.bounds.contains(position)
+        } else {
+            pointerIsInside = false
+        }
+        pointerLocationInWindow = pointerIsInside ? event.locationInWindow : nil
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
+        )
     }
 
     private func sendPointerPosition(

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -44,6 +44,8 @@ struct TerminalMouseEventHandler {
 
     weak var delegate: TerminalMouseEventDelegate?
     private var pressedButtons: [PressedButton] = []
+    private var pointerLocationInWindow: NSPoint?
+    private var pointerIsInside = false
 
     init(delegate: TerminalMouseEventDelegate) {
         self.delegate = delegate
@@ -110,17 +112,18 @@ struct TerminalMouseEventHandler {
         return handled
     }
 
-    func handleMouseEntered(_ event: NSEvent) {
-        guard let delegate,
-              let surface = delegate.surfaceHandle else { return }
-        let pos = delegate.convert(event.locationInWindow, from: nil)
-        let mods = Self.pointerModifiers(event.modifierFlags)
-        Self.mousePositionSender(
-            surface, pos.x, delegate.frame.height - pos.y, mods
+    mutating func handleMouseEntered(_ event: NSEvent) {
+        pointerIsInside = true
+        pointerLocationInWindow = event.locationInWindow
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
         )
     }
 
-    func handleMouseExited(_ event: NSEvent) {
+    mutating func handleMouseExited(_ event: NSEvent) {
+        pointerIsInside = false
+        pointerLocationInWindow = nil
         guard let surface = delegate?.surfaceHandle else { return }
         if NSEvent.pressedMouseButtons != 0 {
             return
@@ -129,30 +132,42 @@ struct TerminalMouseEventHandler {
         Self.mousePositionSender(surface, -1, -1, mods)
     }
 
-    func handleMouseMoved(_ event: NSEvent) {
-        guard let delegate,
-              let surface = delegate.surfaceHandle else { return }
-        let pos = delegate.convert(event.locationInWindow, from: nil)
-        let mods = Self.pointerModifiers(event.modifierFlags)
-        Self.mousePositionSender(
-            surface, pos.x, delegate.frame.height - pos.y, mods
+    mutating func handleMouseMoved(_ event: NSEvent) {
+        pointerIsInside = true
+        pointerLocationInWindow = event.locationInWindow
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
         )
     }
 
     func handleModifierFlagsChanged(_ event: NSEvent) {
-        handleMouseMoved(event)
+        guard pointerIsInside, let pointerLocationInWindow else { return }
+        sendPointerPosition(
+            pointerLocationInWindow,
+            modifiers: event.modifierFlags
+        )
     }
 
     func handleMouseDragged(_ event: NSEvent) {
-        handleMouseMoved(event)
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
+        )
     }
 
     func handleRightMouseDragged(_ event: NSEvent) {
-        handleMouseMoved(event)
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
+        )
     }
 
     func handleOtherMouseDragged(_ event: NSEvent) {
-        handleMouseMoved(event)
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags
+        )
     }
 
     func handleScrollWheel(_ event: NSEvent) {
@@ -191,6 +206,8 @@ struct TerminalMouseEventHandler {
     }
 
     mutating func resetPointerStateForParking() {
+        pointerIsInside = false
+        pointerLocationInWindow = nil
         guard let delegate,
               let surface = delegate.surfaceHandle else { return }
         for pressed in pressedButtons {
@@ -224,6 +241,19 @@ struct TerminalMouseEventHandler {
         _ button: ghostty_input_mouse_button_e
     ) {
         pressedButtons.removeAll { $0.button.rawValue == button.rawValue }
+    }
+
+    private func sendPointerPosition(
+        _ locationInWindow: NSPoint,
+        modifiers: NSEvent.ModifierFlags
+    ) {
+        guard let delegate,
+              let surface = delegate.surfaceHandle else { return }
+        let pos = delegate.convert(locationInWindow, from: nil)
+        let mods = Self.pointerModifiers(modifiers)
+        Self.mousePositionSender(
+            surface, pos.x, delegate.frame.height - pos.y, mods
+        )
     }
 
     private static func pointerModifiers(

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -66,6 +66,14 @@ struct TerminalMouseEventHandler {
             bypassesApplicationMouseReporting:
             bypassesApplicationMouseReporting
         )
+        pointerIsInside = true
+        pointerLocationInWindow = event.locationInWindow
+        sendPointerPosition(
+            event.locationInWindow,
+            modifiers: event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            bypassesApplicationMouseReporting
+        )
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods
         )

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -52,7 +52,7 @@ struct TerminalMouseEventHandler {
     mutating func handleMouseDown(_ event: NSEvent) {
         delegate?.ensureFirstResponder()
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = Self.leftButtonModifiers(event.modifierFlags)
+        let mods = Self.pointerModifiers(event.modifierFlags)
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -62,7 +62,7 @@ struct TerminalMouseEventHandler {
     mutating func handleMouseUp(_ event: NSEvent) {
         delegate?.prevPressureStage = 0
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = Self.leftButtonModifiers(event.modifierFlags)
+        let mods = Self.pointerModifiers(event.modifierFlags)
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -114,7 +114,7 @@ struct TerminalMouseEventHandler {
         guard let delegate,
               let surface = delegate.surfaceHandle else { return }
         let pos = delegate.convert(event.locationInWindow, from: nil)
-        let mods = TerminalInputHelpers.ghosttyMods(event.modifierFlags)
+        let mods = Self.pointerModifiers(event.modifierFlags)
         Self.mousePositionSender(
             surface, pos.x, delegate.frame.height - pos.y, mods
         )
@@ -125,7 +125,7 @@ struct TerminalMouseEventHandler {
         if NSEvent.pressedMouseButtons != 0 {
             return
         }
-        let mods = TerminalInputHelpers.ghosttyMods(event.modifierFlags)
+        let mods = Self.pointerModifiers(event.modifierFlags)
         Self.mousePositionSender(surface, -1, -1, mods)
     }
 
@@ -133,10 +133,14 @@ struct TerminalMouseEventHandler {
         guard let delegate,
               let surface = delegate.surfaceHandle else { return }
         let pos = delegate.convert(event.locationInWindow, from: nil)
-        let mods = TerminalInputHelpers.ghosttyMods(event.modifierFlags)
+        let mods = Self.pointerModifiers(event.modifierFlags)
         Self.mousePositionSender(
             surface, pos.x, delegate.frame.height - pos.y, mods
         )
+    }
+
+    func handleModifierFlagsChanged(_ event: NSEvent) {
+        handleMouseMoved(event)
     }
 
     func handleMouseDragged(_ event: NSEvent) {
@@ -222,7 +226,7 @@ struct TerminalMouseEventHandler {
         pressedButtons.removeAll { $0.button.rawValue == button.rawValue }
     }
 
-    private static func leftButtonModifiers(
+    private static func pointerModifiers(
         _ modifiers: NSEvent.ModifierFlags
     ) -> ghostty_input_mods_e {
         var modifiers = modifiers

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -52,7 +52,7 @@ struct TerminalMouseEventHandler {
     mutating func handleMouseDown(_ event: NSEvent) {
         delegate?.ensureFirstResponder()
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = TerminalInputHelpers.ghosttyMods(event.modifierFlags)
+        let mods = Self.leftButtonModifiers(event.modifierFlags)
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -62,7 +62,7 @@ struct TerminalMouseEventHandler {
     mutating func handleMouseUp(_ event: NSEvent) {
         delegate?.prevPressureStage = 0
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = TerminalInputHelpers.ghosttyMods(event.modifierFlags)
+        let mods = Self.leftButtonModifiers(event.modifierFlags)
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -220,5 +220,17 @@ struct TerminalMouseEventHandler {
         _ button: ghostty_input_mouse_button_e
     ) {
         pressedButtons.removeAll { $0.button.rawValue == button.rawValue }
+    }
+
+    private static func leftButtonModifiers(
+        _ modifiers: NSEvent.ModifierFlags
+    ) -> ghostty_input_mods_e {
+        var modifiers = modifiers
+        if modifiers.contains(.command) {
+            // Libghostty uses Shift to bypass application mouse reporting and
+            // removes it again before matching the Command link binding.
+            modifiers.insert(.shift)
+        }
+        return TerminalInputHelpers.ghosttyMods(modifiers)
     }
 }

--- a/Sources/Terminal/TerminalMouseEventHandler.swift
+++ b/Sources/Terminal/TerminalMouseEventHandler.swift
@@ -47,6 +47,7 @@ struct TerminalMouseEventHandler {
     private var pressedButtons: [PressedButton] = []
     private var pointerLocationInWindow: NSPoint?
     private var pointerIsInside = false
+    private var leftGestureBypassesApplicationMouseReporting: Bool?
 
     init(delegate: TerminalMouseEventDelegate) {
         self.delegate = delegate
@@ -55,7 +56,16 @@ struct TerminalMouseEventHandler {
     mutating func handleMouseDown(_ event: NSEvent) {
         delegate?.ensureFirstResponder()
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = Self.pointerModifiers(event.modifierFlags)
+        let bypassesApplicationMouseReporting =
+            leftGestureBypassesApplicationMouseReporting
+                ?? Self.bypassesApplicationMouseReporting(event.modifierFlags)
+        leftGestureBypassesApplicationMouseReporting =
+            bypassesApplicationMouseReporting
+        let mods = Self.pointerModifiers(
+            event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            bypassesApplicationMouseReporting
+        )
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -64,8 +74,15 @@ struct TerminalMouseEventHandler {
 
     mutating func handleMouseUp(_ event: NSEvent) {
         delegate?.prevPressureStage = 0
+        let bypassesApplicationMouseReporting =
+            leftGestureBypassesApplicationMouseReporting
+        leftGestureBypassesApplicationMouseReporting = nil
         guard let surface = delegate?.surfaceHandle else { return }
-        let mods = Self.pointerModifiers(event.modifierFlags)
+        let mods = Self.pointerModifiers(
+            event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            bypassesApplicationMouseReporting
+        )
         _ = Self.mouseButtonSender(
             surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods
         )
@@ -118,7 +135,9 @@ struct TerminalMouseEventHandler {
         pointerLocationInWindow = event.locationInWindow
         sendPointerPosition(
             event.locationInWindow,
-            modifiers: event.modifierFlags
+            modifiers: event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            leftGestureBypassesApplicationMouseReporting
         )
     }
 
@@ -138,7 +157,9 @@ struct TerminalMouseEventHandler {
         pointerLocationInWindow = event.locationInWindow
         sendPointerPosition(
             event.locationInWindow,
-            modifiers: event.modifierFlags
+            modifiers: event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            leftGestureBypassesApplicationMouseReporting
         )
     }
 
@@ -146,12 +167,18 @@ struct TerminalMouseEventHandler {
         guard pointerIsInside, let pointerLocationInWindow else { return }
         sendPointerPosition(
             pointerLocationInWindow,
-            modifiers: event.modifierFlags
+            modifiers: event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            leftGestureBypassesApplicationMouseReporting
         )
     }
 
     mutating func handleMouseDragged(_ event: NSEvent) {
-        handleDraggedPointer(event)
+        handleDraggedPointer(
+            event,
+            bypassesApplicationMouseReporting:
+            leftGestureBypassesApplicationMouseReporting
+        )
     }
 
     mutating func handleRightMouseDragged(_ event: NSEvent) {
@@ -200,6 +227,7 @@ struct TerminalMouseEventHandler {
     mutating func resetPointerStateForParking() {
         pointerIsInside = false
         pointerLocationInWindow = nil
+        leftGestureBypassesApplicationMouseReporting = nil
         guard let delegate,
               let surface = delegate.surfaceHandle else { return }
         for pressed in pressedButtons {
@@ -235,7 +263,10 @@ struct TerminalMouseEventHandler {
         pressedButtons.removeAll { $0.button.rawValue == button.rawValue }
     }
 
-    private mutating func handleDraggedPointer(_ event: NSEvent) {
+    private mutating func handleDraggedPointer(
+        _ event: NSEvent,
+        bypassesApplicationMouseReporting: Bool? = nil
+    ) {
         if let delegate {
             let position = delegate.convert(event.locationInWindow, from: nil)
             pointerIsInside = delegate.bounds.contains(position)
@@ -245,32 +276,53 @@ struct TerminalMouseEventHandler {
         pointerLocationInWindow = pointerIsInside ? event.locationInWindow : nil
         sendPointerPosition(
             event.locationInWindow,
-            modifiers: event.modifierFlags
+            modifiers: event.modifierFlags,
+            bypassesApplicationMouseReporting:
+            bypassesApplicationMouseReporting
         )
     }
 
     private func sendPointerPosition(
         _ locationInWindow: NSPoint,
-        modifiers: NSEvent.ModifierFlags
+        modifiers: NSEvent.ModifierFlags,
+        bypassesApplicationMouseReporting: Bool? = nil
     ) {
         guard let delegate,
               let surface = delegate.surfaceHandle else { return }
         let pos = delegate.convert(locationInWindow, from: nil)
-        let mods = Self.pointerModifiers(modifiers)
+        let mods = Self.pointerModifiers(
+            modifiers,
+            bypassesApplicationMouseReporting:
+            bypassesApplicationMouseReporting
+        )
         Self.mousePositionSender(
             surface, pos.x, delegate.frame.height - pos.y, mods
         )
     }
 
     private static func pointerModifiers(
-        _ modifiers: NSEvent.ModifierFlags
+        _ modifiers: NSEvent.ModifierFlags,
+        bypassesApplicationMouseReporting: Bool? = nil
     ) -> ghostty_input_mods_e {
         var modifiers = modifiers
-        if modifiers.contains(.command) {
+        switch bypassesApplicationMouseReporting {
+        case true:
+            modifiers.insert(.shift)
+        case false:
+            modifiers.remove(.shift)
+        case nil where modifiers.contains(.command):
             // Libghostty uses Shift to bypass application mouse reporting and
             // removes it again before matching the Command link binding.
             modifiers.insert(.shift)
+        case nil:
+            break
         }
         return TerminalInputHelpers.ghosttyMods(modifiers)
+    }
+
+    private static func bypassesApplicationMouseReporting(
+        _ modifiers: NSEvent.ModifierFlags
+    ) -> Bool {
+        modifiers.contains(.shift) || modifiers.contains(.command)
     }
 }

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -1294,6 +1294,11 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         case 0x37, 0x36: mod = GHOSTTY_MODS_SUPER.rawValue
         default: return
         }
+        defer {
+            if mod == GHOSTTY_MODS_SUPER.rawValue {
+                mouseEventHandler.handleModifierFlagsChanged(event)
+            }
+        }
 
         if hasMarkedText() {
             return

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -9,6 +9,8 @@ public enum TmuxAttachmentLaunchMode: String, Codable, Equatable, Sendable {
 
 /// An ordinary tmux client launched inside a libghostty terminal surface.
 /// Tmux owns rendering, windows, panes, history, input, and process lifetime.
+/// Ghosthub enables tmux's session mouse option before presenting the client so
+/// wheel scrolling reaches tmux history without requiring user configuration.
 public struct TmuxAttachmentInfo: Equatable, Sendable {
     public let sessionName: String
     public let host: CommandHost
@@ -174,7 +176,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     kwtPath, "pr", "attach", protectedWorkspacePath,
                 ].map(shellQuotedCommandArgument).joined(separator: " ")
                 commands.append(
-                    kwtAttachWithPresentationCommand(
+                    kwtAttachWithSessionSetupCommand(
                         protectedAttach,
                         tmuxPath: tmuxPath
                     )
@@ -201,12 +203,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     // A detached `--start-session` phase is unsafe when the
                     // user's tmux server enables destroy-unattached.
                     commands.append(
-                        kwtAttachWithPresentationCommand(
+                        kwtAttachWithSessionSetupCommand(
                             openWorkspace,
                             tmuxPath: tmuxPath
                         )
                     )
                 } else {
+                    commands.append(mouseSetupCommand(tmuxPath: tmuxPath))
                     commands.append(
                         presentationCommand?.bestEffortCommand(
                             tmuxPath: tmuxPath
@@ -216,6 +219,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 }
             }
         case .attachOnly:
+            commands.append(mouseSetupCommand(tmuxPath: tmuxPath))
             commands.append(
                 presentationCommand?.bestEffortCommand(
                     tmuxPath: tmuxPath
@@ -249,6 +253,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         if let initialCommand, !initialCommand.isEmpty {
             arguments.append(initialCommand)
         }
+        arguments = appendingMouseOption(to: arguments)
         if let presentationCommand {
             arguments = presentationCommand.appendingOptions(to: arguments)
         }
@@ -267,19 +272,22 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     }
 
     /// Kwt establishes or repairs the complete session before starting its
-    /// tmux client. When Ghosthub owns presentation, run kwt as the foreground
-    /// terminal's background child just long enough to observe a client on
-    /// this launch's PTY, then style the finished session and wait on the same
-    /// client process.
+    /// tmux client. Run kwt as the foreground terminal's background child just
+    /// long enough to observe a client on this launch's PTY, then enable mouse
+    /// handling, apply any presentation style, and wait on the same client.
     /// This preserves kwt's atomic create-and-attach path under
     /// `destroy-unattached` while ensuring repair-created windows are included.
-    private func kwtAttachWithPresentationCommand(
+    private func kwtAttachWithSessionSetupCommand(
         _ kwtCommand: String,
         tmuxPath: String
     ) -> String {
-        guard let presentationCommand else {
-            return host.isRemote ? kwtCommand : "exec \(kwtCommand)"
+        var setupCommands = [mouseSetupCommand(tmuxPath: tmuxPath)]
+        if let presentationCommand {
+            setupCommands.append(
+                presentationCommand.bestEffortCommand(tmuxPath: tmuxPath)
+            )
         }
+        let sessionSetup = setupCommands.joined(separator: "; ")
         let listClientTTYs = tmuxArguments(
             tmuxPath,
             "list-clients", "-t", "=\(sessionName)",
@@ -299,7 +307,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 + "[ -n \"$ghosthub_kwt_client_ready\" ] && break; "
                 + "sleep 0.01; done",
             "if [ -n \"$ghosthub_kwt_client_ready\" ]; then "
-                + "\(presentationCommand.bestEffortCommand(tmuxPath: tmuxPath)); fi",
+                + "\(sessionSetup); fi",
             "wait \"$ghosthub_kwt_pid\"",
             "ghosthub_kwt_status=$?",
             "exec 3<&-",
@@ -329,7 +337,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 let kwtAttach = remoteKwtCommandPrelude
                     + "\"$ghosthub_kwt_path\" 'pr' 'attach' "
                     + shellQuotedCommandArgument(protectedWorkspacePath)
-                protectedAttach = kwtAttachWithPresentationCommand(
+                protectedAttach = kwtAttachWithSessionSetupCommand(
                     kwtAttach,
                     tmuxPath: tmuxPath
                 )
@@ -349,6 +357,9 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         var remoteAttachCommands = ["unset TMUX TMUX_PANE"]
         if includesPresentation,
            protectedWorkspacePath == nil || launchMode == .attachOnly {
+            remoteAttachCommands.append(
+                mouseSetupCommand(tmuxPath: tmuxPath)
+            )
             remoteAttachCommands.append(
                 presentationCommand?.bestEffortCommand(
                     tmuxPath: tmuxPath
@@ -395,7 +406,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             let kwtOpen = remoteKwtCommandPrelude
                 + "\"$ghosthub_kwt_path\" 'open' "
                 + shellQuotedCommandArgument(workspacePath)
-            remoteOpen = kwtAttachWithPresentationCommand(
+            remoteOpen = kwtAttachWithSessionSetupCommand(
                 kwtOpen,
                 tmuxPath: tmuxPath
             )
@@ -547,16 +558,18 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     tmuxPath: tmuxPath,
                     workingDirectory: workingDirectory
                 )
+            // Session setup is best effort and must not mask failed creation:
+            // exit with the creation status first, then report success
+            // regardless of mouse or styling outcomes.
+            remoteCreate += " || exit $?; "
+                + mouseSetupCommand(tmuxPath: tmuxPath)
             if let presentationCommand {
-                // Styling is best effort and must not mask a failed creation:
-                // exit with the creation status first, then report success
-                // regardless of styling outcomes.
-                remoteCreate += " || exit $?; "
+                remoteCreate += "; "
                     + presentationCommand.bestEffortCommand(
                         tmuxPath: tmuxPath
                     )
-                    + "; exit 0"
             }
+            remoteCreate += "; exit 0"
             remoteCreate = accountLoginShellCommand(remoteCreate)
         }
         let createOnce = shellCommand(
@@ -598,6 +611,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             "new-session", "-A", "-E", "-s", sessionName
         ) + (workingDirectory.map { ["-c", $0] } ?? [])
         createArguments.append(initialCommand)
+        createArguments = appendingMouseOption(to: createArguments)
         if let presentationCommand {
             createArguments = presentationCommand.appendingOptions(
                 to: createArguments
@@ -636,6 +650,26 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             .map(shellQuotedCommandArgument).joined(separator: " ")
         return "\(hasSession) 2>/dev/null || "
             + "\(createSession) || \(hasSession)"
+    }
+
+    private func appendingMouseOption(to arguments: [String]) -> [String] {
+        arguments + [
+            ";", "set-option", "-t", exactSessionTarget,
+            "mouse", "on",
+        ]
+    }
+
+    private func mouseSetupCommand(tmuxPath: String) -> String {
+        let command = tmuxArguments(
+            tmuxPath,
+            "set-option", "-t", exactSessionTarget,
+            "mouse", "on"
+        ).map(shellQuotedCommandArgument).joined(separator: " ")
+        return "\(command) >/dev/null 2>&1 || :"
+    }
+
+    private var exactSessionTarget: String {
+        "=\(sessionName):"
     }
 
     private func recordedClientTTYCommand(

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -445,7 +445,7 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(!command.contains("'open'"))
     }
 
-    @Test("ordinary worktree path attaches directly through kwt")
+    @Test("ordinary worktree attachment enables mouse after kwt connects")
     func ordinaryWorktreeUsesKwtAttachment() async throws {
         let store = RecordingNativeSessionSurfaceStore()
         let coordinator = NativeTmuxSessionCoordinator(
@@ -475,7 +475,10 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(command.contains("Helpers/kwt"))
         #expect(command.contains("open"))
         #expect(command.contains("/worktrees/widget"))
-        #expect(!command.contains("ghosthub_kwt_pid"))
+        #expect(command.contains("ghosthub_kwt_pid"))
+        #expect(command.contains("'set-option'"))
+        #expect(command.contains("'=kwt-widget-feature:'"))
+        #expect(command.contains("mouse"))
         #expect(!command.contains("@ghosthub_kwt_presentation_ready"))
         #expect(!command.contains("--start-session"))
         #expect(!command.contains("attach-session"))

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -4716,7 +4716,7 @@ struct WorkspaceTmuxDiscoveryTests {
         model.reconnectActiveTmuxSessionNow()
         await waitUntilMainActor {
             surfaceStore.requestCount == 3
-                || model.activeBorrowedTmuxRecoveryState == nil
+                && model.activeBorrowedTmuxSessionIsConnected
         }
 
         #expect(surfaceStore.requestCount == 3)

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1168,7 +1168,10 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
-    func testOpenURLActionOwnsCallbackTextBeforeMainDispatch() {
+    func testOpenURLActionOwnsCallbackTextBeforeMainDispatch() throws {
+        try skipUnlessLibghosttyReady()
+        let runtime = retainedRuntime()
+        let appHandle = try XCTUnwrap(runtime.unsafeAppHandle)
         let rawURL = "https://ghosthub.ai/docs/?mouse=command-click"
         let expectedURL = URL(string: rawURL)!
         let bytes = Array(rawURL.utf8CString)
@@ -1188,11 +1191,21 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         }
         defer { LibghosttyRuntime.urlOpener = originalOpener }
 
-        LibghosttyRuntime.handleOpenURL(ghostty_action_open_url_s(
+        var actionValue = ghostty_action_u()
+        actionValue.open_url = ghostty_action_open_url_s(
             kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
             url: pointer,
             len: UInt(rawURL.utf8.count)
-        ))
+        )
+        let handled = LibghosttyRuntime.handleAction(
+            app: appHandle,
+            target: ghostty_target_s(),
+            action: ghostty_action_s(
+                tag: GHOSTTY_ACTION_OPEN_URL,
+                action: actionValue
+            )
+        )
+        XCTAssertTrue(handled)
 
         for index in bytes.indices {
             pointer[index] = 0

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1168,6 +1168,40 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testOpenURLActionOwnsCallbackTextBeforeMainDispatch() {
+        let rawURL = "https://ghosthub.ai/docs/?mouse=command-click"
+        let expectedURL = URL(string: rawURL)!
+        let bytes = Array(rawURL.utf8CString)
+        let pointer = UnsafeMutablePointer<CChar>.allocate(
+            capacity: bytes.count
+        )
+        for (index, byte) in bytes.enumerated() {
+            pointer[index] = byte
+        }
+        defer { pointer.deallocate() }
+
+        let originalOpener = LibghosttyRuntime.urlOpener
+        var openedURLs: [URL] = []
+        LibghosttyRuntime.urlOpener = { url in
+            openedURLs.append(url)
+            return true
+        }
+        defer { LibghosttyRuntime.urlOpener = originalOpener }
+
+        LibghosttyRuntime.handleOpenURL(ghostty_action_open_url_s(
+            kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
+            url: pointer,
+            len: UInt(rawURL.utf8.count)
+        ))
+
+        for index in bytes.indices {
+            pointer[index] = 0
+        }
+        waitUntil(timeout: 1) { !openedURLs.isEmpty }
+
+        XCTAssertEqual(openedURLs, [expectedURL])
+    }
+
     func testRemoteClipboardPolicyAllowsCopyAndOSC52Write() throws {
         try skipUnlessLibghosttyReady()
         let runtime = retainedRuntime()

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -350,6 +350,61 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(positions.count, 2)
     }
 
+    func testCommandClickEscapesApplicationMouseCapture() throws {
+        let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
+        var modifiers: [UInt32] = []
+        TerminalMouseEventHandler.mouseButtonSender = {
+            _, _, button, mods in
+            if button.rawValue == GHOSTTY_MOUSE_LEFT.rawValue {
+                modifiers.append(mods.rawValue)
+            }
+            return true
+        }
+        defer {
+            TerminalMouseEventHandler.mouseButtonSender = originalButtonSender
+        }
+        let view = try makeSurface()
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        let mouseDown = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [.command],
+            timestamp: 1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 3,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let mouseUp = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [.command],
+            timestamp: 1.1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 4,
+            clickCount: 1,
+            pressure: 0
+        ))
+
+        view.mouseDown(with: mouseDown)
+        view.mouseUp(with: mouseUp)
+
+        XCTAssertEqual(modifiers.count, 2)
+        for modifier in modifiers {
+            XCTAssertNotEqual(
+                modifier & GHOSTTY_MODS_SUPER.rawValue,
+                0
+            )
+            XCTAssertNotEqual(
+                modifier & GHOSTTY_MODS_SHIFT.rawValue,
+                0
+            )
+        }
+    }
+
     func testParkingReleasesUnconsumedRightPressWithOriginalModifiers() throws {
         let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
         var actions: [(UInt32, UInt32, UInt32)] = []

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -355,7 +355,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let originalPositionSender =
             TerminalMouseEventHandler.mousePositionSender
         var buttonModifiers: [UInt32] = []
-        var positionModifiers: [UInt32] = []
+        var positions: [(Double, Double, UInt32)] = []
         TerminalMouseEventHandler.mouseButtonSender = {
             _, _, button, mods in
             if button.rawValue == GHOSTTY_MOUSE_LEFT.rawValue {
@@ -364,8 +364,8 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             return true
         }
         TerminalMouseEventHandler.mousePositionSender = {
-            _, _, _, mods in
-            positionModifiers.append(mods.rawValue)
+            _, x, y, mods in
+            positions.append((x, y, mods.rawValue))
         }
         defer {
             TerminalMouseEventHandler.mouseButtonSender = originalButtonSender
@@ -375,10 +375,9 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let view = try makeSurface()
         let window = hostInWindow(view)
         defer { window.orderOut(nil) }
-        positionModifiers.removeAll()
         let commandChanged = try XCTUnwrap(NSEvent.keyEvent(
             with: .flagsChanged,
-            location: NSPoint(x: 20, y: 20),
+            location: .zero,
             modifierFlags: [.command],
             timestamp: 0.9,
             windowNumber: window.windowNumber,
@@ -391,7 +390,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let mouseMoved = try XCTUnwrap(NSEvent.mouseEvent(
             with: .mouseMoved,
             location: NSPoint(x: 20, y: 20),
-            modifierFlags: [.command],
+            modifierFlags: [],
             timestamp: 1,
             windowNumber: window.windowNumber,
             context: nil,
@@ -422,15 +421,18 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             pressure: 0
         ))
 
-        view.flagsChanged(with: commandChanged)
         view.mouseEntered(with: mouseMoved)
         view.mouseMoved(with: mouseMoved)
+        positions.removeAll()
+        view.flagsChanged(with: commandChanged)
         view.mouseDown(with: mouseDown)
         view.mouseUp(with: mouseUp)
 
-        XCTAssertEqual(positionModifiers.count, 3)
+        XCTAssertEqual(positions.count, 1)
+        XCTAssertEqual(positions.first?.0, 20)
+        XCTAssertEqual(positions.first?.1, view.frame.height - 20)
         XCTAssertEqual(buttonModifiers.count, 2)
-        for modifier in positionModifiers + buttonModifiers {
+        for modifier in positions.map(\.2) + buttonModifiers {
             XCTAssertNotEqual(
                 modifier & GHOSTTY_MODS_SUPER.rawValue,
                 0

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -481,6 +481,120 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         }
     }
 
+    func testLeftMouseGestureKeepsInitialCaptureRouteWhenCommandChanges() throws {
+        let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
+        let originalPositionSender =
+            TerminalMouseEventHandler.mousePositionSender
+        var buttonEvents: [(UInt32, UInt32)] = []
+        var positionModifiers: [UInt32] = []
+        TerminalMouseEventHandler.mouseButtonSender = {
+            _, action, button, mods in
+            if button.rawValue == GHOSTTY_MOUSE_LEFT.rawValue {
+                buttonEvents.append((action.rawValue, mods.rawValue))
+            }
+            return true
+        }
+        TerminalMouseEventHandler.mousePositionSender = {
+            _, _, _, mods in
+            positionModifiers.append(mods.rawValue)
+        }
+        defer {
+            TerminalMouseEventHandler.mouseButtonSender = originalButtonSender
+            TerminalMouseEventHandler.mousePositionSender =
+                originalPositionSender
+        }
+        let view = try makeSurface()
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        let mouseMoved = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 0,
+            pressure: 0
+        ))
+        let mouseDown = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 1.1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let commandChanged = try XCTUnwrap(NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 1.2,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 0x37
+        ))
+        let mouseDragged = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [.command],
+            timestamp: 1.3,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 3,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let mouseUp = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [.command],
+            timestamp: 1.4,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 4,
+            clickCount: 1,
+            pressure: 0
+        ))
+
+        view.mouseMoved(with: mouseMoved)
+        view.mouseDown(with: mouseDown)
+        positionModifiers.removeAll()
+        view.flagsChanged(with: commandChanged)
+        view.mouseDragged(with: mouseDragged)
+        view.mouseUp(with: mouseUp)
+
+        XCTAssertEqual(buttonEvents.count, 2)
+        XCTAssertEqual(buttonEvents[0].0, GHOSTTY_MOUSE_PRESS.rawValue)
+        XCTAssertEqual(buttonEvents[1].0, GHOSTTY_MOUSE_RELEASE.rawValue)
+        XCTAssertEqual(
+            buttonEvents[0].1 & GHOSTTY_MODS_SHIFT.rawValue,
+            0
+        )
+        XCTAssertEqual(
+            buttonEvents[1].1 & GHOSTTY_MODS_SHIFT.rawValue,
+            0
+        )
+        XCTAssertEqual(
+            buttonEvents[1].1 & GHOSTTY_MODS_SUPER.rawValue,
+            GHOSTTY_MODS_SUPER.rawValue
+        )
+        XCTAssertEqual(positionModifiers.count, 2)
+        for modifiers in positionModifiers {
+            XCTAssertEqual(modifiers & GHOSTTY_MODS_SHIFT.rawValue, 0)
+            XCTAssertEqual(
+                modifiers & GHOSTTY_MODS_SUPER.rawValue,
+                GHOSTTY_MODS_SUPER.rawValue
+            )
+        }
+    }
+
     func testParkingReleasesUnconsumedRightPressWithOriginalModifiers() throws {
         let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
         var actions: [(UInt32, UInt32, UInt32)] = []

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -350,7 +350,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(positions.count, 2)
     }
 
-    func testCommandPointerEventsEscapeApplicationMouseCapture() throws {
+    func testCommandPointerEventsUseLatestDraggedLocation() throws {
         let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
         let originalPositionSender =
             TerminalMouseEventHandler.mousePositionSender
@@ -398,10 +398,10 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             clickCount: 0,
             pressure: 0
         ))
-        let mouseDown = try XCTUnwrap(NSEvent.mouseEvent(
+        let dragMouseDown = try XCTUnwrap(NSEvent.mouseEvent(
             with: .leftMouseDown,
             location: NSPoint(x: 20, y: 20),
-            modifierFlags: [.command],
+            modifierFlags: [],
             timestamp: 1,
             windowNumber: window.windowNumber,
             context: nil,
@@ -409,28 +409,65 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             clickCount: 1,
             pressure: 1
         ))
-        let mouseUp = try XCTUnwrap(NSEvent.mouseEvent(
-            with: .leftMouseUp,
-            location: NSPoint(x: 20, y: 20),
-            modifierFlags: [.command],
+        let mouseDragged = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [],
             timestamp: 1.1,
             windowNumber: window.windowNumber,
             context: nil,
             eventNumber: 4,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let dragMouseUp = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [],
+            timestamp: 1.2,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 5,
+            clickCount: 1,
+            pressure: 0
+        ))
+        let commandMouseDown = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [.command],
+            timestamp: 1.3,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 6,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let commandMouseUp = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 40, y: 40),
+            modifierFlags: [.command],
+            timestamp: 1.4,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 7,
             clickCount: 1,
             pressure: 0
         ))
 
         view.mouseEntered(with: mouseMoved)
         view.mouseMoved(with: mouseMoved)
+        view.mouseDown(with: dragMouseDown)
+        view.mouseDragged(with: mouseDragged)
+        view.mouseUp(with: dragMouseUp)
         positions.removeAll()
+        buttonModifiers.removeAll()
         view.flagsChanged(with: commandChanged)
-        view.mouseDown(with: mouseDown)
-        view.mouseUp(with: mouseUp)
+        view.mouseDown(with: commandMouseDown)
+        view.mouseUp(with: commandMouseUp)
 
         XCTAssertEqual(positions.count, 1)
-        XCTAssertEqual(positions.first?.0, 20)
-        XCTAssertEqual(positions.first?.1, view.frame.height - 20)
+        XCTAssertEqual(positions.first?.0, 40)
+        XCTAssertEqual(positions.first?.1, view.frame.height - 40)
         XCTAssertEqual(buttonModifiers.count, 2)
         for modifier in positions.map(\.2) + buttonModifiers {
             XCTAssertNotEqual(

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -339,15 +339,15 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             GHOSTTY_MOUSE_RELEASE.rawValue,
         ])
         XCTAssertEqual(pressureStages, [0])
-        XCTAssertEqual(positions.count, 1)
-        XCTAssertEqual(positions.first?.0, -1)
-        XCTAssertEqual(positions.first?.1, -1)
+        XCTAssertEqual(positions.count, 2)
+        XCTAssertEqual(positions.last?.0, -1)
+        XCTAssertEqual(positions.last?.1, -1)
 
         view.setParkedForPreview(false)
         view.mouseMoved(with: event)
 
         XCTAssertFalse(view.trackingAreas.isEmpty)
-        XCTAssertEqual(positions.count, 2)
+        XCTAssertEqual(positions.count, 3)
     }
 
     func testCommandPointerEventsUseLatestDraggedLocation() throws {
@@ -465,9 +465,11 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         view.mouseDown(with: commandMouseDown)
         view.mouseUp(with: commandMouseUp)
 
-        XCTAssertEqual(positions.count, 1)
-        XCTAssertEqual(positions.first?.0, 40)
-        XCTAssertEqual(positions.first?.1, view.frame.height - 40)
+        XCTAssertEqual(positions.count, 2)
+        for position in positions {
+            XCTAssertEqual(position.0, 40)
+            XCTAssertEqual(position.1, view.frame.height - 40)
+        }
         XCTAssertEqual(buttonModifiers.count, 2)
         for modifier in positions.map(\.2) + buttonModifiers {
             XCTAssertNotEqual(
@@ -479,6 +481,61 @@ final class TerminalSurfacePreviewTests: XCTestCase {
                 0
             )
         }
+    }
+
+    func testCommandMouseDownSendsPositionBeforePressWithoutMovement() throws {
+        let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
+        let originalPositionSender =
+            TerminalMouseEventHandler.mousePositionSender
+        var sequence: [String] = []
+        var position: (Double, Double, UInt32)?
+        TerminalMouseEventHandler.mouseButtonSender = {
+            _, action, button, _ in
+            if action.rawValue == GHOSTTY_MOUSE_PRESS.rawValue,
+               button.rawValue == GHOSTTY_MOUSE_LEFT.rawValue {
+                sequence.append("press")
+            }
+            return true
+        }
+        TerminalMouseEventHandler.mousePositionSender = {
+            _, x, y, mods in
+            sequence.append("position")
+            position = (x, y, mods.rawValue)
+        }
+        defer {
+            TerminalMouseEventHandler.mouseButtonSender = originalButtonSender
+            TerminalMouseEventHandler.mousePositionSender =
+                originalPositionSender
+        }
+        let view = try makeSurface()
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        let mouseDown = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 20, y: 30),
+            modifierFlags: [.command],
+            timestamp: 1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+
+        view.mouseDown(with: mouseDown)
+
+        let sentPosition = try XCTUnwrap(position)
+        XCTAssertEqual(sequence, ["position", "press"])
+        XCTAssertEqual(sentPosition.0, 20)
+        XCTAssertEqual(sentPosition.1, view.frame.height - 30)
+        XCTAssertNotEqual(
+            sentPosition.2 & GHOSTTY_MODS_SUPER.rawValue,
+            0
+        )
+        XCTAssertNotEqual(
+            sentPosition.2 & GHOSTTY_MODS_SHIFT.rawValue,
+            0
+        )
     }
 
     func testLeftMouseGestureKeepsInitialCaptureRouteWhenCommandChanges() throws {

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -350,22 +350,55 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(positions.count, 2)
     }
 
-    func testCommandClickEscapesApplicationMouseCapture() throws {
+    func testCommandPointerEventsEscapeApplicationMouseCapture() throws {
         let originalButtonSender = TerminalMouseEventHandler.mouseButtonSender
-        var modifiers: [UInt32] = []
+        let originalPositionSender =
+            TerminalMouseEventHandler.mousePositionSender
+        var buttonModifiers: [UInt32] = []
+        var positionModifiers: [UInt32] = []
         TerminalMouseEventHandler.mouseButtonSender = {
             _, _, button, mods in
             if button.rawValue == GHOSTTY_MOUSE_LEFT.rawValue {
-                modifiers.append(mods.rawValue)
+                buttonModifiers.append(mods.rawValue)
             }
             return true
         }
+        TerminalMouseEventHandler.mousePositionSender = {
+            _, _, _, mods in
+            positionModifiers.append(mods.rawValue)
+        }
         defer {
             TerminalMouseEventHandler.mouseButtonSender = originalButtonSender
+            TerminalMouseEventHandler.mousePositionSender =
+                originalPositionSender
         }
         let view = try makeSurface()
         let window = hostInWindow(view)
         defer { window.orderOut(nil) }
+        positionModifiers.removeAll()
+        let commandChanged = try XCTUnwrap(NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [.command],
+            timestamp: 0.9,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 0x37
+        ))
+        let mouseMoved = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [.command],
+            timestamp: 1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 0,
+            pressure: 0
+        ))
         let mouseDown = try XCTUnwrap(NSEvent.mouseEvent(
             with: .leftMouseDown,
             location: NSPoint(x: 20, y: 20),
@@ -389,11 +422,15 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             pressure: 0
         ))
 
+        view.flagsChanged(with: commandChanged)
+        view.mouseEntered(with: mouseMoved)
+        view.mouseMoved(with: mouseMoved)
         view.mouseDown(with: mouseDown)
         view.mouseUp(with: mouseUp)
 
-        XCTAssertEqual(modifiers.count, 2)
-        for modifier in modifiers {
+        XCTAssertEqual(positionModifiers.count, 3)
+        XCTAssertEqual(buttonModifiers.count, 2)
+        for modifier in positionModifiers + buttonModifiers {
             XCTAssertNotEqual(
                 modifier & GHOSTTY_MODS_SUPER.rawValue,
                 0

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -110,8 +110,72 @@ struct TmuxAttachmentInfoTests {
         #expect(CommandHost.local.displayName == "localhost")
     }
 
-    @Test("local attachment leaves tmux presentation unchanged by default")
-    func localAttachCommandLeavesTmuxPresentationUnchanged() {
+    @Test("every POSIX attachment enables tmux mouse handling")
+    func posixAttachmentsEnableTmuxMouseHandling() {
+        let local = TmuxAttachmentInfo(
+            sessionName: "docbank",
+            host: .local
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+        let localWorktree = TmuxAttachmentInfo(
+            sessionName: "kwt-docbank",
+            host: .local,
+            workspacePath: "/worktrees/docbank"
+        ).attachCommand(
+            tmuxPath: "/opt/bin/tmux",
+            kwtPath: "/Applications/Ghosthub.app/Contents/Helpers/kwt"
+        )
+        let localCreate = TmuxAttachmentInfo(
+            sessionName: "new-docbank",
+            host: .local,
+            launchMode: .create
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+        let remoteHost = CommandHost.ssh(SSHHostInfo(
+            user: "operator",
+            hostname: "build.example.test",
+            port: nil
+        ))
+        let remote = TmuxAttachmentInfo(
+            sessionName: "docbank",
+            host: remoteHost
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+        let remoteWorktree = TmuxAttachmentInfo(
+            sessionName: "kwt-docbank",
+            host: remoteHost,
+            workspacePath: "/worktrees/docbank"
+        ).attachCommand(
+            tmuxPath: "/opt/bin/tmux",
+            remoteKwtCommandPrelude:
+            "ghosthub_kwt_path=\"$HOME/.ghosthub/helpers/kwt/pinned/kwt\"; "
+        )
+        let remoteCreate = TmuxAttachmentInfo(
+            sessionName: "new-docbank",
+            host: remoteHost,
+            launchMode: .create
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+        let remoteProfile = TmuxAttachmentInfo(
+            sessionName: "profile-docbank",
+            host: remoteHost,
+            launchMode: .create,
+            initialCommand: "exec codex"
+        ).attachCommand(tmuxPath: "/opt/bin/tmux")
+
+        for command in [
+            local,
+            localWorktree,
+            localCreate,
+            remote,
+            remoteWorktree,
+            remoteCreate,
+            remoteProfile,
+        ] {
+            #expect(command.contains("set-option"))
+            #expect(command.contains("mouse"))
+            #expect(command.contains("on"))
+        }
+    }
+
+    @Test("local attachment otherwise leaves presentation unchanged")
+    func localAttachCommandOtherwiseLeavesPresentationUnchanged() {
         let info = TmuxAttachmentInfo(
             sessionName: "doc bank's work",
             host: .local
@@ -122,7 +186,6 @@ struct TmuxAttachmentInfoTests {
         )
 
         #expect(command.contains("unset TMUX TMUX_PANE"))
-        #expect(!command.contains("set-option"))
         #expect(!command.contains("status-style"))
         #expect(command.contains("exec"))
         #expect(command.contains("attach-session"))
@@ -131,7 +194,6 @@ struct TmuxAttachmentInfoTests {
         #expect(!command.contains("capture-pane"))
         #expect(!command.contains("bind-key"))
         #expect(!command.contains("unbind-key"))
-        #expect(!command.contains("'mouse'"))
     }
 
     @Test("presentation styles target only the exact selected session")
@@ -146,7 +208,7 @@ struct TmuxAttachmentInfoTests {
         ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
 
         #expect(
-            command.components(separatedBy: "=alpha:").count - 1 == 4
+            command.components(separatedBy: "=alpha:").count - 1 == 5
         )
     }
 
@@ -172,15 +234,14 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("'fg=#3B4851,bg=#FFFFFF'"))
     }
 
-    @Test("follow-config leaves tmux pane defaults unchanged")
-    func followConfigLeavesPaneDefaultsUnchanged() {
+    @Test("follow-config leaves tmux color defaults unchanged")
+    func followConfigLeavesTmuxColorDefaultsUnchanged() {
         let command = TmuxAttachmentInfo(
             sessionName: "docbank",
             host: .local
         ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
 
         #expect(!command.contains("list-windows"))
-        #expect(!command.contains("set-option"))
         #expect(!command.contains("status-style"))
         #expect(!command.contains("window-style"))
         #expect(!command.contains("window-active-style"))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -580,10 +580,12 @@ so wheel input reaches tmux copy mode under a vanilla configuration. This is a
 shared session option visible to every client; Ghosthub does not replace tmux's
 mouse bindings. Native Windows/psmux remains unchanged.
 
-For a Command-modified left click, Ghosthub adds libghostty's Shift override
-for mouse capture only at the embedded input boundary. Libghostty removes that
-override before matching its Command link binding, so the click opens a link
-instead of reaching tmux while all other tmux mouse input remains native.
+For a Command-modified pointer interaction, Ghosthub adds libghostty's Shift
+override for mouse capture only at the embedded input boundary. Pointer
+movement and Command modifier changes use the same override as the left-button
+events, so link highlighting and activation both bypass tmux. Libghostty
+removes the override before matching its Command link binding, while all other
+tmux mouse input remains native.
 
 Cmd-D and Cmd-Shift-D provide Ghostty-style split-right and split-down actions,
 also exposed in the File menu. A tmux attachment requires tmux 3.4 or newer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -574,7 +574,11 @@ Ghosthub supplies keepalives. Remote shell commands are one-shot; each retained
 presentation owns its own transport-status-255 recovery, probe scheduling,
 authentication and host-key escalation state, and attach-only client
 replacement. Inactive presentations remain supervised. Tmux owns all windows,
-panes, history, input, rendering, and server-side lifetime.
+panes, history, input, rendering, and server-side lifetime. Ghosthub
+best-effort enables the exact POSIX session's `mouse` option before attachment
+so wheel input reaches tmux copy mode under a vanilla configuration. This is a
+shared session option visible to every client; Ghosthub does not replace tmux's
+mouse bindings. Native Windows/psmux remains unchanged.
 
 Cmd-D and Cmd-Shift-D provide Ghostty-style split-right and split-down actions,
 also exposed in the File menu. A tmux attachment requires tmux 3.4 or newer.
@@ -634,8 +638,9 @@ terminal defaults and supply the selected foreground and background to existing
 windows in the exact session. Tmux shares the result with every attached client.
 The best-effort styling can never prevent attachment. Native Windows/psmux
 sessions do not offer either shared styling path. Tmux still owns all interaction
-behavior; Ghosthub does not modify its prefix, key tables, mouse mode,
-window/pane commands, history, or layout.
+behavior. Other than enabling its session mouse option for POSIX attachments,
+Ghosthub does not modify its prefix, key tables, mouse bindings, window/pane
+commands, history, or layout.
 
 An explicit New Tmux Session action is the sole boundary where Ghosthub
 creates a bare tmux session itself. For a user-supplied exact name, local

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -583,9 +583,11 @@ mouse bindings. Native Windows/psmux remains unchanged.
 For a Command-modified pointer interaction, Ghosthub adds libghostty's Shift
 override for mouse capture only at the embedded input boundary. Pointer
 movement and Command modifier changes use the same override as the left-button
-events, so link highlighting and activation both bypass tmux. Libghostty
-removes the override before matching its Command link binding, while all other
-tmux mouse input remains native.
+events, so link highlighting and activation both bypass tmux. Modifier changes
+reuse the last tracked in-window pointer position instead of the keyboard
+event's unreliable coordinates. Libghostty removes the override before
+matching its Command link binding, while all other tmux mouse input remains
+native.
 
 Cmd-D and Cmd-Shift-D provide Ghostty-style split-right and split-down actions,
 also exposed in the File menu. A tmux attachment requires tmux 3.4 or newer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -580,6 +580,11 @@ so wheel input reaches tmux copy mode under a vanilla configuration. This is a
 shared session option visible to every client; Ghosthub does not replace tmux's
 mouse bindings. Native Windows/psmux remains unchanged.
 
+For a Command-modified left click, Ghosthub adds libghostty's Shift override
+for mouse capture only at the embedded input boundary. Libghostty removes that
+override before matching its Command link binding, so the click opens a link
+instead of reaching tmux while all other tmux mouse input remains native.
+
 Cmd-D and Cmd-Shift-D provide Ghostty-style split-right and split-down actions,
 also exposed in the File menu. A tmux attachment requires tmux 3.4 or newer.
 Each explicit action runs `split-window -h` or `split-window -v` against the

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -62,9 +62,11 @@ not add or replace mouse bindings. Native Windows/psmux attachment retains its
 documented mouse-reporting limitation and does not receive this setup.
 Command-click remains a macOS terminal action: Ghosthub supplies libghostty's
 Shift mouse-capture override internally for Command-modified pointer movement,
-modifier changes, and the left click. Libghostty removes the override before
-matching its Command link binding. Tmux therefore does not capture link
-highlighting or activation, and users do not need to hold Shift.
+modifier changes, and the left click. Modifier changes reuse the last tracked
+in-window pointer position because keyboard events do not carry a reliable
+mouse location. Libghostty removes the override before matching its Command
+link binding. Tmux therefore does not capture link highlighting or activation,
+and users do not need to hold Shift.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, and session name. Navigating to another host,
 worktree, or session removes the previous surface from the visible hierarchy

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -60,6 +60,10 @@ copy mode even when the server started from tmux's vanilla mouse-off default.
 The option is session-scoped, so every attached client sees it; Ghosthub does
 not add or replace mouse bindings. Native Windows/psmux attachment retains its
 documented mouse-reporting limitation and does not receive this setup.
+Command-click remains a macOS terminal action: Ghosthub supplies libghostty's
+Shift mouse-capture override internally for that left click, and libghostty
+removes the override before matching its Command link binding. Tmux therefore
+does not capture link activation, and users do not need to hold Shift.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, and session name. Navigating to another host,
 worktree, or session removes the previous surface from the visible hierarchy

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -50,9 +50,16 @@ map, split-tree projection, or Ghosthub tab bar. Tmux owns:
 - windows, panes, layout, focus, and status-line presentation
 - terminal history and alternate-screen state
 - pane processes and session lifetime
-- tmux-native key bindings and mouse behavior
+- tmux-native key bindings and mouse behavior after Ghosthub enables the
+  session-scoped `mouse` option
 
 Ghosthub owns inventory presentation, terminal clients, and connection state.
+Before each POSIX tmux presentation, Ghosthub best-effort enables the exact
+session's `mouse` option. This makes wheel scrolling enter and navigate tmux
+copy mode even when the server started from tmux's vanilla mouse-off default.
+The option is session-scoped, so every attached client sees it; Ghosthub does
+not add or replace mouse bindings. Native Windows/psmux attachment retains its
+documented mouse-reporting limitation and does not receive this setup.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, and session name. Navigating to another host,
 worktree, or session removes the previous surface from the visible hierarchy
@@ -98,9 +105,9 @@ matching command-palette action apply the selected effective style immediately
 to the connected active workspace tmux attachment without changing the
 persistent preference or reconnecting. Console Panel terminals are not tmux
 session targets. Both paths change shared tmux options, so every attached client
-sees the result. These best-effort style commands do not change tmux interaction:
-prefix and key tables, mouse behavior, windows, panes, history, and layout
-remain untouched.
+sees the result. Apart from enabling the session mouse option during attachment,
+these best-effort style commands do not change tmux interaction: prefix and key
+tables, mouse bindings, windows, panes, history, and layout remain untouched.
 Native Windows attachment leaves psmux's status and message styles user-owned;
 psmux does not preserve tmux's session-scoped rendering for these style resets
 and may apply `reverse` across the client rather than only its status line. The

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -61,9 +61,10 @@ The option is session-scoped, so every attached client sees it; Ghosthub does
 not add or replace mouse bindings. Native Windows/psmux attachment retains its
 documented mouse-reporting limitation and does not receive this setup.
 Command-click remains a macOS terminal action: Ghosthub supplies libghostty's
-Shift mouse-capture override internally for that left click, and libghostty
-removes the override before matching its Command link binding. Tmux therefore
-does not capture link activation, and users do not need to hold Shift.
+Shift mouse-capture override internally for Command-modified pointer movement,
+modifier changes, and the left click. Libghostty removes the override before
+matching its Command link binding. Tmux therefore does not capture link
+highlighting or activation, and users do not need to hold Shift.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, and session name. Navigating to another host,
 worktree, or session removes the previous surface from the visible hierarchy

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -45,6 +45,15 @@ Palette with ++shift+cmd+p++. Ghosthub opens an ordinary local or SSH client
 for the selected backend. Herdr receives the complete terminal and continues
 to own its workspaces, tabs, panes, history, and key bindings.
 
+For POSIX tmux sessions, Ghosthub enables tmux mouse mode on attachment. Wheel
+scrolling therefore opens and navigates tmux copy mode even when the session
+uses tmux's vanilla configuration. Mouse mode is a shared session option, so
+other attached clients see it too; tmux's own mouse bindings remain in charge.
+Native Windows/psmux keeps its existing mouse-reporting limitation.
+
+Hold ++cmd++ while pointing at a highlighted terminal link, then click to open
+it in the default macOS application.
+
 Switching to another host, worktree, or session hides an opened tmux terminal
 without detaching it. Each workspace keeps every tmux session you explicitly
 open connected, and returning to one reuses the same terminal and client.


### PR DESCRIPTION
Ghosthub presents tmux through an ordinary terminal client, but vanilla tmux starts with mouse mode off and libghostty's open-URL callback owns its text only for the callback lifetime. Wheel scrolling could not reach tmux history, and Command-click highlighted links without opening them.

- Enables mouse handling for the exact POSIX tmux session during attach and create, including kwt and remote paths. Setup is best effort so it cannot prevent attachment.
- Keeps tmux in charge of mouse bindings. The session option is shared with other clients, while native Windows/psmux remains unchanged.
- Copies length-bounded link text at the libghostty callback boundary before main-queue dispatch, so Command-click reliably opens the highlighted URL or file in its default macOS application.
- Routes the full Command-pointer sequence through libghostty's capture override. Modifier changes reuse the latest tracked in-window pointer position, including positions reached by dragging. Mouse-down establishes the current target before the press, and the left-button capture route stays fixed through release.
- Documents the shared-session consequence and covers attachment paths, callback ownership, static-hover and first-click Command-click, post-drag targeting, and modifier changes during a left-button gesture.
