### PR TITLE
Open project worktrees as native tabs

### DIFF
--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -56,6 +56,11 @@ final class WorkspaceWindowRequests<Window: AnyObject> {
         let requiredParentMissing: Bool
     }
 
+    struct Cancellation {
+        let requestIDs: [UUID]
+        let windowIDs: [UUID]
+    }
+
     private final class Request {
         weak var parent: Window?
         let requiresParent: Bool
@@ -96,6 +101,24 @@ final class WorkspaceWindowRequests<Window: AnyObject> {
             parent: parent === window ? nil : parent,
             remainingStates: request.remainingStates,
             requiredParentMissing: request.requiresParent && parent == nil
+        )
+    }
+
+    func cancel(requiring parent: Window) -> Cancellation {
+        let requestIDs = requests.compactMap { id, request in
+            request.requiresParent && request.parent === parent ? id : nil
+        }
+        var windowIDs: [UUID] = []
+        for id in requestIDs {
+            guard let request = requests.removeValue(forKey: id) else {
+                continue
+            }
+            windowIDs.append(id)
+            windowIDs.append(contentsOf: request.remainingStates.map(\.windowID))
+        }
+        return Cancellation(
+            requestIDs: requestIDs,
+            windowIDs: windowIDs
         )
     }
 }
@@ -148,6 +171,8 @@ final class ApplicationDelegate: NSObject,
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
     private let windowLaunchIntents = WorkspaceWindowLaunchIntents()
+    private let closedWorkspaceWindows = NSHashTable<NSWindow>.weakObjects()
+    private var cancelledWorkspaceWindowRequestIDs: Set<UUID> = []
     private var windowRestorationFinishedHandler: (Int) -> Void = { _ in }
     private var restoredWorkspaceWindowCount: Int?
     private(set) var terminationConfirmed = false
@@ -164,12 +189,23 @@ final class ApplicationDelegate: NSObject,
             name: NSApplication.didFinishRestoringWindowsNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(workspaceWindowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil
+        )
     }
 
     deinit {
         NotificationCenter.default.removeObserver(
             self,
             name: NSApplication.didFinishRestoringWindowsNotification,
+            object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.willCloseNotification,
             object: nil
         )
     }
@@ -192,6 +228,18 @@ final class ApplicationDelegate: NSObject,
         )
         restoredWorkspaceWindowCount = count
         windowRestorationFinishedHandler(count)
