### PR TITLE
Hide project removal until interaction

### DIFF
--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -130,6 +130,78 @@ struct WorkspaceWorktreeRemovalActionPresentation: Equatable {
     }
 }
 
+struct WorkspaceProjectRemovalActionPresentation: Equatable {
+    static let controlWidth: CGFloat = 30
+
+    let isVisible: Bool
+    let reservedWidth: CGFloat
+    let hitTargetWidth: CGFloat
+
+    init(
+        isRemovable: Bool,
+        isRowHovered: Bool,
+        isActionHovered: Bool,
+        isFocused: Bool
+    ) {
+        isVisible = isRemovable
+            && (isRowHovered || isActionHovered || isFocused)
+        reservedWidth = isRemovable ? Self.controlWidth : 0
+        hitTargetWidth = isRemovable ? Self.controlWidth : 0
+    }
+}
+
+private struct ProjectRemovalButton: View {
+    let project: ProjectSummary
+    let isRowHovered: Bool
+    let onRemove: (ProjectSummary) -> Void
+
+    @FocusState private var isFocused: Bool
+    @State private var isHovered = false
+
+    var body: some View {
+        let presentation = WorkspaceProjectRemovalActionPresentation(
+            isRemovable: true,
+            isRowHovered: isRowHovered,
+            isActionHovered: isHovered,
+            isFocused: isFocused
+        )
+        Button {
+            onRemove(project)
+        } label: {
+            ZStack {
+                Color.clear
+                if presentation.isVisible {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+            }
+            .frame(
+                width: presentation.hitTargetWidth,
+                height: 30
+            )
+            .background {
+                if presentation.isVisible {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(
+                            Color.primary.opacity(
+                                isHovered ? 0.14 : 0.05
+                            )
+                        )
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .focused($isFocused)
+        .onHover { isHovered = $0 }
+        .help("Remove Project…")
+        .accessibilityLabel(
+            "Remove project \(project.sidebarTitle)"
+        )
+    }
+}
+
 struct WorktreeStatusCluster: View {
     let status: WorktreeRowStatus
 
@@ -513,6 +585,7 @@ struct WorkspaceSidebarView: View {
     @State private var hoveredWorktreeID: UUID?
     @State private var hoveredWorktreeActionID: UUID?
     @State private var worktreeHoverDismissTask: Task<Void, Never>?
+    @State private var hoveredProjectID: UUID?
     @State private var draggedSidebarItem: WorkspaceSidebarDragItem?
     @State private var reorderIndicator:
         WorkspaceSidebarReorderIndicator?
@@ -2110,20 +2183,19 @@ struct WorkspaceSidebarView: View {
             .accessibilityIdentifier("project-actions")
 
             if canRemove {
-                Button {
-                    onRequestRemoveProject(project.project)
-                } label: {
-                    Image(systemName: "trash")
-                        .font(.system(size: 10, weight: .semibold))
-                        .frame(width: 24, height: 28)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .help("Remove Project…")
-                .accessibilityLabel(
-                    "Remove project \(project.project.sidebarTitle)"
+                ProjectRemovalButton(
+                    project: project.project,
+                    isRowHovered:
+                    hoveredProjectID == project.project.id,
+                    onRemove: onRequestRemoveProject
                 )
+            }
+        }
+        .onHover { isHovered in
+            if isHovered {
+                hoveredProjectID = project.project.id
+            } else if hoveredProjectID == project.project.id {
+                hoveredProjectID = nil
             }
         }
     }

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -368,6 +368,42 @@ struct WorkspaceSidebarModelTests {
         #expect(primary.reservedWidth == 0)
     }
 
+    @Test("project removal appears on hover or keyboard focus")
+    func projectRemovalHoverAndFocusKeepStableHitTarget() {
+        let idle = WorkspaceProjectRemovalActionPresentation(
+            isRemovable: true,
+            isRowHovered: false,
+            isActionHovered: false,
+            isFocused: false
+        )
+        let hovered = WorkspaceProjectRemovalActionPresentation(
+            isRemovable: true,
+            isRowHovered: true,
+            isActionHovered: false,
+            isFocused: false
+        )
+        let focused = WorkspaceProjectRemovalActionPresentation(
+            isRemovable: true,
+            isRowHovered: false,
+            isActionHovered: false,
+            isFocused: true
+        )
+        let unavailable = WorkspaceProjectRemovalActionPresentation(
+            isRemovable: false,
+            isRowHovered: true,
+            isActionHovered: true,
+            isFocused: true
+        )
+
+        #expect(!idle.isVisible)
+        #expect(hovered.isVisible)
+        #expect(focused.isVisible)
+        #expect(!unavailable.isVisible)
+        #expect(idle.reservedWidth == hovered.reservedWidth)
+        #expect(focused.hitTargetWidth >= 28)
+        #expect(unavailable.reservedWidth == 0)
+    }
+
     @Test("hosts remain visible before they have projects or tmux sessions")
     func exposesEmptyHosts() {
         let local = HostSummary.fixture(name: "This Mac")

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -34,7 +34,7 @@ sheet and start again so the confirmation applies to the current host.
 
 ## Remove a project
 
-Hover over a project row and select its trash control, or Control-click the row
+Hover over a project row and select its × control, or Control-click the row
 and choose **Remove Project…**. Then confirm the project and host. Ghosthub asks
 kwt to unregister that project and refreshes inventory. You can remove the
 registration even if its checkout folder has already been deleted. This does


### PR DESCRIPTION
Project rows currently show a permanent trash icon beside the primary create and import menu, making routine navigation look unnecessarily destructive.

- Reveals a compact × only while the project row is hovered or the remove action has keyboard focus.
- Keeps the 30-point hit target, context-menu action, help text, accessibility label, and confirmation flow.
- Leaves New Worktree and Import Pull Request permanently available.
- Keeps focus state local to the button and adds no activation callback, terminal-focus work, polling, or libghostty work.
- Updates the Projects and Worktrees Guide and its deterministic synthetic screenshot.

![Project removal confirmation with idle project rows free of permanent destructive controls](https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/guide-project-removal.png?asset=hover-project-removal)

Focused sidebar tests, the activation gate, the app build, formatting, the release bundle, and the strict Guide build pass locally.
