### PR TITLE
Stop rebuilding the sidebar on window activation

### DIFF
--- a/Sources/App/WorkspaceSceneModel+Selection.swift
+++ b/Sources/App/WorkspaceSceneModel+Selection.swift
@@ -160,23 +160,41 @@ extension WorkspaceSceneModel {
     }
 
     private var keyboardNavigationContext: KeyboardNavigationContext {
-        KeyboardNavigationContext(
-            snapshot: snapshot,
+        let tmuxSessionVisibility = TmuxSessionVisibility(
+            hiddenPatterns: SettingsStore.shared.tmuxSessionPreferences
+                .hiddenSessionPatterns,
+            hideKwtManagedSessions: SettingsStore.shared
+                .worktreePreferences.hideKwtManagedSessions
+        )
+        let worktreeOrderRawValue = WorkspaceSidebarOrderStorage
+            .worktreeRawValue()
+        let tmuxSessionOrderRawValue = WorkspaceSidebarOrderStorage
+            .tmuxSessionRawValue()
+        let herdrSessionOrderRawValue = WorkspaceSidebarOrderStorage
+            .herdrSessionRawValue()
+        let zellijSessionOrderRawValue = WorkspaceSidebarOrderStorage
+            .zellijSessionRawValue()
+        let sidebarSections = sidebarSectionCache.sections(
+            in: snapshot,
+            snapshotRevision: sidebarSnapshotRevision,
             visibility: worktreeVisibility,
-            tmuxSessionVisibility: TmuxSessionVisibility(
-                hiddenPatterns: SettingsStore.shared.tmuxSessionPreferences
-                    .hiddenSessionPatterns,
-                hideKwtManagedSessions: SettingsStore.shared
-                    .worktreePreferences.hideKwtManagedSessions
-            ),
-            worktreeOrderRawValue: WorkspaceSidebarOrderStorage
-                .worktreeRawValue(),
-            tmuxSessionOrderRawValue: WorkspaceSidebarOrderStorage
-                .tmuxSessionRawValue(),
-            herdrSessionOrderRawValue: WorkspaceSidebarOrderStorage
-                .herdrSessionRawValue(),
-            zellijSessionOrderRawValue: WorkspaceSidebarOrderStorage
-                .zellijSessionRawValue()
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            connectedTmuxSessionIDs: connectedBorrowedTmuxSessionIDs,
+            liveTmuxWindowCounts: tmuxWindowCountsBySessionID,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
+        )
+        return KeyboardNavigationContext(
+            snapshot: snapshot,
+            sidebarSections: sidebarSections,
+            visibility: worktreeVisibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
         )
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -579,10 +579,13 @@ final class WorkspaceSceneModel: ObservableObject {
 
     @Published var snapshot: WorkspaceSnapshot {
         didSet {
+            sidebarSnapshotRevision &+= 1
             publishProtectedTmuxEndpoints()
             reconcileInventoryHosts()
         }
     }
+    let sidebarSectionCache = WorkspaceSidebarSectionCache()
+    private(set) var sidebarSnapshotRevision: UInt64 = 0
     private var tmuxDiscoveryEnabled = false
     private var isApplyingInventoryOverlay = false
     private var inventoryHosts: [UUID: CommandHost] = [:]

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -635,6 +635,9 @@ struct WorkspaceWindow: View {
         return RootView(
             display: WorkspaceDisplayState(
                 snapshot: sceneModel.snapshot,
+                sidebarSectionCache: sceneModel.sidebarSectionCache,
+                sidebarSnapshotRevision:
+                sceneModel.sidebarSnapshotRevision,
                 workspaceResourceSummary:
                 sceneModel.workspaceResourceSummary,
                 activatedWorktreeIDs:

--- a/Sources/UI/KeyboardNavigationModel.swift
+++ b/Sources/UI/KeyboardNavigationModel.swift
@@ -3,6 +3,7 @@ import GhosthubWorkspace
 
 public struct KeyboardNavigationContext: Sendable {
     public var snapshot: WorkspaceSnapshot
+    public var sidebarSections: [WorkspaceSidebarSection]?
     public var visibility: WorktreeVisibility
     public var tmuxSessionVisibility: TmuxSessionVisibility
     public var worktreeOrderRawValue: String
@@ -12,6 +13,7 @@ public struct KeyboardNavigationContext: Sendable {
 
     public init(
         snapshot: WorkspaceSnapshot,
+        sidebarSections: [WorkspaceSidebarSection]? = nil,
         visibility: WorktreeVisibility = .default,
         tmuxSessionVisibility: TmuxSessionVisibility = .init(),
         worktreeOrderRawValue: String = "",
@@ -20,6 +22,7 @@ public struct KeyboardNavigationContext: Sendable {
         zellijSessionOrderRawValue: String = ""
     ) {
         self.snapshot = snapshot
+        self.sidebarSections = sidebarSections
         self.visibility = visibility
         self.tmuxSessionVisibility = tmuxSessionVisibility
         self.worktreeOrderRawValue = worktreeOrderRawValue
@@ -34,15 +37,16 @@ public enum KeyboardNavigationModel {
         for currentTarget: WorkspaceNavigationTarget,
         in context: KeyboardNavigationContext
     ) -> [WorkspaceNavigationTarget] {
-        let sections = WorkspaceSidebarModel.sections(
-            in: context.snapshot,
-            visibility: context.visibility,
-            tmuxSessionVisibility: context.tmuxSessionVisibility,
-            worktreeOrderRawValue: context.worktreeOrderRawValue,
-            tmuxSessionOrderRawValue: context.tmuxSessionOrderRawValue,
-            herdrSessionOrderRawValue: context.herdrSessionOrderRawValue,
-            zellijSessionOrderRawValue: context.zellijSessionOrderRawValue
-        )
+        let sections = context.sidebarSections
+            ?? WorkspaceSidebarModel.sections(
+                in: context.snapshot,
+                visibility: context.visibility,
+                tmuxSessionVisibility: context.tmuxSessionVisibility,
+                worktreeOrderRawValue: context.worktreeOrderRawValue,
+                tmuxSessionOrderRawValue: context.tmuxSessionOrderRawValue,
+                herdrSessionOrderRawValue: context.herdrSessionOrderRawValue,
+                zellijSessionOrderRawValue: context.zellijSessionOrderRawValue
+            )
 
         switch currentTarget {
         case .worktree:

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -642,6 +642,8 @@ public struct RootView: View {
     private var workspaceSidebarColumn: some View {
         WorkspaceSidebarView(
             snapshot: snapshot,
+            sectionCache: display.sidebarSectionCache,
+            snapshotRevision: display.sidebarSnapshotRevision,
             selection: Binding(
                 get: { selection },
                 set: { selectWorkspace($0) }

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -7,6 +7,8 @@ import SwiftUI
 /// Snapshot data and display flags consumed by RootView.
 public struct WorkspaceDisplayState {
     public let snapshot: WorkspaceSnapshot
+    public let sidebarSectionCache: WorkspaceSidebarSectionCache?
+    public let sidebarSnapshotRevision: UInt64
     public let workspaceResourceSummary: WorkspaceResourceSummary
     public let activatedWorktreeIDs: Set<UUID>
     public let activeAgentWorktreeIDs: Set<UUID>
@@ -41,6 +43,8 @@ public struct WorkspaceDisplayState {
 
     public init(
         snapshot: WorkspaceSnapshot,
+        sidebarSectionCache: WorkspaceSidebarSectionCache? = nil,
+        sidebarSnapshotRevision: UInt64 = 0,
         workspaceResourceSummary: WorkspaceResourceSummary = .empty,
         activatedWorktreeIDs: Set<UUID> = [],
         activeAgentWorktreeIDs: Set<UUID> = [],
@@ -74,6 +78,8 @@ public struct WorkspaceDisplayState {
         sessionPreviewMode: SessionPreviewMode = .off
     ) {
         self.snapshot = snapshot
+        self.sidebarSectionCache = sidebarSectionCache
+        self.sidebarSnapshotRevision = sidebarSnapshotRevision
         self.workspaceResourceSummary = workspaceResourceSummary
         self.activatedWorktreeIDs = activatedWorktreeIDs
         self.activeAgentWorktreeIDs = activeAgentWorktreeIDs

--- a/Sources/UI/WorkspaceSidebarSectionCache.swift
+++ b/Sources/UI/WorkspaceSidebarSectionCache.swift
@@ -1,0 +1,63 @@
+import Foundation
+import GhosthubWorkspace
+
+@MainActor
+public final class WorkspaceSidebarSectionCache {
+    private struct Input: Equatable {
+        var snapshotRevision: UInt64
+        var visibility: WorktreeVisibility
+        var tmuxSessionVisibility: TmuxSessionVisibility
+        var connectedTmuxSessionIDs: Set<String>
+        var liveTmuxWindowCounts: [String: Int]
+        var worktreeOrderRawValue: String
+        var tmuxSessionOrderRawValue: String
+        var herdrSessionOrderRawValue: String
+        var zellijSessionOrderRawValue: String
+    }
+
+    private var cached: (input: Input, sections: [WorkspaceSidebarSection])?
+
+    public init() {}
+
+    public func sections(
+        in snapshot: WorkspaceSnapshot,
+        snapshotRevision: UInt64,
+        visibility: WorktreeVisibility = .default,
+        tmuxSessionVisibility: TmuxSessionVisibility = .init(),
+        connectedTmuxSessionIDs: Set<String> = [],
+        liveTmuxWindowCounts: [String: Int] = [:],
+        worktreeOrderRawValue: String = "",
+        tmuxSessionOrderRawValue: String = "",
+        herdrSessionOrderRawValue: String = "",
+        zellijSessionOrderRawValue: String = ""
+    ) -> [WorkspaceSidebarSection] {
+        let input = Input(
+            snapshotRevision: snapshotRevision,
+            visibility: visibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            connectedTmuxSessionIDs: connectedTmuxSessionIDs,
+            liveTmuxWindowCounts: liveTmuxWindowCounts,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
+        )
+        if let cached, cached.input == input {
+            return cached.sections
+        }
+
+        let sections = WorkspaceSidebarModel.sections(
+            in: snapshot,
+            visibility: visibility,
+            tmuxSessionVisibility: tmuxSessionVisibility,
+            connectedTmuxSessionIDs: connectedTmuxSessionIDs,
+            liveTmuxWindowCounts: liveTmuxWindowCounts,
+            worktreeOrderRawValue: worktreeOrderRawValue,
+            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+            zellijSessionOrderRawValue: zellijSessionOrderRawValue
+        )
+        cached = (input, sections)
+        return sections
+    }
+}

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -460,6 +460,8 @@ struct WorkspaceSidebarView: View {
     private var differentiateWithoutColor
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     let snapshot: WorkspaceSnapshot
+    let sectionCache: WorkspaceSidebarSectionCache?
+    let snapshotRevision: UInt64
     @Binding var selection: WorkspaceSelection
     let visibility: WorktreeVisibility
     let tmuxSessionVisibility: TmuxSessionVisibility
@@ -528,6 +530,8 @@ struct WorkspaceSidebarView: View {
 
     init(
         snapshot: WorkspaceSnapshot,
+        sectionCache: WorkspaceSidebarSectionCache? = nil,
+        snapshotRevision: UInt64 = 0,
         selection: Binding<WorkspaceSelection>,
         visibility: WorktreeVisibility,
         tmuxSessionVisibility: TmuxSessionVisibility = TmuxSessionVisibility(),
@@ -596,6 +600,8 @@ struct WorkspaceSidebarView: View {
         onOpen: @escaping (WorktreeSummary) -> Void = { _ in }
     ) {
         self.snapshot = snapshot
+        self.sectionCache = sectionCache
+        self.snapshotRevision = snapshotRevision
         _selection = selection
         self.visibility = visibility
         self.tmuxSessionVisibility = tmuxSessionVisibility
@@ -643,17 +649,32 @@ struct WorkspaceSidebarView: View {
     // MARK: - Computed
 
     private var sections: [WorkspaceSidebarSection] {
-        WorkspaceSidebarModel.sections(
-            in: snapshot,
-            visibility: visibility,
-            tmuxSessionVisibility: tmuxSessionVisibility,
-            connectedTmuxSessionIDs: connectedTmuxSessionIDs,
-            liveTmuxWindowCounts: tmuxWindowCountsBySessionID,
-            worktreeOrderRawValue: worktreeOrderRawValue,
-            tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
-            herdrSessionOrderRawValue: herdrSessionOrderRawValue,
-            zellijSessionOrderRawValue: zellijSessionOrderRawValue
-        )
+        if let sectionCache {
+            sectionCache.sections(
+                in: snapshot,
+                snapshotRevision: snapshotRevision,
+                visibility: visibility,
+                tmuxSessionVisibility: tmuxSessionVisibility,
+                connectedTmuxSessionIDs: connectedTmuxSessionIDs,
+                liveTmuxWindowCounts: tmuxWindowCountsBySessionID,
+                worktreeOrderRawValue: worktreeOrderRawValue,
+                tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+                herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+                zellijSessionOrderRawValue: zellijSessionOrderRawValue
+            )
+        } else {
+            WorkspaceSidebarModel.sections(
+                in: snapshot,
+                visibility: visibility,
+                tmuxSessionVisibility: tmuxSessionVisibility,
+                connectedTmuxSessionIDs: connectedTmuxSessionIDs,
+                liveTmuxWindowCounts: tmuxWindowCountsBySessionID,
+                worktreeOrderRawValue: worktreeOrderRawValue,
+                tmuxSessionOrderRawValue: tmuxSessionOrderRawValue,
+                herdrSessionOrderRawValue: herdrSessionOrderRawValue,
+                zellijSessionOrderRawValue: zellijSessionOrderRawValue
+            )
+        }
     }
 
     // MARK: - Body

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -22,17 +22,16 @@ import Testing
 struct ActivationWorkGateTests {
     /// Budgets are a ratchet at the measured baseline plus 30%: 10 switches
     /// cost exactly 20 root body evaluations (one per window per switch)
-    /// and 40 sidebar section computations (two call sites per root
-    /// evaluation until the sections result is memoized). The
-    /// headroom absorbs a stray framework re-evaluation, while any new
-    /// per-switch invalidation source adds at least one root evaluation
-    /// per switch (+10 and +20 here) and trips the gate. Lower the budgets
-    /// when render work shrinks; never raise them without profiling why
-    /// the work grew.
+    /// and no sidebar section recomputation. The headroom absorbs a stray
+    /// framework re-evaluation, while any new per-switch invalidation source
+    /// adds at least one root evaluation per switch (+10 here) and trips the
+    /// gate. The section budget has no headroom because activation changes
+    /// none of its inputs. Lower the budgets when render work shrinks; never
+    /// raise them without profiling why the work grew.
     private enum Budget {
         static let switches = 10
         static let rootBodyEvaluations = 26
-        static let sidebarSectionComputations = 52
+        static let sidebarSectionComputations = 0
     }
 
     @Test("key-window switching stays within the render work budget")
@@ -199,6 +198,7 @@ private final class GateEnvironment {
 @MainActor
 private final class GateWindowModel: ObservableObject {
     let snapshot: WorkspaceSnapshot
+    let sidebarSectionCache = WorkspaceSidebarSectionCache()
     @Published var selection: WorkspaceSelection
     @Published var activeSession: WorkspaceTmuxSessionSelection?
     @Published var columnVisibility: NavigationSplitViewVisibility = .all
@@ -228,6 +228,7 @@ private struct GateHarness: View {
         RootView(
             display: WorkspaceDisplayState(
                 snapshot: model.snapshot,
+                sidebarSectionCache: model.sidebarSectionCache,
                 activeTmuxSession: model.activeSession
             ),
             content: ContentBuilders(

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -5,6 +5,32 @@ import Testing
 @testable import GhosthubUI
 
 struct WorkspaceSidebarModelTests {
+    @MainActor
+    @Test("section cache refreshes only when its inputs change")
+    func sectionCacheInvalidation() {
+        let hostID = UUID()
+        let cache = WorkspaceSidebarSectionCache()
+        var snapshot = WorkspaceSnapshot.fixture(hosts: [
+            .fixture(
+                id: hostID,
+                tmuxSessions: [
+                    .init(name: "first", managed: false, windows: []),
+                ]
+            ),
+        ])
+
+        let first = cache.sections(in: snapshot, snapshotRevision: 0)
+        let repeated = cache.sections(in: snapshot, snapshotRevision: 0)
+        #expect(first == repeated)
+
+        snapshot.hosts[0].tmuxSessions.append(
+            .init(name: "second", managed: false, windows: [])
+        )
+        let refreshed = cache.sections(in: snapshot, snapshotRevision: 1)
+        #expect(refreshed[0].tmuxSessionRows.map(\.title)
+            == ["first", "second"])
+    }
+
     @Test("drag ordering is durable and scoped to one project")
     func worktreeDragOrdering() {
         let first = WorktreeSummary.fixture(name: "first")


### PR DESCRIPTION
Switching between Ghosthub windows reevaluates their root views. The sidebar previously sorted and filtered the full fleet inventory twice per evaluation even though activation changed none of its inputs, adding avoidable work to a latency-sensitive path.

- Shares one scene-owned, revision-keyed sidebar result between rendering and keyboard navigation.
- Invalidates it when the snapshot, visibility, connected tmux state, live counts, or persisted ordering changes.
- Adds no activation callback, focus hook, observer, timer, task, notification, or libghostty work.
- Ratchets the activation gate from 40 section computations across ten switches to zero.

The full Swift suite passes locally (191 XCTest + 1,734 Swift Testing; five expected headless skips), along with the app build, format check, and activation gate.
