### PR TITLE
Scope Command-W to the active workspace

### DIFF
--- a/Sources/App/MenuCommands.swift
+++ b/Sources/App/MenuCommands.swift
@@ -182,10 +182,16 @@ struct FileMenuCommands: Commands {
             Divider()
 
             Button("Close") {
-                NotificationCenter.default.post(
-                    name: .ghosthubCloseTab,
-                    object: nil
-                )
+                if let focusedSceneModel {
+                    NotificationCenter.default.post(
+                        name: .ghosthubCloseTab,
+                        object: focusedSceneModel
+                    )
+                } else {
+                    applicationDelegate.requestWorkspaceTabClose(
+                        NSApplication.shared.keyWindow
+                    )
+                }
             }
             .keyboardShortcut("w")
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -7284,9 +7284,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 surface: { [weak self] in
                     self?.protectedTmuxSurface(handle: handle)
                 },
-                onCloseRequest: {
+                onCloseRequest: { [weak self] in
+                    guard let self else { return }
                     NotificationCenter.default.post(
-                        name: .ghosthubCloseTab, object: nil
+                        name: .ghosthubCloseTab,
+                        object: self
                     )
                 },
                 onRetryRequest: { [weak self] in
@@ -7387,10 +7389,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 surface: { [weak self] in
                     self?.nativeHerdrSessionCoordinator.surface(handle: handle)
                 },
-                onCloseRequest: {
+                onCloseRequest: { [weak self] in
+                    guard let self else { return }
                     NotificationCenter.default.post(
                         name: .ghosthubCloseTab,
-                        object: nil
+                        object: self
                     )
                 },
                 onRetryRequest: { [weak self] in
@@ -7450,10 +7453,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 surface: { [weak self] in
                     self?.nativeZellijSessionCoordinator.surface(handle: handle)
                 },
-                onCloseRequest: {
+                onCloseRequest: { [weak self] in
+                    guard let self else { return }
                     NotificationCenter.default.post(
                         name: .ghosthubCloseTab,
-                        object: nil
+                        object: self
                     )
                 },
                 onRetryRequest: { [weak self] in

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1059,6 +1059,9 @@ struct WorkspaceWindow: View {
             sidebarWidthChanged: { width in
                 titlebarSidebarWidth = width
             },
+            workspaceWindowProvider: { [weak sceneModel] in
+                sceneModel?.workspaceWindow
+            },
             settingsStore: settingsStore,
             selection: Binding(
                 get: { sceneModel.selection },

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -393,9 +393,10 @@ public struct RootView: View {
             ) { _ in handleNewWorktreeNotification() }
             .onReceive(
                 NotificationCenter.default.publisher(
-                    for: .ghosthubCloseTab
+                    for: .ghosthubCloseTab,
+                    object: sidebarToggleTarget
                 )
-            ) { _ in handleCloseTabNotification() }
+            ) { _ in handleCloseTab() }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: .ghosthubCommandPalette
@@ -2258,11 +2259,6 @@ public struct RootView: View {
     }
 
     // MARK: - Notification handlers
-
-    private func handleCloseTabNotification() {
-        guard controlActiveState == .key else { return }
-        handleCloseTab()
-    }
 
     private func handleNewWorktreeNotification() {
         guard controlActiveState == .key,

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -396,7 +396,10 @@ public struct RootView: View {
                     for: .ghosthubCloseTab,
                     object: sidebarToggleTarget
                 )
-            ) { _ in handleCloseTab() }
+            ) { _ in
+                guard controlActiveState == .key else { return }
+                handleCloseTab()
+            }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: .ghosthubCommandPalette

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -10,6 +10,7 @@ public struct RootView: View {
     private let handlers: InteractionHandlers
     private let sidebarToggleTarget: AnyObject
     private let sidebarWidthChanged: (CGFloat) -> Void
+    private let workspaceWindowProvider: () -> NSWindow?
     @Binding private var selection: WorkspaceSelection
     @Binding private var isSidePanelVisible: Bool
     @Binding private var columnVisibility: NavigationSplitViewVisibility
@@ -70,6 +71,7 @@ public struct RootView: View {
         handlers: InteractionHandlers = InteractionHandlers(),
         sidebarToggleTarget: AnyObject = NSObject(),
         sidebarWidthChanged: @escaping (CGFloat) -> Void = { _ in },
+        workspaceWindowProvider: @escaping () -> NSWindow? = { nil },
         settingsStore: SettingsStore = .shared,
         selection: Binding<WorkspaceSelection>,
         isSidePanelVisible: Binding<Bool> = .constant(false),
@@ -83,6 +85,7 @@ public struct RootView: View {
         self.handlers = handlers
         self.sidebarToggleTarget = sidebarToggleTarget
         self.sidebarWidthChanged = sidebarWidthChanged
+        self.workspaceWindowProvider = workspaceWindowProvider
         self.settingsStore = settingsStore
         _selection = selection
         _isSidePanelVisible = isSidePanelVisible
@@ -397,7 +400,10 @@ public struct RootView: View {
                     object: sidebarToggleTarget
                 )
             ) { _ in
-                guard controlActiveState == .key else { return }
+                guard let window = workspaceWindowProvider(),
+                      window.isKeyWindow,
+                      window.attachedSheet == nil
+                else { return }
                 handleCloseTab()
             }
             .onReceive(

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -168,38 +168,56 @@ struct SidebarToggleStabilityTests {
         let firstTarget = SidebarToggleTarget()
         let secondTarget = SidebarToggleTarget()
         let first = StabilityTestEnvironment(
-            sidebarToggleTarget: firstTarget,
-            presentsWindow: false
+            sidebarToggleTarget: firstTarget
         )
         let second = StabilityTestEnvironment(
-            sidebarToggleTarget: secondTarget,
-            presentsWindow: false
+            sidebarToggleTarget: secondTarget
         )
         defer {
             first.close()
             second.close()
         }
+        first.workspaceWindow?.makeKeyAndOrderFront(nil)
+
+        #expect(first.workspaceWindow?.isKeyWindow == true)
 
         NotificationCenter.default.post(
             name: .ghosthubCloseTab,
             object: firstTarget
         )
+        #expect(first.closedSessionNames == ["alpha"])
+
         first.settle()
         second.settle()
 
-        #expect(first.closedSessionNames == ["alpha"])
         #expect(second.closedSessionNames.isEmpty)
     }
 
-    @Test("close command ignores a targeted inactive workspace")
-    func closeCommandIgnoresTargetedInactiveWorkspace() {
+    @Test("close command ignores a targeted workspace behind a sheet")
+    func closeCommandIgnoresTargetedWorkspaceBehindSheet() {
         let target = SidebarToggleTarget()
         let env = StabilityTestEnvironment(
-            sidebarToggleTarget: target,
-            presentsWindow: false,
-            controlActiveState: .inactive
+            sidebarToggleTarget: target
         )
         defer { env.close() }
+        guard let window = env.workspaceWindow else {
+            Issue.record("workspace window should exist")
+            return
+        }
+        let sheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.beginSheet(sheet)
+        env.settle()
+        defer {
+            window.endSheet(sheet)
+            sheet.orderOut(nil)
+        }
+
+        #expect(window.attachedSheet === sheet)
 
         NotificationCenter.default.post(
             name: .ghosthubCloseTab,
@@ -242,6 +260,14 @@ struct SidebarToggleStabilityTests {
 // MARK: - Test Helpers
 
 private final class SidebarToggleTarget {}
+
+private final class StabilityTestWindow: NSWindow {
+    override var isKeyWindow: Bool { true }
+}
+
+private final class WeakWindow {
+    weak var window: NSWindow?
+}
 
 @MainActor
 private final class StabilityTestEnvironment {
@@ -296,10 +322,13 @@ private final class StabilityTestEnvironment {
         model.closedSessionNames
     }
 
+    var workspaceWindow: NSWindow? {
+        window
+    }
+
     init(
         sidebarToggleTarget: AnyObject = SidebarToggleTarget(),
-        presentsWindow: Bool = true,
-        controlActiveState: ControlActiveState = .key
+        presentsWindow: Bool = true
     ) {
         self.sidebarToggleTarget = sidebarToggleTarget
         let hostID = UUID()
@@ -359,17 +388,20 @@ private final class StabilityTestEnvironment {
             ),
             userDefaults: defaults
         )
+        let windowReference = WeakWindow()
         hostingView = NSHostingView(
             rootView: StabilityTestHarness(
                 model: model,
                 settingsStore: settingsStore,
                 defaults: defaults,
                 sidebarToggleTarget: sidebarToggleTarget,
-                controlActiveState: controlActiveState
+                workspaceWindowProvider: {
+                    windowReference.window
+                }
             )
         )
         if presentsWindow {
-            let window = NSWindow(
+            let window = StabilityTestWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1000, height: 700),
                 styleMask: [.titled],
                 backing: .buffered,
@@ -378,6 +410,7 @@ private final class StabilityTestEnvironment {
             window.contentView = hostingView
             window.makeKeyAndOrderFront(nil)
             self.window = window
+            windowReference.window = window
         } else {
             window = nil
             hostingView.frame = NSRect(
@@ -476,7 +509,7 @@ private struct StabilityTestHarness: View {
     let settingsStore: SettingsStore
     let defaults: UserDefaults
     let sidebarToggleTarget: AnyObject
-    let controlActiveState: ControlActiveState
+    let workspaceWindowProvider: () -> NSWindow?
 
     var body: some View {
         RootView(
@@ -502,13 +535,14 @@ private struct StabilityTestHarness: View {
                 closeTmuxSession: model.closeSession
             ),
             sidebarToggleTarget: sidebarToggleTarget,
+            workspaceWindowProvider: workspaceWindowProvider,
             settingsStore: settingsStore,
             selection: $model.selection,
             columnVisibility: $model.columnVisibility,
             isCommandPalettePresented: $model.isCommandPalettePresented
         )
         .defaultAppStorage(defaults)
-        .environment(\.controlActiveState, controlActiveState)
+        .environment(\.controlActiveState, .key)
     }
 }
 

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -163,6 +163,34 @@ struct SidebarToggleStabilityTests {
         #expect(!second.isCommandPalettePresented)
     }
 
+    @Test("close command detaches only its targeted window")
+    func closeCommandDetachesOnlyTargetedWindow() {
+        let firstTarget = SidebarToggleTarget()
+        let secondTarget = SidebarToggleTarget()
+        let first = StabilityTestEnvironment(
+            sidebarToggleTarget: firstTarget,
+            presentsWindow: false
+        )
+        let second = StabilityTestEnvironment(
+            sidebarToggleTarget: secondTarget,
+            presentsWindow: false
+        )
+        defer {
+            first.close()
+            second.close()
+        }
+
+        NotificationCenter.default.post(
+            name: .ghosthubCloseTab,
+            object: firstTarget
+        )
+        first.settle()
+        second.settle()
+
+        #expect(first.closedSessionNames == ["alpha"])
+        #expect(second.closedSessionNames.isEmpty)
+    }
+
     @Test("right side panel toggle preserves main column view identity")
     func rightSidePanelTogglePreservesMainColumn() {
         let env = SidePanelStabilityTestEnvironment()
@@ -243,6 +271,10 @@ private final class StabilityTestEnvironment {
 
     var terminalResizeDeferrals: [Bool] {
         model.terminalResizeDeferrals
+    }
+
+    var closedSessionNames: [String] {
+        model.closedSessionNames
     }
 
     init(
@@ -389,6 +421,7 @@ private final class StabilityTestModel: ObservableObject {
     @Published var columnVisibility: NavigationSplitViewVisibility = .all
     @Published var isCommandPalettePresented = false
     private(set) var terminalResizeDeferrals: [Bool] = []
+    private(set) var closedSessionNames: [String] = []
 
     init(
         snapshot: WorkspaceSnapshot,
@@ -406,6 +439,13 @@ private final class StabilityTestModel: ObservableObject {
 
     func clearTerminalResizeDeferrals() {
         terminalResizeDeferrals.removeAll()
+    }
+
+    func closeSession(_ session: WorkspaceTmuxSessionSelection) {
+        closedSessionNames.append(session.name)
+        if activeSession == session {
+            activeSession = nil
+        }
     }
 
 }
@@ -435,6 +475,9 @@ private struct StabilityTestHarness: View {
                 tmuxSessionPreviewParkingBuilder: {
                     AnyView(Color.clear)
                 }
+            ),
+            handlers: InteractionHandlers(
+                closeTmuxSession: model.closeSession
             ),
             sidebarToggleTarget: sidebarToggleTarget,
             settingsStore: settingsStore,

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -191,6 +191,25 @@ struct SidebarToggleStabilityTests {
         #expect(second.closedSessionNames.isEmpty)
     }
 
+    @Test("close command ignores a targeted inactive workspace")
+    func closeCommandIgnoresTargetedInactiveWorkspace() {
+        let target = SidebarToggleTarget()
+        let env = StabilityTestEnvironment(
+            sidebarToggleTarget: target,
+            presentsWindow: false,
+            controlActiveState: .inactive
+        )
+        defer { env.close() }
+
+        NotificationCenter.default.post(
+            name: .ghosthubCloseTab,
+            object: target
+        )
+        env.settle()
+
+        #expect(env.closedSessionNames.isEmpty)
+    }
+
     @Test("right side panel toggle preserves main column view identity")
     func rightSidePanelTogglePreservesMainColumn() {
         let env = SidePanelStabilityTestEnvironment()
@@ -279,7 +298,8 @@ private final class StabilityTestEnvironment {
 
     init(
         sidebarToggleTarget: AnyObject = SidebarToggleTarget(),
-        presentsWindow: Bool = true
+        presentsWindow: Bool = true,
+        controlActiveState: ControlActiveState = .key
     ) {
         self.sidebarToggleTarget = sidebarToggleTarget
         let hostID = UUID()
@@ -344,7 +364,8 @@ private final class StabilityTestEnvironment {
                 model: model,
                 settingsStore: settingsStore,
                 defaults: defaults,
-                sidebarToggleTarget: sidebarToggleTarget
+                sidebarToggleTarget: sidebarToggleTarget,
+                controlActiveState: controlActiveState
             )
         )
         if presentsWindow {
@@ -455,6 +476,7 @@ private struct StabilityTestHarness: View {
     let settingsStore: SettingsStore
     let defaults: UserDefaults
     let sidebarToggleTarget: AnyObject
+    let controlActiveState: ControlActiveState
 
     var body: some View {
         RootView(
@@ -486,7 +508,7 @@ private struct StabilityTestHarness: View {
             isCommandPalettePresented: $model.isCommandPalettePresented
         )
         .defaultAppStorage(defaults)
-        .environment(\.controlActiveState, .key)
+        .environment(\.controlActiveState, controlActiveState)
     }
 }
 


### PR DESCRIPTION
Command-W currently broadcasts a close request process-wide. If multiple SwiftUI scenes retain key-window state, one shortcut detaches every active presentation even though the underlying tmux sessions remain alive.

- Targets menu and pane-originated close requests to the originating workspace scene.
- Checks that scene's live AppKit window at close time and requires it to be key with no attached sheet.
- Leaves every other window and session presentation attached; non-workspace windows still close through AppKit's key window.
- Covers cross-window isolation and an attached sheet on a real workspace window.
- Adds no activation callback, focus observer, timer, polling, or libghostty work.

Focused lifecycle and AppKit close tests, the activation gate, essential workflows, formatting, and the app build pass. A full parallel Swift run exposed existing timing flakes in four unrelated async suites; every affected suite passes independently.