+    }
+
+    @objc func workspaceWindowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              WorkspaceWindowIdentity.matches(window)
+        else { return }
+        closedWorkspaceWindows.add(window)
+        let cancellation = windowRequests.cancel(requiring: window)
+        cancelledWorkspaceWindowRequestIDs.formUnion(
+            cancellation.requestIDs
+        )
+        windowLaunchIntents.remove(for: cancellation.windowIDs)
     }
 
     func applicationDidFinishLaunching(
@@ -275,13 +323,20 @@ final class ApplicationDelegate: NSObject,
         _ window: NSWindow,
         requestID: UUID?
     ) {
-        guard WorkspaceWindowIdentity.matches(window),
-              let request = windowRequests.consume(
-                  for: requestID,
-                  window: window
-              )
+        guard WorkspaceWindowIdentity.matches(window) else { return }
+        if let requestID,
+           cancelledWorkspaceWindowRequestIDs.remove(requestID) != nil {
+            windowLaunchIntents.remove(for: [requestID])
+            window.close()
+            return
+        }
+        guard let request = windowRequests.consume(
+            for: requestID,
+            window: window
+        )
         else { return }
-        if request.requiredParentMissing {
+        if request.requiredParentMissing
+            || request.parent.map(closedWorkspaceWindows.contains) == true {
             windowLaunchIntents.remove(
                 for: requestID.map { [$0] } ?? []
                     + request.remainingStates.map(\.windowID)
@@ -297,7 +352,11 @@ final class ApplicationDelegate: NSObject,
                 .contains(where: { $0 === window })
             else { return }
             let parentFrame = parent.frame
-            parent.addTabbedWindow(window, ordered: .above)
+            if let group = parent.tabGroup {
+                group.insertWindow(window, at: group.windows.count)
+            } else {
+                parent.addTabbedWindow(window, ordered: .above)
+            }
             window.makeKeyAndOrderFront(nil)
             NativeTabCommands.installBracketShortcuts()
             window.setFrame(parentFrame, display: true)
@@ -335,6 +394,10 @@ final class ApplicationDelegate: NSObject,
         parent: NSWindow
     ) {
         guard let next = states.first else { return }
+        guard !closedWorkspaceWindows.contains(parent) else {
+            windowLaunchIntents.remove(for: states.map(\.windowID))
+            return
+        }
         windowRequests.add(
             next.windowID,
             parent: parent,

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -50,8 +50,15 @@ enum WorkspaceWindowResolver {
 }
 
 final class WorkspaceWindowRequests<Window: AnyObject> {
+    struct ConsumedRequest {
+        let parent: Window?
+        let remainingStates: [WorkspaceWindowState]
+        let requiredParentMissing: Bool
+    }
+
     private final class Request {
         weak var parent: Window?
+        let requiresParent: Bool
         let remainingStates: [WorkspaceWindowState]
 
         init(
@@ -59,6 +66,7 @@ final class WorkspaceWindowRequests<Window: AnyObject> {
             remainingStates: [WorkspaceWindowState]
         ) {
             self.parent = parent
+            requiresParent = parent != nil
             self.remainingStates = remainingStates
         }
     }
@@ -79,16 +87,15 @@ final class WorkspaceWindowRequests<Window: AnyObject> {
     func consume(
         for id: UUID?,
         window: Window
-    ) -> (
-        parent: Window?,
-        remainingStates: [WorkspaceWindowState]
-    )? {
+    ) -> ConsumedRequest? {
         guard let id,
               let request = requests.removeValue(forKey: id)
         else { return nil }
-        return (
-            request.parent === window ? nil : request.parent,
-            request.remainingStates
+        let parent = request.parent
+        return ConsumedRequest(
+            parent: parent === window ? nil : parent,
+            remainingStates: request.remainingStates,
+            requiredParentMissing: request.requiresParent && parent == nil
         )
     }
 }
@@ -107,6 +114,12 @@ final class WorkspaceWindowLaunchIntents {
 
     func consume(for windowID: UUID) -> WorkspaceWindowLaunchIntent? {
         intents.removeValue(forKey: windowID)
+    }
+
+    func remove(for windowIDs: [UUID]) {
+        for windowID in windowIDs {
+            intents.removeValue(forKey: windowID)
+        }
     }
 }
 
@@ -268,6 +281,14 @@ final class ApplicationDelegate: NSObject,
                   window: window
               )
         else { return }
+        if request.requiredParentMissing {
+            windowLaunchIntents.remove(
+                for: requestID.map { [$0] } ?? []
+                    + request.remainingStates.map(\.windowID)
+            )
+            window.close()
+            return
+        }
         let groupWindow: NSWindow
         let adoptedParent: NSWindow?
         let preservedFrame: NSRect?

--- a/Sources/App/ApplicationDelegate.swift
+++ b/Sources/App/ApplicationDelegate.swift
@@ -52,28 +52,61 @@ enum WorkspaceWindowResolver {
 final class WorkspaceWindowRequests<Window: AnyObject> {
     private final class Request {
         weak var parent: Window?
+        let remainingStates: [WorkspaceWindowState]
 
-        init(parent: Window?) {
+        init(
+            parent: Window?,
+            remainingStates: [WorkspaceWindowState]
+        ) {
             self.parent = parent
+            self.remainingStates = remainingStates
         }
     }
 
     private var requests: [UUID: Request] = [:]
 
-    func add(_ id: UUID, parent: Window?) {
-        requests[id] = Request(parent: parent)
+    func add(
+        _ id: UUID,
+        parent: Window?,
+        remainingStates: [WorkspaceWindowState] = []
+    ) {
+        requests[id] = Request(
+            parent: parent,
+            remainingStates: remainingStates
+        )
     }
 
-    func consumeParent(
+    func consume(
         for id: UUID?,
         window: Window
-    ) -> Window? {
+    ) -> (
+        parent: Window?,
+        remainingStates: [WorkspaceWindowState]
+    )? {
         guard let id,
-              let request = requests.removeValue(forKey: id),
-              let parent = request.parent,
-              parent !== window
+              let request = requests.removeValue(forKey: id)
         else { return nil }
-        return parent
+        return (
+            request.parent === window ? nil : request.parent,
+            request.remainingStates
+        )
+    }
+}
+
+final class WorkspaceWindowLaunchIntents {
+    private var intents: [UUID: WorkspaceWindowLaunchIntent] = [:]
+
+    func add(
+        _ intent: WorkspaceWindowLaunchIntent,
+        for windowIDs: [UUID]
+    ) {
+        for windowID in windowIDs {
+            intents[windowID] = intent
+        }
+    }
+
+    func consume(for windowID: UUID) -> WorkspaceWindowLaunchIntent? {
+        intents.removeValue(forKey: windowID)
     }
 }
 
@@ -101,6 +134,7 @@ final class ApplicationDelegate: NSObject,
     var openWorkspaceWindow: (WorkspaceWindowState) -> Void = { _ in }
 
     private let windowRequests = WorkspaceWindowRequests<NSWindow>()
+    private let windowLaunchIntents = WorkspaceWindowLaunchIntents()
     private var windowRestorationFinishedHandler: (Int) -> Void = { _ in }
     private var restoredWorkspaceWindowCount: Int?
     private(set) var terminationConfirmed = false
@@ -201,31 +235,91 @@ final class ApplicationDelegate: NSObject,
         openWorkspaceWindow(requestWorkspaceWindow(parent: parent))
     }
 
+    func requestWorkspaceTabGroup(
+        _ states: [WorkspaceWindowState],
+        launchIntent: WorkspaceWindowLaunchIntent
+    ) {
+        guard let first = states.first else { return }
+        windowLaunchIntents.add(
+            launchIntent,
+            for: states.map(\.windowID)
+        )
+        windowRequests.add(
+            first.windowID,
+            parent: nil,
+            remainingStates: Array(states.dropFirst())
+        )
+        openWorkspaceWindow(first)
+    }
+
+    func consumeWorkspaceWindowLaunchIntent(
+        for windowID: UUID
+    ) -> WorkspaceWindowLaunchIntent? {
+        windowLaunchIntents.consume(for: windowID)
+    }
+
     func adoptWorkspaceWindowAsTabIfRequested(
         _ window: NSWindow,
         requestID: UUID?
     ) {
         guard WorkspaceWindowIdentity.matches(window),
-              let parent = windowRequests.consumeParent(
+              let request = windowRequests.consume(
                   for: requestID,
                   window: window
               )
         else { return }
-        guard !WorkspaceWindowIdentity.group(containing: parent)
-            .contains(where: { $0 === window })
-        else { return }
-        let parentFrame = parent.frame
-        parent.addTabbedWindow(window, ordered: .above)
-        window.makeKeyAndOrderFront(nil)
-        NativeTabCommands.installBracketShortcuts()
-        DispatchQueue.main.async { [weak parent, weak window] in
-            guard let parent,
-                  let window,
-                  let group = parent.tabGroup,
-                  group === window.tabGroup
+        let groupWindow: NSWindow
+        let adoptedParent: NSWindow?
+        let preservedFrame: NSRect?
+        if let parent = request.parent {
+            guard !WorkspaceWindowIdentity.group(containing: parent)
+                .contains(where: { $0 === window })
             else { return }
+            let parentFrame = parent.frame
+            parent.addTabbedWindow(window, ordered: .above)
+            window.makeKeyAndOrderFront(nil)
+            NativeTabCommands.installBracketShortcuts()
             window.setFrame(parentFrame, display: true)
+            groupWindow = parent
+            adoptedParent = parent
+            preservedFrame = parentFrame
+        } else {
+            groupWindow = window
+            adoptedParent = nil
+            preservedFrame = nil
         }
+        DispatchQueue.main.async {
+            [weak self, weak groupWindow, weak window, weak adoptedParent] in
+            guard let self,
+                  let groupWindow,
+                  let window
+            else { return }
+            if let adoptedParent {
+                guard let group = adoptedParent.tabGroup,
+                      group === window.tabGroup
+                else { return }
+                if let preservedFrame {
+                    window.setFrame(preservedFrame, display: true)
+                }
+            }
+            openNextWorkspaceTab(
+                request.remainingStates,
+                parent: groupWindow
+            )
+        }
+    }
+
+    private func openNextWorkspaceTab(
+        _ states: [WorkspaceWindowState],
+        parent: NSWindow
+    ) {
+        guard let next = states.first else { return }
+        windowRequests.add(
+            next.windowID,
+            parent: parent,
+            remainingStates: Array(states.dropFirst())
+        )
+        openWorkspaceWindow(next)
     }
 
     private func requestWorkspaceWindow(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -535,6 +535,8 @@ final class WorkspaceSceneModel: ObservableObject {
             || selectedWorktreeRemovalIsPending
     }
     private var pendingRestoration: WorkspaceWindowState?
+    private var pendingRestorationLaunchIntent:
+        WorkspaceWindowLaunchIntent?
     private var protectedRestorationProbeTask: Task<Void, Never>?
     private var protectedRestorationProbeID: UUID?
     private var protectedRestorationRefreshPending = false
@@ -1715,9 +1717,17 @@ final class WorkspaceSceneModel: ObservableObject {
         activityControllerBacking = nil
     }
 
-    func beginRestoration(_ state: WorkspaceWindowState) {
+    func beginRestoration(
+        _ state: WorkspaceWindowState,
+        launchIntent: WorkspaceWindowLaunchIntent? = nil
+    ) {
         guard state.navigation != nil || state.tmux != nil
             || state.herdr != nil || state.zellij != nil else { return }
+        if let launchIntent {
+            pendingRestorationLaunchIntent = launchIntent
+        } else if pendingRestoration?.windowID != state.windowID {
+            pendingRestorationLaunchIntent = nil
+        }
         zellijRestorationRoute = state.zellij.flatMap { descriptor in
             guard let hostSummary = snapshot.hosts.first(where: {
                 $0.configKey == descriptor.hostKey
@@ -1744,6 +1754,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
     func cancelPendingRestoration() {
         pendingRestoration = nil
+        pendingRestorationLaunchIntent = nil
         isWorkspaceRestorationPending = false
         suppressesAutomaticWorktreeSessionOpen = false
         protectedRestorationProbeTask?.cancel()
@@ -1842,6 +1853,7 @@ final class WorkspaceSceneModel: ObservableObject {
         switch WorkspaceWindowRestorationResolver.resolve(
             pendingRestoration,
             in: snapshot,
+            launchIntent: pendingRestorationLaunchIntent,
             herdrFreshHostIDs: herdrFreshHostIDs,
             zellijFreshHostIDs: zellijFreshHostIDs,
             pendingHerdrSessions: pendingHerdrSessionSelections
@@ -1859,7 +1871,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 _ = presentTmuxSession(
                     tmuxSelection,
                     launchMode: .attach,
-                    intent: .restoreOnly
+                    intent: pendingRestorationLaunchIntent == .openWorktree
+                        ? .userInitiated
+                        : .restoreOnly
                 )
                 suppressesAutomaticWorktreeSessionOpen = false
             case let .herdr(herdrSelection):
@@ -1880,6 +1894,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 applyRestoredSelection(resolvedSelection)
             }
             self.pendingRestoration = nil
+            pendingRestorationLaunchIntent = nil
             isWorkspaceRestorationPending = false
         case let .needsProtectedProbe(resolvedSelection, tmuxSelection):
             beginProtectedRestorationProbe(

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1023,6 +1023,36 @@ struct WorkspaceWindow: View {
                         confirmedHost: host
                     )
                 },
+                openProjectWorktreesAsTabs: {
+                    [applicationDelegate, sceneModel] project, worktrees in
+                    guard let host = sceneModel.snapshot.host(
+                        id: project.hostID
+                    ),
+                        let states = ProjectWorktreeWindowPlan.states(
+                            project: project,
+                            host: host,
+                            worktrees: worktrees
+                        )
+                    else {
+                        sceneModel.refreshWorkspaceInventory()
+                        return
+                    }
+                    applicationDelegate.requestWorkspaceTabGroup(
+                        states,
+                        launchIntent: .openWorktree
+                    )
+                },
+                canOpenProjectWorktreesAsTabs: {
+                    [sceneModel] project, worktrees in
+                    guard let host = sceneModel.snapshot.host(
+                        id: project.hostID
+                    ) else { return false }
+                    return ProjectWorktreeWindowPlan.isAvailable(
+                        project: project,
+                        host: host,
+                        worktrees: worktrees
+                    )
+                },
                 createWorktree: { [sceneModel] request in
                     try await sceneModel.createWorktree(request)
                 },
@@ -1205,7 +1235,7 @@ struct WorkspaceWindow: View {
                 return
             }
             if let restoredState = windowStateBuffer.receive(state) {
-                sceneModel.beginRestoration(restoredState)
+                beginRestoration(restoredState)
             }
         }
         .onAppear {
@@ -1275,8 +1305,16 @@ struct WorkspaceWindow: View {
         _ state: WorkspaceWindowState?
     ) {
         if let state = windowStateBuffer.beginAppearance(with: state) {
-            sceneModel.beginRestoration(state)
+            beginRestoration(state)
         }
+    }
+
+    private func beginRestoration(_ state: WorkspaceWindowState) {
+        sceneModel.beginRestoration(
+            state,
+            launchIntent: applicationDelegate
+                .consumeWorkspaceWindowLaunchIntent(for: state.windowID)
+        )
     }
 
     #if canImport(AppKit)
@@ -1289,7 +1327,7 @@ struct WorkspaceWindow: View {
             windowStateBuffer.prepareToPresent(state)
             windowState = state
         }
-        sceneModel.beginRestoration(state)
+        beginRestoration(state)
         updateRelaunchRestorer.didBeginRestoring(
             windowID: state.windowID
         )

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -66,6 +66,10 @@ struct WorkspaceZellijDescriptor: Codable, Hashable, Sendable {
     var sessionName: String
 }
 
+enum WorkspaceWindowLaunchIntent: Hashable, Sendable {
+    case openWorktree
+}
+
 struct WorkspaceWindowState: Codable, Hashable, Sendable {
     var windowID: UUID
     var navigation: WorkspaceNavigationDescriptor?
@@ -216,6 +220,76 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
     }
 }
 
+enum ProjectWorktreeWindowPlan {
+    static func isAvailable(
+        project: ProjectSummary,
+        host: HostSummary,
+        worktrees: [WorktreeSummary]
+    ) -> Bool {
+        guard !worktrees.isEmpty,
+              !project.isStale,
+              project.hostID == host.id,
+              !host.configKey.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ).isEmpty,
+              !project.scopedKey.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ).isEmpty
+        else { return false }
+
+        return worktrees.allSatisfy { worktree in
+            worktree.hostID == host.id
+                && worktree.projectID == project.id
+                && !worktree.isStale
+                && WorktreeGeneration.canonical(worktree.generation) != nil
+                && worktree.tmuxSessionName.map {
+                    !$0.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ).isEmpty
+                } == true
+                && (worktree.tmuxSocketName.map {
+                    !$0.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ).isEmpty
+                } ?? true)
+        }
+    }
+
+    static func states(
+        project: ProjectSummary,
+        host: HostSummary,
+        worktrees: [WorktreeSummary]
+    ) -> [WorkspaceWindowState]? {
+        guard isAvailable(
+            project: project,
+            host: host,
+            worktrees: worktrees
+        ) else { return nil }
+
+        return worktrees.map { worktree in
+            let generation = WorktreeGeneration.canonical(
+                worktree.generation
+            )!
+            let sessionName = worktree.tmuxSessionName!
+
+            return WorkspaceWindowState(
+                windowID: UUID(),
+                navigation: WorkspaceNavigationDescriptor(
+                    hostKey: host.configKey,
+                    projectKey: project.scopedKey,
+                    worktreeGeneration: generation
+                ),
+                tmux: WorkspaceTmuxDescriptor(
+                    hostKey: host.configKey,
+                    sessionName: sessionName,
+                    socketName: worktree.tmuxSocketName,
+                    owner: .worktree(generation: generation)
+                )
+            )
+        }
+    }
+}
+
 enum UpdateRelaunchStatePolicy {
     static func replacement(
         presented: WorkspaceWindowState?,
@@ -293,6 +367,7 @@ enum WorkspaceWindowRestorationResolver {
     static func resolve(
         _ state: WorkspaceWindowState,
         in snapshot: WorkspaceSnapshot,
+        launchIntent: WorkspaceWindowLaunchIntent? = nil,
         herdrFreshHostIDs: Set<UUID> = [],
         zellijFreshHostIDs: Set<UUID> = [],
         pendingHerdrSessions: Set<WorkspaceHerdrSessionSelection> = []
@@ -318,6 +393,11 @@ enum WorkspaceWindowRestorationResolver {
         ].filter { $0 }.count
         guard presentationCount <= 1 else {
             return .invalid
+        }
+        if launchIntent == .openWorktree {
+            guard let tmux = state.tmux,
+                  case .worktree = tmux.owner
+            else { return .invalid }
         }
 
         if let tmux = state.tmux {
@@ -442,9 +522,6 @@ enum WorkspaceWindowRestorationResolver {
         guard let tmux = state.tmux else {
             return .ready(selection: selection, presentation: nil)
         }
-        if host.kind == .remote, host.connectionState == .offline {
-            return .pending(selection: selection)
-        }
         let worktreeGeneration: String?
         switch tmux.owner {
         case .unbound:
@@ -492,6 +569,16 @@ enum WorkspaceWindowRestorationResolver {
             worktreeGeneration: worktreeGeneration,
             socketName: tmux.socketName
         )
+
+        if launchIntent == .openWorktree {
+            return .ready(
+                selection: selection,
+                presentation: .tmux(tmuxSelection)
+            )
+        }
+        if host.kind == .remote, host.connectionState == .offline {
+            return .pending(selection: selection)
+        }
 
         if tmux.socketName != nil {
             guard owner != nil

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -704,6 +704,15 @@ public struct RootView: View {
             onRequestKillZellijSession: requestZellijSessionKill,
             onRequestRemoveWorktree: requestWorktreeRemoval,
             onRequestRemoveProject: requestProjectRemoval,
+            onOpenProjectWorktreesAsTabs: { project, worktrees in
+                handlers.openProjectWorktreesAsTabs?(project, worktrees)
+            },
+            canOpenProjectWorktreesAsTabs: { project, worktrees in
+                handlers.canOpenProjectWorktreesAsTabs?(
+                    project,
+                    worktrees
+                ) ?? false
+            },
             onNewWorktree: openNewWorktree,
             onImportPullRequest: openImportPullRequest,
             onNewTmuxSession: { host in

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -427,6 +427,10 @@ public struct InteractionHandlers {
         ((HostSummary, String) async -> Result<String, HostProbeError>)?
     public let unregisterProject:
         ((ProjectSummary, HostSummary) async -> Result<String, HostProbeError>)?
+    public let openProjectWorktreesAsTabs:
+        ((ProjectSummary, [WorktreeSummary]) -> Void)?
+    public let canOpenProjectWorktreesAsTabs:
+        ((ProjectSummary, [WorktreeSummary]) -> Bool)?
     public let createWorktree:
         ((WorktreeCreateRequest) async throws -> Void)?
     public let listBranches:
@@ -512,6 +516,10 @@ public struct InteractionHandlers {
         ((ProjectSummary, HostSummary) async -> Result<
             String, HostProbeError
         >)? = nil,
+        openProjectWorktreesAsTabs:
+        ((ProjectSummary, [WorktreeSummary]) -> Void)? = nil,
+        canOpenProjectWorktreesAsTabs:
+        ((ProjectSummary, [WorktreeSummary]) -> Bool)? = nil,
         createWorktree:
         ((WorktreeCreateRequest) async throws -> Void)? = nil,
         listBranches:
@@ -567,6 +575,8 @@ public struct InteractionHandlers {
         self.cancelSSHAuthentication = cancelSSHAuthentication
         self.registerProject = registerProject
         self.unregisterProject = unregisterProject
+        self.openProjectWorktreesAsTabs = openProjectWorktreesAsTabs
+        self.canOpenProjectWorktreesAsTabs = canOpenProjectWorktreesAsTabs
         self.createWorktree = createWorktree
         self.listBranches = listBranches
         self.listPullRequests = listPullRequests

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -184,6 +184,10 @@ struct WorkspaceSidebarView: View {
     let onRequestKillZellijSession: (WorkspaceZellijSessionSelection) -> Void
     let onRequestRemoveWorktree: (WorktreeSummary) -> Void
     let onRequestRemoveProject: (ProjectSummary) -> Void
+    let onOpenProjectWorktreesAsTabs:
+        (ProjectSummary, [WorktreeSummary]) -> Void
+    let canOpenProjectWorktreesAsTabs:
+        (ProjectSummary, [WorktreeSummary]) -> Bool
     let onNewWorktree: (ProjectSummary) -> Void
     let onImportPullRequest: (ProjectSummary) -> Void
     let onNewTmuxSession: (HostSummary) -> Void
@@ -274,6 +278,14 @@ struct WorkspaceSidebarView: View {
         onRequestRemoveProject: @escaping (
             ProjectSummary
         ) -> Void = { _ in },
+        onOpenProjectWorktreesAsTabs: @escaping (
+            ProjectSummary,
+            [WorktreeSummary]
+        ) -> Void = { _, _ in },
+        canOpenProjectWorktreesAsTabs: @escaping (
+            ProjectSummary,
+            [WorktreeSummary]
+        ) -> Bool = { _, _ in false },
         onNewWorktree: @escaping (ProjectSummary) -> Void = { _ in },
         onImportPullRequest: @escaping (ProjectSummary) -> Void = { _ in },
         onNewTmuxSession: @escaping (HostSummary) -> Void = { _ in },
@@ -320,6 +332,9 @@ struct WorkspaceSidebarView: View {
         self.onRequestKillZellijSession = onRequestKillZellijSession
         self.onRequestRemoveWorktree = onRequestRemoveWorktree
         self.onRequestRemoveProject = onRequestRemoveProject
+        self.onOpenProjectWorktreesAsTabs = onOpenProjectWorktreesAsTabs
+        self.canOpenProjectWorktreesAsTabs =
+            canOpenProjectWorktreesAsTabs
         self.onNewWorktree = onNewWorktree
         self.onImportPullRequest = onImportPullRequest
         self.onNewTmuxSession = onNewTmuxSession
@@ -576,6 +591,21 @@ struct WorkspaceSidebarView: View {
                                     .disabled(
                                         !snapshot.canImportPullRequest(
                                             in: project.project
+                                        )
+                                    )
+                                    Divider()
+                                    Button(
+                                        "Open All Worktrees as Tabs"
+                                    ) {
+                                        onOpenProjectWorktreesAsTabs(
+                                            project.project,
+                                            project.worktrees
+                                        )
+                                    }
+                                    .disabled(
+                                        !canOpenProjectWorktreesAsTabs(
+                                            project.project,
+                                            project.worktrees
                                         )
                                     )
                                     if snapshot.host(

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -636,6 +636,67 @@ final class ApplicationDelegateTests: XCTestCase {
         XCTAssertEqual(child.frame, expectedFrame)
     }
 
+    func testWorkspaceTabGroupOpensSequentiallyInProjectOrder() async {
+        let delegate = ApplicationDelegate.forTesting()
+        let firstState = WorkspaceWindowState.fresh()
+        let secondState = WorkspaceWindowState.fresh()
+        let thirdState = WorkspaceWindowState.fresh()
+        var openedStates: [WorkspaceWindowState] = []
+        delegate.openWorkspaceWindow = { state in
+            openedStates.append(state)
+        }
+
+        delegate.requestWorkspaceTabGroup([
+            firstState,
+            secondState,
+            thirdState,
+        ], launchIntent: .openWorktree)
+        XCTAssertEqual(openedStates.map(\.windowID), [firstState.windowID])
+
+        let firstWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        firstWindow.tabbingIdentifier =
+            WorkspaceWindowIdentity.tabbingIdentifier
+        delegate.adoptWorkspaceWindowAsTabIfRequested(
+            firstWindow,
+            requestID: firstState.windowID
+        )
+        await Task.yield()
+
+        XCTAssertEqual(openedStates.map(\.windowID), [
+            firstState.windowID,
+            secondState.windowID,
+        ])
+
+        let secondWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        secondWindow.tabbingIdentifier =
+            WorkspaceWindowIdentity.tabbingIdentifier
+        delegate.adoptWorkspaceWindowAsTabIfRequested(
+            secondWindow,
+            requestID: secondState.windowID
+        )
+        await Task.yield()
+
+        XCTAssertEqual(openedStates.map(\.windowID), [
+            firstState.windowID,
+            secondState.windowID,
+            thirdState.windowID,
+        ])
+        XCTAssertTrue(
+            WorkspaceWindowIdentity.group(containing: firstWindow)
+                .contains(where: { $0 === secondWindow })
+        )
+    }
+
     func testLastWindowClosesWithoutRequestingTermination() {
         let delegate = ApplicationDelegate.forTesting(
             confirmTerminationResult: true

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -691,10 +691,84 @@ final class ApplicationDelegateTests: XCTestCase {
             secondState.windowID,
             thirdState.windowID,
         ])
+        let thirdWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        thirdWindow.tabbingIdentifier =
+            WorkspaceWindowIdentity.tabbingIdentifier
+        delegate.adoptWorkspaceWindowAsTabIfRequested(
+            thirdWindow,
+            requestID: thirdState.windowID
+        )
+
+        XCTAssertEqual(
+            firstWindow.tabGroup?.windows.map(ObjectIdentifier.init),
+            [firstWindow, secondWindow, thirdWindow].map(ObjectIdentifier.init)
+        )
         XCTAssertTrue(
             WorkspaceWindowIdentity.group(containing: firstWindow)
                 .contains(where: { $0 === secondWindow })
         )
+    }
+
+    func testClosingRetainedTabParentCancelsRemainingGroup() async {
+        let delegate = ApplicationDelegate.forTesting()
+        let firstState = WorkspaceWindowState.fresh()
+        let secondState = WorkspaceWindowState.fresh()
+        let thirdState = WorkspaceWindowState.fresh()
+        var openedStates: [WorkspaceWindowState] = []
+        delegate.openWorkspaceWindow = { state in
+            openedStates.append(state)
+        }
+        delegate.requestWorkspaceTabGroup([
+            firstState,
+            secondState,
+            thirdState,
+        ], launchIntent: .openWorktree)
+        let firstWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        firstWindow.tabbingIdentifier =
+            WorkspaceWindowIdentity.tabbingIdentifier
+        delegate.adoptWorkspaceWindowAsTabIfRequested(
+            firstWindow,
+            requestID: firstState.windowID
+        )
+        await Task.yield()
+        XCTAssertEqual(openedStates.map(\.windowID), [
+            firstState.windowID,
+            secondState.windowID,
+        ])
+
+        NotificationCenter.default.post(
+            name: NSWindow.willCloseNotification,
+            object: firstWindow
+        )
+        let secondWindow = CloseSpyWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        secondWindow.tabbingIdentifier =
+            WorkspaceWindowIdentity.tabbingIdentifier
+        delegate.adoptWorkspaceWindowAsTabIfRequested(
+            secondWindow,
+            requestID: secondState.windowID
+        )
+        await Task.yield()
+
+        XCTAssertEqual(secondWindow.closeCallCount, 1)
+        XCTAssertEqual(openedStates.map(\.windowID), [
+            firstState.windowID,
+            secondState.windowID,
+        ])
     }
 
     func testLastWindowClosesWithoutRequestingTermination() {

--- a/Tests/App/WorkspaceTabRequestTests.swift
+++ b/Tests/App/WorkspaceTabRequestTests.swift
@@ -107,6 +107,33 @@ struct WorkspaceTabRequestTests {
             second.windowID,
             third.windowID,
         ])
+        #expect(request?.requiredParentMissing == false)
+    }
+
+    @Test("a request stops when its required tab parent disappears")
+    func requiredParentLossStopsRequest() throws {
+        let state = WorkspaceWindowState.fresh()
+        let remaining = WorkspaceWindowState.fresh()
+        var parent: Window? = Window(isWorkspace: true)
+        let child = Window(isWorkspace: true)
+        let requests = WorkspaceWindowRequests<Window>()
+
+        requests.add(
+            state.windowID,
+            parent: parent,
+            remainingStates: [remaining]
+        )
+        parent = nil
+
+        let request = try #require(requests.consume(
+            for: state.windowID,
+            window: child
+        ))
+        #expect(request.requiredParentMissing)
+        #expect(request.parent == nil)
+        #expect(request.remainingStates.map(\.windowID) == [
+            remaining.windowID,
+        ])
     }
 
     @Test("window launch intents are ephemeral and one shot")

--- a/Tests/App/WorkspaceTabRequestTests.swift
+++ b/Tests/App/WorkspaceTabRequestTests.swift
@@ -31,16 +31,16 @@ struct WorkspaceTabRequestTests {
         requests.add(secondState.windowID, parent: secondParent)
 
         #expect(
-            requests.consumeParent(
+            requests.consume(
                 for: secondState.windowID,
                 window: secondWindow
-            ) === secondParent
+            )?.parent === secondParent
         )
         #expect(
-            requests.consumeParent(
+            requests.consume(
                 for: firstState.windowID,
                 window: firstWindow
-            ) === firstParent
+            )?.parent === firstParent
         )
     }
 
@@ -57,30 +57,69 @@ struct WorkspaceTabRequestTests {
         requests.add(tabState.windowID, parent: parent)
         requests.add(independentState.windowID, parent: nil)
 
-        #expect(
-            requests.consumeParent(
-                for: independentState.windowID,
-                window: independentWindow
-            ) == nil
+        let independent = requests.consume(
+            for: independentState.windowID,
+            window: independentWindow
         )
+        #expect(independent != nil)
+        #expect(independent?.parent == nil)
         #expect(
-            requests.consumeParent(
+            requests.consume(
                 for: restoredState.windowID,
                 window: independentWindow
             ) == nil
         )
         #expect(
-            requests.consumeParent(
+            requests.consume(
                 for: tabState.windowID,
                 window: tabWindow
-            ) === parent
+            )?.parent === parent
         )
         #expect(
-            requests.consumeParent(
+            requests.consume(
                 for: tabState.windowID,
                 window: tabWindow
             ) == nil
         )
+    }
+
+    @Test("a group request preserves the remaining tab order")
+    func groupRequestPreservesRemainingOrder() {
+        let first = WorkspaceWindowState.fresh()
+        let second = WorkspaceWindowState.fresh()
+        let third = WorkspaceWindowState.fresh()
+        let window = Window(isWorkspace: true)
+        let requests = WorkspaceWindowRequests<Window>()
+
+        requests.add(
+            first.windowID,
+            parent: nil,
+            remainingStates: [second, third]
+        )
+
+        let request = requests.consume(
+            for: first.windowID,
+            window: window
+        )
+
+        #expect(request?.parent == nil)
+        #expect(request?.remainingStates.map(\.windowID) == [
+            second.windowID,
+            third.windowID,
+        ])
+    }
+
+    @Test("window launch intents are ephemeral and one shot")
+    func windowLaunchIntentsAreEphemeral() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let intents = WorkspaceWindowLaunchIntents()
+
+        intents.add(.openWorktree, for: [firstID, secondID])
+
+        #expect(intents.consume(for: firstID) == .openWorktree)
+        #expect(intents.consume(for: firstID) == nil)
+        #expect(intents.consume(for: secondID) == .openWorktree)
     }
 
     @Test("a sheet resolves to its workspace parent")

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -176,6 +176,110 @@ private struct RestorationFixture {
 
 @Suite("Workspace window restoration state")
 struct WorkspaceWindowStateTests {
+    @Test("project tab plans preserve visible worktree order and endpoints")
+    func projectTabPlanPreservesWorktreeOrder() throws {
+        let fixture = RestorationFixture.local(sessionName: "main")
+        let host = try #require(fixture.snapshot.hosts.first)
+        let project = try #require(fixture.snapshot.projects.first)
+        var first = try #require(fixture.snapshot.worktrees.first)
+        first.tmuxSocketName = "protected-main"
+        var second = first
+        second = WorktreeSummary(
+            id: UUID(),
+            hostID: host.id,
+            projectID: project.id,
+            scopedKey: "worktree:feature",
+            name: "feature",
+            path: "/tmp/ghosthub-feature",
+            branch: "feature",
+            generation: "fedcba9876543210fedcba9876543210",
+            tmuxSessionName: "feature",
+            sessionBackend: .localTmux
+        )
+        let states = try #require(ProjectWorktreeWindowPlan.states(
+            project: project,
+            host: host,
+            worktrees: [second, first]
+        ))
+
+        #expect(states.map(\.tmux?.sessionName) == ["feature", "main"])
+        #expect(states.last?.tmux?.socketName == "protected-main")
+    }
+
+    @Test("project tab plans reject the entire invalid worktree list")
+    func projectTabPlanRejectsPartialLaunches() throws {
+        let fixture = RestorationFixture.local(sessionName: "main")
+        let host = try #require(fixture.snapshot.hosts.first)
+        let project = try #require(fixture.snapshot.projects.first)
+        let valid = try #require(fixture.snapshot.worktrees.first)
+        var stale = valid
+        stale.isStale = true
+
+        #expect(!ProjectWorktreeWindowPlan.isAvailable(
+            project: project,
+            host: host,
+            worktrees: [valid, stale]
+        ))
+        #expect(ProjectWorktreeWindowPlan.states(
+            project: project,
+            host: host,
+            worktrees: [valid, stale]
+        ) == nil)
+    }
+
+    @Test("project tab launch intent establishes absent worktree sessions")
+    func projectTabLaunchIntentEstablishesAbsentSession() throws {
+        let fixture = RestorationFixture.local(sessionName: "main")
+        var snapshot = fixture.snapshot
+        snapshot.hosts[0].tmuxSessions = []
+        let host = try #require(snapshot.hosts.first)
+        let project = try #require(snapshot.projects.first)
+        let worktree = try #require(snapshot.worktrees.first)
+        let states = try #require(ProjectWorktreeWindowPlan.states(
+            project: project,
+            host: host,
+            worktrees: [worktree]
+        ))
+        let state = try #require(states.first)
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: snapshot
+            ) == .pending(selection: fixture.selection)
+        )
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                state,
+                in: snapshot,
+                launchIntent: .openWorktree
+            ) == .ready(
+                selection: fixture.selection,
+                presentation: .tmux(fixture.tmuxSelection)
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(state)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded)
+                as? [String: Any]
+        )
+        #expect(object["launchIntent"] == nil)
+        object["launchIntent"] = "openWorktree"
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let restored = try JSONDecoder().decode(
+            WorkspaceWindowState.self,
+            from: legacyData
+        )
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(
+                restored,
+                in: snapshot
+            ) == .pending(selection: fixture.selection)
+        )
+    }
+
     @Test("older window descriptors decode without a directory path")
     func decodesOlderDescriptor() throws {
         let fixture = RestorationFixture.local(sessionName: "editor")

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -76,6 +76,12 @@ that session when necessary and then attaches an ordinary tmux client. The
 native window tab and titlebar show the project and worktree names instead of
 that internal session name. New worktree sessions use kwt's short,
 hash-suffixed naming format so they also remain recognizable in `tmux ls`.
+To put the whole project in one new window, right-click the project and choose
+**Open All Worktrees as Tabs**. Ghosthub opens the visible worktrees in sidebar
+order, creating or repairing each Kwt session as needed. If one scene cannot be
+created, the group stops there instead of opening the remaining worktrees as
+unrelated windows.
+
 The worktree row shows a compact window count. While Ghosthub is connected,
 the count refreshes with the existing background activity check: within about
 five seconds for a working session and twenty seconds for a quiet session.


### PR DESCRIPTION
Opening every worktree in a project currently takes repeated sidebar clicks and manual tab assembly.

- Adds **Open All Worktrees as Tabs** to the project context menu.
- Opens every available worktree in one new native tab group, in sidebar order. The action is disabled and the launch is rejected if any worktree lacks a current canonical identity, so it never opens a silent subset.
- Keeps the user-initiated open intent in process memory keyed to each new window. Saved window state cannot retain that intent or create and repair a missing session after restoration.
- Reuses normal scene and AppKit tab-adoption paths, including KWT establishment and protected sockets. If a scene fails to materialize or the parent group closes during launch, the sequence stops instead of spawning unrelated windows.
- Adds no work to app or window activation, terminal focus, rendering, polling, or libghostty paths.

![Representative native tab group from Ghosthub’s isolated synthetic demo](https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/guide-native-tabs.png?asset=open-project-worktrees-tabs)

Focused restoration and AppKit coverage, essential workflows, the activation-work gate, formatting, and the app build pass locally.