### PR TITLE
Keep sandbox image bootstrap from breaking main CI

### DIFF
--- a/.github/workflows/sandbox-image-promote.yml
+++ b/.github/workflows/sandbox-image-promote.yml
@@ -189,119 +189,15 @@ jobs:
           curl --disable --fail --location --proto '=https' --tlsv1.2 \
             --silent --show-error --output "$dispositions" \
             "https://raw.githubusercontent.com/kenn-io/ghosthub/$GITHUB_SHA/images/sandbox/vulnerability-dispositions.json"
-          today="$(date -u +%F)"
-          evaluation="$(jq -cn \
-            --arg today "$today" \
+          policy="$RUNNER_TEMP/post-approval-policy.jq"
+          curl --disable --fail --location --proto '=https' --tlsv1.2 \
+            --silent --show-error --output "$policy" \
+            "https://raw.githubusercontent.com/kenn-io/ghosthub/$GITHUB_SHA/tools/sandbox_image/post_approval_policy.jq"
+          jq -en \
+            --arg today "$(date -u +%F)" \
             --slurpfile scan "$scan" \
-            --slurpfile disposition_documents "$dispositions" '
-            def nonempty_string:
-              type == "string" and length > 0;
-            def same_identity($finding; $disposition):
-              $finding.vulnerability_id == $disposition.vulnerability_id and
-              $finding.package == $disposition.package and
-              $finding.result_class == $disposition.result_class and
-              $finding.result_type == $disposition.result_type and
-              $finding.target == $disposition.target;
-
-            if ($scan | length) != 1 or
-               ($disposition_documents | length) != 1 then
-              error("scan or disposition input is not one JSON document")
-            else
-              $scan[0] as $document |
-              $disposition_documents[0] as $dispositions |
-              if ($document | type) != "object" or
-                 ($document.Results | type) != "array" or
-                 (any($document.Results[]; .Class == "os-pkgs") | not) or
-                 (all($document.Results[];
-                   (.Class == "os-pkgs" or .Class == "lang-pkgs") and
-                   (.Type | nonempty_string) and
-                   (.Target | nonempty_string) and
-                   ((.Vulnerabilities // []) | type) == "array" and
-                   all((.Vulnerabilities // [])[];
-                     (.VulnerabilityID | nonempty_string) and
-                     (.PkgName | nonempty_string) and
-                     ((.Severity | ascii_upcase) |
-                       IN("UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL")) and
-                     (.FixedVersion == null or
-                       (.FixedVersion | type) == "string"))) | not) then
-                error("Trivy vulnerability report has an invalid schema")
-              elif ($dispositions | type) != "array" or
-                   (all($dispositions[];
-                     type == "object" and
-                     (keys | sort) == [
-                       "expires", "owner", "package", "rationale",
-                       "result_class", "result_type", "target",
-                       "vulnerability_id"
-                     ] and
-                     all(.[]; type == "string") and
-                     (.vulnerability_id | nonempty_string) and
-                     (.package | nonempty_string) and
-                     (.result_class | IN("os-pkgs", "lang-pkgs")) and
-                     (.result_type | nonempty_string) and
-                     (.target | nonempty_string) and
-                     (.rationale | test("\\S")) and
-                     (.owner | test("\\S")) and
-                     (.expires >= $today) and
-                     (try ((.expires + "T00:00:00Z") |
-                       fromdateiso8601 | type == "number") catch false)) | not) or
-                   ([$dispositions[] | [
-                     .vulnerability_id, .package, .result_class,
-                     .result_type, .target
-                   ]] | length) !=
-                   ([$dispositions[] | [
-                     .vulnerability_id, .package, .result_class,
-                     .result_type, .target
-                   ]] | unique | length) then
-                error("vulnerability dispositions have an invalid schema")
-              else
-                [
-                  $document.Results[] as $result |
-                  ($result.Vulnerabilities // [])[] |
-                  {
-                    vulnerability_id: .VulnerabilityID,
-                    package: .PkgName,
-                    result_class: $result.Class,
-                    result_type: $result.Type,
-                    target: (
-                      if $result.Class == "os-pkgs" then "rootfs"
-                      else $result.Target
-                      end
-                    ),
-                    severity: (.Severity | ascii_upcase),
-                    fixed_version: (.FixedVersion // "")
-                  }
-                ] as $findings |
-                [
-                  $findings[] |
-                  select(.severity == "HIGH" or .severity == "CRITICAL") |
-                  . as $finding |
-                  select(
-                    (.fixed_version | length) > 0 or
-                    (any($dispositions[];
-                      same_identity($finding; .)) | not)
-                  )
-                ] as $blocking |
-                [
-                  $dispositions[] as $disposition |
-                  select(any($findings[];
-                    (.severity == "HIGH" or .severity == "CRITICAL") and
-                    same_identity(.; $disposition)) | not) |
-                  $disposition
-                ] as $unmatched |
-                {
-                  blocking: $blocking,
-                  unmatched_dispositions: $unmatched
-                }
-              end
-            end
-          ')"
-          if ! jq -e '
-            .blocking == [] and .unmatched_dispositions == []
-          ' <<< "$evaluation" > /dev/null; then
-            echo "Post-approval vulnerability policy failed:" >&2
-            jq . <<< "$evaluation" >&2
-            exit 1
-          fi
+            --slurpfile disposition_documents "$dispositions" \
+            -f "$policy" > /dev/null
           echo "Post-approval vulnerability scan passed for $IMAGE_DIGEST."
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:

--- a/.github/workflows/sandbox-image-promotion-gate.yml
+++ b/.github/workflows/sandbox-image-promotion-gate.yml
@@ -68,6 +68,13 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == workflow_run && \
                 "$(jq -r '.workflow_run.name' "$GITHUB_EVENT_PATH")" == \
                 'Sandbox image merge signal' ]]; then
+            merge_sha="$(jq -r '.workflow_run.head_sha // ""' \
+              "$GITHUB_EVENT_PATH")"
+            if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Merge-group signal SHA is invalid." >&2
+              exit 1
+            fi
+            post_pending "$merge_sha"
             if ! jq -e '
               (.workflow_run.created_at | type == "string") and
               (now - (.workflow_run.created_at | fromdateiso8601) >= 0) and
@@ -77,22 +84,29 @@ jobs:
                 type == "number" and . >= 1 and floor == .) and
               .workflow_run.pull_requests[0].base.ref == "main"
             ' "$GITHUB_EVENT_PATH" > /dev/null; then
-              echo "Ignoring stale or invalid merge-group signal."
-              exit 0
+              echo "Merge-group signal is stale or invalid; authorization remains pending." >&2
+              exit 1
             fi
             number="$(jq -r '.workflow_run.pull_requests[0].number' \
               "$GITHUB_EVENT_PATH")"
-            if ! gh api "repos/kenn-io/ghosthub/pulls/$number" |
-              jq -e '.state == "open" and .base.ref == "main"' > /dev/null; then
-              echo "Ignoring merge-group signal for a closed pull request."
-              exit 0
-            fi
-            merge_sha="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
-            if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "Merge-group signal SHA is invalid." >&2
+            detail="$RUNNER_TEMP/fence-pr-$number.json"
+            if ! gh api "repos/kenn-io/ghosthub/pulls/$number" > "$detail"; then
+              echo "Cannot load pull request $number; authorization remains pending." >&2
               exit 1
             fi
-            post_pending "$merge_sha"
+            if ! jq -e --argjson number "$number" '
+              type == "object" and
+              .number == $number and
+              (.state == "open" or .state == "closed") and
+              .base.ref == "main"
+            ' "$detail" > /dev/null; then
+              echo "Pull request $number metadata is invalid; authorization remains pending." >&2
+              exit 1
+            fi
+            if [[ "$(jq -r '.state' "$detail")" == closed ]]; then
+              echo "Merge-group signal belongs to a closed pull request."
+              exit 0
+            fi
           else
             pulls="$RUNNER_TEMP/pulls.json"
             gh api --paginate --slurp \
@@ -346,6 +360,18 @@ jobs:
               echo "Cannot load pull request $number; leaving it pending." >&2
               return 1
             fi
+            if ! jq -e --argjson number "$number" '
+              type == "object" and
+              .number == $number and
+              (.state == "open" or .state == "closed") and
+              .base.ref == "main"
+            ' "$detail" > /dev/null; then
+              echo "Pull request $number metadata is invalid; leaving it pending." >&2
+              return 1
+            fi
+            if [[ "$(jq -r '.state' "$detail")" == closed ]]; then
+              return 2
+            fi
             if ! gh api --paginate --slurp \
               "repos/kenn-io/ghosthub/pulls/$number/files?per_page=100" \
               | jq '[.[][]]' > "$files"; then
@@ -521,6 +547,13 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == workflow_run && \
                 "$(jq -r '.workflow_run.name' "$GITHUB_EVENT_PATH")" == \
                 'Sandbox image merge signal' ]]; then
