### PR TITLE
Authorize the final promotion gate repair

### DIFF
--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -77,7 +77,7 @@ MERGE_SIGNAL_TRANSITION_WORKFLOW_DIGESTS = {
     ),
 }
 PROMOTION_GATE_REPAIR_DIGEST = (
-    "09a0d39bf4527d2cfec188dcaee522170af3817ab19de5c35d465730bfc60e56"
+    "ccea76000ecbdee9e2ff58b78b430dd89b9a475bd66ec8a341788f6071988afe"
 )
 ALLOWED_REUSABLE_WORKFLOWS = {
     "kenn-io/ghosthub/.github/workflows/ci.yml@main",


### PR DESCRIPTION
The downscoped installation token cannot prove that the App installation has no extra permissions.

- binds the one-time gate repair to #158’s exact App-JWT audit workflow
- changes no workflow or runtime behavior

Merge this prerequisite before #158.