### PR TITLE
Make OSC 52 clipboard failures observable

### DIFF
--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -4,6 +4,7 @@ import Foundation
 import GhosthubTerminalSupport
 import GhosthubWorkspace
 import GhosttyKit
+import os.log
 import UniformTypeIdentifiers
 
 private struct ResolvedColorCallbackGeneration: Equatable {
@@ -114,7 +115,22 @@ public final class LibghosttyRuntime: ObservableObject,
         let data: String
     }
 
-    static let osc52ClipboardWriteMIME = "application/x-ghosthub-osc52"
+    enum OSC52ClipboardWriteDiagnostic: Equatable {
+        case confirmationRequired
+        case surfaceUnavailable
+        case noWritableContent
+        case pasteboardRejected(entryCount: Int, byteCount: Int)
+        case written(entryCount: Int, byteCount: Int)
+    }
+
+    nonisolated static let osc52ClipboardWriteMIME =
+        "application/x-ghosthub-osc52"
+    private static let osc52ClipboardLog = OSLog(
+        subsystem: "com.ghosthub.app",
+        category: "clipboard"
+    )
+    static var osc52ClipboardWriteDiagnosticObserver:
+        ((OSC52ClipboardWriteDiagnostic) -> Void)?
     static var urlOpener: (URL) -> Bool = { url in
         NSWorkspace.shared.open(url)
     }
@@ -1035,11 +1051,6 @@ public final class LibghosttyRuntime: ObservableObject,
         len: Int,
         confirm: Bool
     ) {
-        guard !confirm else {
-            // Confirmed writes require user approval UI. Deny rather
-            // than silently allowing remote clipboard overwrites.
-            return
-        }
         let userdataValue = userdata.map { UInt(bitPattern: $0) }
         guard let content, len > 0 else { return }
         let entries: [ClipboardWriteEntry] = (0 ..< len).compactMap { index in
@@ -1054,21 +1065,127 @@ public final class LibghosttyRuntime: ObservableObject,
                 data: String(cString: dataPtr)
             )
         }
