### PR TITLE
Make debug app load bundled Sparkle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,8 +389,14 @@ debug-app: ensure-kwt ensure-kwt-variants bootstrap-libghostty
 		--kwt-version "$(KWT_VERSION)" \
 		--kwt-source-revision "$(KWT_SOURCE_REVISION)" \
 		--remote-kwt-source-revision "$(KWT_REF)" >/dev/null; \
+	umask 077; \
+	debug_entitlements="$$(mktemp "$${TMPDIR:-/tmp}/ghosthub-debug-entitlements.XXXXXX")"; \
+	trap 'rm -f -- "$$debug_entitlements"' EXIT; \
+	cp -f "$(APP_ENTITLEMENTS_PATH)" "$$debug_entitlements"; \
+	plutil -insert 'com\.apple\.security\.cs\.disable-library-validation' \
+		-bool true "$$debug_entitlements"; \
 	codesign --force --deep --options runtime \
-		--entitlements "$(APP_ENTITLEMENTS_PATH)" \
+		--entitlements "$$debug_entitlements" \
 		--sign - "$(DEBUG_APP_PATH)" >/dev/null; \
 	codesign --verify --deep --strict "$(DEBUG_APP_PATH)"; \
 	printf 'Built debug app bundle: %s\n' "$(DEBUG_APP_PATH)"

--- a/docs/release.md
+++ b/docs/release.md
@@ -683,5 +683,12 @@ resources; the Linux ELF variants do not. Sparkle remains under
 unsealed content that strict code-signing rejects. Ghosthub's AGPL license and
 every third-party notice in `LICENSES` are staged during the same assembly step.
 
+`make debug-app` keeps the hardened runtime but adds the library-validation
+exception only to its temporary ad-hoc signature. Ad-hoc signatures have no
+Team ID, so macOS otherwise rejects the bundled Sparkle framework before the
+debug executable reaches `main`. Developer ID release and nightly signatures
+do not receive this exception: their app and nested framework signatures share
+the release Team ID and retain library validation.
+
 Update this document whenever release packaging, signing, notarization, the
 embedded kwt policy, or `.github/workflows/release.yml` changes.


### PR DESCRIPTION
`make run-app` built a complete debug bundle, but macOS terminated it before `main`: hardened-runtime library validation rejected Sparkle because ad-hoc signatures do not share a Team ID.

- Add the library-validation exception only to a temporary debug entitlement set, allowing the bundled framework to load during local development.
- Keep Developer ID release and nightly entitlements unchanged, so shipped builds retain library validation.
- Document the debug-signing boundary in the release guide.
- The rebuilt packaged executable launches under an isolated home; bundle assembly coverage and the app build pass.