+            merge_sha="$(jq -r '.workflow_run.head_sha // ""' \
+              "$GITHUB_EVENT_PATH")"
+            if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Merge-group signal SHA is invalid." >&2
+              exit 1
+            fi
+            post_pending "$merge_sha"
             if ! jq -e '
               (.workflow_run.created_at | type == "string") and
               (now - (.workflow_run.created_at | fromdateiso8601) >= 0) and
@@ -530,22 +563,22 @@ jobs:
                 type == "number" and . >= 1 and floor == .) and
               .workflow_run.pull_requests[0].base.ref == "main"
             ' "$GITHUB_EVENT_PATH" > /dev/null; then
-              echo "Ignoring stale or invalid merge-group signal."
-              exit 0
+              echo "Merge-group signal is stale or invalid; authorization remains pending." >&2
+              exit 1
             fi
             number="$(jq -r '.workflow_run.pull_requests[0].number' \
               "$GITHUB_EVENT_PATH")"
-            if ! load_pr "$number"; then
-              echo "Ignoring merge-group signal without an open pull request."
+            load_result=0
+            load_pr "$number" || load_result=$?
+            if [[ "$load_result" == 2 ]]; then
+              echo "Merge-group signal belongs to a closed pull request."
               exit 0
             fi
-            merge_signal=true
-            merge_sha="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
-            if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "Merge-group signal SHA is invalid." >&2
+            if [[ "$load_result" != 0 ]]; then
+              echo "Cannot reconcile merge-group pull request; authorization remains pending." >&2
               exit 1
             fi
