### PR TITLE
Open terminal links from owned callback data

### DIFF
--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -141,6 +141,7 @@ public final class LibghosttyRuntime: ObservableObject,
         PassthroughSubject<LibghosttyConfigReloadNotice?, Never>()
     private let pipeline: LibghosttyConfigPipeline
     private let configMonitorFactory: ConfigMonitorFactory
+    private let urlOpener: @MainActor (URL) -> Void
     private nonisolated let resolvedColorGenerations =
         ResolvedColorGenerationTracker()
     private var resolvedColorEntries: [UInt: ResolvedColorEntry] = [:]
@@ -219,10 +220,14 @@ public final class LibghosttyRuntime: ObservableObject,
     init(
         pipeline: LibghosttyConfigPipeline,
         runtimeState: LibghosttyRuntimeState? = nil,
-        configMonitorFactory: @escaping ConfigMonitorFactory
+        configMonitorFactory: @escaping ConfigMonitorFactory,
+        urlOpener: @escaping @MainActor (URL) -> Void = { url in
+            _ = NSWorkspace.shared.open(url)
+        }
     ) {
         self.pipeline = pipeline
         self.configMonitorFactory = configMonitorFactory
+        self.urlOpener = urlOpener
         self.runtimeState = runtimeState ?? LibghosttyRuntimeState()
         bootstrapStatus = .ready()
         phase = .loadingConfig
@@ -739,7 +744,7 @@ public final class LibghosttyRuntime: ObservableObject,
         }
     }
 
-    fileprivate nonisolated static func handleAction(
+    nonisolated static func handleAction(
         app: ghostty_app_t?,
         target: ghostty_target_s,
         action: ghostty_action_s
@@ -838,9 +843,10 @@ public final class LibghosttyRuntime: ObservableObject,
             return true
 
         case GHOSTTY_ACTION_OPEN_URL:
-            let openURLAction = action.action.open_url
+            let rawURL = String(cString: action.action.open_url.url)
             DispatchQueue.main.async {
-                Self.openURL(openURLAction)
+                let state = runtime(from: userdataValue)
+                state.openURL(rawURL)
             }
             return true
 
@@ -1246,9 +1252,7 @@ public final class LibghosttyRuntime: ObservableObject,
         )
     }
 
-    @MainActor
-    private static func openURL(_ value: ghostty_action_open_url_s) {
-        let rawURL = String(cString: value.url)
+    private func openURL(_ rawURL: String) {
         let url: URL
         if let candidate = URL(string: rawURL), candidate.scheme != nil {
             url = candidate
@@ -1256,7 +1260,7 @@ public final class LibghosttyRuntime: ObservableObject,
             url = URL(fileURLWithPath: rawURL)
         }
 
-        NSWorkspace.shared.open(url)
+        urlOpener(url)
     }
 }
 

--- a/Tests/Terminal/LibghosttyRuntimeStateTests.swift
+++ b/Tests/Terminal/LibghosttyRuntimeStateTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyKit
 import Testing
 @testable import GhosthubTerminal
 @testable import GhosthubTerminalSupport
@@ -42,5 +43,62 @@ struct LibghosttyApplicationActionTests {
 
         #expect(runtime.runtimeState.lastAction == .quit)
         #expect(quitRequests == 1)
+    }
+
+    @Test("open URL action owns its string before main-queue dispatch")
+    func openURLActionOwnsStringBeforeDispatch() async throws {
+        let configRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: configRoot) }
+
+        var resume: CheckedContinuation<URL, Never>?
+        let runtime = LibghosttyRuntime(
+            pipeline: LibghosttyConfigPipeline(
+                paths: LibghosttyConfigPaths(
+                    configDirectory: configRoot
+                )
+            ),
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    errorHandler: request.errorHandler,
+                    changeHandler: request.changeHandler
+                )
+            },
+            urlOpener: { url in
+                resume?.resume(returning: url)
+                resume = nil
+            }
+        )
+        let app = try #require(runtime.unsafeAppHandle)
+        var bytes = Array("https://example.test/pull/81".utf8CString)
+
+        let openedURL = await withCheckedContinuation { continuation in
+            resume = continuation
+            bytes.withUnsafeMutableBufferPointer { buffer in
+                var actionValue = ghostty_action_u()
+                actionValue.open_url = ghostty_action_open_url_s(
+                    kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT,
+                    url: buffer.baseAddress,
+                    len: UInt(buffer.count - 1)
+                )
+                let action = ghostty_action_s(
+                    tag: GHOSTTY_ACTION_OPEN_URL,
+                    action: actionValue
+                )
+                let handled = LibghosttyRuntime.handleAction(
+                    app: app,
+                    target: ghostty_target_s(),
+                    action: action
+                )
+                #expect(handled)
+
+                for index in buffer.indices {
+                    buffer[index] = index == buffer.indices.last ? 0 : 120
+                }
+            }
+        }
+
+        #expect(openedURL.absoluteString == "https://example.test/pull/81")
     }
 }


### PR DESCRIPTION
Cmd-clicking an underlined terminal URL could do nothing because Ghosthub queued libghostty's temporary URL pointer after the callback returned.

- Copy the URL into Swift-owned storage before main-thread dispatch, so detected links reliably reach the default browser.
- Preserve libghostty's existing hover, mouse, and URL resolution behavior; only the callback ownership boundary changes.
- Cover the lifetime bug by invalidating the original C buffer before queued delivery.

The app build, formatting, Python, bootstrap, and focused terminal checks pass. The fully concurrent Swift suite still exposes unrelated timing flakes in tmux probing and SSH askpass; the affected suites pass serially.

<sup>generated by a clanker</sup>
