### PR TITLE
Retry tmux splits after pane movement

### DIFF
--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -95,6 +95,11 @@ final class NativeTmuxSessionCoordinator {
         var task: Task<Void, Never>
     }
 
+    private struct PaneSplitErrorDismissal {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
+
     private let terminalCoordinator: any NativeSessionSurfaceStoring
     private let tmuxPathProvider:
         @Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>
@@ -110,6 +115,7 @@ final class NativeTmuxSessionCoordinator {
     private let appliesPresentationStyleToExistingSessionsProvider:
         () -> Bool
     private let paneSplitter: TmuxPaneSplitter
+    private let paneSplitErrorDuration: Duration
     private let clientIdentityRetryDelays: [Duration]
     private let sleep: @Sendable (Duration) async throws -> Void
     private let remoteExitStatusStore: RemoteExitStatusStore
@@ -127,6 +133,7 @@ final class NativeTmuxSessionCoordinator {
     private var paneSplitWorkers: [UUID: PaneSplitWorker] = [:]
     private var paneSplitClientBindings: [UUID: PaneSplitClientBinding] = [:]
     private var paneSplitClients: [UUID: TmuxPaneSplitClientIdentity] = [:]
+    private var paneSplitErrorDismissals: [UUID: PaneSplitErrorDismissal] = [:]
     private var previewIdentityRetryHandles: Set<UUID> = []
     private var unavailablePreviewIdentityHandles: Set<UUID> = []
     private var deferredPresentationStyleHandles: Set<UUID> = []
@@ -197,6 +204,7 @@ final class NativeTmuxSessionCoordinator {
                 )
             },
         paneSplitter: TmuxPaneSplitter = TmuxPaneSplitter(),
+        paneSplitErrorDuration: Duration = .seconds(4),
         clientIdentityRetryDelays: [Duration] = [
             .milliseconds(250), .seconds(1),
         ],
@@ -223,6 +231,7 @@ final class NativeTmuxSessionCoordinator {
         self.sshConnectionArgumentsProvider =
             sshConnectionArgumentsProvider
         self.paneSplitter = paneSplitter
+        self.paneSplitErrorDuration = paneSplitErrorDuration
         self.clientIdentityRetryDelays = clientIdentityRetryDelays
         self.sleep = sleep
         remoteExitStatusStore = RemoteExitStatusStore(
@@ -591,12 +600,12 @@ final class NativeTmuxSessionCoordinator {
         attachmentID: UUID
     ) {
         guard let client = paneSplitClients[handle.id] else {
-            surface.paneSplitErrorMessage = TmuxPaneSplitFailure(
+            presentPaneSplitError(TmuxPaneSplitFailure(
                 host: target.host.displayName,
                 sessionName: target.sessionName,
                 status: 75,
                 diagnostic: "The attached tmux client identity is unavailable."
-            ).localizedDescription
+            ), on: surface, handle: handle, attachmentID: attachmentID)
             startPaneSplitClientBinding(
                 target: target,
                 handle: handle,
@@ -667,7 +676,10 @@ final class NativeTmuxSessionCoordinator {
                   launchedHandles.contains(handle.id)
             else { continue }
 
-            request.surface.paneSplitErrorMessage = nil
+            clearPaneSplitError(
+                on: request.surface,
+                handleID: handle.id
+            )
             var target = request.target
             let expectedClient = target.expectedClient
                 ?? paneSplitClients[handle.id]
@@ -684,8 +696,12 @@ final class NativeTmuxSessionCoordinator {
                         status: 75,
                         diagnostic: "The attached tmux session changed."
                     )
-                    request.surface.paneSplitErrorMessage =
-                        failure.localizedDescription
+                    presentPaneSplitError(
+                        failure,
+                        on: request.surface,
+                        handle: handle,
+                        attachmentID: request.attachmentID
+                    )
                     continue
                 }
                 paneSplitClients[handle.id] = client
@@ -696,11 +712,15 @@ final class NativeTmuxSessionCoordinator {
                       paneSplitWorkers[handle.id]?.id == workerID,
                       attachments[handle.id]?.id == request.attachmentID
                 else { return }
-                request.surface.paneSplitErrorMessage =
-                    failure.localizedDescription
+                presentPaneSplitError(
+                    failure,
+                    on: request.surface,
+                    handle: handle,
+                    attachmentID: request.attachmentID
+                )
                 continue
             }
-            let failure = await paneSplitter.split(
+            var failure = await paneSplitter.split(
                 request.shortcut,
                 target: target
             )
@@ -708,10 +728,51 @@ final class NativeTmuxSessionCoordinator {
                   paneSplitWorkers[handle.id]?.id == workerID,
                   attachments[handle.id]?.id == request.attachmentID
             else { return }
-            request.surface.paneSplitErrorMessage = failure?.localizedDescription
+            if failure?.kind == .atomicGuardChanged,
+               let expectedClient = target.expectedClient {
+                switch await paneSplitter.clientIdentity(target: target) {
+                case let .success(client):
+                    guard !Task.isCancelled,
+                          paneSplitWorkers[handle.id]?.id == workerID,
+                          attachments[handle.id]?.id == request.attachmentID
+                    else { return }
+                    guard client.matchesClient(expectedClient) else {
+                        failure = TmuxPaneSplitFailure(
+                            host: target.host.displayName,
+                            sessionName: target.sessionName,
+                            status: 75,
+                            diagnostic: "The attached tmux session changed."
+                        )
+                        break
+                    }
+                    paneSplitClients[handle.id] = client
+                    target.expectedClient = client
+                    failure = await paneSplitter.split(
+                        request.shortcut,
+                        target: target
+                    )
+                    guard !Task.isCancelled,
+                          paneSplitWorkers[handle.id]?.id == workerID,
+                          attachments[handle.id]?.id == request.attachmentID
+                    else { return }
+                case let .failure(identityFailure):
+                    failure = identityFailure
+                }
+            }
             if let failure {
+                presentPaneSplitError(
+                    failure,
+                    on: request.surface,
+                    handle: handle,
+                    attachmentID: request.attachmentID
+                )
                 AppLogger.shared.error(
                     "tmux pane split: \(failure.localizedDescription)"
+                )
+            } else {
+                clearPaneSplitError(
+                    on: request.surface,
+                    handleID: handle.id
                 )
             }
         }
@@ -755,9 +816,11 @@ final class NativeTmuxSessionCoordinator {
                     paneSplitClients[handle.id] = client
                     previewIdentityRetryHandles.remove(handle.id)
                     unavailablePreviewIdentityHandles.remove(handle.id)
-                    terminalCoordinator.paneSurfaceIfPresent(
+                    if let surface = terminalCoordinator.paneSurfaceIfPresent(
                         for: surfaceKey(handle)
-                    )?.paneSplitErrorMessage = nil
+                    ) {
+                        clearPaneSplitError(on: surface, handleID: handle.id)
+                    }
                     onSurfaceReady?(handle)
                     return
                 }
@@ -789,10 +852,48 @@ final class NativeTmuxSessionCoordinator {
     private func cancelPaneSplits(handleID: UUID) {
         paneSplitClientBindings.removeValue(forKey: handleID)?.task.cancel()
         paneSplitWorkers.removeValue(forKey: handleID)?.task.cancel()
+        paneSplitErrorDismissals.removeValue(forKey: handleID)?.task.cancel()
         paneSplitRequests.removeValue(forKey: handleID)
         paneSplitClients.removeValue(forKey: handleID)
         previewIdentityRetryHandles.remove(handleID)
         unavailablePreviewIdentityHandles.remove(handleID)
+    }
+
+    private func presentPaneSplitError(
+        _ failure: TmuxPaneSplitFailure,
+        on surface: any NativeSessionPaneSurfacing,
+        handle: BorrowedTmuxSessionHandle,
+        attachmentID: UUID
+    ) {
+        paneSplitErrorDismissals.removeValue(forKey: handle.id)?.task.cancel()
+        surface.paneSplitErrorMessage = failure.localizedDescription
+        let dismissalID = UUID()
+        let duration = paneSplitErrorDuration
+        let task = Task { [weak self] in
+            do {
+                try await Task.sleep(for: duration)
+            } catch {
+                return
+            }
+            guard let self,
+                  paneSplitErrorDismissals[handle.id]?.id == dismissalID,
+                  attachments[handle.id]?.id == attachmentID
+            else { return }
+            paneSplitErrorDismissals.removeValue(forKey: handle.id)
+            surface.paneSplitErrorMessage = nil
+        }
+        paneSplitErrorDismissals[handle.id] = PaneSplitErrorDismissal(
+            id: dismissalID,
+            task: task
+        )
+    }
+
+    private func clearPaneSplitError(
+        on surface: any NativeSessionPaneSurfacing,
+        handleID: UUID
+    ) {
+        paneSplitErrorDismissals.removeValue(forKey: handleID)?.task.cancel()
+        surface.paneSplitErrorMessage = nil
     }
 
     private func failSurfaceLaunch(
@@ -964,9 +1065,11 @@ final class NativeTmuxSessionCoordinator {
         provisioningTasks.values.forEach { $0.cancel() }
         paneSplitClientBindings.values.forEach { $0.task.cancel() }
         paneSplitWorkers.values.forEach { $0.task.cancel() }
+        paneSplitErrorDismissals.values.forEach { $0.task.cancel() }
         provisioningTasks.removeAll()
         paneSplitClientBindings.removeAll()
         paneSplitWorkers.removeAll()
+        paneSplitErrorDismissals.removeAll()
         paneSplitRequests.removeAll()
         paneSplitClients.removeAll()
         previewIdentityRetryHandles.removeAll()

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -47,6 +47,12 @@ struct TmuxPaneSplitFailure: Error, Equatable, LocalizedError, Sendable {
     var sessionName: String
     var status: Int32
     var diagnostic: String
+    var kind: Kind = .terminal
+
+    enum Kind: Equatable, Sendable {
+        case terminal
+        case atomicGuardChanged
+    }
 
     var errorDescription: String? {
         var description =
@@ -154,7 +160,8 @@ struct TmuxPaneSplitter: Sendable {
                 host: target.host.displayName,
                 sessionName: target.sessionName,
                 status: 75,
-                diagnostic: "The attached tmux session changed."
+                diagnostic: "The attached tmux session changed.",
+                kind: .atomicGuardChanged
             )
         }
         if result.status != 0,

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -21,6 +21,15 @@ private func supportedPaneSplitter(
     TmuxPaneSplitter(runner: runner)
 }
 
+private func splitMismatchMarker(in command: String) -> String? {
+    let prefix = "GHOSTHUB_TMUX_SPLIT_IDENTITY_MISMATCH_"
+    guard let start = command.range(of: prefix)?.lowerBound else { return nil }
+    return String(command[start...].prefix { character in
+        character.isLetter || character.isNumber
+            || character == "_" || character == "-"
+    })
+}
+
 @Suite("Native tmux connection identity", .serialized)
 @MainActor
 struct NativeTmuxSessionCoordinatorTests {
@@ -554,7 +563,8 @@ struct NativeTmuxSessionCoordinatorTests {
                 }
                 calls.withLock { $0.append((host, arguments, command)) }
                 return (1, "no space for new pane\n")
-            }
+            },
+            paneSplitErrorDuration: .milliseconds(100)
         )
         var readyCount = 0
         coordinator.onSurfaceReady = { _ in readyCount += 1 }
@@ -601,6 +611,9 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(store.surface.paneSplitErrorMessage?.contains(
             "no space for new pane"
         ) == true)
+        await waitUntilMainActor {
+            store.surface.paneSplitErrorMessage == nil
+        }
     }
 
     @Test("remote tmux path cache follows the frozen SSH route")
@@ -1067,6 +1080,63 @@ struct NativeTmuxSessionCoordinatorTests {
 
         #expect(clientLookups.load() == 3)
         #expect(splitCommands.load().count == 2)
+        #expect(splitCommands.load().last?.contains("'%10'") == true)
+        #expect(store.surface.paneSplitErrorMessage == nil)
+    }
+
+    @Test("an atomic pane movement rereads the client and retries once")
+    func atomicPaneMovementRetriesOnce() async throws {
+        let clientLookups = LockedValue(0)
+        let splitCommands = LockedValue<[String]>([])
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    var lookup = 0
+                    clientLookups.withLock {
+                        $0 += 1
+                        lookup = $0
+                    }
+                    if lookup <= 2 {
+                        return (0, coordinatorSplitClientOutput)
+                    }
+                    return (
+                        0,
+                        "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t123\t789\t321"
+                            + "\t/dev/ttys001\t$7\t456\t%10\n"
+                    )
+                }
+                var attempt = 0
+                splitCommands.withLock {
+                    $0.append(command)
+                    attempt = $0.count
+                }
+                if attempt == 1,
+                   let marker = splitMismatchMarker(in: command) {
+                    return (0, marker + "\n")
+                }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "moving-during-split",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity
+        )
+
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { readyCount == 2 }
+        let handler = try #require(store.surface.paneSplitShortcutHandler)
+        handler(.right)
+        await waitUntilMainActor { splitCommands.load().count == 2 }
+
+        #expect(clientLookups.load() == 3)
         #expect(splitCommands.load().last?.contains("'%10'") == true)
         #expect(store.surface.paneSplitErrorMessage == nil)
     }

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -863,6 +863,49 @@ struct TmuxPaneSplitterTests {
         #expect(failure == nil)
     }
 
+    @Test("only the atomic guard mismatch is retryable")
+    func atomicGuardMismatchIsRetryable() async {
+        let mismatch = await TmuxPaneSplitter { _, _, command in
+            let prefix = "GHOSTHUB_TMUX_SPLIT_IDENTITY_MISMATCH_"
+            guard let start = command.range(of: prefix)?.lowerBound else {
+                return (1, "missing mismatch marker")
+            }
+            let marker = command[start...].prefix { character in
+                character.isLetter || character.isNumber
+                    || character == "_" || character == "-"
+            }
+            return (0, String(marker) + "\n")
+        }.split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: "/usr/bin/tmux",
+                sessionName: "moving",
+                socketName: nil,
+                sshConnectionArguments: [],
+                expectedIdentity: testSplitClient.sessionIdentity,
+                expectedClient: testSplitClient
+            )
+        )
+        let missingClient = await TmuxPaneSplitter { _, _, _ in
+            (1, "can't find client: /dev/ttys001\n")
+        }.split(
+            .right,
+            target: TmuxPaneSplitTarget(
+                host: .local,
+                tmuxPath: "/usr/bin/tmux",
+                sessionName: "missing",
+                socketName: nil,
+                sshConnectionArguments: [],
+                expectedIdentity: testSplitClient.sessionIdentity,
+                expectedClient: testSplitClient
+            )
+        )
+
+        #expect(mismatch?.kind == .atomicGuardChanged)
+        #expect(missingClient?.kind == .terminal)
+    }
+
     @Test("cancellation removes an installed split hook")
     func cancellationRemovesInstalledHook() async {
         let hookInstalled = LockedValue(false)


### PR DESCRIPTION
Tmux clients can move panes between Ghosthub's identity check and the guarded split. Ghosthub currently treats that safe race like a replaced client, so the split fails and leaves a persistent error banner.

- Re-read the exact client identity and retry once only when the atomic split guard reports pane movement. A replaced client or session remains a hard failure.
- Clear final tmux split errors after four seconds. Herdr behavior is unchanged.
- Keep all new work inside explicit split handling. This adds no work to activation, focus, rendering, polling, SwiftUI body evaluation, or libghostty paths.

The focused split suites, essential workflows, activation-work gate, and app build pass on the rebased branch.