-            post_pending "$merge_sha"
+            merge_signal=true
           else
             pulls="$RUNNER_TEMP/pulls.json"
             gh api --paginate --slurp \

--- a/.github/workflows/sandbox-image-promotion-gate.yml
+++ b/.github/workflows/sandbox-image-promotion-gate.yml
@@ -341,8 +341,11 @@ jobs:
             jq -er '
               any(.[];
                 .filename == "SANDBOX_IMAGE" or
+                .filename == "tools/sandbox_image/post_approval_policy.jq" or
                 (.filename | startswith("images/sandbox/reports/")) or
                 (.previous_filename? == "SANDBOX_IMAGE") or
+                (.previous_filename? ==
+                  "tools/sandbox_image/post_approval_policy.jq") or
                 (.previous_filename? | strings | startswith("images/sandbox/reports/"))) |
               tostring
             ' "$1"

--- a/.github/workflows/sandbox-image-promotion-gate.yml
+++ b/.github/workflows/sandbox-image-promotion-gate.yml
@@ -31,7 +31,8 @@ jobs:
     name: Fence promotion authorization
     if: >-
       github.repository == 'kenn-io/ghosthub' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      vars.SANDBOX_PROMOTION_APP_ID != ''
     runs-on: ubuntu-24.04
     environment: sandbox-image-promotion-status
     permissions:
@@ -67,6 +68,25 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == workflow_run && \
                 "$(jq -r '.workflow_run.name' "$GITHUB_EVENT_PATH")" == \
                 'Sandbox image merge signal' ]]; then
+            if ! jq -e '
+              (.workflow_run.created_at | type == "string") and
+              (now - (.workflow_run.created_at | fromdateiso8601) >= 0) and
+              (now - (.workflow_run.created_at | fromdateiso8601) <= 86400) and
+              (.workflow_run.pull_requests | length) == 1 and
+              (.workflow_run.pull_requests[0].number |
+                type == "number" and . >= 1 and floor == .) and
+              .workflow_run.pull_requests[0].base.ref == "main"
+            ' "$GITHUB_EVENT_PATH" > /dev/null; then
+              echo "Ignoring stale or invalid merge-group signal."
+              exit 0
+            fi
+            number="$(jq -r '.workflow_run.pull_requests[0].number' \
+              "$GITHUB_EVENT_PATH")"
+            if ! gh api "repos/kenn-io/ghosthub/pulls/$number" |
+              jq -e '.state == "open" and .base.ref == "main"' > /dev/null; then
+              echo "Ignoring merge-group signal for a closed pull request."
+              exit 0
+            fi
             merge_sha="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
             if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
               echo "Merge-group signal SHA is invalid." >&2
@@ -110,7 +130,8 @@ jobs:
     name: Audit promotion authority
     if: >-
       github.repository == 'kenn-io/ghosthub' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      vars.SANDBOX_PROMOTION_APP_ID != ''
     runs-on: ubuntu-24.04
     environment: sandbox-image-promotion-status
     permissions:
@@ -251,7 +272,8 @@ jobs:
     if: >-
       always() &&
       github.repository == 'kenn-io/ghosthub' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      vars.SANDBOX_PROMOTION_APP_ID != ''
     needs: [fence, audit]
     runs-on: ubuntu-24.04
     environment: sandbox-image-promotion-status
@@ -408,8 +430,15 @@ jobs:
                 .state == "success" and
                 .creator.login == "ghosthub-sandbox-promotion[bot]" and
                 .creator.type == "Bot" and
-                (.target_url | type == "string" and startswith($url_prefix)) and
-                ((.target_url | ltrimstr($url_prefix)) | test("^[1-9][0-9]*$")) and
+                ((
+                  .description == "Sandbox image promotion not required" and
+                  (.target_url == null or .target_url == "")
+                ) or (
+                  .description == "Ghosthub sandbox image promotion" and
+                  (.target_url | type == "string" and startswith($url_prefix)) and
+                  ((.target_url | ltrimstr($url_prefix)) |
+                    test("^[1-9][0-9]*$"))
+                )) and
                 (.created_at | fromdateiso8601) >=
                   ($created_at | fromdateiso8601) and
                 (now - (.created_at | fromdateiso8601) >= 0) and