-        dispatchToMainSync {
-            guard surfaceView(from: userdataValue) != nil else { return }
-            let acceptedEntries = acceptedClipboardWriteEntries(entries)
-            let pasteboard = TerminalPasteboardAccess.current
-            pasteboard.clearContents()
-            let types = acceptedEntries.compactMap {
-                pasteboardType(forMIMEType: $0.mime)
-            }
-            pasteboard.declareTypes(types, owner: nil)
-            for entry in acceptedEntries {
-                guard let type = pasteboardType(forMIMEType: entry.mime) else {
-                    continue
+        let isOSC52Write = entries.contains {
+            $0.mime == osc52ClipboardWriteMIME
+        }
+        guard !confirm else {
+            // Confirmed writes require user approval UI. Deny rather
+            // than silently allowing remote clipboard overwrites.
+            if isOSC52Write {
+                dispatchToMainSync {
+                    recordOSC52ClipboardWriteDiagnostic(
+                        .confirmationRequired
+                    )
                 }
-                pasteboard.setString(entry.data, forType: type)
             }
+            return
+        }
+        dispatchToMainSync {
+            guard surfaceView(from: userdataValue) != nil else {
+                if isOSC52Write {
+                    recordOSC52ClipboardWriteDiagnostic(
+                        .surfaceUnavailable
+                    )
+                }
+                return
+            }
+            let diagnostic = writeClipboardEntries(
+                entries,
+                to: TerminalPasteboardAccess.current
+            )
+            if isOSC52Write {
+                recordOSC52ClipboardWriteDiagnostic(diagnostic)
+            }
+        }
+    }
+
+    static func writeClipboardEntries(
+        _ entries: [ClipboardWriteEntry],
+        to pasteboard: any TerminalPasteboard
+    ) -> OSC52ClipboardWriteDiagnostic {
+        let writableEntries = acceptedClipboardWriteEntries(entries)
+            .compactMap { entry -> (
+                entry: ClipboardWriteEntry,
+                type: NSPasteboard.PasteboardType
+            )? in
+                guard let type = pasteboardType(forMIMEType: entry.mime) else {
+                    return nil
+                }
+                return (entry, type)
+            }
+        guard !writableEntries.isEmpty else {
+            return .noWritableContent
+        }
+
+        pasteboard.clearContents()
+        pasteboard.declareTypes(
+            writableEntries.map(\.type),
+            owner: nil
+        )
+        let byteCount = writableEntries.reduce(into: 0) { count, writable in
+            count += writable.entry.data.utf8.count
+        }
+        let wroteEveryEntry = writableEntries.reduce(into: true) {
+            wroteEveryEntry, writable in
+            if !pasteboard.setString(
+                writable.entry.data,
+                forType: writable.type
+            ) {
+                wroteEveryEntry = false
+            }
+        }
+        let entryCount = writableEntries.count
+        if wroteEveryEntry {
+            return .written(
+                entryCount: entryCount,
+                byteCount: byteCount
+            )
+        }
+        return .pasteboardRejected(
+            entryCount: entryCount,
+            byteCount: byteCount
+        )
+    }
+
+    private static func recordOSC52ClipboardWriteDiagnostic(
+        _ diagnostic: OSC52ClipboardWriteDiagnostic
+    ) {
+        osc52ClipboardWriteDiagnosticObserver?(diagnostic)
+        switch diagnostic {
+        case .confirmationRequired:
+            os_log(
+                "OSC 52 clipboard write requires confirmation and was denied",
+                log: osc52ClipboardLog,
+                type: .error
+            )
+        case .surfaceUnavailable:
+            os_log(
+                "OSC 52 clipboard write arrived after its surface detached",
+                log: osc52ClipboardLog,
+                type: .error
+            )
+        case .noWritableContent:
+            os_log(
+                "OSC 52 clipboard write had no writable content",
+                log: osc52ClipboardLog,
+                type: .error
+            )
+        case let .pasteboardRejected(entryCount, byteCount):
+            os_log(
+                "OSC 52 pasteboard write failed: entries=%{public}d bytes=%{public}d",
+                log: osc52ClipboardLog,
+                type: .error,
+                entryCount,
+                byteCount
+            )
+        case let .written(entryCount, byteCount):
+            os_log(
+                "OSC 52 pasteboard write completed: entries=%{public}d bytes=%{public}d",
+                log: osc52ClipboardLog,
+                type: .info,
+                entryCount,
+                byteCount
+            )
         }
     }
 

--- a/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
+++ b/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
@@ -10,6 +10,7 @@ import XCTest
 @MainActor
 final class InMemoryTerminalPasteboard: TerminalPasteboard {
     private var contents: [NSPasteboard.PasteboardType: String] = [:]
+    var acceptsWrites = true
 
     func string(forType dataType: NSPasteboard.PasteboardType) -> String? {
         contents[dataType]
@@ -35,6 +36,7 @@ final class InMemoryTerminalPasteboard: TerminalPasteboard {
         _ string: String,
         forType dataType: NSPasteboard.PasteboardType
     ) -> Bool {
+        guard acceptsWrites else { return false }
         contents[dataType] = string
         return true
     }

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -25,9 +25,11 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         try skipUnlessLibghosttyReady()
         pasteboard = InMemoryTerminalPasteboard()
         TerminalPasteboardAccess.current = pasteboard
+        LibghosttyRuntime.osc52ClipboardWriteDiagnosticObserver = nil
     }
 
     override func tearDown() async throws {
+        LibghosttyRuntime.osc52ClipboardWriteDiagnosticObserver = nil
         TerminalPasteboardAccess.reset()
         pasteboard = nil
         try await super.tearDown()
@@ -2810,6 +2812,12 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             )
         )
         view.blocksClipboardReads = true
+        var diagnostics: [
+            LibghosttyRuntime.OSC52ClipboardWriteDiagnostic
+        ] = []
+        LibghosttyRuntime.osc52ClipboardWriteDiagnosticObserver = {
+            diagnostics.append($0)
+        }
 
         pasteboard.clearContents()
 
@@ -2824,6 +2832,37 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             pasteboard.string(forType: .string),
             copiedText,
             "OSC 52 copy from a remote surface must reach the Mac clipboard."
+        )
+        XCTAssertEqual(
+            diagnostics.last,
+            .written(
+                entryCount: 1,
+                byteCount: copiedText.utf8.count
+            )
+        )
+    }
+
+    func testOSC52ClipboardDiagnosticReportsPasteboardRejection() {
+        pasteboard.acceptsWrites = false
+        let copiedText = "clipboard write"
+
+        let diagnostic = LibghosttyRuntime.writeClipboardEntries(
+            [
+                .init(mime: "text/plain", data: copiedText),
+                .init(
+                    mime: LibghosttyRuntime.osc52ClipboardWriteMIME,
+                    data: ""
+                ),
+            ],
+            to: pasteboard
+        )
+
+        XCTAssertEqual(
+            diagnostic,
+            .pasteboardRejected(
+                entryCount: 1,
+                byteCount: copiedText.utf8.count
+            )
         )
     }
 


### PR DESCRIPTION
Tmux mouse selection can finish and clear its highlight while the macOS clipboard retains old contents. Ghosthub previously discarded every clipboard-write outcome, so the intermittent failure left no evidence.

- Records whether an OSC 52 write was denied, arrived after surface teardown, lacked writable content, was rejected by `NSPasteboard`, or completed.
- Logs only the outcome, entry count, and UTF-8 byte count—never clipboard text, session identity, host, or filesystem data.
- Checks the pasteboard write result and leaves the existing clipboard intact when a callback contains no writable entry.
- Extends the real libghostty OSC 52 smoke path and covers pasteboard rejection at Ghosthub's owned boundary.
- Adds no work to mouse movement, rendering, terminal focus, app or window activation, or window switching.

The focused terminal smoke test, essential workflows, activation-work gate, Python suite, formatting, and app build pass locally. The full Swift aggregate run exposed unrelated timing flakes in Herdr restoration, tmux discovery, and Zellij reconnect tests; each affected suite passes independently.
