### PR TITLE
Make Tailscale host imports deliberate

### DIFF
--- a/Sources/App/TailscaleDiscovery.swift
+++ b/Sources/App/TailscaleDiscovery.swift
@@ -35,10 +35,21 @@ enum TailscaleDiscovery {
     static func discoverPeers() async -> Result<
         [TailscalePeer], TailscaleError
     > {
-        await discoverPeers(
-            tailscalePaths: tailscalePaths,
-            environment: ProcessInfo.processInfo.environment
+        let environment = ProcessInfo.processInfo.environment
+        return await discoverPeers(
+            tailscalePaths: candidatePaths(environment: environment),
+            environment: environment
         )
+    }
+
+    static func candidatePaths(
+        environment: [String: String]
+    ) -> [String] {
+        guard let demoRoot = environment["GHOSTHUB_DEMO_ROOT"],
+              demoRoot.hasPrefix("/")
+        else { return tailscalePaths }
+
+        return ["\(demoRoot)/bin/tailscale"]
     }
 
     static func discoverPeers(

--- a/Sources/Settings/TailscalePeer.swift
+++ b/Sources/Settings/TailscalePeer.swift
@@ -124,22 +124,10 @@ public enum TailscalePeerImportSelection {
     }
 
     public static func defaultSelectedPeerIDs(
-        peers: [TailscalePeer],
-        existingAddresses: Set<String>
+        peers _: [TailscalePeer],
+        existingAddresses _: Set<String>
     ) -> Set<String> {
-        let normalizedExisting = normalizedExistingAddresses(
-            existingAddresses
-        )
-        return Set(
-            peers
-                .filter {
-                    $0.isOnline
-                        && !normalizedExisting.contains(
-                            normalizedHost($0.sshAddress)
-                        )
-                }
-                .map(\.id)
-        )
+        []
     }
 
     public static func selectedPeers(

--- a/Sources/UI/HostsSettingsView.swift
+++ b/Sources/UI/HostsSettingsView.swift
@@ -301,24 +301,31 @@ public struct HostsSettingsView: View {
                     Button {
                         requestTailscalePeers()
                     } label: {
-                        Image(systemName: "network")
+                        Label("Tailscale", systemImage: "network")
+                            .frame(height: 16)
                     }
                     .help("Import from Tailscale")
-                    .disabled(isLoadingTailscale)
+                    .disabled(
+                        isLoadingTailscale || isTailscaleSheetPresented
+                    )
                     Button {
                         addSSHHost()
                     } label: {
                         Image(systemName: "plus")
+                            .frame(width: 16, height: 16)
                     }
                     .help("Add Host")
                     Button {
                         removeSelectedSSHHost()
                     } label: {
                         Image(systemName: "minus")
+                            .frame(width: 16, height: 16)
                     }
                     .help("Remove Host")
                     .disabled(sshHosts.isEmpty)
                 }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
 
                 List(selection: $selectedSSHHostDraftID) {
                     ForEach(sshHosts) { host in
@@ -686,7 +693,10 @@ public struct HostsSettingsView: View {
                             ) {
                                 requestTailscalePeers()
                             }
-                            .disabled(isLoadingTailscale)
+                            .disabled(
+                                isLoadingTailscale
+                                    || isTailscaleSheetPresented
+                            )
                             Button(
                                 "Add Host Manually",
                                 action: addSSHHost
@@ -856,7 +866,6 @@ public struct HostsSettingsView: View {
         tailscaleError = nil
         Task {
             let result = await loadTailscalePeers()
-            isLoadingTailscale = false
             switch result {
             case let .success(peers):
                 tailscalePeers = peers
@@ -869,6 +878,7 @@ public struct HostsSettingsView: View {
             case let .failure(message):
                 tailscaleError = message
             }
+            isLoadingTailscale = false
         }
     }
 

--- a/Tests/App/TailscaleDiscoveryTests.swift
+++ b/Tests/App/TailscaleDiscoveryTests.swift
@@ -4,6 +4,15 @@ import Testing
 
 @Suite("Tailscale discovery")
 struct TailscaleDiscoveryTests {
+    @Test("isolated demo never falls back to installed Tailscale paths")
+    func isolatesDemoBinary() {
+        #expect(TailscaleDiscovery.candidatePaths(environment: [
+            "GHOSTHUB_DEMO_ROOT": "/tmp/ghosthub-demo-root",
+        ]) == [
+            "/tmp/ghosthub-demo-root/bin/tailscale",
+        ])
+    }
+
     @Test("forces the macOS application binary into CLI mode")
     func forcesCLIEnvironment() async throws {
         let fixture = try TempDirectoryFixture()

--- a/Tests/Settings/TailscalePeerImportSelectionTests.swift
+++ b/Tests/Settings/TailscalePeerImportSelectionTests.swift
@@ -33,10 +33,6 @@ struct TailscalePeerImportSelectionTests {
             peer,
             existingAddresses: ["builder"]
         ))
-        #expect(TailscalePeerImportSelection.defaultSelectedPeerIDs(
-            peers: [peer],
-            existingAddresses: ["builder"]
-        ) == ["builder"])
     }
 
     @Test("marks existing peers after normalizing SSH destinations")
@@ -55,8 +51,8 @@ struct TailscalePeerImportSelectionTests {
         )
     }
 
-    @Test("default selection includes only online peers not already imported")
-    func defaultSelectionIncludesOnlyOnlineNewPeers() {
+    @Test("default selection leaves every peer unselected")
+    func defaultSelectionIsEmpty() {
         let selectedIDs =
             TailscalePeerImportSelection.defaultSelectedPeerIDs(
                 peers: [
@@ -73,7 +69,7 @@ struct TailscalePeerImportSelectionTests {
                 ]
             )
 
-        #expect(selectedIDs == ["online"])
+        #expect(selectedIDs.isEmpty)
     }
 
     @Test("selected peers preserve discovery order")

--- a/tools/tests/test_demo_scripts.py
+++ b/tools/tests/test_demo_scripts.py
@@ -24,6 +24,7 @@ WEBSITE_ASSET_NAMES = (
     "guide-session-previews.png",
     "guide-session-activity.png",
     "guide-hosts.png",
+    "guide-tailscale-import.png",
     "guide-exe-dev.png",
     "guide-worktree.png",
     "guide-worktree-window-counts.png",

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -25,8 +25,11 @@ static __weak NSWindow *DemoControlledWindow;
 static NSWindow *DemoRootWindow(void);
 
 static NSWindow *DemoEventWindow(void) {
-  NSWindow *root = DemoRootWindow();
-  return root.attachedSheet ?: root ?: [NSApp keyWindow] ?: [NSApp mainWindow];
+  NSWindow *window = DemoRootWindow() ?: [NSApp keyWindow] ?: [NSApp mainWindow];
+  while (window.attachedSheet != nil) {
+    window = window.attachedSheet;
+  }
+  return window;
 }
 
 static NSString *DemoHostName(id self, SEL _cmd) {
@@ -108,6 +111,32 @@ static BOOL DemoClickWindow(NSWindow *window, NSPoint point) {
                                    pressure:0];
   [NSApp sendEvent:down];
   [NSApp sendEvent:up];
+  return YES;
+}
+
+static BOOL DemoQueuedClickWindow(NSWindow *window, NSPoint point) {
+  if (window == nil) return NO;
+  NSTimeInterval now = [NSProcessInfo processInfo].systemUptime;
+  NSEvent *down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                     location:point
+                                modifierFlags:0
+                                    timestamp:now
+                                 windowNumber:window.windowNumber
+                                      context:nil
+                                  eventNumber:0
+                                   clickCount:1
+                                     pressure:1];
+  NSEvent *up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                   location:point
+                              modifierFlags:0
+                                  timestamp:now
+                               windowNumber:window.windowNumber
+                                    context:nil
+                                eventNumber:0
+                                 clickCount:1
+                                   pressure:0];
+  [NSApp postEvent:up atStart:YES];
+  [NSApp sendEvent:down];
   return YES;
 }
 
@@ -547,7 +576,8 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                     @"requestID": requestID,
                     @"success": @(success),
                     @"message": message ?: @"",
-                  }];
+                  }
+        deliverImmediately:YES];
 }
 
 - (void)capture:(NSNotification *)notification {
@@ -572,49 +602,59 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
 
   dispatch_async(dispatch_get_main_queue(), ^{
     if ([action isEqualToString:@"palette"]) {
-      [[NSNotificationCenter defaultCenter]
-          postNotificationName:@"ghosthubCommandPalette"
-                        object:nil];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      [NSApp activateIgnoringOtherApps:YES];
+#pragma clang diagnostic pop
+      [DemoRootWindow() makeKeyAndOrderFront:nil];
       dispatch_after(
-          dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
+          dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
           dispatch_get_main_queue(), ^{
-            if (!DemoInsertText(text)) {
-              [self acknowledge:requestID
-                        success:NO
-                        message:@"command palette did not accept text"];
-              return;
-            }
-            NSWindow *paletteSheet = DemoRootWindow().attachedSheet;
+            [[NSNotificationCenter defaultCenter]
+                postNotificationName:@"ghosthubCommandPalette"
+                              object:nil];
             dispatch_after(
-                dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
+                dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC),
                 dispatch_get_main_queue(), ^{
-                  if (!submit) {
-                    BOOL matched = DemoPalettePostcondition(
-                        expectKind, paletteSheet);
+                  if (!DemoInsertText(text)) {
                     [self acknowledge:requestID
-                              success:matched
-                              message:matched
-                                  ? @"command palette matched requested state"
-                                  : @"command palette did not match requested state"];
+                              success:NO
+                              message:@"command palette did not accept text"];
                     return;
                   }
+                  NSWindow *paletteSheet = DemoRootWindow().attachedSheet;
                   dispatch_after(
-                      dispatch_time(
-                          DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
+                      dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
                       dispatch_get_main_queue(), ^{
-                        if (!DemoSendKey(@"\r", 36, 0)) {
+                        if (!submit) {
+                          BOOL matched = DemoPalettePostcondition(
+                              expectKind, paletteSheet);
                           [self acknowledge:requestID
-                                    success:NO
-                                    message:@"command palette lost its window"];
+                                    success:matched
+                                    message:matched
+                                        ? @"command palette matched requested state"
+                                        : @"command palette did not match requested state"];
                           return;
                         }
-                        DemoWaitForPalettePostcondition(
-                            expectKind, paletteSheet, 50, ^(BOOL matched) {
-                              [self acknowledge:requestID
-                                        success:matched
-                                        message:matched
-                                            ? @"command reached requested state"
-                                            : @"command did not reach requested state"];
+                        dispatch_after(
+                            dispatch_time(
+                                DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
+                            dispatch_get_main_queue(), ^{
+                              if (!DemoSendKey(@"\r", 36, 0)) {
+                                [self acknowledge:requestID
+                                          success:NO
+                                          message:@"command palette lost its window"];
+                                return;
+                              }
+                              DemoWaitForPalettePostcondition(
+                                  expectKind, paletteSheet, 50,
+                                  ^(BOOL matched) {
+                                    [self acknowledge:requestID
+                                              success:matched
+                                              message:matched
+                                                  ? @"command reached requested state"
+                                                  : @"command did not reach requested state"];
+                                  });
                             });
                       });
                 });
@@ -814,7 +854,7 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                                       : @"no workspace window"];
     } else if ([action isEqualToString:@"expect-text"]) {
       BOOL found = text.length > 0 &&
-          DemoContainsText(DemoRootWindow(), text, 0);
+          DemoContainsText(DemoEventWindow(), text, 0);
       [self acknowledge:requestID
                 success:found
                 message:found ? @"expected text is visible"
@@ -859,6 +899,19 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                 success:clicked
                 message:clicked ? @"window title clicked"
                                 : @"workspace title was not available"];
+    } else if ([action isEqualToString:@"click-sheet"]) {
+      NSArray<NSString *> *parts =
+          [text componentsSeparatedByString:@","];
+      BOOL clicked =
+          parts.count == 2 &&
+          DemoQueuedClickWindow(
+              DemoEventWindow(),
+              NSMakePoint(parts[0].doubleValue,
+                          parts[1].doubleValue));
+      [self acknowledge:requestID
+                success:clicked
+                message:clicked ? @"sheet click sent"
+                                : @"sheet click requires x,y and a window"];
     } else if ([action isEqualToString:@"scroll-detail"]) {
       BOOL scrolled = text.length > 0 && DemoScrollDetail(text.doubleValue);
       [self acknowledge:requestID
@@ -868,7 +921,7 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
     } else if ([action isEqualToString:@"press"]) {
       BOOL pressed =
           text.length > 0 &&
-          DemoPressLabel(DemoRootWindow().contentView, text, 0);
+          DemoPressLabel(DemoEventWindow().contentView, text, 0);
       [self acknowledge:requestID
                 success:pressed
                 message:pressed ? @"accessibility control pressed"

--- a/website/demo/bin/tailscale
+++ b/website/demo/bin/tailscale
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Faux Tailscale status for the isolated website screenshot environment.
+set -euo pipefail
+
+scratch="${GHOSTHUB_DEMO_SCRATCH:?GHOSTHUB_DEMO_SCRATCH is not set}"
+if [[ ! -f "$scratch/.ghosthub-demo-scratch" ]]; then
+  echo "faux tailscale: demo scratch is not staged" >&2
+  exit 64
+fi
+if [[ "${TAILSCALE_BE_CLI:-}" != "1" ]]; then
+  echo "faux tailscale: CLI mode is required" >&2
+  exit 64
+fi
+if [[ "${1:-}" != "status" || "${2:-}" != "--json" || "$#" -ne 2 ]]; then
+  echo "faux tailscale: unsupported command" >&2
+  exit 64
+fi
+
+cat <<'EOF'
+{"Peer":{"build-node":{"ID":"build-node","HostName":"build-node","DNSName":"build-node.demo.example.","OS":"linux","Online":true},"studio-mini":{"ID":"studio-mini","HostName":"studio-mini","DNSName":"studio-mini.demo.example.","OS":"macos","Online":true},"windows-lab":{"ID":"windows-lab","HostName":"windows-lab","DNSName":"windows-lab.demo.example.","OS":"windows","Online":false},"phone":{"ID":"phone","HostName":"phone","DNSName":"phone.demo.example.","OS":"iOS","Online":true}}}
+EOF

--- a/website/demo/capture.sh
+++ b/website/demo/capture.sh
@@ -37,13 +37,14 @@ let environment = ProcessInfo.processInfo.environment
 guard let pid = environment["GHOSTHUB_DEMO_PID"],
       let output = environment["GHOSTHUB_DEMO_CAPTURE_OUT"]
 else { exit(1) }
-DistributedNotificationCenter.default().post(
-    name: Notification.Name("com.ghosthub.demo.capture"),
+DistributedNotificationCenter.default().postNotificationName(
+    Notification.Name("com.ghosthub.demo.capture"),
     object: pid,
     userInfo: [
         "path": output,
         "mode": environment["GHOSTHUB_DEMO_CAPTURE_MODE"] ?? "window",
-    ]
+    ],
+    deliverImmediately: true
 )
 EOF
 

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -64,8 +64,8 @@ notifications.addObserver(
     name: Notification.Name("com.ghosthub.demo.input.ack"),
     object: pid
 )
-notifications.post(
-    name: Notification.Name("com.ghosthub.demo.input"),
+notifications.postNotificationName(
+    Notification.Name("com.ghosthub.demo.input"),
     object: pid,
     userInfo: [
         "requestID": requestID,
@@ -73,7 +73,8 @@ notifications.post(
         "text": environment["GHOSTHUB_DEMO_TEXT"] ?? "",
         "submit": environment["GHOSTHUB_DEMO_SUBMIT"] ?? "false",
         "expectKind": environment["GHOSTHUB_DEMO_EXPECT_KIND"] ?? "",
-    ]
+    ],
+    deliverImmediately: true
 )
 let deadline = Date(timeIntervalSinceNow: 60)
 while acknowledgement.result == nil && Date() < deadline {
@@ -261,6 +262,25 @@ capture_window_title() {
   sleep 1
 }
 
+capture_host_settings() {
+  palette "Open Hosts Settings" true sheet
+  sleep 2
+  echo "==> guide: selective Tailscale import"
+  # The Settings sheet is fixed at 1040×744. SwiftUI does not expose this
+  # toolbar button as a pressable node on every supported macOS build.
+  demo_input click-sheet "396,634"
+  sleep 2
+  capture_state guide-tailscale-import.png
+  dismiss_sheet
+  # Bring the Verification actions above the settings toolbar. The Hosts
+  # detail is taller than the fixed demo sheet, so its initial top position
+  # clips those controls in the capture even though they are scrollable.
+  demo_input scroll-detail "120"
+  sleep 1
+  capture_state guide-hosts.png
+  dismiss_sheet
+}
+
 if [[ "${GHOSTHUB_DEMO_WINDOW_TITLE_ONLY:-}" == "1" ]]; then
   echo "==> guide: editable workspace title"
   capture_window_title
@@ -285,6 +305,13 @@ if [[ "${GHOSTHUB_DEMO_EXE_ONLY:-}" == "1" ]]; then
   sleep 2
   capture_state guide-exe-dev.png
   echo "captured exe.dev website asset -> $out_dir"
+  exit 0
+fi
+
+if [[ "${GHOSTHUB_DEMO_TAILSCALE_ONLY:-}" == "1" ]]; then
+  echo "==> guide: remote host settings"
+  capture_host_settings
+  echo "captured Tailscale import website asset -> $out_dir"
   exit 0
 fi
 
@@ -357,15 +384,7 @@ demo_input click "31,746"
 sleep 0.5
 
 echo "==> guide: remote host settings"
-palette "Open Hosts Settings" true sheet
-sleep 2
-# Bring the Verification actions above the settings toolbar. The Hosts detail
-# is taller than the fixed demo sheet, so its initial top position clips those
-# controls in the capture even though they are available by scrolling.
-demo_input scroll-detail "120"
-sleep 1
-capture_state guide-hosts.png
-dismiss_sheet
+capture_host_settings
 
 echo "==> guide: existing branch picker"
 palette "fix-reconnect-backoff"

--- a/website/demo/ssh-config
+++ b/website/demo/ssh-config
@@ -1,4 +1,4 @@
-Host ghosthub-demo-remote exe.dev exe-gpu-east exe-builder
+Host ghosthub-demo-remote exe.dev exe-gpu-east exe-builder build-node.demo.example studio-mini.demo.example windows-lab.demo.example
     HostName 127.0.0.1
     Port 2201
     User demo

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -130,7 +130,10 @@ Ghosthub never scans a remote filesystem. See
 
 Importing a Tailscale peer preserves its full MagicDNS name. Ghosthub uses the
 user selected by OpenSSH configuration and falls back to the local macOS user
-name when none is configured.
+name when none is configured. The import picker starts with every peer
+unselected so you can choose only the hosts you want to add.
+
+![Host Settings with explicit Tailscale import controls](assets/guide-tailscale-import.png)
 
 ## Experimental Windows hosts
 

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -20,6 +20,7 @@ assets=(
   guide-session-previews.png
   guide-session-activity.png
   guide-hosts.png
+  guide-tailscale-import.png
   guide-exe-dev.png
   guide-worktree.png
   guide-worktree-window-counts.png


### PR DESCRIPTION
Large tailnets made Host Settings easy to misread and risky to use: the toolbar exposed an unlabeled globe, and the import picker preselected every available peer.

![Host Settings with explicit Tailscale import controls](https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets/guide-tailscale-import.png?asset=selective-picker)

- Labels Tailscale explicitly and gives the Tailscale, add, and remove controls one consistent bordered size.
- Starts every import with no peers selected while preserving existing-peer protections and discovery order.
- Regenerates the Guide image from reserved synthetic peers instead of live tailnet data.
- Makes libghostty resource-locator fixtures independent of an installed Ghosthub app so local aggregate tests match CI.