@@ -492,6 +521,24 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == workflow_run && \
                 "$(jq -r '.workflow_run.name' "$GITHUB_EVENT_PATH")" == \
                 'Sandbox image merge signal' ]]; then
+            if ! jq -e '
+              (.workflow_run.created_at | type == "string") and
+              (now - (.workflow_run.created_at | fromdateiso8601) >= 0) and
+              (now - (.workflow_run.created_at | fromdateiso8601) <= 86400) and
+              (.workflow_run.pull_requests | length) == 1 and
+              (.workflow_run.pull_requests[0].number |
+                type == "number" and . >= 1 and floor == .) and
+              .workflow_run.pull_requests[0].base.ref == "main"
+            ' "$GITHUB_EVENT_PATH" > /dev/null; then
+              echo "Ignoring stale or invalid merge-group signal."
+              exit 0
+            fi
+            number="$(jq -r '.workflow_run.pull_requests[0].number' \
+              "$GITHUB_EVENT_PATH")"
+            if ! load_pr "$number"; then
+              echo "Ignoring merge-group signal without an open pull request."
+              exit 0
+            fi
             merge_signal=true
             merge_sha="$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")"
             if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
@@ -534,6 +581,9 @@ jobs:
               .workflow_run.head_repository.full_name == "kenn-io/ghosthub" and
               (.workflow_run.head_branch | startswith("gh-readonly-queue/main/")) and
               (.workflow_run.head_sha | test("^[0-9a-f]{40}$")) and
+              (.workflow_run.created_at | type == "string") and
+              (now - (.workflow_run.created_at | fromdateiso8601) >= 0) and
+              (now - (.workflow_run.created_at | fromdateiso8601) <= 86400) and
               (.workflow_run.pull_requests | length) == 1 and
               .workflow_run.pull_requests[0].base.ref == "main" and
               (.workflow_run.pull_requests[0].base.sha |

--- a/.github/workflows/sandbox-image-publish.yml
+++ b/.github/workflows/sandbox-image-publish.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   check:
     name: Validate sandbox image
+    if: >-
+      github.repository == 'kenn-io/ghosthub' &&
+      vars.SANDBOX_PROMOTION_APP_ID != ''
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -99,6 +102,12 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: image=docker.io/moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.SANDBOX_PACKAGE_WRITER_USERNAME }}
+          password: ${{ secrets.SANDBOX_PACKAGE_WRITER_TOKEN }}
       - name: Validate artifact and inspect candidate alias
         id: inspect
         shell: bash
@@ -138,13 +147,6 @@ jobs:
             cat "$diagnostic" >&2
             exit 1
           fi
-      - name: Log in to GHCR
-        if: steps.inspect.outputs.push_required == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.SANDBOX_PACKAGE_WRITER_USERNAME }}
-          password: ${{ secrets.SANDBOX_PACKAGE_WRITER_TOKEN }}
       - name: Publish prepared candidate
         if: steps.inspect.outputs.push_required == 'true'
         shell: bash
@@ -163,7 +165,7 @@ jobs:
           fi
           docker push "$CANDIDATE_TAG"
       - name: Remove registry credentials
-        if: always() && steps.inspect.outputs.push_required == 'true'
+        if: always()
         run: docker logout ghcr.io
       - name: Verify published digest and identity
         id: published

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -1376,6 +1376,7 @@ struct WorkspaceTmuxDiscoveryTests {
         previewCoordinator.setExpanded(true, for: key)
         await waitUntilMainActor {
             captures.count == 1
+                && previewCoordinator.viewState(for: key)?.image != nil
         }
 
         #expect(identityReads.count == 0)
@@ -4716,7 +4717,7 @@ struct WorkspaceTmuxDiscoveryTests {
         model.reconnectActiveTmuxSessionNow()
         await waitUntilMainActor {
             surfaceStore.requestCount == 3
-                || model.activeBorrowedTmuxRecoveryState == nil
+                && model.activeBorrowedTmuxSessionIsConnected
         }
 
         #expect(surfaceStore.requestCount == 3)

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -722,10 +722,13 @@ final class TerminalSurfacePreviewTests: XCTestCase {
     }
 
     private func waitForIOSurface(in view: TerminalSurfaceView) throws {
-        let deadline = Date().addingTimeInterval(5)
+        let deadline = Date().addingTimeInterval(10)
         while !(view.layer?.contents is IOSurface), Date() < deadline {
             RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         }
-        XCTAssertTrue(view.layer?.contents is IOSurface)
+        _ = try XCTUnwrap(
+            view.layer?.contents as? IOSurface,
+            "libghostty did not render an IOSurface before the deadline"
+        )
     }
 }

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -285,7 +285,9 @@ structurally audits every proposed workflow, and requires every workflow that
 can reference a credential-bearing environment to remain byte-identical to
 trusted `main`. The audit rejects job-level reusable workflows except the
 exact repository-owned `ci.yml@main` call, and it keeps the merge-signal name,
-trigger, and file byte-identical to trusted `main`.
+trigger, and file byte-identical to trusted `main`. The executable
+post-approval vulnerability policy is part of the same byte-identical authority
+closure, and changing it is promotion-relevant.
 It then rechecks the complete App, environment, ruleset, file, base,
 promotion-run, and freshness authority before the dedicated App authorizes that
 queue SHA. If GitHub cannot run reconciliation, the queue SHA never succeeds

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -109,6 +109,10 @@ make sandbox-image-authority-audit
 gh workflow run sandbox-image-promotion-gate.yml --ref main
 ```
 
+Until `sandbox-image-authority-configure` completes and publishes its repository
+readiness marker, the publication and promotion-gate workflows skip cleanly.
+Once the marker exists, missing or drifted authority configuration fails closed.
+
 Enabling the rules before their producing workflows exist would deadlock the
 bootstrap pull request. The enable command verifies the inherited pull-request
 policy, then creates or updates a narrow repository-owned ruleset instead of
@@ -166,7 +170,8 @@ checks, scans, and transfers one inert Docker archive plus its evidence to a
 fresh package-writer job. That job never checks out the repository or runs its
 Python, Make targets, dependency configuration, or image source. It validates
 the transferred tag and content identity, exposes the GHCR credential only to
-the pinned login action and fixed Docker push, logs out, then verifies the
+the pinned login action and fixed Docker inspect/push operations, logs out,
+then verifies the
 public object by digest and records provenance and SBOM attestations. The
 repository-wide token can record attestations but cannot write the GHCR
 package. Provenance includes a

--- a/tools/sandbox_image/authority.py
+++ b/tools/sandbox_image/authority.py
@@ -442,6 +442,8 @@ def configure_promotion_authority(
             ),
             private_key,
         )
+    verify_promotion_status_environment(root, runner, numeric_id)
+    verify_production_environment(runner, expected_app_id=numeric_id)
     runner.run(
         (
             "gh",
@@ -454,8 +456,6 @@ def configure_promotion_authority(
             CANONICAL_REPOSITORY,
         )
     )
-    verify_promotion_status_environment(root, runner, numeric_id)
-    verify_production_environment(runner, expected_app_id=numeric_id)
 
 
 def enable_promotion_authority(root: Path, runner: SecretRunner) -> int:

--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -56,6 +56,7 @@ REVIEWED_IMAGE_INPUTS = (
 PROMOTION_STATUS_ENVIRONMENT = "sandbox-image-promotion-status"
 PROMOTION_STATUS_WORKFLOW = "sandbox-image-promotion-gate.yml"
 PROMOTION_WORKFLOW = "sandbox-image-promote.yml"
+POST_APPROVAL_POLICY = Path("tools/sandbox_image/post_approval_policy.jq")
 PACKAGE_WRITER_ENVIRONMENT = "sandbox-image-package-writer"
 PACKAGE_WRITER_WORKFLOW = "sandbox-image-publish.yml"
 PRODUCTION_ENVIRONMENT = "sandbox-image-production"
@@ -626,10 +627,38 @@ def _read_regular_workflow(path: Path) -> bytes:
         raise ValueError(f"cannot audit workflow: {path.name}") from error
 
 
+def _read_regular_authority_file(root: Path, relative_path: Path) -> bytes:
+    current = root
+    directories = [root]
+    for part in relative_path.parts[:-1]:
+        current /= part
+        directories.append(current)
+    for directory in directories:
+        try:
+            mode = directory.lstat().st_mode
+        except OSError as error:
+            raise ValueError("cannot audit promotion authority path") from error
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise ValueError("promotion authority path must contain directories")
+    path = current / relative_path.name
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ValueError("cannot audit promotion authority file") from error
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+        raise ValueError("promotion authority file must be a regular file")
+    try:
+        return path.read_bytes()
+    except OSError as error:
+        raise ValueError("cannot audit promotion authority file") from error
+
+
 def verify_promotion_workflows(
     workflow_root: Path,
     *,
     trusted_workflow_root: Path | None = None,
+    repository_root: Path | None = None,
+    trusted_repository_root: Path | None = None,
 ) -> None:
     status_references: set[str] = set()
     package_references: set[str] = set()
@@ -723,6 +752,23 @@ def verify_promotion_workflows(
                 raise ValueError(f"cannot compare trusted {label} workflow") from error
             if trusted_content != proposed_content:
                 raise ValueError(f"trusted {label} workflow changed in proposed tree")
+        if repository_root is not None or trusted_repository_root is not None:
+            if repository_root is None or trusted_repository_root is None:
+                raise ValueError(
+                    "repository roots are required for proposed authority"
+                )
+            trusted_policy = _read_regular_authority_file(
+                trusted_repository_root,
+                POST_APPROVAL_POLICY,
+            )
+            proposed_policy = _read_regular_authority_file(
+                repository_root,
+                POST_APPROVAL_POLICY,
+            )
+            if trusted_policy != proposed_policy:
+                raise ValueError(
+                    "trusted post-approval policy changed in proposed tree"
+                )
 
 
 def verify_package_writer_environment(runner: Runner) -> None:
@@ -778,6 +824,10 @@ def verify_promotion_status_environment(
     verify_promotion_workflows(
         proposed_workflows,
         trusted_workflow_root=trusted_workflows,
+        repository_root=(
+            workflow_root.parent.parent if workflow_root is not None else None
+        ),
+        trusted_repository_root=(root if workflow_root is not None else None),
     )
 
     endpoint = f"repos/kenn-io/ghosthub/environments/{PROMOTION_STATUS_ENVIRONMENT}"

--- a/tools/sandbox_image/post_approval_policy.jq
+++ b/tools/sandbox_image/post_approval_policy.jq
@@ -1,0 +1,96 @@
+def nonempty_string:
+  type == "string" and length > 0;
+
+def same_identity($finding; $disposition):
+  $finding.vulnerability_id == $disposition.vulnerability_id and
+  $finding.package == $disposition.package and
+  $finding.result_class == $disposition.result_class and
+  $finding.result_type == $disposition.result_type and
+  $finding.target == $disposition.target;
+
+if ($scan | length) != 1 or
+   ($disposition_documents | length) != 1 then
+  error("scan or disposition input is not one JSON document")
+else
+  $scan[0] as $document |
+  $disposition_documents[0] as $dispositions |
+  if ($document | type) != "object" or
+     ($document.Results | type) != "array" or
+     (any($document.Results[]; .Class == "os-pkgs") | not) or
+     (all($document.Results[];
+       (.Class == "os-pkgs" or .Class == "lang-pkgs") and
+       (.Type | nonempty_string) and
+       (.Target | nonempty_string) and
+       ((.Vulnerabilities // []) | type) == "array" and
+       all((.Vulnerabilities // [])[];
+         (.VulnerabilityID | nonempty_string) and
+         (.PkgName | nonempty_string) and
+         ((.Severity | ascii_upcase) |
+           IN("UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL")) and
+         (.FixedVersion == null or
+           (.FixedVersion | type) == "string"))) | not) then
+    error("Trivy vulnerability report has an invalid schema")
+  elif ($dispositions | type) != "array" or
+       (all($dispositions[];
+         type == "object" and
+         (keys | sort) == [
+           "expires", "owner", "package", "rationale",
+           "result_class", "result_type", "target", "vulnerability_id"
+         ] and
+         all(.[]; type == "string") and
+         (.vulnerability_id | nonempty_string) and
+         (.package | nonempty_string) and
+         (.result_class | IN("os-pkgs", "lang-pkgs")) and
+         (.result_type | nonempty_string) and
+         (.target | nonempty_string) and
+         (.rationale | test("\\S")) and
+         (.owner | test("\\S")) and
+         (.expires >= $today) and
+         (try ((.expires + "T00:00:00Z") |
+           fromdateiso8601 | type == "number") catch false)) | not) or
+       ([$dispositions[] | [
+         .vulnerability_id, .package, .result_class, .result_type, .target
+       ]] | length) !=
+       ([$dispositions[] | [
+         .vulnerability_id, .package, .result_class, .result_type, .target
+       ]] | unique | length) then
+    error("vulnerability dispositions have an invalid schema")
+  else
+    [
+      $document.Results[] as $result |
+      ($result.Vulnerabilities // [])[] |
+      {
+        vulnerability_id: .VulnerabilityID,
+        package: .PkgName,
+        result_class: $result.Class,
+        result_type: $result.Type,
+        target: (
+          if $result.Class == "os-pkgs" then "rootfs" else $result.Target end
+        ),
+        severity: (.Severity | ascii_upcase),
+        fixed_version: (.FixedVersion // "")
+      }
+    ] as $findings |
+    [
+      $findings[] |
+      select(.severity == "HIGH" or .severity == "CRITICAL") |
+      . as $finding |
+      select(
+        (.fixed_version | length) > 0 or
+        (any($dispositions[]; same_identity($finding; .)) | not)
+      )
+    ] as $blocking |
+    [
+      $dispositions[] as $disposition |
+      select(any($findings[];
+        (.severity == "HIGH" or .severity == "CRITICAL") and
+        same_identity(.; $disposition)) | not) |
+      $disposition
+    ] as $unmatched |
+    if $blocking == [] and $unmatched == [] then
+      {blocking: [], unmatched_dispositions: []}
+    else
+      error("post-approval vulnerability policy failed")
+    end
+  end
+end

--- a/tools/tests/test_sandbox_image_authority.py
+++ b/tools/tests/test_sandbox_image_authority.py
@@ -543,6 +543,7 @@ def test_promotion_authority_rotation_updates_both_credential_environments(
         "-----BEGIN " + "PRIVATE KEY-----\nvalue\n-----END " + "PRIVATE KEY-----\n"
     )
     key.write_text(private_key, encoding="utf-8")
+    completion_events: list[str] = []
 
     class Runner:
         def __init__(self) -> None:
@@ -559,6 +560,17 @@ def test_promotion_authority_rotation_updates_both_credential_environments(
             del check, capture
             call = tuple(argv)
             self.calls.append(call)
+            if call == (
+                "gh",
+                "variable",
+                "set",
+                authority.APP_ID_VARIABLE,
+                "--body",
+                "424242",
+                "--repo",
+                "kenn-io/ghosthub",
+            ):
+                completion_events.append("ready")
             if call == (
                 "git",
                 "-C",
@@ -611,10 +623,12 @@ def test_promotion_authority_rotation_updates_both_credential_environments(
     monkeypatch.setattr(
         authority,
         "verify_production_environment",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: completion_events.append("production"),
     )
     monkeypatch.setattr(
-        authority, "verify_promotion_status_environment", lambda *_args: None
+        authority,
+        "verify_promotion_status_environment",
+        lambda *_args: completion_events.append("status"),
     )
     runner = Runner()
 
@@ -625,6 +639,8 @@ def test_promotion_authority_rotation_updates_both_credential_environments(
         key,
         runner,
     )
+
+    assert completion_events[-3:] == ["status", "production", "ready"]
 
     for environment in (
         "sandbox-image-promotion-status",

--- a/tools/tests/test_sandbox_image_commands.py
+++ b/tools/tests/test_sandbox_image_commands.py
@@ -1589,6 +1589,82 @@ def test_proposed_workflow_audit_rejects_merge_signal_changes(
         )
 
 
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("identical", None),
+        ("changed", "trusted post-approval policy changed"),
+        ("missing", "cannot audit promotion authority file"),
+        ("symlink", "promotion authority file must be a regular file"),
+        ("directory", "promotion authority file must be a regular file"),
+    ],
+)
+def test_proposed_authority_audit_rejects_policy_tampering(
+    tmp_path: Path,
+    mutation: str,
+    message: str | None,
+) -> None:
+    trusted_root = tmp_path / "trusted"
+    proposed_root = tmp_path / "proposed"
+    status = (
+        "permissions: {}\njobs:\n"
+        "  reconcile:\n"
+        "    environment: sandbox-image-promotion-status\n"
+    )
+    workflows = {
+        "sandbox-image-promotion-gate.yml": status,
+        "sandbox-image-promote.yml": (
+            status
+            + "  retag:\n"
+            "    environment: sandbox-image-production\n"
+        ),
+        "sandbox-image-publish.yml": (
+            "permissions: {}\njobs:\n"
+            "  publish:\n"
+            "    environment: sandbox-image-package-writer\n"
+        ),
+        "sandbox-image-merge-signal.yml": MERGE_SIGNAL_WORKFLOW,
+    }
+    for root in (trusted_root, proposed_root):
+        workflow_root = root / ".github/workflows"
+        workflow_root.mkdir(parents=True)
+        for name, content in workflows.items():
+            (workflow_root / name).write_text(content)
+        policy = root / github_module.POST_APPROVAL_POLICY
+        policy.parent.mkdir(parents=True)
+        policy.write_text("allow\n")
+
+    proposed_policy = proposed_root / github_module.POST_APPROVAL_POLICY
+    if mutation == "changed":
+        proposed_policy.write_text("deny\n")
+    elif mutation == "missing":
+        proposed_policy.unlink()
+    elif mutation == "symlink":
+        proposed_policy.unlink()
+        proposed_policy.symlink_to(
+            trusted_root / github_module.POST_APPROVAL_POLICY
+        )
+    elif mutation == "directory":
+        proposed_policy.unlink()
+        proposed_policy.mkdir()
+
+    if message is None:
+        github_module.verify_promotion_workflows(
+            proposed_root / ".github/workflows",
+            trusted_workflow_root=trusted_root / ".github/workflows",
+            repository_root=proposed_root,
+            trusted_repository_root=trusted_root,
+        )
+    else:
+        with pytest.raises(ValueError, match=message):
+            github_module.verify_promotion_workflows(
+                proposed_root / ".github/workflows",
+                trusted_workflow_root=trusted_root / ".github/workflows",
+                repository_root=proposed_root,
+                trusted_repository_root=trusted_root,
+            )
+
+
 @pytest.mark.parametrize("link_kind", ["workflow-file", "workflow-root", "parent"])
 def test_proposed_workflow_audit_rejects_symlinked_authority(
     tmp_path: Path,

--- a/tools/tests/test_sandbox_image_post_approval_policy.py
+++ b/tools/tests/test_sandbox_image_post_approval_policy.py
@@ -1,0 +1,135 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+POLICY = Path(__file__).parents[1] / "sandbox_image/post_approval_policy.jq"
+TODAY = "2026-08-15"
+
+
+def evaluate(
+    tmp_path: Path,
+    scan: object,
+    dispositions: object,
+) -> subprocess.CompletedProcess[str]:
+    scan_path = tmp_path / "scan.json"
+    dispositions_path = tmp_path / "dispositions.json"
+    scan_path.write_text(json.dumps(scan), encoding="utf-8")
+    dispositions_path.write_text(json.dumps(dispositions), encoding="utf-8")
+    return subprocess.run(
+        (
+            "jq",
+            "-en",
+            "--arg",
+            "today",
+            TODAY,
+            "--slurpfile",
+            "scan",
+            str(scan_path),
+            "--slurpfile",
+            "disposition_documents",
+            str(dispositions_path),
+            "-f",
+            str(POLICY),
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def trivy_report(
+    *,
+    severity: str = "HIGH",
+    fixed_version: str | None = None,
+) -> dict[str, object]:
+    vulnerability: dict[str, object] = {
+        "VulnerabilityID": "CVE-2026-1",
+        "PkgName": "libexample",
+        "Severity": severity,
+    }
+    if fixed_version is not None:
+        vulnerability["FixedVersion"] = fixed_version
+    return {
+        "Results": [
+            {
+                "Class": "os-pkgs",
+                "Type": "ubuntu",
+                "Target": "ubuntu:26.04",
+                "Vulnerabilities": [vulnerability],
+            }
+        ]
+    }
+
+
+def disposition(*, expires: str = "2026-09-01") -> dict[str, str]:
+    return {
+        "vulnerability_id": "CVE-2026-1",
+        "package": "libexample",
+        "result_class": "os-pkgs",
+        "result_type": "ubuntu",
+        "target": "rootfs",
+        "rationale": "No upstream fix is available",
+        "owner": "security",
+        "expires": expires,
+    }
+
+
+def test_current_disposition_accepts_an_unfixed_high(
+    tmp_path: Path,
+) -> None:
+    result = evaluate(tmp_path, trivy_report(), [disposition()])
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("severity", ["HIGH", "CRITICAL"])
+def test_fixable_severe_finding_is_rejected_even_when_disposed(
+    tmp_path: Path,
+    severity: str,
+) -> None:
+    result = evaluate(
+        tmp_path,
+        trivy_report(severity=severity, fixed_version="2.0"),
+        [disposition()],
+    )
+
+    assert result.returncode != 0
+
+
+def test_expired_disposition_is_rejected(tmp_path: Path) -> None:
+    result = evaluate(
+        tmp_path,
+        trivy_report(),
+        [disposition(expires="2026-08-14")],
+    )
+
+    assert result.returncode != 0
+
+
+def test_disposition_without_a_matching_finding_is_rejected(
+    tmp_path: Path,
+) -> None:
+    result = evaluate(
+        tmp_path,
+        {
+            "Results": [
+                {
+                    "Class": "os-pkgs",
+                    "Type": "ubuntu",
+                    "Target": "ubuntu:26.04",
+                    "Vulnerabilities": [],
+                }
+            ]
+        },
+        [disposition()],
+    )
+
+    assert result.returncode != 0
+
+
+def test_malformed_trivy_report_is_rejected(tmp_path: Path) -> None:
+    result = evaluate(tmp_path, {"Results": []}, [])
+
+    assert result.returncode != 0


### PR DESCRIPTION
The sandbox image pipeline ran before its promotion authority was provisioned, so the first merge made ordinary `main` CI fail instead of remaining safely dormant.

- Skip publication and promotion reconciliation until the existing setup command publishes its readiness marker; configured pipelines still fail closed on missing or drifted authority.
- Authenticate the fixed GHCR inspection path so the first private candidate can be checked and published.
- Execute the post-approval vulnerability policy from one behavior-tested program that merge-queue authority byte-compares with trusted `main`, covering severe fixable findings, dispositions, expiry, unmatched evidence, and malformed scans.
- Wait for final observable preview and reconnect outcomes in two timing-sensitive Swift tests.

The pipeline still requires the documented GitHub App and environment setup before it can publish or authorize promotion.
