### PR TITLE
Keep every tmux session live on demand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ Worktrees are optional; Ghosthub remains fully useful without them.
 - **Sessions:** Worktree sessions and otherwise-unbound tmux sessions open through an ordinary tmux client. Running and stopped Herdr sessions are host inventory; opening a running session attaches, while creating or restarting uses Herdr's launch path. Active Zellij sessions are separate host inventory and open through an ordinary Zellij client. Each backend owns its windows, tabs, panes, layout, history, key bindings, and process lifetime.
 - **Attachment:** Each scene has at most one active interactive native tmux,
   Herdr, or Zellij presentation. Already-opened tmux clients may remain retained
-  and noninteractive, and may render only when the user explicitly enables
-  session previews. Previews never create another client. Ghosthub owns
+  and noninteractive. The explicit Always Live preview mode may also connect
+  every freshly discovered tmux session in the scene without activating it.
+  Preview rendering reuses that session's retained client rather than creating
+  a second client. Ghosthub owns
   discovery, local/SSH client presentation, keepalives, and reconnect. Closing
   a presentation detaches. Tmux and Zellij destruction require explicit,
   confirmed Kill Session actions. Herdr Stop and Delete are separate confirmed

--- a/Sources/App/NativeSessionAttachmentSupport.swift
+++ b/Sources/App/NativeSessionAttachmentSupport.swift
@@ -16,6 +16,9 @@ protocol NativeSessionPaneSurfacing: AnyObject {
     /// attach can recover from, rather than a rejected launch.
     var launchFailureIsRetryable: Bool { get }
     var childExitCode: UInt32? { get }
+    @discardableResult
+    func sizeForPreviewGrid(columns: Int, rows: Int) -> Bool
+    func clearPreviewGridSize()
     func registerSurfaceCloseObserver(
         id: UUID,
         onSurfaceClosed: @escaping (Bool, UInt32?) -> Void
@@ -36,6 +39,13 @@ extension NativeSessionPaneSurfacing {
     var hasEffectiveKeyboardFocus: Bool { false }
 
     var launchFailureIsRetryable: Bool { false }
+
+    @discardableResult
+    func sizeForPreviewGrid(columns _: Int, rows _: Int) -> Bool {
+        false
+    }
+
+    func clearPreviewGridSize() {}
 }
 
 extension TerminalSurfaceView: NativeSessionPaneSurfacing {

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -47,6 +47,30 @@ private struct NativeTmuxPathCacheKey: Hashable {
     var routeIdentity: String
 }
 
+private final class NativeTmuxResolutionCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var caches: [NativeTmuxPathCacheKey: TmuxPathCache] = [:]
+
+    func resolve(
+        key: NativeTmuxPathCacheKey,
+        using resolver: @escaping @Sendable ()
+            -> Result<ResolvedTmuxBinary, TmuxBinaryError>
+    ) -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
+        let cache = lock.withLock {
+            if let existing = caches[key] {
+                return existing
+            }
+            let created = TmuxPathCache(
+                cancellationShell: key.host.displayName,
+                resolve: resolver
+            )
+            caches[key] = created
+            return created
+        }
+        return cache.resolveTmuxBinary()
+    }
+}
+
 private struct NativeTmuxAttachment {
     var id: UUID
     var host: CommandHost
@@ -65,6 +89,8 @@ private struct NativeTmuxAttachment {
     var sessionIdentity: TmuxSessionIdentity?
     var paneSplitClientToken: String
     var clientTTYDirectory: String?
+    var ignoresClientSize: Bool
+    var previewGridSize: TmuxGridSize?
     var supportsPaneSplitting: Bool
     var remoteExitStatusURL: URL?
 }
@@ -73,6 +99,13 @@ enum TmuxAttachedSessionIdentityResolution: Equatable {
     case pending
     case resolved(TmuxSessionIdentity)
     case unavailable
+}
+
+enum TmuxClientSizingTransitionResult: Equatable {
+    case applied
+    case pending
+    case stale
+    case failure(TmuxPaneSplitFailure)
 }
 
 /// Hosts ordinary tmux clients for kwt workspaces and unbound sessions.
@@ -128,8 +161,7 @@ final class NativeTmuxSessionCoordinator {
     private var attachmentClosures: [UUID: BorrowedTmuxAttachmentClosure] = [:]
     private var launchedHandles: Set<UUID> = []
     private var reportedConnectedAttachmentIDs: [UUID: UUID] = [:]
-    private var tmuxBinariesByConnection:
-        [NativeTmuxPathCacheKey: ResolvedTmuxBinary] = [:]
+    private let tmuxResolutionCache = NativeTmuxResolutionCache()
     private var provisioningHandles: Set<UUID> = []
     private var provisioningTasks: [UUID: Task<Void, Never>] = [:]
     private var paneSplitRequests: [UUID: [PaneSplitRequest]] = [:]
@@ -140,6 +172,8 @@ final class NativeTmuxSessionCoordinator {
     private var previewIdentityRetryHandles: Set<UUID> = []
     private var unavailablePreviewIdentityHandles: Set<UUID> = []
     private var deferredPresentationStyleHandles: Set<UUID> = []
+    private var interactiveSizingHandles: Set<UUID> = []
+    private var interactiveSizingTransitionHandles: Set<UUID> = []
     private var isShuttingDown = false
 
     var onStateChanged: ((BorrowedTmuxSessionHandle, ConnectionState) -> Void)?
@@ -227,7 +261,9 @@ final class NativeTmuxSessionCoordinator {
         workingDirectory: String? = nil,
         openWorkspace: Bool = false,
         sessionIdentity: TmuxSessionIdentity? = nil,
-        expectedRouteIdentity: String? = nil
+        expectedRouteIdentity: String? = nil,
+        ignoresClientSize: Bool = false,
+        previewGridSize: TmuxGridSize? = nil
     ) -> BorrowedTmuxSessionHandle {
         let key = NativeTmuxSessionKey(
             hostID: hostID,
@@ -257,7 +293,7 @@ final class NativeTmuxSessionCoordinator {
 
         provisioningHandles.insert(handle.id)
         onStateChanged?(handle, .connecting)
-        let cachedBinaries = tmuxBinariesByConnection
+        let tmuxResolutionCache = tmuxResolutionCache
         let tmuxPathProvider = tmuxPathProvider
         let remoteTmuxPathProvider = remoteTmuxPathProvider
         let remoteConnectionProvider = remoteConnectionProvider
@@ -289,21 +325,17 @@ final class NativeTmuxSessionCoordinator {
                     routeIdentity: sshConnection?.routeIdentity ?? "local"
                 )
                 let probe = Task.detached(priority: .userInitiated) {
-                    let resolution: Result<ResolvedTmuxBinary, TmuxBinaryError>
-                    if let cachedBinary = cachedBinaries[cacheKey] {
-                        resolution = .success(cachedBinary)
-                    } else {
+                    tmuxResolutionCache.resolve(key: cacheKey) {
                         switch host {
                         case .local:
-                            resolution = tmuxPathProvider()
+                            return tmuxPathProvider()
                         case let .ssh(info):
-                            resolution = remoteTmuxPathProvider(
+                            return remoteTmuxPathProvider(
                                 info,
                                 sshConnectionSnapshot.arguments
                             )
                         }
                     }
-                    return resolution
                 }
                 let resolution = await withTaskCancellationHandler {
                     await probe.value
@@ -319,6 +351,8 @@ final class NativeTmuxSessionCoordinator {
                     workingDirectory: workingDirectory,
                     openWorkspace: openWorkspace,
                     sessionIdentity: sessionIdentity,
+                    ignoresClientSize: ignoresClientSize,
+                    previewGridSize: previewGridSize,
                     sshConnectionSnapshot: sshConnectionSnapshot,
                     sshConnection: sshConnection,
                     tmuxPathCacheKey: cacheKey,
@@ -340,6 +374,8 @@ final class NativeTmuxSessionCoordinator {
         workingDirectory: String?,
         openWorkspace: Bool,
         sessionIdentity: TmuxSessionIdentity?,
+        ignoresClientSize: Bool,
+        previewGridSize: TmuxGridSize?,
         sshConnectionSnapshot: SSHConnectionArgumentsSnapshot,
         sshConnection: KwtSSHConnection?,
         tmuxPathCacheKey: NativeTmuxPathCacheKey,
@@ -356,8 +392,10 @@ final class NativeTmuxSessionCoordinator {
         }
         switch resolution {
         case let .success(resolved):
-            tmuxBinariesByConnection[tmuxPathCacheKey] = resolved
             let attachmentID = UUID()
+            let enablesInteractiveSizing = interactiveSizingHandles.remove(
+                handle.id
+            ) != nil
             let protectedWorkspacePath = socketName == nil
                 ? nil
                 : workingDirectory
@@ -386,6 +424,10 @@ final class NativeTmuxSessionCoordinator {
                     .appendingPathComponent(
                         "tmux-clients", isDirectory: true
                     ).path,
+                ignoresClientSize: enablesInteractiveSizing
+                    ? false : ignoresClientSize,
+                previewGridSize: enablesInteractiveSizing
+                    ? nil : previewGridSize,
                 supportsPaneSplitting: TmuxPaneSplitter
                     .supportsPaneSplitting(
                         version: resolved.version,
@@ -405,6 +447,7 @@ final class NativeTmuxSessionCoordinator {
                 try? await sshConnection?.release()
             }
             attachmentClosures[handle.id] = .launchFailed
+            interactiveSizingHandles.remove(handle.id)
             onStateChanged?(
                 handle,
                 .disconnected(reason: error.localizedDescription)
@@ -420,6 +463,7 @@ final class NativeTmuxSessionCoordinator {
         provisioningHandles.remove(handle.id)
         guard handlesByKey[sessionKey(handle)] == handle else { return }
         attachmentClosures[handle.id] = .launchFailed
+        interactiveSizingHandles.remove(handle.id)
         onStateChanged?(
             handle,
             .disconnected(reason: error.localizedDescription)
@@ -466,11 +510,16 @@ final class NativeTmuxSessionCoordinator {
         launchedHandles.remove(handle.id)
         reportedConnectedAttachmentIDs.removeValue(forKey: handle.id)
         deferredPresentationStyleHandles.remove(handle.id)
+        interactiveSizingHandles.remove(handle.id)
         terminalCoordinator.removeSurface(for: surfaceKey(handle))
     }
 
     func hasLaunched(_ handle: BorrowedTmuxSessionHandle) -> Bool {
         launchedHandles.contains(handle.id)
+    }
+
+    func isProvisioning(_ handle: BorrowedTmuxSessionHandle) -> Bool {
+        provisioningHandles.contains(handle.id)
     }
 
     func hasClosedAttachment(_ handle: BorrowedTmuxSessionHandle) -> Bool {
@@ -509,6 +558,182 @@ final class NativeTmuxSessionCoordinator {
         deferredPresentationStyleHandles.remove(handle.id)
     }
 
+    func updatePreviewGridSize(
+        _ gridSize: TmuxGridSize?,
+        for handle: BorrowedTmuxSessionHandle
+    ) {
+        // Inventory refreshes repeat the current grid. Reapplying it resizes
+        // and rerenders every hidden surface even when tmux did not change.
+        guard !interactiveSizingTransitionHandles.contains(handle.id),
+              var attachment = attachments[handle.id],
+              attachment.ignoresClientSize,
+              attachment.previewGridSize != gridSize
+        else { return }
+        attachment.previewGridSize = gridSize
+        attachments[handle.id] = attachment
+        guard let gridSize,
+              let surface = terminalCoordinator.paneSurfaceIfPresent(
+                  for: surfaceKey(handle)
+              )
+        else { return }
+        _ = surface.sizeForPreviewGrid(
+            columns: gridSize.columns,
+            rows: gridSize.rows
+        )
+    }
+
+    func enableInteractiveSizing(
+        for handle: BorrowedTmuxSessionHandle
+    ) async -> TmuxClientSizingTransitionResult {
+        guard var attachment = attachments[handle.id] else {
+            if provisioningHandles.contains(handle.id) {
+                interactiveSizingHandles.insert(handle.id)
+                return .pending
+            }
+            return .failure(TmuxPaneSplitFailure(
+                host: targetHostsByHandle[handle.id]?.displayName
+                    ?? "the selected host",
+                sessionName: handle.name,
+                status: 75,
+                diagnostic: "The tmux attachment is unavailable."
+            ))
+        }
+        guard attachment.ignoresClientSize else { return .applied }
+        guard launchedHandles.contains(handle.id) else {
+            attachment.ignoresClientSize = false
+            attachment.previewGridSize = nil
+            attachments[handle.id] = attachment
+            return .applied
+        }
+        let attachmentID = attachment.id
+        var target = paneSplitTarget(
+            handle: handle,
+            attachment: attachment,
+            expectedIdentity: attachment.sessionIdentity
+        )
+        let identityResult = await paneSplitter.clientIdentity(target: target)
+        guard !Task.isCancelled,
+              attachments[handle.id]?.id == attachmentID
+        else { return .stale }
+        switch identityResult {
+        case let .success(client):
+            if let expectedClient = target.expectedClient,
+               !client.matchesClient(expectedClient) {
+                return .failure(TmuxPaneSplitFailure(
+                    host: target.host.displayName,
+                    sessionName: target.sessionName,
+                    status: 75,
+                    diagnostic: "The attached tmux session changed."
+                ))
+            }
+            paneSplitClients[handle.id] = client
+            target.expectedIdentity = client.sessionIdentity
+            target.expectedClient = client
+        case let .failure(failure):
+            return .failure(failure)
+        }
+        interactiveSizingTransitionHandles.insert(handle.id)
+        defer { interactiveSizingTransitionHandles.remove(handle.id) }
+        terminalCoordinator.paneSurfaceIfPresent(
+            for: surfaceKey(handle)
+        )?.clearPreviewGridSize()
+        let failure = await paneSplitter.enableSizing(target: target)
+        guard !Task.isCancelled,
+              attachments[handle.id]?.id == attachmentID
+        else { return .stale }
+        guard let failure else {
+            terminalCoordinator.paneSurfaceIfPresent(
+                for: surfaceKey(handle)
+            )?.clearPreviewGridSize()
+            var promoted = attachment
+            promoted.ignoresClientSize = false
+            promoted.previewGridSize = nil
+            attachments[handle.id] = promoted
+            return .applied
+        }
+        return .failure(failure)
+    }
+
+    func restorePreviewSizing(
+        _ gridSize: TmuxGridSize?,
+        for handle: BorrowedTmuxSessionHandle
+    ) async -> TmuxClientSizingTransitionResult {
+        guard var attachment = attachments[handle.id] else {
+            if provisioningHandles.contains(handle.id) {
+                interactiveSizingHandles.remove(handle.id)
+                return .applied
+            }
+            return .failure(TmuxPaneSplitFailure(
+                host: targetHostsByHandle[handle.id]?.displayName
+                    ?? "the selected host",
+                sessionName: handle.name,
+                status: 75,
+                diagnostic: "The tmux attachment is unavailable."
+            ))
+        }
+        if attachment.ignoresClientSize {
+            attachment.previewGridSize = gridSize
+            attachments[handle.id] = attachment
+            applyPreviewGridSize(gridSize, for: handle)
+            return .applied
+        }
+        guard launchedHandles.contains(handle.id) else {
+            attachment.ignoresClientSize = true
+            attachment.previewGridSize = gridSize
+            attachments[handle.id] = attachment
+            return .applied
+        }
+        let attachmentID = attachment.id
+        var target = paneSplitTarget(
+            handle: handle,
+            attachment: attachment,
+            expectedIdentity: attachment.sessionIdentity
+        )
+        if target.expectedClient == nil {
+            let identityResult = await paneSplitter.clientIdentity(
+                target: target
+            )
+            guard !Task.isCancelled,
+                  attachments[handle.id]?.id == attachmentID
+            else { return .stale }
+            switch identityResult {
+            case let .success(client):
+                paneSplitClients[handle.id] = client
+                target.expectedIdentity = client.sessionIdentity
+                target.expectedClient = client
+            case let .failure(failure):
+                return .failure(failure)
+            }
+        }
+        applyPreviewGridSize(gridSize, for: handle)
+        let failure = await paneSplitter.disableSizing(target: target)
+        guard !Task.isCancelled,
+              attachments[handle.id]?.id == attachmentID
+        else { return .stale }
+        guard let failure else {
+            attachment.ignoresClientSize = true
+            attachment.previewGridSize = gridSize
+            attachments[handle.id] = attachment
+            return .applied
+        }
+        return .failure(failure)
+    }
+
+    private func applyPreviewGridSize(
+        _ gridSize: TmuxGridSize?,
+        for handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let gridSize,
+              let surface = terminalCoordinator.paneSurfaceIfPresent(
+                  for: surfaceKey(handle)
+              )
+        else { return }
+        _ = surface.sizeForPreviewGrid(
+            columns: gridSize.columns,
+            rows: gridSize.rows
+        )
+    }
+
     func surface(handle: BorrowedTmuxSessionHandle) -> TerminalSurfaceView? {
         guard attachmentClosures[handle.id] == nil,
               let attachment = attachments[handle.id]
@@ -520,6 +745,10 @@ final class NativeTmuxSessionCoordinator {
             ? presentationStyleProvider()
             : nil
         let isFirstLaunch = !launchedHandles.contains(handle.id)
+        let surfaceKey = surfaceKey(handle)
+        let previousSurfaceIdentity = terminalCoordinator
+            .paneSurfaceIfPresent(for: surfaceKey)
+            .map { ObjectIdentifier($0) }
         let info = TmuxAttachmentInfo(
             sessionName: handle.name,
             host: attachment.host,
@@ -530,10 +759,14 @@ final class NativeTmuxSessionCoordinator {
             protectedWorkspacePath: attachment.protectedWorkspacePath,
             presentationStyle: presentationStyle,
             launchMode: attachment.launchMode,
-            initialCommand: attachment.initialCommand
+            initialCommand: attachment.initialCommand,
+            ignoresClientSize: attachment.ignoresClientSize,
+            initialClientSize: attachment.previewGridSize.map {
+                TmuxClientSize(columns: $0.columns, rows: $0.rows)
+            }
         )
         let surface = terminalCoordinator.paneSurface(
-            for: surfaceKey(handle),
+            for: surfaceKey,
             configuration: TerminalSurfaceConfiguration(
                 workingDirectory: NSHomeDirectory(),
                 command: info.attachCommand(
@@ -569,11 +802,21 @@ final class NativeTmuxSessionCoordinator {
             )
             return nil
         }
+        let didCreateSurface = previousSurfaceIdentity
+            != ObjectIdentifier(surface)
         if isFirstLaunch, appliesPresentationStyle,
            presentationStyle == nil {
             deferredPresentationStyleHandles.insert(handle.id)
         }
         surface.blocksClipboardReads = attachment.host.isRemote
+        if didCreateSurface,
+           attachment.ignoresClientSize,
+           let previewGridSize = attachment.previewGridSize {
+            _ = surface.sizeForPreviewGrid(
+                columns: previewGridSize.columns,
+                rows: previewGridSize.rows
+            )
+        }
         let splitTarget = TmuxPaneSplitTarget(
             host: attachment.host,
             tmuxPath: attachment.tmuxPath,
@@ -1150,6 +1393,7 @@ final class NativeTmuxSessionCoordinator {
         launchedHandles.removeAll()
         reportedConnectedAttachmentIDs.removeAll()
         deferredPresentationStyleHandles.removeAll()
+        interactiveSizingHandles.removeAll()
         for handle in handles {
             terminalCoordinator.removeSurface(for: surfaceKey(handle))
         }

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -1,6 +1,7 @@
 import GhosthubTransport
 import Foundation
 import GhosthubTmux
+import GhosthubWorkspace
 
 enum TmuxBinaryError: Error, Equatable, LocalizedError, Sendable {
     case notFound(shell: String)
@@ -55,6 +56,8 @@ struct DiscoveredTmuxSession: Equatable, Sendable {
     var serverPID: String?
     var sessionID: String?
     var createdAt: String?
+    var activeWindowSize: TmuxGridSize?
+    var previewClientSize: TmuxGridSize?
     var managed: Bool
 
     init(
@@ -63,6 +66,8 @@ struct DiscoveredTmuxSession: Equatable, Sendable {
         serverPID: String? = nil,
         sessionID: String? = nil,
         createdAt: String?,
+        activeWindowSize: TmuxGridSize? = nil,
+        previewClientSize: TmuxGridSize? = nil,
         managed: Bool
     ) {
         self.name = name
@@ -70,6 +75,8 @@ struct DiscoveredTmuxSession: Equatable, Sendable {
         self.serverPID = serverPID
         self.sessionID = sessionID
         self.createdAt = createdAt
+        self.activeWindowSize = activeWindowSize
+        self.previewClientSize = previewClientSize
         self.managed = managed
     }
 }
@@ -340,6 +347,8 @@ struct TmuxBinaryResolver: Sendable {
         "GHOSTHUB_TMUX_SESSION_ABSENT"
     private static let discoveryFormat = discoveryPrefix
         + "\t#{session_windows}\t#{pid}\t#{session_id}\t#{session_created}"
+        + "\t#{window_width}\t#{window_height}"
+        + "\t#{status}"
         + "\t#{@ghosthub_owner}\t#{session_name}"
     private static let discoveryCommand = probeCommand
         + "; ghosthub_tmux_output=$("
@@ -564,20 +573,43 @@ struct TmuxBinaryResolver: Sendable {
                 guard line.hasPrefix(prefix) else { return nil }
                 let fields = line.split(
                     separator: "\t",
-                    maxSplits: 6,
+                    maxSplits: 9,
                     omittingEmptySubsequences: false
                 )
-                guard fields.count == 7,
+                guard fields.count == 10,
                       let windowCount = Int(fields[1]),
                       windowCount >= 0
                 else { return nil }
+                let activeWindowSize: TmuxGridSize? = if let columns = Int(fields[5]),
+                                                         let rows = Int(fields[6]),
+                                                         columns > 0, rows > 0 {
+                    TmuxGridSize(columns: columns, rows: rows)
+                } else {
+                    nil
+                }
+                let statusRows: Int? = switch fields[7] {
+                case "off": 0
+                case "on": 1
+                default: Int(fields[7]).flatMap { $0 >= 0 ? $0 : nil }
+                }
+                let previewClientSize: TmuxGridSize? = activeWindowSize
+                    .flatMap { size in
+                        guard let statusRows else { return nil }
+                        let (rows, overflow) = size.rows.addingReportingOverflow(
+                            statusRows
+                        )
+                        guard !overflow, rows > 0 else { return nil }
+                        return TmuxGridSize(columns: size.columns, rows: rows)
+                    }
                 return DiscoveredTmuxSession(
-                    name: String(fields[6]),
+                    name: String(fields[9]),
                     windowCount: windowCount,
                     serverPID: fields[2].isEmpty ? nil : String(fields[2]),
                     sessionID: fields[3].isEmpty ? nil : String(fields[3]),
                     createdAt: fields[4].isEmpty ? nil : String(fields[4]),
-                    managed: !fields[5].isEmpty
+                    activeWindowSize: activeWindowSize,
+                    previewClientSize: previewClientSize,
+                    managed: !fields[8].isEmpty
                 )
             }
         return .success(sessions)

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -71,6 +71,8 @@ struct TmuxPaneSplitter: Sendable {
         "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t"
     private static let identityMismatchMarker =
         "GHOSTHUB_TMUX_SPLIT_IDENTITY_MISMATCH"
+    private static let sizingMismatchMarker =
+        "GHOSTHUB_TMUX_CLIENT_SIZING_MISMATCH"
     typealias Runner = @Sendable (
         CommandHost,
         [String],
@@ -184,6 +186,80 @@ struct TmuxPaneSplitter: Sendable {
         )
     }
 
+    func enableSizing(
+        target: TmuxPaneSplitTarget
+    ) async -> TmuxPaneSplitFailure? {
+        await setIgnoreSize(false, target: target)
+    }
+
+    func disableSizing(
+        target: TmuxPaneSplitTarget
+    ) async -> TmuxPaneSplitFailure? {
+        await setIgnoreSize(true, target: target)
+    }
+
+    private func setIgnoreSize(
+        _ ignoresClientSize: Bool,
+        target: TmuxPaneSplitTarget
+    ) async -> TmuxPaneSplitFailure? {
+        guard Self.platform(for: target.host) == .posix,
+              let expectedClient = target.expectedClient
+        else {
+            return TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux client identity is unavailable."
+            )
+        }
+        let mismatchMarker = Self.sizingMismatchMarker
+            + "_\(UUID().uuidString)"
+        let hookIndex = Int.random(in: 1_000_000_000 ... 2_000_000_000)
+        let command = Self.sizingCommand(
+            tmuxPath: target.tmuxPath,
+            socketName: target.socketName,
+            expectedClient: expectedClient,
+            ignoresClientSize: ignoresClientSize,
+            mismatchMarker: mismatchMarker,
+            hookIndex: hookIndex
+        )
+        let result = await run(command: command, target: target)
+        if Task.isCancelled {
+            let cleanup = Self.cleanupCommand(
+                tmuxPath: target.tmuxPath,
+                socketName: target.socketName,
+                hookIndex: hookIndex
+            )
+            let runner = runner
+            let cleanupTask = Task.detached(priority: .userInitiated) {
+                runner(
+                    target.host,
+                    target.sshConnectionArguments,
+                    cleanup
+                )
+            }
+            _ = await cleanupTask.value
+            return nil
+        }
+        if result.diagnostic.split(whereSeparator: \.isNewline)
+            .contains(Substring(mismatchMarker)) {
+            return TmuxPaneSplitFailure(
+                host: target.host.displayName,
+                sessionName: target.sessionName,
+                status: 75,
+                diagnostic: "The attached tmux session changed.",
+                kind: .atomicGuardChanged
+            )
+        }
+        guard result.status != 0 else { return nil }
+        return TmuxPaneSplitFailure(
+            host: target.host.displayName,
+            sessionName: target.sessionName,
+            status: result.status,
+            diagnostic: Self.normalizedDiagnostic(result.diagnostic)
+        )
+    }
+
     static func command(
         tmuxPath: String,
         socketName: String?,
@@ -255,6 +331,76 @@ struct TmuxPaneSplitter: Sendable {
         ]
         return arguments.map(shellQuotedCommandArgument)
             .joined(separator: " ")
+    }
+
+    static func enableSizingCommand(
+        tmuxPath: String,
+        socketName: String?,
+        expectedClient: TmuxPaneSplitClientIdentity,
+        mismatchMarker: String,
+        hookIndex: Int
+    ) -> String {
+        sizingCommand(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            expectedClient: expectedClient,
+            ignoresClientSize: false,
+            mismatchMarker: mismatchMarker,
+            hookIndex: hookIndex
+        )
+    }
+
+    static func sizingCommand(
+        tmuxPath: String,
+        socketName: String?,
+        expectedClient: TmuxPaneSplitClientIdentity,
+        ignoresClientSize: Bool,
+        mismatchMarker: String,
+        hookIndex: Int
+    ) -> String {
+        var arguments = [tmuxPath]
+        if let socketName, !socketName.isEmpty {
+            arguments += ["-L", socketName]
+        }
+        let tmux = arguments.map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        let hookName = "after-refresh-client[\(hookIndex)]"
+        let clientIdentity = "#{&&:"
+            + "#{==:#{client_pid},\(expectedClient.clientPID)},"
+            + "#{&&:"
+            + "#{==:#{client_created},\(expectedClient.clientCreatedAt)},"
+            + "#{==:#{client_tty},\(expectedClient.clientTTY)}}}"
+        let exactClient = "#{==:#{L:#{?\(clientIdentity),1,}},1}"
+        let condition = "#{&&:"
+            + expectedClient.sessionIdentity.formatCondition
+            + ",\(exactClient)}"
+        let updateSizing = [
+            "if-shell", "-F", condition,
+            [
+                "refresh-client", "-t", expectedClient.clientTTY,
+                "-f", ignoresClientSize ? "ignore-size" : "!ignore-size",
+            ].map(shellQuotedCommandArgument).joined(separator: " "),
+            "display-message -p "
+                + shellQuotedCommandArgument(mismatchMarker),
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let guardedMutation = guardedHookBody(
+            hookName: hookName,
+            marker: mismatchMarker,
+            action: updateSizing
+        )
+        let queue = tmux + " " + [
+            "set-hook", "-g", hookName, guardedMutation, ";",
+            "refresh-client", "-t", expectedClient.clientTTY,
+            mismatchMarker, ";",
+            "set-hook", "-gu", hookName,
+        ].map(shellQuotedCommandArgument).joined(separator: " ")
+        let cleanup = cleanupCommand(
+            tmuxPath: tmuxPath,
+            socketName: socketName,
+            hookIndex: hookIndex
+        )
+        return queue + "; ghosthub_status=$?; "
+            + cleanup + " >/dev/null 2>&1; exit \"$ghosthub_status\""
     }
 
     static func guardedHookBody(

--- a/Sources/App/TmuxPathCache.swift
+++ b/Sources/App/TmuxPathCache.swift
@@ -7,36 +7,113 @@ import Foundation
 /// (tmux not on PATH) must NOT be cached the same way: installing tmux after
 /// the first failed resolve (`brew install tmux`) should be picked up on the
 /// next resolve instead of requiring an app restart.
+/// Concurrent callers share the active result, including a failure, without
+/// retaining that failure for later calls. A cancelled active result does not
+/// cancel callers that are still waiting for tmux.
 ///
 /// Lock-guarded and `Sendable` so the first (blocking) resolve can run off the
 /// main actor — a slow login shell must never beachball the UI on first open.
 final class TmuxPathCache: @unchecked Sendable {
+    private final class Resolution: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var result:
+            Result<ResolvedTmuxBinary, TmuxBinaryError>?
+
+        func wait() -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
+            condition.lock()
+            defer { condition.unlock() }
+            while result == nil {
+                condition.wait()
+            }
+            return result!
+        }
+
+        func complete(
+            with result: Result<ResolvedTmuxBinary, TmuxBinaryError>
+        ) {
+            condition.lock()
+            self.result = result
+            condition.broadcast()
+            condition.unlock()
+        }
+    }
+
     private let lock = NSLock()
     private var cachedBinary: ResolvedTmuxBinary?
+    private var activeResolution: Resolution?
+    private let cancellationShell: String
     private let resolve:
         @Sendable () -> Result<ResolvedTmuxBinary, TmuxBinaryError>
 
     init(
+        cancellationShell: String = AccountCommandRunner.loginShell(),
         resolve: @escaping @Sendable ()
             -> Result<ResolvedTmuxBinary, TmuxBinaryError>
     ) {
+        self.cancellationShell = cancellationShell
         self.resolve = resolve
     }
 
     func resolveTmuxBinary()
         -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
-        lock.lock()
-        if let cachedBinary {
+        while true {
+            lock.lock()
+            if let cachedBinary {
+                lock.unlock()
+                return .success(cachedBinary)
+            }
+            if isCurrentTaskCancelled {
+                lock.unlock()
+                return cancellationFailure
+            }
+            if let activeResolution {
+                lock.unlock()
+                let result = activeResolution.wait()
+                if case .failure(.probeCancelled) = result,
+                   !isCurrentTaskCancelled {
+                    continue
+                }
+                return result
+            }
+            let resolution = Resolution()
+            activeResolution = resolution
             lock.unlock()
-            return .success(cachedBinary)
+
+            guard !isCurrentTaskCancelled else {
+                let result = cancellationFailure
+                finish(resolution, with: result)
+                return result
+            }
+            let resolved = resolve()
+            finish(resolution, with: resolved)
+            return resolved
+        }
+    }
+
+    private var isCurrentTaskCancelled: Bool {
+        withUnsafeCurrentTask { task in
+            task?.isCancelled == true
+        }
+    }
+
+    private var cancellationFailure:
+        Result<ResolvedTmuxBinary, TmuxBinaryError> {
+        .failure(.probeCancelled(shell: cancellationShell))
+    }
+
+    private func finish(
+        _ resolution: Resolution,
+        with result: Result<ResolvedTmuxBinary, TmuxBinaryError>
+    ) {
+        lock.lock()
+        if case let .success(binary) = result {
+            cachedBinary = binary
+        }
+        // Publish to current waiters before a new caller can start a retry.
+        resolution.complete(with: result)
+        if activeResolution === resolution {
+            activeResolution = nil
         }
         lock.unlock()
-        let resolved = resolve()
-        if case let .success(binary) = resolved {
-            lock.lock()
-            cachedBinary = binary
-            lock.unlock()
-        }
-        return resolved
     }
 }

--- a/Sources/App/TmuxSessionPreviewCoordinator.swift
+++ b/Sources/App/TmuxSessionPreviewCoordinator.swift
@@ -3,19 +3,43 @@ import AppKit
 import Foundation
 import GhosthubSettings
 import GhosthubTerminal
+import GhosthubTerminalSupport
 import GhosthubTmux
 import GhosthubTransport
 
-struct TmuxPreviewViewState {
-    let image: NSImage?
+struct TmuxPreviewViewState: Equatable {
+    let frame: TerminalSurfacePreviewFrame?
     let capturedAt: Date?
     let placeholder: TmuxPreviewPlaceholder?
     let connectionState: ConnectionState?
     let isLive: Bool
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        let framesMatch = switch (lhs.frame, rhs.frame) {
+        case (nil, nil): true
+        case let (lhsFrame?, rhsFrame?): lhsFrame === rhsFrame
+        default: false
+        }
+        return framesMatch
+            && lhs.capturedAt == rhs.capturedAt
+            && lhs.placeholder == rhs.placeholder
+            && lhs.connectionState == rhs.connectionState
+            && lhs.isLive == rhs.isLive
+    }
 }
 
 @MainActor
-final class TmuxSessionPreviewCoordinator: ObservableObject {
+final class TmuxPreviewViewModel: ObservableObject {
+    @Published private(set) var state: TmuxPreviewViewState?
+
+    func setState(_ state: TmuxPreviewViewState?) {
+        guard self.state != state else { return }
+        self.state = state
+    }
+}
+
+@MainActor
+final class TmuxSessionPreviewCoordinator {
     struct Presentation {
         let key: TmuxPreviewKey
         let surface: () -> TerminalSurfaceView?
@@ -23,6 +47,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         let generation: () -> String?
         let identity: @MainActor () -> TmuxSessionIdentity?
         let connectionState: () -> ConnectionState?
+        let hasLaunched: () -> Bool
         let isActive: () -> Bool
         let activate: () -> Void
         let ensureIdentity: () -> Void
@@ -35,6 +60,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             generation: @escaping () -> String?,
             identity: @escaping @MainActor () -> TmuxSessionIdentity?,
             connectionState: @escaping () -> ConnectionState?,
+            hasLaunched: @escaping () -> Bool = { true },
             isActive: @escaping () -> Bool,
             activate: @escaping () -> Void,
             ensureIdentity: @escaping () -> Void = {},
@@ -47,6 +73,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             self.generation = generation
             self.identity = identity
             self.connectionState = connectionState
+            self.hasLaunched = hasLaunched
             self.isActive = isActive
             self.activate = activate
             self.ensureIdentity = ensureIdentity
@@ -62,6 +89,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         case reconnect
         case close
         case replacement
+        case identityMismatch
     }
 
     typealias Capture = @MainActor (
@@ -84,8 +112,6 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     let sceneID: UUID
-    @Published private(set) var viewStates: [TmuxPreviewKey: TmuxPreviewViewState] = [:]
-
     private let budget: LivePreviewBudget
     private let capture: Capture
     private let finalCapture: Capture
@@ -94,18 +120,23 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     private let injectedIsKeyWindow: (() -> Bool)?
     private let sleep: Sleep
     private let activationDelay: Duration
+    private let parkingInterval: Duration
     private let liveInterval: Duration
     private let now: () -> Date
     private weak var parkingHost: LivePreviewParkingHost?
     private var presentations: [TmuxPreviewKey: Presentation] = [:]
     private var registeredVersions: [TmuxPreviewKey: PresentationVersion] = [:]
-    private var previewStates: [TmuxPreviewKey: TmuxSessionPreviewState<NSImage>] = [:]
+    private var previewStates:
+        [TmuxPreviewKey: TmuxSessionPreviewState<TerminalSurfacePreviewFrame>]
+        = [:]
+    private var viewModels: [TmuxPreviewKey: TmuxPreviewViewModel] = [:]
     private var expandedKeys: Set<TmuxPreviewKey> = []
     private var parkedKeys: Set<TmuxPreviewKey> = []
     private var parkedSurfaces: [TmuxPreviewKey: TerminalSurfaceView] = [:]
     private var activatingKeys: Set<TmuxPreviewKey> = []
     private var deactivatingKeys: Set<TmuxPreviewKey> = []
     private var reconnectingKeys: Set<TmuxPreviewKey> = []
+    private var identityMismatchKeys: Set<TmuxPreviewKey> = []
     private var unresolvedIdentityKeys: Set<TmuxPreviewKey> = []
     private var unavailableIdentityKeys: Set<TmuxPreviewKey> = []
     private var parkingBlockedKeys: Set<TmuxPreviewKey> = []
@@ -143,6 +174,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             try await Task.sleep(for: duration)
         },
         activationDelay: Duration = .milliseconds(250),
+        parkingInterval: Duration = .milliseconds(10),
         liveInterval: Duration = .milliseconds(500),
         now: @escaping () -> Date = Date.init
     ) {
@@ -181,6 +213,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         injectedIsKeyWindow = isKeyWindow
         self.sleep = sleep
         self.activationDelay = activationDelay
+        self.parkingInterval = parkingInterval
         self.liveInterval = max(liveInterval, .milliseconds(500))
         self.now = now
         lastGranted = budget.granted
@@ -198,7 +231,16 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     func viewState(for key: TmuxPreviewKey) -> TmuxPreviewViewState? {
-        viewStates[key]
+        viewModels[key]?.state
+    }
+
+    func viewModel(for key: TmuxPreviewKey) -> TmuxPreviewViewModel {
+        if let viewModel = viewModels[key] {
+            return viewModel
+        }
+        let viewModel = TmuxPreviewViewModel()
+        viewModels[key] = viewModel
+        return viewModel
     }
 
     func register(
@@ -220,6 +262,9 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         }
         presentations[key] = presentation
         registeredVersions[key] = version
+        if identityMismatchKeys.remove(key) != nil {
+            previewStates[key]?.clear()
+        }
         parkingBlockedKeys.remove(key)
         if identityIsResolved || identityIsUnavailable {
             unresolvedIdentityKeys.remove(key)
@@ -283,7 +328,9 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     func setExpanded(_ expanded: Bool, for key: TmuxPreviewKey) {
-        guard presentations[key] != nil else { return }
+        if expanded, presentations[key] == nil {
+            return
+        }
         let changed = expanded
             ? expandedKeys.insert(key).inserted
             : expandedKeys.remove(key) != nil
@@ -310,8 +357,10 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     func setMode(_ newMode: SessionPreviewMode) {
         guard mode != newMode else { return }
         let keys = Array(presentations.keys)
+        let retainedMismatchKeys = Array(identityMismatchKeys)
         let formerlyParked = parkedKeys
-        let isLeavingOff = mode == .off
+        let oldMode = mode
+        let isLeavingOff = oldMode == .off
         mode = newMode
         deactivatingKeys.removeAll()
         navigationCaptureCompletions.removeAll()
@@ -319,6 +368,11 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         keys.forEach(invalidate)
         liveTask?.cancel()
         liveTask = nil
+        if oldMode == .alwaysLive, newMode != .alwaysLive {
+            for retainedMismatchKey in retainedMismatchKeys {
+                discardIdentityMismatch(retainedMismatchKey, removesExpansion: false)
+            }
+        }
 
         switch newMode {
         case .off:
@@ -345,11 +399,14 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             }
             keys.filter { !formerlyParked.contains($0) }
                 .forEach(unparkAndRelease)
-        case .live:
+        case .live, .alwaysLive:
             deferredEfficientCaptureKeys.removeAll()
             deferredNavigationCaptureKeys.removeAll()
             if isLeavingOff {
                 keys.forEach(restorePreviewState)
+            }
+            if newMode == .live, oldMode == .alwaysLive {
+                keys.forEach(unparkAndRelease)
             }
             reconcileEligibility()
         }
@@ -379,17 +436,24 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         guard isApplicationActive else { return }
         isApplicationActive = false
         invalidateAllEligibility()
-        releaseAllParking()
+        parkingHost?.setRenderingSuspended(true)
         liveTask?.cancel()
         liveTask = nil
+        presentations.keys.forEach(publish)
     }
 
     func applicationDidBecomeActive() {
         guard !isApplicationActive else { return }
         isApplicationActive = true
+        parkingHost?.setRenderingSuspended(false)
         retryDeferredEfficientCaptures()
         retryDeferredNavigationCaptures()
-        guard sceneIsKeyWindow() else { return }
+        presentations.keys.forEach(publish)
+        guard sceneIsKeyWindow() else {
+            invalidateAllEligibility()
+            releaseAllParking()
+            return
+        }
         scheduleParkingReacquisition()
     }
 
@@ -397,9 +461,16 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         guard isApplicationActive else { return }
         guard isKey else {
             invalidateActivationDelay()
+            invalidateAllEligibility()
+            releaseAllParking()
+            liveTask?.cancel()
+            liveTask = nil
+            presentations.keys.forEach(publish)
             return
         }
+        presentations.keys.forEach(publish)
         scheduleParkingReacquisition()
+        restartLiveTaskIfNeeded()
     }
 
     func cancelPendingActivation() {
@@ -434,13 +505,15 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         presentations.removeAll()
         registeredVersions.removeAll()
         previewStates.removeAll()
-        viewStates.removeAll()
+        viewModels.values.forEach { $0.setState(nil) }
+        viewModels.removeAll()
         expandedKeys.removeAll()
         parkedKeys.removeAll()
         parkedSurfaces.removeAll()
         activatingKeys.removeAll()
         deactivatingKeys.removeAll()
         reconnectingKeys.removeAll()
+        identityMismatchKeys.removeAll()
         unresolvedIdentityKeys.removeAll()
         unavailableIdentityKeys.removeAll()
         parkingBlockedKeys.removeAll()
@@ -450,7 +523,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     private func scheduleParkingReacquisition() {
-        guard mode == .live,
+        guard mode.usesLiveRefresh,
               isApplicationActive,
               isSidebarVisible,
               activationTask == nil
@@ -459,20 +532,29 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         let generation = activationGeneration
         activationTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer {
+                if generation == activationGeneration {
+                    activationTask = nil
+                    restartLiveTaskIfNeeded()
+                }
+            }
             do {
                 try await sleep(activationDelay)
             } catch {
                 return
             }
-            guard generation == activationGeneration else { return }
-            activationTask = nil
-            guard isApplicationActive,
+            while generation == activationGeneration,
+                  isApplicationActive,
                   isSidebarVisible,
-                  mode == .live,
-                  sceneIsKeyWindow()
-            else { return }
-            reconcileEligibility()
-            restartLiveTaskIfNeeded()
+                  mode.usesLiveRefresh,
+                  sceneIsKeyWindow() {
+                guard reacquireNextParkingSurface() else { return }
+                do {
+                    try await sleep(parkingInterval)
+                } catch {
+                    return
+                }
+            }
         }
     }
 
@@ -532,7 +614,19 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     func remove(_ key: TmuxPreviewKey, reason: RemovalReason) {
-        guard presentations[key] != nil else { return }
+        guard presentations[key] != nil else {
+            guard identityMismatchKeys.contains(key) else { return }
+            switch reason {
+            case .close:
+                discardIdentityMismatch(key, removesExpansion: true)
+            case .replacement:
+                discardIdentityMismatch(key, removesExpansion: false)
+            case .reconnect, .identityMismatch:
+                return
+            }
+            restartLiveTaskIfNeeded()
+            return
+        }
         invalidate(key)
         invalidateActivationDelay()
         deactivatingKeys.remove(key)
@@ -558,7 +652,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             presentations.removeValue(forKey: key)
             registeredVersions.removeValue(forKey: key)
             previewStates.removeValue(forKey: key)
-            viewStates.removeValue(forKey: key)
+            viewModels.removeValue(forKey: key)?.setState(nil)
             generations.removeValue(forKey: key)
             unresolvedIdentityKeys.remove(key)
             unavailableIdentityKeys.remove(key)
@@ -571,13 +665,47 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             presentations.removeValue(forKey: key)
             registeredVersions.removeValue(forKey: key)
             previewStates.removeValue(forKey: key)
-            viewStates.removeValue(forKey: key)
+            viewModels[key]?.setState(nil)
             generations.removeValue(forKey: key)
             unresolvedIdentityKeys.remove(key)
             unavailableIdentityKeys.remove(key)
             parkingBlockedKeys.remove(key)
+        case .identityMismatch:
+            deferredEfficientCaptureKeys.remove(key)
+            deferredNavigationCaptureKeys.remove(key)
+            activatingKeys.remove(key)
+            reconnectingKeys.remove(key)
+            presentations.removeValue(forKey: key)
+            registeredVersions.removeValue(forKey: key)
+            identityMismatchKeys.insert(key)
+            unresolvedIdentityKeys.remove(key)
+            unavailableIdentityKeys.remove(key)
+            parkingBlockedKeys.remove(key)
+            publish(key)
         }
         restartLiveTaskIfNeeded()
+    }
+
+    private func discardIdentityMismatch(
+        _ key: TmuxPreviewKey,
+        removesExpansion: Bool
+    ) {
+        identityMismatchKeys.remove(key)
+        deferredEfficientCaptureKeys.remove(key)
+        deferredNavigationCaptureKeys.remove(key)
+        activatingKeys.remove(key)
+        reconnectingKeys.remove(key)
+        presentations.removeValue(forKey: key)
+        registeredVersions.removeValue(forKey: key)
+        previewStates.removeValue(forKey: key)
+        viewModels.removeValue(forKey: key)?.setState(nil)
+        generations.removeValue(forKey: key)
+        unresolvedIdentityKeys.remove(key)
+        unavailableIdentityKeys.remove(key)
+        parkingBlockedKeys.remove(key)
+        if removesExpansion {
+            expandedKeys.remove(key)
+        }
     }
 
     func installParkingHost(_ host: LivePreviewParkingHost) {
@@ -588,6 +716,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             isParkingHostChanging = false
         }
         parkingHost = host
+        host.setRenderingSuspended(!isApplicationActive)
         reconcileEligibility()
     }
 
@@ -600,20 +729,24 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     func refreshLivePreviews() async {
-        guard mode == .live,
+        guard mode.usesLiveRefresh,
               isApplicationActive,
               isSidebarVisible,
+              sceneIsKeyWindow(),
               !isParkingHostChanging
         else { return }
         presentations.keys.forEach(requestIdentityIfNeeded)
         reconcileEligibility()
-        for key in expandedKeys {
+        for key in presentations.keys where isExpanded(key) {
             guard let presentation = presentations[key],
                   isConnected(presentation),
                   presentation.identity() != nil
             else { continue }
             if presentation.isActive()
-                || (parkedKeys.contains(key) && isGranted(key)) {
+                || (
+                    parkedKeys.contains(key)
+                        && (mode == .alwaysLive || isGranted(key))
+                ) {
                 startCapture(key, reason: .scheduled)
             }
         }
@@ -681,7 +814,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
                         reason: reason
                     ) {
                     previewStates[key]?.recordCapture(
-                        image: snapshot.image,
+                        image: snapshot.frame,
                         capturedAt: now(),
                         captureToken: snapshot.captureToken,
                         identity: identity
@@ -735,17 +868,17 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
         case .scheduled:
             guard isApplicationActive,
                   isSidebarVisible,
-                  expandedKeys.contains(key)
+                  isExpanded(key)
             else { return false }
             if presentation.isActive() {
-                return mode == .efficient || mode == .live
+                return mode == .efficient || mode.usesLiveRefresh
             }
-            return mode == .live
+            return mode.usesLiveRefresh
                 && parkedKeys.contains(key)
-                && isGranted(key)
+                && (mode == .alwaysLive || isGranted(key))
         case .navigationAway:
             guard isApplicationActive else { return false }
-            return mode == .efficient || expandedKeys.contains(key)
+            return mode == .efficient || isExpanded(key)
         case .finalBeforeUnpark:
             return mode == .efficient && parkedKeys.contains(key)
         }
@@ -769,61 +902,114 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     }
 
     private func reconcileEligibility() {
-        guard !isShutDown,
-              mode == .live,
-              isApplicationActive,
-              isSidebarVisible,
-              !isParkingHostChanging
-        else {
+        guard prepareParkingEligibility() else {
             restartLiveTaskIfNeeded()
             return
         }
+
+        // App activation owns incremental reacquisition while its task is
+        // alive. Other presentation updates may still invalidate parking, but
+        // must not mount the remaining fleet in the same main-thread turn.
+        guard activationTask == nil else {
+            restartLiveTaskIfNeeded()
+            return
+        }
+
+        _ = parkEligiblePresentations(limit: nil)
+        restartLiveTaskIfNeeded()
+    }
+
+    private func reacquireNextParkingSurface() -> Bool {
+        guard prepareParkingEligibility() else { return false }
+        return parkEligiblePresentations(limit: 1)
+    }
+
+    private func prepareParkingEligibility() -> Bool {
+        guard !isShutDown,
+              mode.usesLiveRefresh,
+              isApplicationActive,
+              isSidebarVisible,
+              sceneIsKeyWindow(),
+              !isParkingHostChanging
+        else { return false }
 
         for key in presentations.keys {
             guard let presentation = presentations[key] else { continue }
             if deactivatingKeys.contains(key) {
                 continue
             }
-            let eligible = expandedKeys.contains(key)
-                && isConnected(presentation)
-                && presentation.identity() != nil
-                && !reconnectingKeys.contains(key)
-                && !parkingBlockedKeys.contains(key)
+            let eligible = canPark(key, presentation: presentation)
             if activatingKeys.contains(key) {
                 continue
             }
             if !eligible || presentation.isActive() {
                 unparkAndRelease(key)
+            } else if mode == .alwaysLive {
+                budget.release(requestID(for: key))
             } else {
                 budget.request(requestID(for: key))
             }
         }
 
+        return true
+    }
+
+    /// Parks at most `limit` new surfaces and reports whether another eligible
+    /// surface remains. Parking reparents an AppKit terminal view and can
+    /// synchronously resize libghostty, so activation deliberately performs
+    /// only one of these operations per main-thread turn.
+    private func parkEligiblePresentations(limit: Int?) -> Bool {
+        var parkedCount = 0
+        var hasRemaining = false
         for key in presentations.keys {
             guard let presentation = presentations[key],
-                  expandedKeys.contains(key),
-                  !presentation.isActive(),
-                  !activatingKeys.contains(key),
-                  !deactivatingKeys.contains(key),
-                  !reconnectingKeys.contains(key),
-                  !parkingBlockedKeys.contains(key),
-                  isConnected(presentation),
-                  presentation.identity() != nil
+                  canPark(key, presentation: presentation)
             else { continue }
-            if isGranted(key) {
-                do {
-                    try park(key, presentation: presentation)
-                } catch {
-                    parkingBlockedKeys.insert(key)
-                    budget.release(requestID(for: key))
+            if mode == .alwaysLive || isGranted(key) {
+                if !parkedKeys.contains(key) {
+                    if let limit, parkedCount >= limit {
+                        hasRemaining = true
+                    } else {
+                        do {
+                            try park(key, presentation: presentation)
+                            parkedCount += 1
+                        } catch {
+                            parkingBlockedKeys.insert(key)
+                            budget.release(requestID(for: key))
+                        }
+                    }
                 }
             }
             previewStates[key]?.setLiveLimitReached(
-                budget.isWaiting(requestID(for: key))
+                mode == .live && budget.isWaiting(requestID(for: key))
             )
             publish(key)
         }
-        restartLiveTaskIfNeeded()
+        return hasRemaining
+    }
+
+    private func canPark(
+        _ key: TmuxPreviewKey,
+        presentation: Presentation
+    ) -> Bool {
+        guard isExpanded(key),
+              presentation.hasLaunched(),
+              !presentation.isActive(),
+              !activatingKeys.contains(key),
+              !deactivatingKeys.contains(key),
+              !unavailableIdentityKeys.contains(key),
+              !parkingBlockedKeys.contains(key)
+        else { return false }
+
+        if mode == .alwaysLive {
+            return switch presentation.connectionState() {
+            case .connecting, .reconnecting, .connected: true
+            case .disconnected, nil: false
+            }
+        }
+        return !reconnectingKeys.contains(key)
+            && isConnected(presentation)
+            && presentation.identity() != nil
     }
 
     private func park(
@@ -865,10 +1051,12 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
 
     private func restartLiveTaskIfNeeded() {
         let shouldRun = !isShutDown
-            && mode == .live
+            && mode.usesLiveRefresh
             && isApplicationActive
             && isSidebarVisible
-            && !expandedKeys.isEmpty
+            && sceneIsKeyWindow()
+            && activationTask == nil
+            && presentations.keys.contains(where: isExpanded)
         guard shouldRun else {
             liveTask?.cancel()
             liveTask = nil
@@ -894,10 +1082,11 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     private func budgetGrantsChanged(
         _ granted: Set<LivePreviewRequestID>
     ) {
-        guard !isShutDown else { return }
-        let lost = lastGranted.subtracting(granted)
-            .filter { $0.sceneID == sceneID }
+        let previousGrants = lastGranted
         lastGranted = granted
+        guard !isShutDown, mode == .live else { return }
+        let lost = previousGrants.subtracting(granted)
+            .filter { $0.sceneID == sceneID }
         for request in lost {
             if activatingKeys.contains(request.presentation)
                 || deactivatingKeys.contains(request.presentation) {
@@ -959,6 +1148,10 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
 
     private func isGranted(_ key: TmuxPreviewKey) -> Bool {
         budget.isGranted(requestID(for: key))
+    }
+
+    private func isExpanded(_ key: TmuxPreviewKey) -> Bool {
+        expandedKeys.contains(key)
     }
 
     private func isConnected(_ presentation: Presentation) -> Bool {
@@ -1038,7 +1231,7 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
             && unresolvedIdentityKeys.contains(key)
             && presentations[key].map(isConnected) == true
             && (
-                expandedKeys.contains(key)
+                isExpanded(key)
                     || (
                         mode == .efficient
                             && presentations[key]?.isActive() == true
@@ -1063,18 +1256,20 @@ final class TmuxSessionPreviewCoordinator: ObservableObject {
     private func publish(_ key: TmuxPreviewKey) {
         guard let state = previewStates[key] else { return }
         let presentation = presentations[key]
-        viewStates[key] = TmuxPreviewViewState(
-            image: state.visibleFrame?.image,
+        viewModel(for: key).setState(TmuxPreviewViewState(
+            frame: state.visibleFrame?.image,
             capturedAt: state.visibleFrame?.capturedAt,
             placeholder: state.placeholder,
             connectionState: presentation?.connectionState(),
-            isLive: mode == .live
+            isLive: mode.usesLiveRefresh
                 && isApplicationActive
                 && isSidebarVisible
+                && sceneIsKeyWindow()
                 && presentation.map(isConnected) == true
                 && !reconnectingKeys.contains(key)
                 && !unresolvedIdentityKeys.contains(key)
+                && !unavailableIdentityKeys.contains(key)
                 && (presentation?.isActive() == true || parkedKeys.contains(key))
-        )
+        ))
     }
 }

--- a/Sources/App/TmuxSessionPreviewCoordinator.swift
+++ b/Sources/App/TmuxSessionPreviewCoordinator.swift
@@ -788,6 +788,10 @@ final class TmuxSessionPreviewCoordinator {
             }
             return
         }
+        // Preview sizing can be rejected while libghostty is still
+        // initializing, and no notification reports when it settles, so each
+        // capture re-drives the surface's retained tmux grid until adopted.
+        presentation.surface()?.ensurePreviewGridSize()
         let captureGeneration = generations[key, default: 0]
         let presentationVersion = version(of: presentation)
         let previousToken = previewStates[key]?.visibleFrame?.captureToken

--- a/Sources/App/TmuxSessionPreviewViews.swift
+++ b/Sources/App/TmuxSessionPreviewViews.swift
@@ -5,8 +5,7 @@ import GhosthubTransport
 import SwiftUI
 
 struct TmuxSessionPreviewTile: View {
-    @ObservedObject var coordinator: TmuxSessionPreviewCoordinator
-    let key: TmuxPreviewKey
+    @ObservedObject var viewModel: TmuxPreviewViewModel
     let sessionName: String
     let onActivate: () -> Void
 
@@ -16,7 +15,7 @@ struct TmuxSessionPreviewTile: View {
         } label: {
             ZStack(alignment: .bottomLeading) {
                 previewContent
-                if let status = statusText {
+                if let status = visualStatusText {
                     Text(status)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
@@ -26,7 +25,12 @@ struct TmuxSessionPreviewTile: View {
                         .background(.regularMaterial)
                 }
             }
-            .aspectRatio(tileAspectRatio, contentMode: .fit)
+            .aspectRatio(
+                TerminalPreviewGeometry.aspectRatio(
+                    for: viewState?.frame?.pixelSize
+                ),
+                contentMode: .fit
+            )
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .overlay {
                 RoundedRectangle(cornerRadius: 6)
@@ -43,10 +47,8 @@ struct TmuxSessionPreviewTile: View {
 
     @ViewBuilder
     private var previewContent: some View {
-        if let image = viewState?.image {
-            Image(nsImage: image)
-                .resizable()
-                .scaledToFit()
+        if let frame = viewState?.frame {
+            TmuxSessionPreviewSurface(frame: frame)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.black)
         } else {
@@ -59,32 +61,25 @@ struct TmuxSessionPreviewTile: View {
     }
 
     private var viewState: TmuxPreviewViewState? {
-        coordinator.viewState(for: key)
+        viewModel.state
     }
 
-    private var tileAspectRatio: CGFloat {
-        TerminalPreviewGeometry.aspectRatio(for: viewState?.image?.size)
-    }
-
-    private var statusText: String? {
+    private var visualStatusText: String? {
         guard let state = viewState else { return nil }
         if state.isLive {
-            return "Live"
+            return nil
         }
-        switch state.placeholder {
-        case .awaitingFirstFrame: return "Open to capture"
-        case .reconnecting: return "Reconnecting"
-        case .disconnected: return "Disconnected"
-        case .unavailable: return "Preview unavailable"
-        case .liveLimitReached: return "Live preview limit reached"
-        case nil:
-            guard let capturedAt = state.capturedAt else { return nil }
-            return "Retained, updated \(Self.relativeFormatter.localizedString(for: capturedAt, relativeTo: Date()))"
-        }
+        return TmuxSessionPreviewStatus.text(
+            connectionState: state.connectionState,
+            placeholder: state.placeholder,
+            capturedAt: state.capturedAt
+        )
     }
 
     private var accessibilityLabel: String {
-        let status = statusText ?? "Preview available"
+        let status = viewState?.isLive == true
+            ? "Live"
+            : visualStatusText ?? "Preview available"
         let connection = switch viewState?.connectionState {
         case .connecting: "connecting"
         case .reconnecting: "reconnecting"
@@ -95,11 +90,62 @@ struct TmuxSessionPreviewTile: View {
         return "\(sessionName), \(status), \(connection)"
     }
 
-    private static let relativeFormatter: RelativeDateTimeFormatter = {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter
-    }()
+}
+
+private struct TmuxSessionPreviewSurface: NSViewRepresentable {
+    let frame: TerminalSurfacePreviewFrame
+
+    func makeNSView(context: Context) -> TerminalSurfacePreviewView {
+        let view = TerminalSurfacePreviewView(frame: .zero)
+        view.display(frame)
+        return view
+    }
+
+    func updateNSView(
+        _ nsView: TerminalSurfacePreviewView,
+        context: Context
+    ) {
+        nsView.display(frame)
+    }
+
+    static func dismantleNSView(
+        _ nsView: TerminalSurfacePreviewView,
+        coordinator: Void
+    ) {
+        nsView.display(nil)
+    }
+}
+
+enum TmuxSessionPreviewStatus {
+    static func text(
+        connectionState: ConnectionState?,
+        placeholder: TmuxPreviewPlaceholder?,
+        capturedAt: Date?,
+        now: Date = Date()
+    ) -> String? {
+        switch connectionState {
+        case .connecting:
+            return "Connecting"
+        case .reconnecting:
+            return "Reconnecting"
+        case .disconnected:
+            return "Disconnected"
+        case .connected, nil:
+            break
+        }
+        switch placeholder {
+        case .awaitingFirstFrame: return "Open to capture"
+        case .reconnecting: return "Reconnecting"
+        case .disconnected: return "Disconnected"
+        case .unavailable: return "Preview unavailable"
+        case .liveLimitReached: return "Live preview limit reached"
+        case nil:
+            guard let capturedAt else { return nil }
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+            return "Retained, updated \(formatter.localizedString(for: capturedAt, relativeTo: now))"
+        }
+    }
 }
 
 struct TmuxSessionPreviewParkingView: NSViewRepresentable {

--- a/Sources/App/WorkspaceSceneModel+Subscriptions.swift
+++ b/Sources/App/WorkspaceSceneModel+Subscriptions.swift
@@ -23,13 +23,11 @@ extension WorkspaceSceneModel {
         let center = NotificationCenter.default
         appDidBecomeActiveCancellable = center
             .publisher(for: NSApplication.didBecomeActiveNotification)
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.handleApplicationDidBecomeActiveForResourceMonitoring()
             }
         appDidResignActiveCancellable = center
-            .publisher(for: NSApplication.didResignActiveNotification)
-            .receive(on: DispatchQueue.main)
+            .publisher(for: NSApplication.willResignActiveNotification)
             .sink { [weak self] _ in
                 self?.handleApplicationDidResignActiveForResourceMonitoring()
             }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -504,6 +504,19 @@ final class WorkspaceSceneModel: ObservableObject {
         var verifiedPreviewIdentity: TmuxSessionIdentity?
         var reconnectExpectedIdentity: TmuxSessionIdentity?
         var previewIdentityUnavailable = false
+        var previewPromotionID: UUID?
+        var previewPromotionTask: Task<Void, Never>?
+        var previewPromotionNavigationRevision: UInt64?
+        var pendingPreviewPromotionNavigationRevision: UInt64?
+
+        var previewPromotionIsPending: Bool {
+            previewPromotionTask != nil
+                || pendingPreviewPromotionNavigationRevision != nil
+        }
+
+        var expectedPreviewIdentity: TmuxSessionIdentity? {
+            verifiedPreviewIdentity ?? reconnectExpectedIdentity
+        }
 
         init(
             selection: WorkspaceTmuxSessionSelection,
@@ -532,6 +545,15 @@ final class WorkspaceSceneModel: ObservableObject {
         [TmuxPresentationKey: RetainedTmuxPresentation] = [:]
     private var retainedTmuxPresentationKeysByHandle:
         [UUID: TmuxPresentationKey] = [:]
+    private var alwaysLiveManagedTmuxPresentationKeys:
+        Set<TmuxPresentationKey> = []
+    private var alwaysLiveIneligibleTmuxPresentationIdentities:
+        [TmuxPresentationKey: TmuxSessionIdentity] = [:]
+    private var pendingAlwaysLiveTmuxSurfaceHandles:
+        [BorrowedTmuxSessionHandle] = []
+    private var pendingAlwaysLiveTmuxSurfaceHandleIDs: Set<UUID> = []
+    private var alwaysLiveTmuxSurfaceLaunchTask: Task<Void, Never>?
+    private var alwaysLiveTmuxSurfaceLaunchID: UUID?
     private var protectedTmuxAttachmentScopesByHandle:
         [UUID: WorktreeMutationCoordinator.Scope] = [:]
     private var pendingProtectedTmuxAttachmentScopesByHandle:
@@ -1562,30 +1584,12 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         nativeTmuxSessionCoordinatorBacking?.onSurfaceReady = {
             [weak self] handle in
-            guard let self,
-                  let presentation = retainedTmuxPresentation(for: handle)
-            else { return }
-            if presentation.reconnectContext?.handleID == handle.id,
-               let routeIdentity = nativeTmuxSessionCoordinator
-               .attachmentRouteIdentity(handle) {
-                presentation.reconnectContext?.routeIdentity = routeIdentity
-            }
-            guard acquireProtectedTmuxAttachmentScopeIfNeeded(
-                for: presentation
-            ) else { return }
-            _ = protectedTmuxSurface(handle: handle)
-            readTmuxPreviewIdentityIfNeeded(presentation)
-            if activeBorrowedTmuxHandle == handle {
-                objectWillChange.send()
-            }
+            self?.tmuxSurfaceBecameReady(handle)
         }
         nativeTmuxSessionCoordinatorBacking?
             .onAttachedSessionIdentityUnavailable = {
                 [weak self] handle in
-                guard let self,
-                      let presentation = retainedTmuxPresentation(for: handle)
-                else { return }
-                readTmuxPreviewIdentityIfNeeded(presentation)
+                self?.tmuxAttachedSessionIdentityBecameUnavailable(handle)
             }
         nativeHerdrSessionCoordinatorBacking = NativeHerdrSessionCoordinator(
             terminalCoordinator: nativeHerdrSurfaceStore
@@ -1807,7 +1811,7 @@ final class WorkspaceSceneModel: ObservableObject {
             sessionPreviewModeCancellable = previewModePublisher?
                 .removeDuplicates()
                 .sink { [weak self] mode in
-                    self?.tmuxSessionPreviewCoordinator.setMode(mode)
+                    self?.sessionPreviewModeDidChange(mode)
                 }
             configuredSSHHostsCancellable = sshHostsPublisher.sink {
                 [weak self] hosts in
@@ -1972,6 +1976,7 @@ final class WorkspaceSceneModel: ObservableObject {
         cancelPendingHerdrShortcutNavigation()
         invalidateZellijPresentationIntent()
         userNavigationRevision &+= 1
+        cancelPendingTmuxPreviewActivations()
         if let worktreeID = newSelection.selectedWorktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
@@ -2453,9 +2458,18 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         sceneActivityGeneration &+= 1
         userNavigationRevision &+= 1
+        alwaysLiveTmuxSurfaceLaunchTask?.cancel()
+        alwaysLiveTmuxSurfaceLaunchTask = nil
+        alwaysLiveTmuxSurfaceLaunchID = nil
+        pendingAlwaysLiveTmuxSurfaceHandles.removeAll()
+        pendingAlwaysLiveTmuxSurfaceHandleIDs.removeAll()
         cancelPendingRestoration()
         cancelPendingHerdrShortcutNavigation()
         for presentation in retainedTmuxPresentations.values {
+            presentation.previewPromotionID = nil
+            presentation.previewPromotionNavigationRevision = nil
+            presentation.previewPromotionTask?.cancel()
+            presentation.previewPromotionTask = nil
             tmuxSessionPreviewCoordinator.remove(
                 TmuxPresentationKey(presentation.selection).previewKey,
                 reason: .close
@@ -3680,6 +3694,11 @@ final class WorkspaceSceneModel: ObservableObject {
             return
         }
 
+        let invalidatedHostIDs = Set(inventoryHosts.compactMap {
+            hostID, previousHost in
+            resolved[hostID] != previousHost ? hostID : nil
+        })
+        invalidateAlwaysLiveTmuxPresentations(for: invalidatedHostIDs)
         let retainedHostIDs = Set(resolved.compactMap { hostID, target in
             inventoryHosts[hostID] == target ? hostID : nil
         })
@@ -5492,6 +5511,7 @@ final class WorkspaceSceneModel: ObservableObject {
             applyRuntimeInventoryOverlayIfNeeded(hostID: hostID)
             updateWorkspaceInventoryState()
             applyDeferredTmuxPresentationsIfReady()
+            reconcileAlwaysLiveTmuxPresentations(hostID: hostID)
         }
     }
 
@@ -5783,6 +5803,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     .removeValue(forKey: handle.id),
                     let presentation = retainedTmuxPresentations
                     .removeValue(forKey: key) {
+                    alwaysLiveManagedTmuxPresentationKeys.remove(key)
                     tmuxSessionPreviewCoordinator.remove(
                         key.previewKey,
                         reason: .replacement
@@ -7399,6 +7420,7 @@ final class WorkspaceSceneModel: ObservableObject {
         cancelPendingRestoration()
         invalidateZellijPresentationIntent()
         userNavigationRevision &+= 1
+        cancelPendingTmuxPreviewActivations()
         if let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.remove(worktreeID)
         }
@@ -7422,6 +7444,227 @@ final class WorkspaceSceneModel: ObservableObject {
             commandReplayAuthorized:
             pendingCreation?.commandReplayAuthorized == true
         )
+    }
+
+    private func sessionPreviewModeDidChange(_ mode: SessionPreviewMode) {
+        let wasAlwaysLive = tmuxSessionPreviewCoordinator.mode == .alwaysLive
+        tmuxSessionPreviewCoordinator.setMode(mode)
+        if mode == .alwaysLive {
+            reconcileAlwaysLiveTmuxPresentations()
+        } else if wasAlwaysLive {
+            closeAlwaysLiveManagedTmuxPresentations()
+        }
+    }
+
+    private func reconcileAlwaysLiveTmuxPresentations(hostID: UUID? = nil) {
+        guard tmuxSessionPreviewCoordinator.mode == .alwaysLive else { return }
+
+        let targetHostIDs = hostID.map { Set([$0]) } ?? tmuxFreshHostIDs
+        for targetHostID in targetHostIDs
+            where tmuxFreshHostIDs.contains(targetHostID) {
+            reconcileAlwaysLiveTmuxPresentations(for: targetHostID)
+        }
+
+        guard hostID == nil else { return }
+        let removedHostSelections = alwaysLiveManagedTmuxPresentationKeys
+            .filter { !inventoryHosts.keys.contains($0.hostID) }
+            .compactMap { retainedTmuxPresentations[$0]?.selection }
+        for selection in removedHostSelections {
+            invalidateBorrowedTmuxSession(selection)
+        }
+    }
+
+    private func invalidateAlwaysLiveTmuxPresentations(
+        for hostIDs: Set<UUID>
+    ) {
+        guard !hostIDs.isEmpty else { return }
+        for key in alwaysLiveIneligibleTmuxPresentationIdentities.keys
+            where hostIDs.contains(key.hostID) {
+            tmuxSessionPreviewCoordinator.remove(
+                key.previewKey,
+                reason: .replacement
+            )
+        }
+        alwaysLiveIneligibleTmuxPresentationIdentities =
+            alwaysLiveIneligibleTmuxPresentationIdentities.filter {
+                !hostIDs.contains($0.key.hostID)
+            }
+        let selections = alwaysLiveManagedTmuxPresentationKeys
+            .filter { hostIDs.contains($0.hostID) }
+            .compactMap { retainedTmuxPresentations[$0]?.selection }
+        for selection in selections {
+            invalidateBorrowedTmuxSession(selection)
+        }
+    }
+
+    private func reconcileAlwaysLiveTmuxPresentations(for hostID: UUID) {
+        let supportsNonSizingClients = snapshot.host(id: hostID).map {
+            $0.platform != .windows
+        } ?? false
+        let sessions = (supportsNonSizingClients
+            ? tmuxSessionsByHost[hostID]?.filter {
+                $0.previewClientSize != nil && $0.hasStableIdentity
+            } ?? []
+            : []).sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+        let selections = sessions.map {
+            alwaysLiveTmuxSelection(hostID: hostID, name: $0.name)
+        }
+        let desiredKeys = Set(selections.map(TmuxPresentationKey.init))
+        let desiredIdentities = Dictionary(uniqueKeysWithValues:
+            zip(sessions, selections).compactMap { session, selection in
+                Self.tmuxSessionIdentity(session).map {
+                    (TmuxPresentationKey(selection), $0)
+                }
+            })
+        for key in alwaysLiveIneligibleTmuxPresentationIdentities.keys
+            where key.hostID == hostID && !desiredKeys.contains(key) {
+            tmuxSessionPreviewCoordinator.remove(
+                key.previewKey,
+                reason: .replacement
+            )
+        }
+        alwaysLiveIneligibleTmuxPresentationIdentities =
+            alwaysLiveIneligibleTmuxPresentationIdentities.filter {
+                $0.key.hostID != hostID
+                    || desiredIdentities[$0.key] == $0.value
+            }
+        let obsoleteSelections = alwaysLiveManagedTmuxPresentationKeys
+            .filter { $0.hostID == hostID && !desiredKeys.contains($0) }
+            .compactMap { retainedTmuxPresentations[$0]?.selection }
+        for selection in obsoleteSelections {
+            invalidateBorrowedTmuxSession(selection)
+        }
+
+        for (session, selection) in zip(sessions, selections) {
+            let key = TmuxPresentationKey(selection)
+            guard let discoveredIdentity = desiredIdentities[key],
+                  alwaysLiveIneligibleTmuxPresentationIdentities[key]
+                  != discoveredIdentity
+            else { continue }
+            if let retained = retainedTmuxPresentations[key],
+               !nativeTmuxSessionCoordinator.hasClosedAttachment(
+                   retained.handle
+               ),
+               let attachedIdentity = retained.expectedPreviewIdentity,
+               attachedIdentity != discoveredIdentity {
+                invalidateBorrowedTmuxSession(retained.selection)
+            }
+            let wasRetained = retainedTmuxPresentations[key] != nil
+            guard let handle = presentTmuxSession(
+                selection,
+                launchMode: .attachOnly,
+                intent: .restoreOnly,
+                activatesPresentation: false,
+                ignoresClientSize: true,
+                previewGridSize: session.previewClientSize
+            ) else { continue }
+            if !wasRetained {
+                alwaysLiveManagedTmuxPresentationKeys.insert(key)
+            }
+            if alwaysLiveManagedTmuxPresentationKeys.contains(key) {
+                nativeTmuxSessionCoordinator.updatePreviewGridSize(
+                    session.previewClientSize,
+                    for: handle
+                )
+            }
+            guard canAttachToDisplay,
+                  let presentation = retainedTmuxPresentation(for: handle)
+            else { continue }
+            if nativeTmuxSessionCoordinator.hasClosedAttachment(handle) {
+                guard activeBorrowedTmuxHandle != handle,
+                      let host = snapshot.host(id: selection.hostID),
+                      let discoveredIdentity = Self
+                      .discoveredTmuxSessionIdentity(
+                          selection,
+                          hostSummary: host
+                      ),
+                      discoveredIdentity
+                      != presentation.reconnectExpectedIdentity
+                      || nativeTmuxSessionCoordinator
+                      .attachmentClosure(handle) == .surfaceUnavailable
+                else { continue }
+                // A closed hidden client stays closed for the same server-side
+                // session. This respects an explicit detach and prevents a
+                // persistent attach failure from becoming a spawn loop. A
+                // same-name session with a new stable identity gets one fresh
+                // attachment attempt, and a retryable surface failure (no
+                // display during creation) relaunches display-gated, one
+                // attempt per inventory pass.
+                presentation.reconnectExpectedIdentity = discoveredIdentity
+                relaunchTmuxSession(
+                    presentation,
+                    launchMode: .attachOnly,
+                    intent: .restoreOnly
+                )
+            } else if !nativeTmuxSessionCoordinator.hasLaunched(handle) {
+                // A pending promotion owns this handle's sizing transition.
+                // Launching now could attach a hidden client between the
+                // interactive-sizing commit and the preview restore, letting
+                // it resize the shared tmux session. The promotion re-drives
+                // readiness when it settles.
+                guard !presentation.previewPromotionIsPending else { continue }
+                enqueueAlwaysLiveTmuxSurface(handle)
+            } else {
+                _ = protectedTmuxSurface(handle: handle)
+            }
+        }
+    }
+
+    private func alwaysLiveTmuxSelection(
+        hostID: UUID,
+        name: String
+    ) -> WorkspaceTmuxSessionSelection {
+        if let worktree = snapshot.worktrees.first(where: {
+            $0.hostID == hostID
+                && !$0.isStale
+                && $0.tmuxSocketName == nil
+                && $0.tmuxSessionName == name
+        }),
+            let selection = WorkspaceSidebarModel.tmuxSessionSelection(
+                for: worktree
+            ) {
+            return selection
+        }
+        if let workspace = snapshot.directoryWorkspaces.first(where: {
+            $0.hostID == hostID && $0.tmuxSessionName == name
+        }) {
+            return WorkspaceSidebarModel.tmuxSessionSelection(for: workspace)
+        }
+        return WorkspaceTmuxSessionSelection(hostID: hostID, name: name)
+    }
+
+    private func closeAlwaysLiveManagedTmuxPresentations() {
+        alwaysLiveTmuxSurfaceLaunchTask?.cancel()
+        alwaysLiveTmuxSurfaceLaunchTask = nil
+        alwaysLiveTmuxSurfaceLaunchID = nil
+        pendingAlwaysLiveTmuxSurfaceHandles.removeAll()
+        pendingAlwaysLiveTmuxSurfaceHandleIDs.removeAll()
+        var pendingPromotionKeys: Set<TmuxPresentationKey> = []
+        let selections: [WorkspaceTmuxSessionSelection] =
+            alwaysLiveManagedTmuxPresentationKeys.compactMap {
+                guard let presentation = retainedTmuxPresentations[$0] else {
+                    return nil
+                }
+                if presentation.handle == activeBorrowedTmuxHandle
+                    || presentation.previewPromotionIsPending {
+                    if presentation.previewPromotionIsPending {
+                        pendingPromotionKeys.insert($0)
+                    }
+                    return nil
+                }
+                return presentation.selection
+            }
+        for selection in selections {
+            tmuxSessionPreviewCoordinator.setExpanded(
+                false,
+                for: TmuxPresentationKey(selection).previewKey
+            )
+            invalidateBorrowedTmuxSession(selection)
+        }
+        alwaysLiveManagedTmuxPresentationKeys = pendingPromotionKeys
+        alwaysLiveIneligibleTmuxPresentationIdentities.removeAll()
     }
 
     func borrowedHerdrSessionView(
@@ -7562,6 +7805,7 @@ final class WorkspaceSceneModel: ObservableObject {
             return
         }
         cancelPendingRestoration()
+        cancelPendingTmuxPreviewActivations()
         validateAndPresentZellijSession(selection)
     }
 
@@ -7686,6 +7930,7 @@ final class WorkspaceSceneModel: ObservableObject {
                   zellijSessionKillCoordinator.revision(for: killKey) == $0
               }) ?? true
         else { return nil }
+        cancelPendingTmuxPreviewActivations()
         if activeBorrowedZellijSelection == selection,
            let handle = activeBorrowedZellijHandle,
            nativeZellijSessionCoordinator.attachmentClosure(handle) == nil {
@@ -8137,6 +8382,7 @@ final class WorkspaceSceneModel: ObservableObject {
         _ selection: WorkspaceHerdrSessionSelection
     ) async throws {
         invalidateZellijPresentationIntent()
+        cancelPendingTmuxPreviewActivations()
         let activityGeneration = try captureSceneActivity()
         let navigationRevision = userNavigationRevision
         guard snapshot.host(id: selection.hostID)?.herdrSessions.contains(
@@ -8591,6 +8837,7 @@ final class WorkspaceSceneModel: ObservableObject {
         validation: HerdrSessionValidation? = nil
     ) -> BorrowedHerdrSessionHandle? {
         guard !isShutDown else { return nil }
+        cancelPendingTmuxPreviewActivations()
         if let activeTmux = activeBorrowedTmuxSelection {
             hideBorrowedTmuxSession(activeTmux)
         }
@@ -8904,12 +9151,18 @@ final class WorkspaceSceneModel: ObservableObject {
         initialCommand: String? = nil,
         commandReplayAuthorized: Bool = false,
         intent: TmuxPresentationIntent = .userInitiated,
-        activatesPresentation: Bool = true
+        activatesPresentation: Bool = true,
+        ignoresClientSize: Bool = false,
+        previewGridSize: TmuxGridSize? = nil
     ) -> BorrowedTmuxSessionHandle? {
-        if let activeHerdr = activeBorrowedHerdrSelection {
+        if activatesPresentation {
+            cancelPendingTmuxPreviewActivations()
+        }
+        if activatesPresentation, let activeHerdr = activeBorrowedHerdrSelection {
             closeBorrowedHerdrSession(activeHerdr)
         }
-        if let activeZellij = activeBorrowedZellijSelection {
+        if activatesPresentation,
+           let activeZellij = activeBorrowedZellijSelection {
             closeBorrowedZellijSession(activeZellij)
         }
         var selection = selection
@@ -8937,14 +9190,11 @@ final class WorkspaceSceneModel: ObservableObject {
                         retained,
                         selection
                     )
-                    let generationChanged = if let retainedGeneration =
-                        retained.worktreeGeneration,
-                        let selectionGeneration = selection
-                        .worktreeGeneration {
-                        retainedGeneration != selectionGeneration
-                    } else {
-                        false
-                    }
+                    let generationChanged = Self
+                        .hasDifferentKnownWorktreeGeneration(
+                            retained,
+                            selection
+                        )
                     return endpointChanged || generationChanged
                         ? retained
                         : nil
@@ -8995,6 +9245,15 @@ final class WorkspaceSceneModel: ObservableObject {
                     }
                 }
                 if activatesPresentation {
+                    if alwaysLiveManagedTmuxPresentationKeys.contains(key) {
+                        stageTmuxPresentationActivation(retained)
+                        promoteAlwaysLiveManagedPresentation(
+                            retained,
+                            key: key,
+                            navigationRevision: userNavigationRevision
+                        )
+                        return retained.handle
+                    }
                     activateTmuxPresentation(retained)
                 }
                 return retained.handle
@@ -9044,7 +9303,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 : nil,
             workingDirectory: selection.workspacePath,
             openWorkspace: openWorkspace,
-            sessionIdentity: discoveredIdentity
+            sessionIdentity: discoveredIdentity,
+            ignoresClientSize: ignoresClientSize,
+            previewGridSize: previewGridSize
         )
         let phase: RemoteTmuxEstablishmentPhase
         if openWorkspace || protectedSessionNeedsEstablishment {
@@ -9110,6 +9371,171 @@ final class WorkspaceSceneModel: ObservableObject {
         return handle
     }
 
+    private func promoteAlwaysLiveManagedPresentation(
+        _ presentation: RetainedTmuxPresentation,
+        key: TmuxPresentationKey,
+        navigationRevision: UInt64,
+        resumesProvisioning: Bool = false
+    ) {
+        presentation.previewPromotionNavigationRevision = navigationRevision
+        if !resumesProvisioning {
+            presentation.pendingPreviewPromotionNavigationRevision =
+                navigationRevision
+        }
+        pendingAlwaysLiveTmuxSurfaceHandleIDs.remove(presentation.handle.id)
+        pendingAlwaysLiveTmuxSurfaceHandles.removeAll {
+            $0.id == presentation.handle.id
+        }
+        guard presentation.previewPromotionTask == nil else { return }
+        let promotionID = UUID()
+        presentation.previewPromotionID = promotionID
+        presentation.previewPromotionTask = Task { @MainActor [weak self, weak presentation] in
+            guard let self, let presentation else { return }
+            defer {
+                if presentation.previewPromotionID == promotionID {
+                    presentation.previewPromotionID = nil
+                    presentation.previewPromotionTask = nil
+                    let provisioningFinished = presentation
+                        .pendingPreviewPromotionNavigationRevision != nil
+                        && !nativeTmuxSessionCoordinator.isProvisioning(
+                            presentation.handle
+                        )
+                    let restoredManagedPreview =
+                        alwaysLiveManagedTmuxPresentationKeys.contains(key)
+                            && !nativeTmuxSessionCoordinator.isProvisioning(
+                                presentation.handle
+                            )
+                            && !nativeTmuxSessionCoordinator.hasLaunched(
+                                presentation.handle
+                            )
+                    if resumesProvisioning || provisioningFinished
+                        || restoredManagedPreview,
+                        retainedTmuxPresentations[key] === presentation {
+                        tmuxSurfaceBecameReady(presentation.handle)
+                    }
+                }
+            }
+
+            while !Task.isCancelled {
+                var promotionResult: TmuxClientSizingTransitionResult
+                repeat {
+                    promotionResult = await nativeTmuxSessionCoordinator
+                        .enableInteractiveSizing(for: presentation.handle)
+                    guard !Task.isCancelled,
+                          presentation.previewPromotionID == promotionID,
+                          retainedTmuxPresentations[key] === presentation,
+                          alwaysLiveManagedTmuxPresentationKeys.contains(key)
+                    else { return }
+                } while promotionResult == .stale
+                switch promotionResult {
+                case .applied:
+                    presentation.pendingPreviewPromotionNavigationRevision = nil
+                case .pending:
+                    return
+                case .stale:
+                    return
+                case let .failure(failure):
+                    presentation.pendingPreviewPromotionNavigationRevision = nil
+                    let retriesInteractiveAttachment =
+                        presentation.previewPromotionNavigationRevision
+                            == userNavigationRevision
+                    let selection = presentation.selection
+                    presentation.previewPromotionNavigationRevision = nil
+                    excludeAlwaysLiveTmuxPresentation(
+                        presentation,
+                        key: key
+                    )
+                    AppLogger.shared.error(
+                        "tmux preview promotion: "
+                            + failure.localizedDescription,
+                        context: "tmux"
+                    )
+                    if retriesInteractiveAttachment {
+                        openBorrowedTmuxSession(selection)
+                    }
+                    return
+                }
+
+                if tmuxPresentationActivationIsPending(presentation) {
+                    presentation.previewPromotionNavigationRevision = nil
+                    activateTmuxPresentation(presentation)
+                    alwaysLiveManagedTmuxPresentationKeys.remove(key)
+                    pendingAlwaysLiveTmuxSurfaceHandleIDs.remove(
+                        presentation.handle.id
+                    )
+                    pendingAlwaysLiveTmuxSurfaceHandles.removeAll {
+                        $0.id == presentation.handle.id
+                    }
+                    return
+                }
+
+                presentation.previewPromotionNavigationRevision = nil
+                if activeBorrowedTmuxHandle == presentation.handle {
+                    alwaysLiveManagedTmuxPresentationKeys.remove(key)
+                    pendingAlwaysLiveTmuxSurfaceHandleIDs.remove(
+                        presentation.handle.id
+                    )
+                    pendingAlwaysLiveTmuxSurfaceHandles.removeAll {
+                        $0.id == presentation.handle.id
+                    }
+                    return
+                }
+                var restoreResult: TmuxClientSizingTransitionResult
+                repeat {
+                    restoreResult = await nativeTmuxSessionCoordinator
+                        .restorePreviewSizing(
+                            previewGridSize(for: presentation.selection),
+                            for: presentation.handle
+                        )
+                    guard !Task.isCancelled,
+                          presentation.previewPromotionID == promotionID,
+                          retainedTmuxPresentations[key] === presentation,
+                          alwaysLiveManagedTmuxPresentationKeys.contains(key)
+                    else { return }
+                } while restoreResult == .stale
+                if case let .failure(failure) = restoreResult {
+                    excludeAlwaysLiveTmuxPresentation(
+                        presentation,
+                        key: key
+                    )
+                    AppLogger.shared.error(
+                        "tmux preview sizing restore: "
+                            + failure.localizedDescription,
+                        context: "tmux"
+                    )
+                    return
+                }
+                if tmuxSessionPreviewCoordinator.mode != .alwaysLive,
+                   activeBorrowedTmuxHandle != presentation.handle,
+                   !tmuxPresentationActivationIsPending(presentation) {
+                    invalidateBorrowedTmuxSession(presentation.selection)
+                    return
+                }
+                guard presentation.previewPromotionNavigationRevision
+                    == userNavigationRevision
+                    || activeBorrowedTmuxHandle == presentation.handle
+                    || tmuxPresentationActivationIsPending(presentation)
+                else { return }
+            }
+        }
+    }
+
+    private func cancelPendingTmuxPreviewActivations() {
+        for presentation in retainedTmuxPresentations.values {
+            presentation.previewPromotionNavigationRevision = nil
+        }
+    }
+
+    private func previewGridSize(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> TmuxGridSize? {
+        let sessions = tmuxSessionsByHost[selection.hostID]
+            ?? snapshot.host(id: selection.hostID)?.tmuxSessions
+        return sessions?.first {
+            $0.name == selection.name
+        }?.previewClientSize
+    }
+
     private func retainedTmuxPresentation(
         for handle: BorrowedTmuxSessionHandle
     ) -> RetainedTmuxPresentation? {
@@ -9150,6 +9576,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 connectionState: { [weak self, weak presentation] in
                     guard let self, let presentation else { return nil }
                     return borrowedTmuxConnectionStates[presentation.handle.id]
+                },
+                hasLaunched: { [weak self, weak presentation] in
+                    guard let self, let presentation else { return false }
+                    return nativeTmuxSessionCoordinator.hasLaunched(
+                        presentation.handle
+                    )
                 },
                 isActive: { [weak self, weak presentation] in
                     guard let self, let presentation else { return false }
@@ -9209,6 +9641,25 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
+    func tmuxAttachedSessionIdentityBecameUnavailable(
+        _ handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let presentation = retainedTmuxPresentation(for: handle) else {
+            return
+        }
+        if presentation.reconnectContext?.handleID == handle.id,
+           let routeIdentity = nativeTmuxSessionCoordinator
+           .attachmentRouteIdentity(handle) {
+            presentation.reconnectContext?.routeIdentity = routeIdentity
+        }
+        let key = TmuxPresentationKey(presentation.selection)
+        if alwaysLiveManagedTmuxPresentationKeys.contains(key) {
+            excludeAlwaysLiveTmuxPresentation(presentation, key: key)
+            return
+        }
+        readTmuxPreviewIdentityIfNeeded(presentation)
+    }
+
     private func revalidateTmuxPreviewIdentity(
         _ presentation: RetainedTmuxPresentation
     ) async -> TmuxSessionIdentity? {
@@ -9227,6 +9678,20 @@ final class WorkspaceSceneModel: ObservableObject {
               presentation.verifiedPreviewIdentity == expectedIdentity
         else { return nil }
         guard currentIdentity == expectedIdentity else {
+            // A managed hidden client that switched sessions must be
+            // released, not just marked unavailable: clearing the verified
+            // identity below would blind reconciliation to the mismatch and
+            // leave the client attached under a permanently dead tile.
+            // Exclusion records the expected identity, so a recreated
+            // session gets one fresh attachment attempt.
+            if alwaysLiveManagedTmuxPresentationKeys.contains(key) {
+                excludeAlwaysLiveTmuxPresentation(
+                    presentation,
+                    key: key,
+                    previewRemovalReason: .identityMismatch
+                )
+                return nil
+            }
             presentation.previewIdentityUnavailable = true
             presentation.verifiedPreviewIdentity = nil
             registerTmuxPreview(
@@ -9272,6 +9737,126 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
             }
         )
+    }
+
+    private func tmuxSurfaceBecameReady(
+        _ handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let presentation = retainedTmuxPresentation(for: handle) else {
+            return
+        }
+        if presentation.reconnectContext?.handleID == handle.id,
+           let routeIdentity = nativeTmuxSessionCoordinator
+           .attachmentRouteIdentity(handle) {
+            presentation.reconnectContext?.routeIdentity = routeIdentity
+        }
+        let key = TmuxPresentationKey(presentation.selection)
+        // Resume a pending user promotion before the preview-support
+        // filter: a session the user explicitly opened during provisioning
+        // must become an ordinary interactive attachment even when the
+        // resolved tmux version cannot host automatic previews. A stale
+        // promotion restores preview sizing and re-drives readiness, so a
+        // still-managed unsupported preview reaches the exclusion below.
+        if let navigationRevision = presentation
+            .pendingPreviewPromotionNavigationRevision {
+            guard presentation.previewPromotionTask == nil else { return }
+            presentation.pendingPreviewPromotionNavigationRevision = nil
+            promoteAlwaysLiveManagedPresentation(
+                presentation,
+                key: key,
+                navigationRevision: navigationRevision,
+                resumesProvisioning: true
+            )
+            return
+        }
+        if alwaysLiveManagedTmuxPresentationKeys.contains(key),
+           !nativeTmuxSessionCoordinator.supportsPaneSplitting(handle) {
+            excludeAlwaysLiveTmuxPresentation(presentation, key: key)
+            return
+        }
+        if alwaysLiveManagedTmuxPresentationKeys.contains(key),
+           activeBorrowedTmuxHandle != handle,
+           !nativeTmuxSessionCoordinator.hasLaunched(handle) {
+            enqueueAlwaysLiveTmuxSurface(handle)
+            return
+        }
+        finishTmuxSurfaceReadiness(handle)
+    }
+
+    private func excludeAlwaysLiveTmuxPresentation(
+        _ presentation: RetainedTmuxPresentation,
+        key: TmuxPresentationKey,
+        previewRemovalReason: TmuxSessionPreviewCoordinator.RemovalReason =
+            .replacement
+    ) {
+        if let identity = presentation.expectedPreviewIdentity {
+            alwaysLiveIneligibleTmuxPresentationIdentities[key] = identity
+        }
+        invalidateBorrowedTmuxSession(
+            presentation.selection,
+            previewRemovalReason: previewRemovalReason
+        )
+    }
+
+    private func enqueueAlwaysLiveTmuxSurface(
+        _ handle: BorrowedTmuxSessionHandle
+    ) {
+        guard pendingAlwaysLiveTmuxSurfaceHandleIDs.insert(handle.id).inserted
+        else { return }
+        pendingAlwaysLiveTmuxSurfaceHandles.append(handle)
+        startAlwaysLiveTmuxSurfaceLaunchIfNeeded()
+    }
+
+    private func startAlwaysLiveTmuxSurfaceLaunchIfNeeded() {
+        guard canAttachToDisplay,
+              !pendingAlwaysLiveTmuxSurfaceHandles.isEmpty,
+              alwaysLiveTmuxSurfaceLaunchTask == nil
+        else { return }
+        let launchID = UUID()
+        alwaysLiveTmuxSurfaceLaunchID = launchID
+        alwaysLiveTmuxSurfaceLaunchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if alwaysLiveTmuxSurfaceLaunchID == launchID {
+                    alwaysLiveTmuxSurfaceLaunchTask = nil
+                    alwaysLiveTmuxSurfaceLaunchID = nil
+                }
+            }
+            while !Task.isCancelled,
+                  canAttachToDisplay,
+                  !pendingAlwaysLiveTmuxSurfaceHandles.isEmpty {
+                let next = pendingAlwaysLiveTmuxSurfaceHandles.removeFirst()
+                pendingAlwaysLiveTmuxSurfaceHandleIDs.remove(next.id)
+                finishTmuxSurfaceReadiness(next)
+                if !pendingAlwaysLiveTmuxSurfaceHandles.isEmpty {
+                    do {
+                        // Give AppKit a render opportunity between expensive
+                        // libghostty surface creations for large fleets.
+                        try await Task.sleep(for: .milliseconds(10))
+                    } catch {
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    private func finishTmuxSurfaceReadiness(
+        _ handle: BorrowedTmuxSessionHandle
+    ) {
+        guard let presentation = retainedTmuxPresentation(for: handle),
+              acquireProtectedTmuxAttachmentScopeIfNeeded(
+                  for: presentation
+              )
+        else { return }
+        _ = protectedTmuxSurface(handle: handle)
+        tmuxSessionPreviewCoordinator.presentationDidChange(
+            TmuxPresentationKey(presentation.selection).previewKey
+        )
+        readTmuxPreviewIdentityIfNeeded(presentation)
+        if activeBorrowedTmuxHandle == handle {
+            objectWillChange.send()
+        }
     }
 
     private func protectedTmuxSurface(
@@ -9393,6 +9978,12 @@ final class WorkspaceSceneModel: ObservableObject {
                           .tmuxSessionSelection(for: worktree),
                           Self.sameTmuxEndpoint(retained, current)
                     else { return retained }
+                    if Self.hasDifferentKnownWorktreeGeneration(
+                        retained,
+                        current
+                    ) {
+                        return retained
+                    }
                     if retained.worktreeGeneration == nil,
                        let canonicalGeneration = WorktreeGeneration.canonical(
                            current.worktreeGeneration
@@ -9402,11 +9993,6 @@ final class WorkspaceSceneModel: ObservableObject {
                         if activeBorrowedTmuxHandle == presentation.handle {
                             activeBorrowedTmuxSelection = retained
                         }
-                    }
-                    if let retainedGeneration = retained.worktreeGeneration,
-                       let currentGeneration = current.worktreeGeneration,
-                       retainedGeneration != currentGeneration {
-                        return retained
                     }
                     return nil
                 }
@@ -9474,6 +10060,27 @@ final class WorkspaceSceneModel: ObservableObject {
                 commitTmuxPresentationActivation(presentation)
             }
         )
+    }
+
+    private func stageTmuxPresentationActivation(
+        _ presentation: RetainedTmuxPresentation
+    ) {
+        if let activeHandle = activeBorrowedTmuxHandle,
+           activeHandle != presentation.handle {
+            prepareActiveTmuxPreviewForDeactivation()
+        }
+        activeBorrowedTmuxSelection = presentation.selection
+        activeBorrowedTmuxHandle = nil
+        activeBorrowedTmuxLaunchMode = presentation.launchMode
+        activeBorrowedTmuxRecoveryState = presentation.recoveryState
+        sessionConnectionRecoveryRequest = presentation.recoveryRequest
+    }
+
+    private func tmuxPresentationActivationIsPending(
+        _ presentation: RetainedTmuxPresentation
+    ) -> Bool {
+        activeBorrowedTmuxSelection == presentation.selection
+            && activeBorrowedTmuxHandle == nil
     }
 
     private func commitTmuxPresentationActivation(
@@ -9553,6 +10160,18 @@ final class WorkspaceSceneModel: ObservableObject {
             && lhs.worktreeGeneration == rhs.worktreeGeneration
     }
 
+    private static func hasDifferentKnownWorktreeGeneration(
+        _ lhs: WorkspaceTmuxSessionSelection,
+        _ rhs: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        guard lhs.worktreeID != nil,
+              lhs.worktreeID == rhs.worktreeID,
+              let lhsGeneration = lhs.worktreeGeneration,
+              let rhsGeneration = rhs.worktreeGeneration
+        else { return false }
+        return lhsGeneration != rhsGeneration
+    }
+
     /// Kill targets a live tmux endpoint; inventory can change the owning
     /// worktree generation while that endpoint keeps running, so kill
     /// probing and cleanup must not compare generations.
@@ -9603,6 +10222,7 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     func closeBorrowedTmuxSession(_ selection: WorkspaceTmuxSessionSelection) {
+        cancelPendingRestoration()
         closeBorrowedTmuxSession(
             selection,
             recordsExplicitDismissal: true,
@@ -9611,12 +10231,14 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func invalidateBorrowedTmuxSession(
-        _ selection: WorkspaceTmuxSessionSelection
+        _ selection: WorkspaceTmuxSessionSelection,
+        previewRemovalReason: TmuxSessionPreviewCoordinator.RemovalReason =
+            .replacement
     ) {
         closeBorrowedTmuxSession(
             selection,
             recordsExplicitDismissal: false,
-            previewRemovalReason: .replacement
+            previewRemovalReason: previewRemovalReason
         )
     }
 
@@ -9625,7 +10247,6 @@ final class WorkspaceSceneModel: ObservableObject {
         recordsExplicitDismissal: Bool,
         previewRemovalReason: TmuxSessionPreviewCoordinator.RemovalReason
     ) {
-        cancelPendingRestoration()
         if recordsExplicitDismissal, let worktreeID = selection.worktreeID {
             explicitlyDismissedWorktreePresentationIDs.insert(worktreeID)
         }
@@ -9634,6 +10255,18 @@ final class WorkspaceSceneModel: ObservableObject {
             explicitlyDismissedDirectoryPresentationIDs.insert(directoryID)
         }
         let key = TmuxPresentationKey(selection)
+        if recordsExplicitDismissal,
+           tmuxSessionPreviewCoordinator.mode == .alwaysLive,
+           let identity = retainedTmuxPresentations[key]?
+           .expectedPreviewIdentity {
+            alwaysLiveIneligibleTmuxPresentationIdentities[key] = identity
+        }
+        alwaysLiveManagedTmuxPresentationKeys.remove(key)
+        retainedTmuxPresentations[key]?.previewPromotionID = nil
+        retainedTmuxPresentations[key]?
+            .previewPromotionNavigationRevision = nil
+        retainedTmuxPresentations[key]?.previewPromotionTask?.cancel()
+        retainedTmuxPresentations[key]?.previewPromotionTask = nil
         if activeBorrowedTmuxSelection == selection {
             prepareActiveTmuxPreviewForDeactivation()
         }
@@ -9870,8 +10503,15 @@ final class WorkspaceSceneModel: ObservableObject {
         guard selection.socketName == nil,
               let summary = hostSummary.tmuxSessions.first(where: {
                   $0.name == selection.name
-              }),
-              summary.hasStableIdentity,
+              })
+        else { return nil }
+        return tmuxSessionIdentity(summary)
+    }
+
+    private static func tmuxSessionIdentity(
+        _ summary: TmuxSessionSummary
+    ) -> TmuxSessionIdentity? {
+        guard summary.hasStableIdentity,
               let serverPID = summary.serverPID,
               let sessionID = summary.sessionID,
               let createdAt = summary.createdAt
@@ -9917,6 +10557,19 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         borrowedTmuxConnectionStates[handle.id] = state
         guard let presentation = retainedTmuxPresentation(for: handle) else {
+            return
+        }
+        let key = TmuxPresentationKey(presentation.selection)
+        if case .disconnected = state,
+           alwaysLiveManagedTmuxPresentationKeys.contains(key),
+           !nativeTmuxSessionCoordinator.hasLaunched(handle),
+           nativeTmuxSessionCoordinator.attachmentClosure(handle)
+           != .surfaceUnavailable {
+            // Identity exclusion is for permanent launch and setup failures.
+            // A retryable surface failure (for example the display vanished
+            // during creation) keeps the policy-owned presentation so
+            // reconciliation can relaunch it once a display returns.
+            excludeAlwaysLiveTmuxPresentation(presentation, key: key)
             return
         }
         if case .disconnected = state {
@@ -10861,6 +11514,8 @@ final class WorkspaceSceneModel: ObservableObject {
         if zellijReconnectSupervisor.isRunning {
             zellijReconnectSupervisor.reconnectNow()
         }
+        reconcileAlwaysLiveTmuxPresentations()
+        startAlwaysLiveTmuxSurfaceLaunchIfNeeded()
     }
 
     private func attemptTmuxReconnect(
@@ -11351,6 +12006,12 @@ final class WorkspaceSceneModel: ObservableObject {
             && selection.workspacePath != nil
         let previousHandle = presentation.handle
         let routeIdentity = presentation.reconnectContext?.routeIdentity
+        let presentationKey = TmuxPresentationKey(selection)
+        let isAlwaysLiveManaged = alwaysLiveManagedTmuxPresentationKeys
+            .contains(presentationKey)
+        let previewGridSize = (tmuxSessionsByHost[selection.hostID]
+            ?? host.tmuxSessions).first { $0.name == selection.name }?
+            .previewClientSize
         let handle = nativeTmuxSessionCoordinator.attach(
             hostID: selection.hostID,
             name: selection.name,
@@ -11361,7 +12022,10 @@ final class WorkspaceSceneModel: ObservableObject {
             workingDirectory: selection.workspacePath,
             openWorkspace: openWorkspace,
             sessionIdentity: presentation.reconnectExpectedIdentity,
-            expectedRouteIdentity: routeIdentity
+            expectedRouteIdentity: routeIdentity,
+            ignoresClientSize: isAlwaysLiveManaged
+                && host.platform != .windows,
+            previewGridSize: isAlwaysLiveManaged ? previewGridSize : nil
         )
         if handle.id != previousHandle.id {
             retainedTmuxPresentationKeysByHandle.removeValue(
@@ -11907,7 +12571,9 @@ final class WorkspaceSceneModel: ObservableObject {
                 },
                 serverPID: session.serverPID,
                 sessionID: session.sessionID,
-                createdAt: session.createdAt
+                createdAt: session.createdAt,
+                activeWindowSize: session.activeWindowSize,
+                previewClientSize: session.previewClientSize
             )
         }
         let discoveredNames = Set(summaries.map(\.name))

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -938,14 +938,14 @@ struct WorkspaceWindow: View {
                 },
                 tmuxSessionPreviewBuilder: {
                     [sceneModel] selection, activate in
-                    AnyView(TmuxSessionPreviewTile(
-                        coordinator:
-                        sceneModel.tmuxSessionPreviewCoordinator,
-                        key: TmuxPreviewKey(
-                            hostID: selection.hostID,
-                            name: selection.name,
-                            socketName: selection.socketName
-                        ),
+                    let key = TmuxPreviewKey(
+                        hostID: selection.hostID,
+                        name: selection.name,
+                        socketName: selection.socketName
+                    )
+                    return AnyView(TmuxSessionPreviewTile(
+                        viewModel: sceneModel.tmuxSessionPreviewCoordinator
+                            .viewModel(for: key),
                         sessionName: selection.name,
                         onActivate: activate
                     ))

--- a/Sources/Settings/SessionPreviewMode.swift
+++ b/Sources/Settings/SessionPreviewMode.swift
@@ -2,6 +2,7 @@ public enum SessionPreviewMode: String, CaseIterable, Identifiable, Sendable {
     case off
     case efficient
     case live
+    case alwaysLive = "always-live"
 
     public var id: Self { self }
 
@@ -13,6 +14,16 @@ public enum SessionPreviewMode: String, CaseIterable, Identifiable, Sendable {
             "Efficient"
         case .live:
             "Live"
+        case .alwaysLive:
+            "Always Live"
         }
+    }
+
+    public var usesLiveRefresh: Bool {
+        self == .live || self == .alwaysLive
+    }
+
+    public var expandsEverySession: Bool {
+        self == .alwaysLive
     }
 }

--- a/Sources/Terminal/LivePreviewParkingHost.swift
+++ b/Sources/Terminal/LivePreviewParkingHost.swift
@@ -12,6 +12,7 @@ public final class LivePreviewParkingHost: NSView {
     }
 
     private var geometryBySurface: [ObjectIdentifier: Geometry] = [:]
+    private var renderingSuspended = false
 
     override public init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -52,8 +53,8 @@ public final class LivePreviewParkingHost: NSView {
         )
         surface.setParkedForPreview(true)
         addSubview(surface)
-        surface.bounds = geometry.bounds
-        surface.frame = geometry.frame
+        surface.completePreviewParkingMount()
+        surface.setPreviewRenderingSuspended(renderingSuspended)
         geometryBySurface[identifier] = geometry
     }
 
@@ -68,6 +69,10 @@ public final class LivePreviewParkingHost: NSView {
         let geometry = geometryBySurface.removeValue(
             forKey: ObjectIdentifier(surface)
         )
+        // Stop libghostty before AppKit mutates the layer hierarchy. The
+        // renderer reads CALayer geometry independently; letting it draw
+        // during removal can expose transient invalid bounds.
+        surface.setPreviewRenderingSuspended(true)
         surface.removeFromSuperview()
         if let geometry {
             surface.bounds = geometry.bounds
@@ -86,6 +91,16 @@ public final class LivePreviewParkingHost: NSView {
 
     public func contains(_ surface: TerminalSurfaceView) -> Bool {
         surface.superview === self
+    }
+
+    public func setRenderingSuspended(_ suspended: Bool) {
+        guard renderingSuspended != suspended else { return }
+        renderingSuspended = suspended
+        for surface in subviews.compactMap({
+            $0 as? TerminalSurfaceView
+        }) {
+            surface.setPreviewRenderingSuspended(suspended)
+        }
     }
 
     private func configure() {

--- a/Sources/Terminal/TerminalSurfacePreviewView.swift
+++ b/Sources/Terminal/TerminalSurfacePreviewView.swift
@@ -1,0 +1,43 @@
+import AppKit
+import QuartzCore
+
+/// Presents a GPU-produced terminal thumbnail through Core Animation.
+@MainActor
+public final class TerminalSurfacePreviewView: NSView {
+    override public init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        let previewLayer = CALayer()
+        previewLayer.backgroundColor = NSColor.black.cgColor
+        previewLayer.contentsGravity = .resize
+        previewLayer.minificationFilter = .linear
+        previewLayer.magnificationFilter = .linear
+        previewLayer.actions = [
+            "bounds": NSNull(),
+            "contents": NSNull(),
+            "contentsScale": NSNull(),
+            "position": NSNull(),
+        ]
+        layer = previewLayer
+        wantsLayer = true
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func display(_ frame: TerminalSurfacePreviewFrame?) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.contents = frame?.ioSurface
+        CATransaction.commit()
+    }
+
+    override public func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        layer?.contentsScale = window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 1
+    }
+}

--- a/Sources/Terminal/TerminalSurfaceSnapshotter.swift
+++ b/Sources/Terminal/TerminalSurfaceSnapshotter.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreImage
 import CoreVideo
 import GhosthubTerminalSupport
 import IOSurface
@@ -7,7 +8,9 @@ import Metal
 public enum TerminalSurfaceSnapshotError: Error, Equatable {
     case invalidOutputSize
     case missingIOSurface
-    case imageCopyFailed
+    case gpuUnavailable
+    case invalidIOSurface
+    case outputSurfaceCreationFailed
     case unstableIOSurface
 }
 
@@ -21,12 +24,27 @@ public struct TerminalSurfaceCaptureToken: Hashable, Sendable {
     }
 }
 
+/// A GPU-produced thumbnail that Core Animation can present without a CPU
+/// pixel copy or a second texture upload.
+public final class TerminalSurfacePreviewFrame: @unchecked Sendable {
+    public let ioSurface: IOSurface
+    public let pixelSize: CGSize
+
+    public init(ioSurface: IOSurface, pixelSize: CGSize) {
+        self.ioSurface = ioSurface
+        self.pixelSize = pixelSize
+    }
+}
+
 public struct TerminalSurfaceSnapshot: @unchecked Sendable {
-    public let image: NSImage
+    public let frame: TerminalSurfacePreviewFrame
     public let captureToken: TerminalSurfaceCaptureToken
 
-    public init(image: NSImage, captureToken: TerminalSurfaceCaptureToken) {
-        self.image = image
+    public init(
+        frame: TerminalSurfacePreviewFrame,
+        captureToken: TerminalSurfaceCaptureToken
+    ) {
+        self.frame = frame
         self.captureToken = captureToken
     }
 }
@@ -45,24 +63,23 @@ public final class TerminalSurfaceSnapshotter {
         let backgroundColor: CGColor
         let pixelSize: (width: Int, height: Int)
         let previousCaptureToken: TerminalSurfaceCaptureToken?
-        let metal: MetalCaptureContext
+        let gpu: GPUCaptureContext
         let captureToken: @Sendable (IOSurface) -> TerminalSurfaceCaptureToken
     }
 
-    private struct MetalCaptureContext: @unchecked Sendable {
-        let device: MTLDevice
-        let commandQueue: MTLCommandQueue
+    private struct GPUCaptureContext: @unchecked Sendable {
+        let context: CIContext
+        let colorSpace: CGColorSpace
     }
 
     private struct RenderedSnapshot: @unchecked Sendable {
-        let image: CGImage
+        let frame: TerminalSurfacePreviewFrame
         let captureToken: TerminalSurfaceCaptureToken
     }
 
-    private let metal: MetalCaptureContext?
+    private let gpu: GPUCaptureContext?
     private let captureToken: @Sendable (IOSurface) -> TerminalSurfaceCaptureToken
-    private var inFlight:
-        [RequestKey: Task<RenderedSnapshot?, Error>] = [:]
+    private var inFlight: [RequestKey: Task<RenderedSnapshot?, Error>] = [:]
 
     public convenience init() {
         self.init(captureToken: Self.captureToken)
@@ -74,13 +91,16 @@ public final class TerminalSurfaceSnapshotter {
     ) {
         self.captureToken = captureToken
         if let device = MTLCreateSystemDefaultDevice(),
-           let commandQueue = device.makeCommandQueue() {
-            metal = MetalCaptureContext(
-                device: device,
-                commandQueue: commandQueue
+           let colorSpace = CGColorSpace(name: CGColorSpace.displayP3) {
+            gpu = GPUCaptureContext(
+                context: CIContext(
+                    mtlDevice: device,
+                    options: [.cacheIntermediates: false]
+                ),
+                colorSpace: colorSpace
             )
         } else {
-            metal = nil
+            gpu = nil
         }
     }
 
@@ -96,7 +116,7 @@ public final class TerminalSurfaceSnapshotter {
         guard let ioSurface = surface.layer?.contents as? IOSurface else {
             throw TerminalSurfaceSnapshotError.missingIOSurface
         }
-        let adaptiveSize = TerminalPreviewGeometry.thumbnailSize(
+        let thumbnailSize = TerminalPreviewGeometry.thumbnailSize(
             sourceSize: CGSize(
                 width: IOSurfaceGetWidth(ioSurface),
                 height: IOSurfaceGetHeight(ioSurface)
@@ -104,8 +124,8 @@ public final class TerminalSurfaceSnapshotter {
             outputWidth: outputWidth
         )
         let pixelSize = (
-            width: Int(adaptiveSize.width),
-            height: Int(adaptiveSize.height)
+            width: Int(thumbnailSize.width),
+            height: Int(thumbnailSize.height)
         )
         let requestKey = RequestKey(
             surface: ObjectIdentifier(surface),
@@ -115,11 +135,11 @@ public final class TerminalSurfaceSnapshotter {
         )
         if coalescesInFlight, let pending = inFlight[requestKey] {
             guard let rendered = try await pending.value else { return nil }
-            return Self.snapshot(from: rendered, pixelSize: pixelSize)
+            return Self.snapshot(from: rendered)
         }
 
-        guard let metal else {
-            throw TerminalSurfaceSnapshotError.imageCopyFailed
+        guard let gpu else {
+            throw TerminalSurfaceSnapshotError.gpuUnavailable
         }
         let source = RenderSource(
             ioSurface: ioSurface,
@@ -127,7 +147,7 @@ public final class TerminalSurfaceSnapshotter {
                 ?? NSColor.black.cgColor,
             pixelSize: pixelSize,
             previousCaptureToken: previousCaptureToken,
-            metal: metal,
+            gpu: gpu,
             captureToken: captureToken
         )
         let task = Task.detached(priority: .utility) {
@@ -142,18 +162,14 @@ public final class TerminalSurfaceSnapshotter {
             }
         }
         guard let rendered = try await task.value else { return nil }
-        return Self.snapshot(from: rendered, pixelSize: pixelSize)
+        return Self.snapshot(from: rendered)
     }
 
     private static func snapshot(
-        from rendered: RenderedSnapshot,
-        pixelSize: (width: Int, height: Int)
+        from rendered: RenderedSnapshot
     ) -> TerminalSurfaceSnapshot {
         TerminalSurfaceSnapshot(
-            image: NSImage(
-                cgImage: rendered.image,
-                size: CGSize(width: pixelSize.width, height: pixelSize.height)
-            ),
+            frame: rendered.frame,
             captureToken: rendered.captureToken
         )
     }
@@ -164,102 +180,94 @@ public final class TerminalSurfaceSnapshotter {
         guard IOSurfaceGetPixelFormat(source.ioSurface)
             == kCVPixelFormatType_32BGRA
         else {
-            throw TerminalSurfaceSnapshotError.imageCopyFailed
+            throw TerminalSurfaceSnapshotError.invalidIOSurface
         }
         let sourceWidth = IOSurfaceGetWidth(source.ioSurface)
         let sourceHeight = IOSurfaceGetHeight(source.ioSurface)
         guard sourceWidth > 0, sourceHeight > 0 else {
-            throw TerminalSurfaceSnapshotError.imageCopyFailed
-        }
-        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .bgra8Unorm,
-            width: sourceWidth,
-            height: sourceHeight,
-            mipmapped: false
-        )
-        descriptor.storageMode = .shared
-        descriptor.usage = [.shaderRead]
-        guard let texture = source.metal.device.makeTexture(
-            descriptor: descriptor,
-            iosurface: source.ioSurface,
-            plane: 0
-        ) else {
-            throw TerminalSurfaceSnapshotError.imageCopyFailed
+            throw TerminalSurfaceSnapshotError.invalidIOSurface
         }
 
         for _ in 0 ..< 3 {
-            let captureTokenBeforeCopy = source.captureToken(source.ioSurface)
-            guard captureTokenBeforeCopy != source.previousCaptureToken else {
+            let captureTokenBeforeRender = source.captureToken(source.ioSurface)
+            guard captureTokenBeforeRender != source.previousCaptureToken else {
                 return nil
             }
-            let bytesPerRow = alignedBytesPerRow(sourceWidth * 4)
-            guard let buffer = source.metal.device.makeBuffer(
-                length: bytesPerRow * sourceHeight,
-                options: .storageModeShared
-            ),
-                let commandBuffer = source.metal.commandQueue.makeCommandBuffer(),
-                let blit = commandBuffer.makeBlitCommandEncoder()
-            else {
-                throw TerminalSurfaceSnapshotError.imageCopyFailed
-            }
-            blit.copy(
-                from: texture,
-                sourceSlice: 0,
-                sourceLevel: 0,
-                sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
-                sourceSize: MTLSize(
-                    width: sourceWidth,
-                    height: sourceHeight,
-                    depth: 1
-                ),
-                to: buffer,
-                destinationOffset: 0,
-                destinationBytesPerRow: bytesPerRow,
-                destinationBytesPerImage: bytesPerRow * sourceHeight
+            let outputSurface = try makeOutputSurface(
+                width: source.pixelSize.width,
+                height: source.pixelSize.height,
+                colorSpace: source.gpu.colorSpace
             )
-            blit.endEncoding()
-            commandBuffer.commit()
-            commandBuffer.waitUntilCompleted()
-            guard commandBuffer.status == .completed else {
-                throw TerminalSurfaceSnapshotError.imageCopyFailed
-            }
-            let captureToken = source.captureToken(source.ioSurface)
-            guard captureToken == captureTokenBeforeCopy else { continue }
+            let outputBounds = CGRect(
+                x: 0,
+                y: 0,
+                width: source.pixelSize.width,
+                height: source.pixelSize.height
+            )
+            let sourceImage = CIImage(
+                ioSurface: source.ioSurface,
+                options: [.colorSpace: source.gpu.colorSpace]
+            )
+            let scale = min(
+                outputBounds.width / CGFloat(sourceWidth),
+                outputBounds.height / CGFloat(sourceHeight)
+            )
+            let scaledSize = CGSize(
+                width: CGFloat(sourceWidth) * scale,
+                height: CGFloat(sourceHeight) * scale
+            )
+            let transformed = sourceImage
+                .transformed(by: CGAffineTransform(
+                    scaleX: scale,
+                    y: scale
+                ))
+                .transformed(by: CGAffineTransform(
+                    translationX: (outputBounds.width - scaledSize.width) / 2,
+                    y: (outputBounds.height - scaledSize.height) / 2
+                ))
+            let background = CIImage(
+                color: CIColor(cgColor: source.backgroundColor)
+            ).cropped(to: outputBounds)
+            source.gpu.context.render(
+                transformed.composited(over: background),
+                to: outputSurface,
+                bounds: outputBounds,
+                colorSpace: source.gpu.colorSpace
+            )
 
-            let ownedPixels = Data(
-                bytes: buffer.contents(),
-                count: bytesPerRow * sourceHeight
-            )
-            guard let provider = CGDataProvider(data: ownedPixels as CFData),
-                  let sourceImage = CGImage(
-                      width: sourceWidth,
-                      height: sourceHeight,
-                      bitsPerComponent: 8,
-                      bitsPerPixel: 32,
-                      bytesPerRow: bytesPerRow,
-                      space: CGColorSpaceCreateDeviceRGB(),
-                      bitmapInfo: CGBitmapInfo(
-                          rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue
-                      ).union(.byteOrder32Little),
-                      provider: provider,
-                      decode: nil,
-                      shouldInterpolate: false,
-                      intent: .defaultIntent
-                  ),
-                  let thumbnail = makeThumbnail(
-                      sourceImage,
-                      outputSize: source.pixelSize,
-                      backgroundColor: source.backgroundColor
-                  )
-            else {
-                throw TerminalSurfaceSnapshotError.imageCopyFailed
-            }
+            let captureToken = source.captureToken(source.ioSurface)
+            guard captureToken == captureTokenBeforeRender else { continue }
             return RenderedSnapshot(
-                image: thumbnail,
+                frame: TerminalSurfacePreviewFrame(
+                    ioSurface: outputSurface,
+                    pixelSize: outputBounds.size
+                ),
                 captureToken: captureToken
             )
         }
         throw TerminalSurfaceSnapshotError.unstableIOSurface
+    }
+
+    private nonisolated static func makeOutputSurface(
+        width: Int,
+        height: Int,
+        colorSpace: CGColorSpace
+    ) throws -> IOSurface {
+        guard let colorSpaceProperties = colorSpace.copyPropertyList(),
+              let surface = IOSurfaceCreate([
+                  kIOSurfaceWidth: width,
+                  kIOSurfaceHeight: height,
+                  kIOSurfaceBytesPerElement: 4,
+                  kIOSurfacePixelFormat: kCVPixelFormatType_32BGRA,
+              ] as CFDictionary) else {
+            throw TerminalSurfaceSnapshotError.outputSurfaceCreationFailed
+        }
+        IOSurfaceSetValue(
+            surface,
+            kIOSurfaceColorSpace,
+            colorSpaceProperties
+        )
+        return surface
     }
 
     private nonisolated static func captureToken(
@@ -269,57 +277,5 @@ public final class TerminalSurfaceSnapshotter {
             surfaceID: IOSurfaceGetID(ioSurface),
             seed: IOSurfaceGetSeed(ioSurface)
         )
-    }
-
-    private nonisolated static func alignedBytesPerRow(_ bytes: Int) -> Int {
-        let alignment = 256
-        return (bytes + alignment - 1) / alignment * alignment
-    }
-
-    private nonisolated static func makeThumbnail(
-        _ sourceImage: CGImage,
-        outputSize: (width: Int, height: Int),
-        backgroundColor: CGColor
-    ) -> CGImage? {
-        let outputWidth = outputSize.width
-        let outputHeight = outputSize.height
-        let bytesPerRow = outputWidth * 4
-        guard let context = CGContext(
-            data: nil,
-            width: outputWidth,
-            height: outputHeight,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGBitmapInfo(
-                rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue
-            ).union(.byteOrder32Little).rawValue
-        ) else { return nil }
-        let outputSize = CGSize(width: outputWidth, height: outputHeight)
-        context.setFillColor(backgroundColor)
-        context.fill(CGRect(origin: .zero, size: outputSize))
-        context.interpolationQuality = .high
-        let sourceSize = CGSize(
-            width: sourceImage.width,
-            height: sourceImage.height
-        )
-        let scale = min(
-            outputSize.width / sourceSize.width,
-            outputSize.height / sourceSize.height
-        )
-        let scaledSize = CGSize(
-            width: sourceSize.width * scale,
-            height: sourceSize.height * scale
-        )
-        context.draw(
-            sourceImage,
-            in: CGRect(
-                x: (outputSize.width - scaledSize.width) / 2,
-                y: (outputSize.height - scaledSize.height) / 2,
-                width: scaledSize.width,
-                height: scaledSize.height
-            )
-        )
-        return context.makeImage()
     }
 }

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -529,7 +529,11 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// fit in the existing bounds, so control-mode panes must report a fresh
     /// grid to tmux immediately after the binding action lands.
     func refreshGridSize() {
-        if previewGridSize != nil, applyPreviewGridSize() {
+        if previewGridSize != nil {
+            // A rejected apply must not fall back to view bounds: a parked
+            // preview's bounds still hold the creation frame, and sizing to
+            // them would discard the retained tmux grid.
+            _ = applyPreviewGridSize()
             return
         }
         let backingSize = convertToBacking(bounds.size)
@@ -622,12 +626,26 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// Sizes a hidden preview surface to the tmux window's existing grid.
     /// The preview client must have tmux's `ignore-size` flag while this is
     /// applied so the local rendering surface cannot change the shared window.
+    /// Returns whether libghostty adopted the grid. Sizing races surface
+    /// initialization, so a false result is not final: the retained grid is
+    /// re-driven through `ensurePreviewGridSize()`.
     @discardableResult
     public func sizeForPreviewGrid(columns: Int, rows: Int) -> Bool {
         guard columns > 0, rows > 0 else { return false }
         clearsPreviewGridOnInteractiveMount = false
         previewGridSize = (columns, rows)
         return applyPreviewGridSize()
+    }
+
+    /// Re-applies retained preview sizing when libghostty has not yet
+    /// adopted it. The initial apply can be rejected while the surface is
+    /// still initializing, and libghostty posts no notification when its
+    /// metrics settle, so periodic preview refresh drives convergence.
+    public func ensurePreviewGridSize() {
+        guard previewGridSize != nil,
+              !clearsPreviewGridOnInteractiveMount
+        else { return }
+        _ = applyPreviewGridSize()
     }
 
     /// Releases preview sizing before the caller clears tmux's `ignore-size`
@@ -656,6 +674,13 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             return false
         }
         let current = ghostty_surface_size(surface)
+        if Int(current.columns) == previewGridSize.columns,
+           Int(current.rows) == previewGridSize.rows {
+            if surfaceSize == nil {
+                surfaceSize = current
+            }
+            return true
+        }
         guard current.columns > 0, current.rows > 0,
               current.width_px > 0, current.height_px > 0,
               current.cell_width_px > 0, current.cell_height_px > 0
@@ -686,7 +711,14 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         // it. Preview sizing changes libghostty's render grid only; changing
         // the reusable view's frame here poisons SwiftUI's later interactive
         // layout with the parked grid's pixel dimensions.
-        return true
+        //
+        // Success means adoption, not merely a submitted resize: a surface
+        // mid-initialization can pass the metric guards yet not take the
+        // requested grid, and would otherwise keep rendering its creation
+        // default while the tmux client tty already has the session size.
+        let applied = ghostty_surface_size(surface)
+        return Int(applied.columns) == previewGridSize.columns
+            && Int(applied.rows) == previewGridSize.rows
     }
 
     /// Inject bytes into the terminal as OUTPUT (as if read from the pty).

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -59,6 +59,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         surface, width, height in
         ghostty_surface_set_size(surface, width, height)
     }
+    static var contentScaleSetter: (ghostty_surface_t, Double, Double) -> Void = {
+        surface, xScale, yScale in
+        ghostty_surface_set_content_scale(surface, xScale, yScale)
+    }
     typealias ClipboardConfirmationPresenter = (
         _ view: TerminalSurfaceView,
         _ contents: String,
@@ -130,6 +134,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// leaf is no longer focused.
     public var suppressAutoFocus: Bool = false
     public private(set) var isParkedForPreview = false
+    private var previewRenderingSuspended = false
 
     /// Unique per-surface identity handed to libghostty as `userdata`. Held
     /// strongly here for the view's lifetime and re-captured by the
@@ -154,6 +159,8 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     private var consumedCommandKeyCodes: Set<UInt16> = []
     private var consumedPaneSplitKeyCodes: Set<UInt16> = []
     private var surfaceResizeState = SurfaceResizeState()
+    private var previewGridSize: (columns: Int, rows: Int)?
+    private var clearsPreviewGridOnInteractiveMount = false
     private var isDeferringLiveResize = false
     private var isDeferringPresentationResize = false
     private var isDeferringSurfaceResize: Bool {
@@ -232,11 +239,20 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             setSurfaceOcclusion(false)
             return
         }
-        if bounds.size.width > 0, bounds.size.height > 0 {
-            handleSizeChange(bounds.size)
+        if !isParkedForPreview,
+           bounds.size.width.isFinite,
+           bounds.size.height.isFinite,
+           bounds.size.width > 0, bounds.size.height > 0 {
+            let releasedPreviewGrid = prepareForInteractiveSizeChange()
+            if releasedPreviewGrid || !applyPreviewGridSize() {
+                handleSizeChange(bounds.size)
+            }
         }
         syncInitialOcclusionState(for: window)
-        guard !suppressAutoFocus, window.isKeyWindow else { return }
+        guard !isParkedForPreview,
+              !suppressAutoFocus,
+              window.isKeyWindow
+        else { return }
         DispatchQueue.main.async { [weak self] in
             guard let self, !self.suppressAutoFocus,
                   let currentWindow = self.window,
@@ -439,9 +455,11 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
 
     override public func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)
-        guard window != nil,
+        guard !isParkedForPreview,
+              window != nil,
               newSize.width > 0, newSize.height > 0
         else { return }
+        _ = prepareForInteractiveSizeChange()
         handleSizeChange(newSize)
     }
 
@@ -459,10 +477,9 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
 
     private func handleSizeChange(_ size: CGSize) {
         let scaledSize = convertToBacking(size)
-        guard scaledSize.width >= 1, scaledSize.height >= 1
-        else { return }
-        let width = UInt32(scaledSize.width)
-        let height = UInt32(scaledSize.height)
+        guard let pixelSize = SurfacePixelSize(scaledSize) else { return }
+        let width = pixelSize.width
+        let height = pixelSize.height
         guard surfaceResizeState.needsResize(
             width: width,
             height: height
@@ -480,6 +497,14 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
                 height: height
             )
         }
+    }
+
+    @discardableResult
+    private func prepareForInteractiveSizeChange() -> Bool {
+        guard clearsPreviewGridOnInteractiveMount else { return false }
+        clearsPreviewGridOnInteractiveMount = false
+        previewGridSize = nil
+        return true
     }
 
     // MARK: - Private Helpers
@@ -504,11 +529,14 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// fit in the existing bounds, so control-mode panes must report a fresh
     /// grid to tmux immediately after the binding action lands.
     func refreshGridSize() {
+        if previewGridSize != nil, applyPreviewGridSize() {
+            return
+        }
         let backingSize = convertToBacking(bounds.size)
-        guard backingSize.width > 0, backingSize.height > 0 else { return }
+        guard let pixelSize = SurfacePixelSize(backingSize) else { return }
         setSurfaceSize(
-            width: UInt32(backingSize.width),
-            height: UInt32(backingSize.height)
+            width: pixelSize.width,
+            height: pixelSize.height
         )
     }
 
@@ -544,6 +572,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             suppressAutoFocus = true
             mouseEventHandler.resetPointerStateForParking()
             isParkedForPreview = true
+            previewRenderingSuspended = false
             updateTrackingAreas()
             if window?.firstResponder === self {
                 window?.makeFirstResponder(nil)
@@ -551,8 +580,113 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             focusDidChange(false)
         } else {
             isParkedForPreview = false
+            previewRenderingSuspended = false
             updateTrackingAreas()
         }
+    }
+
+    public func setPreviewRenderingSuspended(_ suspended: Bool) {
+        guard isParkedForPreview,
+              previewRenderingSuspended != suspended
+        else { return }
+        previewRenderingSuspended = suspended
+        if suspended {
+            setSurfaceOcclusion(false)
+        } else {
+            syncOcclusionState()
+        }
+    }
+
+    /// Completes a preview mount after AppKit has finished reparenting the
+    /// view. Automatic backing and frame callbacks stay suppressed while a
+    /// surface is parked: their intermediate geometry is not a valid terminal
+    /// DPI or resize source, and parked previews do not need to track window
+    /// layout changes.
+    public func completePreviewParkingMount() {
+        guard isParkedForPreview, let window else { return }
+        let contentScale = window.backingScaleFactor
+        guard contentScale.isFinite,
+              contentScale >= 1,
+              contentScale <= 8
+        else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.contentsScale = contentScale
+        CATransaction.commit()
+        if let surface {
+            Self.contentScaleSetter(surface, contentScale, contentScale)
+        }
+        _ = applyPreviewGridSize()
+    }
+
+    /// Sizes a hidden preview surface to the tmux window's existing grid.
+    /// The preview client must have tmux's `ignore-size` flag while this is
+    /// applied so the local rendering surface cannot change the shared window.
+    @discardableResult
+    public func sizeForPreviewGrid(columns: Int, rows: Int) -> Bool {
+        guard columns > 0, rows > 0 else { return false }
+        clearsPreviewGridOnInteractiveMount = false
+        previewGridSize = (columns, rows)
+        return applyPreviewGridSize()
+    }
+
+    /// Releases preview sizing before the caller clears tmux's `ignore-size`
+    /// client flag. Hidden and parked surfaces retain their safe preview grid
+    /// until an interactive mount provides valid geometry.
+    public func clearPreviewGridSize() {
+        guard previewGridSize != nil else { return }
+        guard !isParkedForPreview,
+              window != nil,
+              bounds.size.width.isFinite,
+              bounds.size.height.isFinite,
+              bounds.size.width > 0,
+              bounds.size.height > 0
+        else {
+            clearsPreviewGridOnInteractiveMount = true
+            return
+        }
+        clearsPreviewGridOnInteractiveMount = false
+        previewGridSize = nil
+        refreshGridSize()
+    }
+
+    @discardableResult
+    private func applyPreviewGridSize() -> Bool {
+        guard let surface, let previewGridSize else {
+            return false
+        }
+        let current = ghostty_surface_size(surface)
+        guard current.columns > 0, current.rows > 0,
+              current.width_px > 0, current.height_px > 0,
+              current.cell_width_px > 0, current.cell_height_px > 0
+        else { return false }
+        let horizontalSlack = Int64(current.width_px)
+            - Int64(current.cell_width_px) * Int64(current.columns)
+        let verticalSlack = Int64(current.height_px)
+            - Int64(current.cell_height_px) * Int64(current.rows)
+        let targetWidth = Int64(current.cell_width_px)
+            * Int64(previewGridSize.columns) + horizontalSlack
+        let targetHeight = Int64(current.cell_height_px)
+            * Int64(previewGridSize.rows) + verticalSlack
+        guard targetWidth > 0,
+              targetHeight > 0,
+              targetWidth <= Int64(UInt32.max),
+              targetHeight <= Int64(UInt32.max)
+        else { return false }
+        let backingSize = NSSize(
+            width: CGFloat(targetWidth),
+            height: CGFloat(targetHeight)
+        )
+        guard SurfacePixelSize(backingSize) != nil else { return false }
+        applySurfaceSize(
+            width: UInt32(targetWidth),
+            height: UInt32(targetHeight)
+        )
+        // The AppKit view belongs to whichever presentation currently hosts
+        // it. Preview sizing changes libghostty's render grid only; changing
+        // the reusable view's frame here poisons SwiftUI's later interactive
+        // layout with the parked grid's pixel dimensions.
+        return true
     }
 
     /// Inject bytes into the terminal as OUTPUT (as if read from the pty).
@@ -797,13 +931,18 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
 
     private func syncOcclusionState() {
         guard let window else { return }
-        let visible = Self.resolvedOcclusionVisibility(for: window)
+        let visible = !previewRenderingSuspended
+            && Self.resolvedOcclusionVisibility(for: window)
         setSurfaceOcclusion(visible)
     }
 
     private func syncInitialOcclusionState(
         for window: NSWindow
     ) {
+        guard !previewRenderingSuspended else {
+            setSurfaceOcclusion(false)
+            return
+        }
         let initialVisible = window.isVisible
             || window.isKeyWindow
             || window.occlusionState.contains(.visible)
@@ -815,6 +954,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             guard let self,
                   let currentWindow = self.window,
                   currentWindow === window else { return }
+            guard !previewRenderingSuspended else {
+                setSurfaceOcclusion(false)
+                return
+            }
             let settledVisible = currentWindow.isVisible
                 || currentWindow.isKeyWindow
                 || currentWindow.occlusionState.contains(.visible)
@@ -973,22 +1116,39 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     override public func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
 
-        if let window {
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            layer?.contentsScale = window.backingScaleFactor
-            CATransaction.commit()
-        }
+        // Reparenting a parked view can briefly expose a degenerate AppKit
+        // transform. Publishing a scale derived from that transition can make
+        // libghostty's DPI conversion abort. A parked preview retains its last
+        // terminal scale and pixel size until it becomes interactive again.
+        guard !isParkedForPreview,
+              let window,
+              let surface
+        else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.contentsScale = window.backingScaleFactor
+        CATransaction.commit()
 
-        guard let surface else { return }
-
-        let fbFrame = convertToBacking(frame)
-        let xScale = fbFrame.size.width / frame.size.width
-        let yScale = fbFrame.size.height / frame.size.height
-        ghostty_surface_set_content_scale(surface, xScale, yScale)
+        let logicalSize = bounds.size
+        guard logicalSize.width.isFinite,
+              logicalSize.height.isFinite,
+              logicalSize.width > 0,
+              logicalSize.height > 0
+        else { return }
+        let fbFrame = convertToBacking(NSRect(
+            origin: .zero,
+            size: logicalSize
+        ))
+        guard let pixelSize = SurfacePixelSize(fbFrame.size) else { return }
+        let contentScale = window.backingScaleFactor
+        guard contentScale.isFinite,
+              contentScale >= 1,
+              contentScale <= 8
+        else { return }
+        Self.contentScaleSetter(surface, contentScale, contentScale)
         applySurfaceSize(
-            width: UInt32(fbFrame.size.width),
-            height: UInt32(fbFrame.size.height)
+            width: pixelSize.width,
+            height: pixelSize.height
         )
     }
 

--- a/Sources/TerminalSupport/SurfacePixelSize.swift
+++ b/Sources/TerminalSupport/SurfacePixelSize.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+package struct SurfacePixelSize: Equatable {
+    /// libghostty derives its u16 grid dimensions by dividing screen pixels by
+    /// a nonzero cell size. Bounding each pixel dimension to u16 keeps that
+    /// conversion representable before crossing the C boundary.
+    package static let maximumDimension = CGFloat(UInt16.max)
+
+    package let width: UInt32
+    package let height: UInt32
+
+    package init?(_ size: CGSize) {
+        guard size.width.isFinite,
+              size.height.isFinite,
+              size.width >= 1,
+              size.height >= 1,
+              size.width <= Self.maximumDimension,
+              size.height <= Self.maximumDimension
+        else { return nil }
+
+        width = UInt32(size.width)
+        height = UInt32(size.height)
+    }
+}

--- a/Sources/TerminalSupport/TerminalPreviewGeometry.swift
+++ b/Sources/TerminalSupport/TerminalPreviewGeometry.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum TerminalPreviewGeometry {
-    public static let minimumAspectRatio: CGFloat = 4 / 3
-    public static let maximumAspectRatio: CGFloat = 2
     public static let placeholderAspectRatio: CGFloat = 16 / 10
+    private static let minimumCanvasDimension: CGFloat = 1
+    private static let maximumCanvasDimension: CGFloat = 1_024
 
     public static func aspectRatio(for size: CGSize?) -> CGFloat {
         guard let size,
@@ -12,10 +12,7 @@ public enum TerminalPreviewGeometry {
               size.width > 0,
               size.height > 0
         else { return placeholderAspectRatio }
-        return min(
-            max(size.width / size.height, minimumAspectRatio),
-            maximumAspectRatio
-        )
+        return size.width / size.height
     }
 
     public static func thumbnailSize(
@@ -23,9 +20,20 @@ public enum TerminalPreviewGeometry {
         outputWidth: CGFloat
     ) -> CGSize {
         let aspectRatio = aspectRatio(for: sourceSize)
+        let width = min(
+            max(outputWidth.rounded(), minimumCanvasDimension),
+            maximumCanvasDimension
+        )
+        let height = min(
+            max(
+                (width / aspectRatio).rounded(),
+                minimumCanvasDimension
+            ),
+            maximumCanvasDimension
+        )
         return CGSize(
-            width: outputWidth,
-            height: (outputWidth / aspectRatio).rounded()
+            width: width,
+            height: height
         )
     }
 }

--- a/Sources/TerminalUnavailable/LibghosttyRuntime.swift
+++ b/Sources/TerminalUnavailable/LibghosttyRuntime.swift
@@ -4,7 +4,13 @@ import GhosthubTerminalSupport
 import GhosthubWorkspace
 
 @MainActor
-public final class LibghosttyRuntime: ObservableObject {
+public protocol ApplicationQuitRequestSource: AnyObject {
+    var quitRequestHandler: (() -> Void)? { get set }
+}
+
+@MainActor
+public final class LibghosttyRuntime: ObservableObject,
+    ApplicationQuitRequestSource {
     public static let shared = LibghosttyRuntime(
         pipeline: LibghosttyConfigPipeline(
             paths: LibghosttyConfigPaths(
@@ -24,6 +30,7 @@ public final class LibghosttyRuntime: ObservableObject {
 
     public let runtimeState: LibghosttyRuntimeState
     public let renderTracker = SurfaceRenderTracker()
+    public var quitRequestHandler: (() -> Void)?
 
     private let configReloadNoticeSubject =
         PassthroughSubject<LibghosttyConfigReloadNotice?, Never>()

--- a/Sources/TerminalUnavailable/TerminalPreviewStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalPreviewStubs.swift
@@ -1,0 +1,108 @@
+import AppKit
+
+public enum TerminalSurfaceSnapshotError: Error, Equatable {
+    case invalidOutputSize
+    case missingIOSurface
+    case gpuUnavailable
+    case invalidIOSurface
+    case outputSurfaceCreationFailed
+    case unstableIOSurface
+}
+
+public struct TerminalSurfaceCaptureToken: Hashable, Sendable {
+    public let surfaceID: UInt32
+    public let seed: UInt32
+
+    public init(surfaceID: UInt32, seed: UInt32) {
+        self.surfaceID = surfaceID
+        self.seed = seed
+    }
+}
+
+public final class TerminalSurfacePreviewFrame: @unchecked Sendable {
+    public let pixelSize: CGSize
+
+    public init(pixelSize: CGSize) {
+        self.pixelSize = pixelSize
+    }
+}
+
+public struct TerminalSurfaceSnapshot: @unchecked Sendable {
+    public let frame: TerminalSurfacePreviewFrame
+    public let captureToken: TerminalSurfaceCaptureToken
+
+    public init(
+        frame: TerminalSurfacePreviewFrame,
+        captureToken: TerminalSurfaceCaptureToken
+    ) {
+        self.frame = frame
+        self.captureToken = captureToken
+    }
+}
+
+@MainActor
+public final class TerminalSurfaceSnapshotter {
+    public init() {}
+
+    public func snapshot(
+        of _: TerminalSurfaceView,
+        outputWidth: CGFloat,
+        previousCaptureToken _: TerminalSurfaceCaptureToken?,
+        coalescesInFlight _: Bool = true
+    ) async throws -> TerminalSurfaceSnapshot? {
+        guard outputWidth.isFinite, outputWidth > 0 else {
+            throw TerminalSurfaceSnapshotError.invalidOutputSize
+        }
+        throw TerminalSurfaceSnapshotError.gpuUnavailable
+    }
+}
+
+@MainActor
+public final class TerminalSurfacePreviewView: NSView {
+    override public init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func display(_: TerminalSurfacePreviewFrame?) {}
+}
+
+public enum LivePreviewParkingError: Error, Equatable {
+    case surfaceStillMounted
+}
+
+@MainActor
+public final class LivePreviewParkingHost: NSView {
+    private var parkedSurfaces: Set<ObjectIdentifier> = []
+
+    override public init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public func park(_ surface: TerminalSurfaceView) throws {
+        parkedSurfaces.insert(ObjectIdentifier(surface))
+    }
+
+    public func unpark(_ surface: TerminalSurfaceView) {
+        parkedSurfaces.remove(ObjectIdentifier(surface))
+    }
+
+    public func unparkAll() {
+        parkedSurfaces.removeAll()
+    }
+
+    public func contains(_ surface: TerminalSurfaceView) -> Bool {
+        parkedSurfaces.contains(ObjectIdentifier(surface))
+    }
+
+    public func setRenderingSuspended(_: Bool) {}
+}

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -162,6 +162,13 @@ public final class TerminalSurfaceView: ObservableObject {
     public func sizeDidChange(_ size: CGSize) {
         _ = size
     }
+    public func setParkedForPreview(_ parked: Bool) {
+        _ = parked
+    }
+    public func setPreviewRenderingSuspended(_ suspended: Bool) {
+        _ = suspended
+    }
+    public func completePreviewParkingMount() {}
     func setPresentationResizeDeferred(_ deferred: Bool) {
         _ = deferred
     }

--- a/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
+++ b/Sources/TerminalUnavailable/TerminalSurfaceStubs.swift
@@ -169,6 +169,7 @@ public final class TerminalSurfaceView: ObservableObject {
         _ = suspended
     }
     public func completePreviewParkingMount() {}
+    public func ensurePreviewGridSize() {}
     func setPresentationResizeDeferred(_ deferred: Bool) {
         _ = deferred
     }

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -7,6 +7,16 @@ public enum TmuxAttachmentLaunchMode: String, Codable, Equatable, Sendable {
     case create
 }
 
+public struct TmuxClientSize: Equatable, Sendable {
+    public let columns: Int
+    public let rows: Int
+
+    public init(columns: Int, rows: Int) {
+        self.columns = columns
+        self.rows = rows
+    }
+}
+
 /// An ordinary tmux client launched inside a libghostty terminal surface.
 /// Tmux owns rendering, windows, panes, history, input, and process lifetime.
 /// Ghosthub enables tmux's session mouse option before presenting the client so
@@ -20,6 +30,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     public let presentationStyle: TmuxPresentationStyle?
     public var launchMode: TmuxAttachmentLaunchMode
     public let initialCommand: String?
+    public let ignoresClientSize: Bool
+    public let initialClientSize: TmuxClientSize?
 
     public init(
         sessionName: String,
@@ -29,7 +41,9 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         protectedWorkspacePath: String? = nil,
         presentationStyle: TmuxPresentationStyle? = nil,
         launchMode: TmuxAttachmentLaunchMode = .attach,
-        initialCommand: String? = nil
+        initialCommand: String? = nil,
+        ignoresClientSize: Bool = false,
+        initialClientSize: TmuxClientSize? = nil
     ) {
         self.sessionName = sessionName
         self.host = host
@@ -39,6 +53,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         self.presentationStyle = presentationStyle
         self.launchMode = launchMode
         self.initialCommand = initialCommand
+        self.ignoresClientSize = ignoresClientSize
+        self.initialClientSize = initialClientSize
     }
 
     public func attachCommand(
@@ -139,7 +155,15 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             } else {
                 recordedCommand = command
             }
-            return surfaceAccountLoginShellCommand(recordedCommand)
+            let terminalCommand = if let initialSizeCommand {
+                shellCommand([
+                    "/bin/sh", "-c",
+                    initialSizeCommand + "; exec " + recordedCommand,
+                ])
+            } else {
+                recordedCommand
+            }
+            return surfaceAccountLoginShellCommand(terminalCommand)
         }
     }
 
@@ -148,11 +172,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         kwtPath: String?,
         workingDirectory: String?
     ) -> String {
-        let attach = tmuxArguments(
-            tmuxPath,
-            "attach-session", "-E", "-t", "=\(sessionName)"
-        ).map(shellQuotedCommandArgument).joined(separator: " ")
+        let attach = tmuxArguments(tmuxPath, attachArguments)
+            .map(shellQuotedCommandArgument).joined(separator: " ")
         var commands = ["unset TMUX TMUX_PANE"]
+        if let initialSizeCommand {
+            commands.append(initialSizeCommand)
+        }
         switch launchMode {
         case .attach:
             if let protectedWorkspacePath {
@@ -273,6 +298,25 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         )
     }
 
+    private var attachArguments: [String] {
+        var arguments = ["attach-session", "-E"]
+        if ignoresClientSize {
+            arguments += ["-f", "ignore-size"]
+        }
+        arguments += ["-t", "=\(sessionName)"]
+        return arguments
+    }
+
+    private var initialSizeCommand: String? {
+        guard ignoresClientSize,
+              let initialClientSize,
+              initialClientSize.columns > 0,
+              initialClientSize.rows > 0
+        else { return nil }
+        return "stty columns \(initialClientSize.columns)"
+            + " rows \(initialClientSize.rows) || exit $?"
+    }
+
     /// Kwt establishes or repairs the complete session before starting its
     /// tmux client. Run kwt as the foreground terminal's background child just
     /// long enough to observe a client on this launch's PTY, then enable mouse
@@ -350,10 +394,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             }
             attach = protectedAttach
         } else {
-            let tmuxAttach = tmuxArguments(
-                tmuxPath,
-                "attach-session", "-E", "-t", "=\(sessionName)"
-            ).map(shellQuotedCommandArgument).joined(separator: " ")
+            let tmuxAttach = tmuxArguments(tmuxPath, attachArguments)
+                .map(shellQuotedCommandArgument).joined(separator: " ")
             attach = "exec \(tmuxAttach)"
         }
         var remoteAttachCommands = ["unset TMUX TMUX_PANE"]
@@ -493,9 +535,7 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         } else {
             attach = windowsMuxCommand(
                 tmuxPath: tmuxPath,
-                arguments: [
-                    "attach-session", "-E", "-t", "=\(sessionName)",
-                ]
+                arguments: attachArguments
             )
         }
         let script = """
@@ -779,6 +819,13 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     private func tmuxArguments(
         _ tmuxPath: String,
         _ arguments: String...
+    ) -> [String] {
+        tmuxArguments(tmuxPath, arguments)
+    }
+
+    private func tmuxArguments(
+        _ tmuxPath: String,
+        _ arguments: [String]
     ) -> [String] {
         var result = [tmuxPath]
         if let socketName, !socketName.isEmpty {

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -448,7 +448,12 @@ public struct SettingsView: View {
                     "Efficient stores the latest frame when you leave a"
                         + " session. Live refreshes up to twice per second"
                         + " and parks at most four inactive sessions across"
-                        + " the app. Off avoids preview GPU work."
+                        + " the app. Always Live connects every discovered"
+                        + " tmux session on POSIX hosts, expands every"
+                        + " preview by default, and removes that limit."
+                        + " Windows/psmux sessions stay on-demand. It can use substantial"
+                        + " CPU, GPU, memory, and SSH capacity. Off avoids"
+                        + " preview GPU work."
                 )
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)

--- a/Sources/UI/WorkspaceSidebarPresentation.swift
+++ b/Sources/UI/WorkspaceSidebarPresentation.swift
@@ -1,21 +1,38 @@
 import Foundation
 import GhosthubSettings
-import GhosthubTerminalSupport
 import GhosthubWorkspace
 import SwiftUI
 
 struct TmuxSessionPreviewExpansionState: Equatable {
     private(set) var expandedSessionIDs: Set<String> = []
+    private(set) var collapsedSessionIDs: Set<String> = []
 
-    func isExpanded(_ sessionID: String) -> Bool {
-        expandedSessionIDs.contains(sessionID)
+    func isExpanded(
+        _ sessionID: String,
+        defaultExpanded: Bool = false
+    ) -> Bool {
+        if expandedSessionIDs.contains(sessionID) {
+            return true
+        }
+        if collapsedSessionIDs.contains(sessionID) {
+            return false
+        }
+        return defaultExpanded
     }
 
-    mutating func setExpanded(_ expanded: Bool, sessionID: String) {
-        if expanded {
-            expandedSessionIDs.insert(sessionID)
-        } else {
-            expandedSessionIDs.remove(sessionID)
+    mutating func setExpanded(
+        _ expanded: Bool,
+        sessionID: String,
+        defaultExpanded: Bool = false
+    ) {
+        expandedSessionIDs.remove(sessionID)
+        collapsedSessionIDs.remove(sessionID)
+        if expanded != defaultExpanded {
+            if expanded {
+                expandedSessionIDs.insert(sessionID)
+            } else {
+                collapsedSessionIDs.insert(sessionID)
+            }
         }
     }
 }
@@ -43,13 +60,6 @@ struct TmuxSessionPreviewMountState {
 }
 
 enum TmuxSessionPreviewRowPresentation {
-    static let placeholderAspectRatio =
-        TerminalPreviewGeometry.placeholderAspectRatio
-
-    static func aspectRatio(for imageSize: CGSize?) -> CGFloat {
-        TerminalPreviewGeometry.aspectRatio(for: imageSize)
-    }
-
     static func canDisclose(
         mode: SessionPreviewMode,
         sessionID: String,
@@ -68,7 +78,22 @@ enum TmuxSessionPreviewRowPresentation {
             mode: mode,
             sessionID: sessionID,
             previewableSessionIDs: previewableSessionIDs
-        ) && expansion.isExpanded(sessionID)
+        ) && isExpanded(
+            mode: mode,
+            sessionID: sessionID,
+            expansion: expansion
+        )
+    }
+
+    static func isExpanded(
+        mode: SessionPreviewMode,
+        sessionID: String,
+        expansion: TmuxSessionPreviewExpansionState
+    ) -> Bool {
+        expansion.isExpanded(
+            sessionID,
+            defaultExpanded: mode.expandsEverySession
+        )
     }
 }
 

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -946,7 +946,7 @@ struct WorkspaceSidebarView: View {
                     Self.activateTmuxSession(
                         tmuxSelection,
                         rowTarget: row.target,
-                        selection: &selection,
+                        selection: $selection,
                         snapshot: snapshot,
                         visibility: visibility,
                         onOpen: onOpenTmuxSession
@@ -960,7 +960,7 @@ struct WorkspaceSidebarView: View {
                     Self.activateTmuxSession(
                         tmuxSelection,
                         rowTarget: row.target,
-                        selection: &selection,
+                        selection: $selection,
                         snapshot: snapshot,
                         visibility: visibility,
                         onOpen: onOpenTmuxSession
@@ -977,7 +977,7 @@ struct WorkspaceSidebarView: View {
                             for: workspace
                         ),
                         rowTarget: row.target,
-                        selection: &selection,
+                        selection: $selection,
                         snapshot: snapshot,
                         visibility: visibility,
                         onOpen: onOpenTmuxSession
@@ -1529,14 +1529,20 @@ struct WorkspaceSidebarView: View {
                   previewableSessionIDs: previewableTmuxSessionIDs
               )
         else { return content }
-        let isExpanded = tmuxPreviewExpansion.isExpanded(tmuxSession.id)
+        let isExpanded = TmuxSessionPreviewRowPresentation.isExpanded(
+            mode: sessionPreviewMode,
+            sessionID: tmuxSession.id,
+            expansion: tmuxPreviewExpansion
+        )
         return AnyView(
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 0) {
                     Button {
                         tmuxPreviewExpansion.setExpanded(
                             !isExpanded,
-                            sessionID: tmuxSession.id
+                            sessionID: tmuxSession.id,
+                            defaultExpanded:
+                            sessionPreviewMode.expandsEverySession
                         )
                         onTmuxSessionPreviewExpanded(
                             tmuxSession,
@@ -1573,7 +1579,7 @@ struct WorkspaceSidebarView: View {
                             Self.activateTmuxSession(
                                 tmuxSession,
                                 rowTarget: row.target,
-                                selection: &selection,
+                                selection: $selection,
                                 snapshot: snapshot,
                                 visibility: visibility,
                                 onOpen: onOpenTmuxSession
@@ -1611,17 +1617,19 @@ struct WorkspaceSidebarView: View {
     static func activateTmuxSession(
         _ tmuxSession: WorkspaceTmuxSessionSelection,
         rowTarget: WorkspaceNavigationTarget,
-        selection: inout WorkspaceSelection,
+        selection: Binding<WorkspaceSelection>,
         snapshot: WorkspaceSnapshot,
         visibility: WorktreeVisibility,
         onOpen: (WorkspaceTmuxSessionSelection, WorkspaceSelection) -> Void
     ) {
-        selection.select(
+        var routeSelection = selection.wrappedValue
+        routeSelection.select(
             rowTarget,
             in: snapshot,
             visibility: visibility
         )
-        onOpen(tmuxSession, selection)
+        selection.wrappedValue = routeSelection
+        onOpen(tmuxSession, routeSelection)
     }
 
     private func reorderableRow<Content: View>(

--- a/Sources/Workspace/SessionModels.swift
+++ b/Sources/Workspace/SessionModels.swift
@@ -88,6 +88,16 @@ public struct TmuxWindowSummary: Codable, Equatable, Sendable {
     }
 }
 
+public struct TmuxGridSize: Codable, Equatable, Sendable {
+    public var columns: Int
+    public var rows: Int
+
+    public init(columns: Int, rows: Int) {
+        self.columns = columns
+        self.rows = rows
+    }
+}
+
 public struct TmuxSessionSummary: Codable, Equatable, Sendable {
     public var name: String
     public var managed: Bool
@@ -96,6 +106,8 @@ public struct TmuxSessionSummary: Codable, Equatable, Sendable {
     public var serverPID: String?
     public var sessionID: String?
     public var createdAt: String?
+    public var activeWindowSize: TmuxGridSize?
+    public var previewClientSize: TmuxGridSize?
 
     public init(
         name: String, managed: Bool,
@@ -103,7 +115,9 @@ public struct TmuxSessionSummary: Codable, Equatable, Sendable {
         windows: [TmuxWindowSummary],
         serverPID: String? = nil,
         sessionID: String? = nil,
-        createdAt: String? = nil
+        createdAt: String? = nil,
+        activeWindowSize: TmuxGridSize? = nil,
+        previewClientSize: TmuxGridSize? = nil
     ) {
         self.name = name
         self.managed = managed
@@ -112,6 +126,8 @@ public struct TmuxSessionSummary: Codable, Equatable, Sendable {
         self.serverPID = serverPID
         self.sessionID = sessionID
         self.createdAt = createdAt
+        self.activeWindowSize = activeWindowSize
+        self.previewClientSize = previewClientSize
     }
 
     public var hasStableIdentity: Bool {

--- a/Tests/App/AppTestFixtures.swift
+++ b/Tests/App/AppTestFixtures.swift
@@ -1,9 +1,35 @@
+import CoreVideo
 import Foundation
 import GhosthubTestSupport
+import GhosthubTerminal
+import IOSurface
 import Testing
 @testable import GhosthubApp
 import GhosthubPersistence
 import GhosthubWorkspace
+
+func makePreviewSnapshot(
+    surfaceID: UInt32 = 1,
+    seed: UInt32 = 1
+) throws -> TerminalSurfaceSnapshot {
+    let ioSurface = try #require(IOSurfaceCreate([
+        kIOSurfaceWidth: 32,
+        kIOSurfaceHeight: 20,
+        kIOSurfaceBytesPerElement: 4,
+        kIOSurfaceBytesPerRow: 32 * 4,
+        kIOSurfacePixelFormat: kCVPixelFormatType_32BGRA,
+    ] as CFDictionary))
+    return TerminalSurfaceSnapshot(
+        frame: TerminalSurfacePreviewFrame(
+            ioSurface: ioSurface,
+            pixelSize: CGSize(width: 32, height: 20)
+        ),
+        captureToken: TerminalSurfaceCaptureToken(
+            surfaceID: surfaceID,
+            seed: seed
+        )
+    )
+}
 
 // MARK: - Seeded Database
 
@@ -256,6 +282,24 @@ final class AsyncGate: @unchecked Sendable {
             try? await Task.sleep(for: .milliseconds(5))
         }
         return lock.withLock { opened }
+    }
+}
+
+final class BlockingGate: @unchecked Sendable {
+    private let started = LockedValue(false)
+    private let release = DispatchSemaphore(value: 0)
+
+    func block() {
+        started.store(true)
+        release.wait()
+    }
+
+    func waitUntilBlocked() async {
+        await waitUntil { self.started.load() }
+    }
+
+    func open() {
+        release.signal()
     }
 }
 

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -1,6 +1,7 @@
 import GhosthubTransport
 import Foundation
 import GhosthubTerminal
+import GhosthubTestSupport
 import GhosthubTmux
 import GhosthubWorkspace
 import Testing
@@ -1502,6 +1503,456 @@ struct NativeTmuxSessionCoordinatorTests {
                 == .processExited(code: 255)
         )
         await waitUntilMainActor { invalidations.load() == 1 }
+    }
+
+    @Test("interactive sizing reports an attachment replacement")
+    func interactiveSizingReportsAttachmentReplacement() async throws {
+        let identityLookups = LockedValue(0)
+        let promotionStarted = LockedValue(false)
+        let promotionMutations = LockedValue(0)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    identityLookups.withLock { $0 += 1 }
+                    let lookup = identityLookups.load()
+                    if lookup == 2 {
+                        promotionStarted.withLock { $0 = true }
+                        releasePromotion.wait()
+                    }
+                    return (0, coordinatorSplitClientOutput)
+                }
+                if command.contains("'!ignore-size'") {
+                    promotionMutations.withLock { $0 += 1 }
+                }
+                return (0, "")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = {
+            (_: BorrowedTmuxSessionHandle) in readyCount += 1
+        }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "replaced-preview",
+            host: CommandHost.local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: TmuxGridSize(columns: 120, rows: 37)
+        )
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+        await waitUntilMainActor { identityLookups.load() == 1 }
+
+        let firstPromotion = Task { @MainActor in
+            await coordinator.enableInteractiveSizing(for: handle)
+        }
+        await waitUntilMainActor { promotionStarted.load() }
+        let close = try #require(store.surface.closeObservers[handle.id])
+        close(true, nil as UInt32?)
+        let readyCountBeforeReplacement = readyCount
+        let replacement = coordinator.attach(
+            hostID: handle.hostID,
+            name: handle.name,
+            host: CommandHost.local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: TmuxGridSize(columns: 120, rows: 37)
+        )
+        await waitUntilMainActor {
+            readyCount > readyCountBeforeReplacement
+        }
+        _ = coordinator.surface(handle: replacement)
+        releasePromotion.signal()
+
+        let firstResult = await firstPromotion.value
+        #expect(firstResult == TmuxClientSizingTransitionResult.stale)
+        let replacementResult = await coordinator.enableInteractiveSizing(
+            for: replacement
+        )
+        #expect(replacementResult == TmuxClientSizingTransitionResult.applied)
+        #expect(promotionMutations.load() == 1)
+    }
+
+    @Test("interactive sizing refreshes geometry before clearing ignore-size")
+    func interactiveSizingRefreshesGeometryBeforePromotion() async {
+        let store = RecordingNativeSessionSurfaceStore()
+        let promotionEvents = LockedValue<[String]>([])
+        store.surface.onClearPreviewGrid = {
+            promotionEvents.withLock { $0.append("geometry") }
+        }
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                if command.contains("'!ignore-size'") {
+                    promotionEvents.withLock { $0.append("sizing") }
+                }
+                return (0, "")
+            }
+        )
+        var isSurfaceReady = false
+        coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "promotion-order",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: TmuxGridSize(columns: 120, rows: 37)
+        )
+        await waitUntilMainActor { isSurfaceReady }
+        _ = coordinator.surface(handle: handle)
+
+        let result = await coordinator.enableInteractiveSizing(for: handle)
+
+        #expect(result == TmuxClientSizingTransitionResult.applied)
+        #expect(promotionEvents.load() == ["geometry", "sizing", "geometry"])
+        #expect(store.surface.clearPreviewGridCount == 2)
+    }
+
+    @Test("stale promotion restore recovers the tmux window dimensions")
+    func stalePromotionRestoreRecoversTmuxWindowDimensions() async throws {
+        guard case let .success(binary) = TmuxBinaryResolver()
+            .resolveTmuxBinary(),
+            TmuxPaneSplitter.supportsPaneSplitting(
+                version: binary.version,
+                host: .local
+            )
+        else { return }
+        let server = try TestTmuxServer(
+            tmuxPath: binary.path,
+            socket: .runOwned(purpose: "stale-promotion-size")
+        )
+        defer { server.stop() }
+        try server.createSession("restored")
+        let status = AccountCommandRunner.runProcess(
+            executable: binary.path,
+            arguments: server.connectionArguments + [
+                "set-option", "-g", "status", "off",
+            ],
+            timeout: 5
+        )
+        #expect(status.status == 0)
+
+        let clientToken = UUID().uuidString.lowercased()
+        let clientTTYDirectory = try #require(
+            ProcessInfo.processInfo.environment["TMUX_TMPDIR"]
+        )
+        let client = try TestTmuxClient(
+            tmuxPath: binary.path,
+            socketName: server.socketName,
+            sessionName: "restored",
+            clientToken: clientToken,
+            clientTTYDirectory: URL(
+                fileURLWithPath: clientTTYDirectory,
+                isDirectory: true
+            )
+        )
+        defer { client.stop() }
+        _ = try await client.publishedTTY()
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: binary.path,
+            sessionName: "restored",
+            socketName: server.socketName,
+            sshConnectionArguments: [],
+            clientToken: clientToken,
+            clientTTYDirectory: clientTTYDirectory
+        )
+        let clientIdentity = try await TmuxPaneSplitter()
+            .clientIdentity(target: target).get()
+        let identityOutput = [
+            "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY",
+            clientIdentity.serverPID,
+            clientIdentity.clientPID,
+            clientIdentity.clientCreatedAt,
+            clientIdentity.clientTTY,
+            clientIdentity.sessionID,
+            clientIdentity.sessionCreatedAt,
+            clientIdentity.paneID,
+        ].joined(separator: "\t") + "\n"
+        let interactiveGrid = TmuxGridSize(columns: 80, rows: 24)
+        let previewGrid = TmuxGridSize(columns: 120, rows: 37)
+        let interactiveResize = AccountCommandRunner.runProcess(
+            executable: binary.path,
+            arguments: server.connectionArguments + [
+                "resize-window", "-t", "restored:",
+                "-x", String(interactiveGrid.columns),
+                "-y", String(interactiveGrid.rows),
+            ],
+            timeout: 5
+        )
+        #expect(interactiveResize.status == 0)
+
+        let store = RecordingNativeSessionSurfaceStore()
+        var previewResizeStatus: Int32?
+        store.surface.onPreviewGridSize = { gridSize in
+            let clients = AccountCommandRunner.runProcess(
+                executable: binary.path,
+                arguments: server.connectionArguments + [
+                    "list-clients", "-F",
+                    "#{client_tty}\t#{client_flags}",
+                ],
+                timeout: 5
+            )
+            let clientFlags = clients.stdout.split(whereSeparator: \.isNewline)
+                .map(String.init)
+                .first { $0.hasPrefix(clientIdentity.clientTTY + "\t") }
+            guard clientFlags?.contains("ignore-size") == false else {
+                return
+            }
+            previewResizeStatus = AccountCommandRunner.runProcess(
+                executable: binary.path,
+                arguments: server.connectionArguments + [
+                    "resize-window", "-t", "restored:",
+                    "-x", String(gridSize.columns),
+                    "-y", String(gridSize.rows),
+                ],
+                timeout: 5
+            ).status
+        }
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { .success(binary) },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, identityOutput)
+                }
+                let result = AccountCommandRunner.runProcess(
+                    executable: "/bin/sh",
+                    arguments: ["-c", command],
+                    timeout: 15
+                )
+                return (result.status, result.stdout + result.stderr)
+            }
+        )
+        var isSurfaceReady = false
+        coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "restored",
+            host: CommandHost.local,
+            socketName: server.socketName,
+            sessionIdentity: clientIdentity.sessionIdentity
+        )
+        await waitUntilMainActor { isSurfaceReady }
+        _ = coordinator.surface(handle: handle)
+
+        #expect(
+            await coordinator.restorePreviewSizing(previewGrid, for: handle)
+                == .applied
+        )
+        let measured = AccountCommandRunner.runProcess(
+            executable: binary.path,
+            arguments: server.connectionArguments + [
+                "display-message", "-p", "-t", "restored:",
+                "#{window_width}x#{window_height}",
+            ],
+            timeout: 5
+        )
+
+        #expect(previewResizeStatus == 0)
+        #expect(measured.status == 0)
+        #expect(
+            measured.stdout.trimmingCharacters(
+                in: CharacterSet.whitespacesAndNewlines
+            ) == "120x37"
+        )
+    }
+
+    @Test("interactive sizing suppresses grid refresh during promotion")
+    func interactiveSizingSuppressesGridRefreshDuringPromotion() async {
+        let promotionStarted = LockedValue(false)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                if command.contains("'!ignore-size'") {
+                    promotionStarted.withLock { $0 = true }
+                    releasePromotion.wait()
+                }
+                return (0, "")
+            }
+        )
+        var isSurfaceReady = false
+        coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
+        let initialGrid = TmuxGridSize(columns: 120, rows: 37)
+        let refreshedGrid = TmuxGridSize(columns: 140, rows: 41)
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "promotion-refresh",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: initialGrid
+        )
+        await waitUntilMainActor { isSurfaceReady }
+        _ = coordinator.surface(handle: handle)
+
+        let promotion = Task { @MainActor in
+            await coordinator.enableInteractiveSizing(for: handle)
+        }
+        await waitUntilMainActor { promotionStarted.load() }
+        coordinator.updatePreviewGridSize(refreshedGrid, for: handle)
+        releasePromotion.signal()
+
+        let result = await promotion.value
+
+        #expect(result == TmuxClientSizingTransitionResult.applied)
+        #expect(store.surface.previewGridSizes == [
+            initialGrid,
+        ])
+        #expect(store.surface.clearPreviewGridCount == 2)
+    }
+
+    @Test("unchanged preview grids do not resize live surfaces")
+    func unchangedPreviewGridDoesNotResizeSurface() async {
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: {
+                successfulTmuxResolution("/opt/homebrew/bin/tmux")
+            }
+        )
+        var isSurfaceReady = false
+        coordinator.onSurfaceReady = { _ in isSurfaceReady = true }
+        let initialGrid = TmuxGridSize(columns: 180, rows: 50)
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "stable-preview",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: initialGrid
+        )
+        await waitUntilMainActor { isSurfaceReady }
+        _ = coordinator.surface(handle: handle)
+        _ = coordinator.surface(handle: handle)
+
+        coordinator.updatePreviewGridSize(initialGrid, for: handle)
+        coordinator.updatePreviewGridSize(
+            TmuxGridSize(columns: 160, rows: 48),
+            for: handle
+        )
+
+        #expect(store.surface.previewGridSizes == [
+            initialGrid,
+            TmuxGridSize(columns: 160, rows: 48),
+        ])
+    }
+
+    @Test("a reconnected preview sizes its replacement surface")
+    func reconnectedPreviewSizesReplacementSurface() async throws {
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: {
+                successfulTmuxResolution("/opt/homebrew/bin/tmux")
+            }
+        )
+        var readyCount = 0
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        let grid = TmuxGridSize(columns: 180, rows: 50)
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "reconnected-preview",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: grid
+        )
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: handle)
+
+        let close = try #require(store.surface.closeObservers[handle.id])
+        close(true, nil)
+        let replacement = coordinator.attach(
+            hostID: handle.hostID,
+            name: handle.name,
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: grid
+        )
+        await waitUntilMainActor { readyCount == 2 }
+        _ = coordinator.surface(handle: replacement)
+
+        #expect(replacement == handle)
+        #expect(store.surface.previewGridSizes == [grid, grid])
+    }
+
+    @Test("failed provisioning does not leak pending interactive sizing")
+    func failedProvisioningDoesNotLeakInteractiveSizing() async throws {
+        let resolutions = LockedValue(0)
+        let releaseResolution = DispatchSemaphore(value: 0)
+        defer { releaseResolution.signal() }
+        let store = RecordingNativeSessionSurfaceStore()
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: {
+                var attempt = 0
+                resolutions.withLock {
+                    $0 += 1
+                    attempt = $0
+                }
+                guard attempt == 1 else {
+                    return successfulTmuxResolution("/usr/bin/tmux")
+                }
+                _ = releaseResolution.wait(timeout: .now() + 5)
+                return .failure(.shellFailed(status: 1))
+            }
+        )
+        var readyCount = 0
+        var sawDisconnected = false
+        coordinator.onSurfaceReady = { _ in readyCount += 1 }
+        coordinator.onStateChanged = { _, state in
+            if case .disconnected = state {
+                sawDisconnected = true
+            }
+        }
+        let grid = TmuxGridSize(columns: 120, rows: 37)
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "leaked-sizing",
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: grid
+        )
+        let promotion = await coordinator.enableInteractiveSizing(for: handle)
+        #expect(promotion == TmuxClientSizingTransitionResult.pending)
+        releaseResolution.signal()
+        await waitUntilMainActor { sawDisconnected }
+
+        let replacement = coordinator.attach(
+            hostID: handle.hostID,
+            name: handle.name,
+            host: .local,
+            sessionIdentity: coordinatorSplitIdentity,
+            ignoresClientSize: true,
+            previewGridSize: grid
+        )
+        await waitUntilMainActor { readyCount == 1 }
+        _ = coordinator.surface(handle: replacement)
+
+        let command = try #require(
+            store.requestedConfigurations.last?.command
+        )
+        #expect(command.contains("ignore-size"))
     }
 }
 

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -660,6 +660,7 @@ final class RecordingNativeSessionSurfaceStore: NativeSessionSurfaceStoring {
     private(set) var requestedKeys: [SurfaceKey] = []
     private(set) var requestedConfigurations: [TerminalSurfaceConfiguration] = []
     private(set) var removedKeys: [SurfaceKey] = []
+    private var hasSurface = false
 
     var lastCommand: String? { requestedConfigurations.last?.command }
 
@@ -681,17 +682,19 @@ final class RecordingNativeSessionSurfaceStore: NativeSessionSurfaceStoring {
     ) -> (any NativeSessionPaneSurfacing)? {
         requestedKeys.append(key)
         requestedConfigurations.append(configuration)
+        hasSurface = true
         return surface
     }
 
     func paneSurfaceIfPresent(
         for _: SurfaceKey
     ) -> (any NativeSessionPaneSurfacing)? {
-        requestedConfigurations.isEmpty ? nil : surface
+        hasSurface ? surface : nil
     }
 
     func removeSurface(for key: SurfaceKey) {
         removedKeys.append(key)
+        hasSurface = false
     }
 }
 
@@ -708,6 +711,10 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     private var closeOnRegistrationCode: UInt32?
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
+    private(set) var previewGridSizes: [TmuxGridSize] = []
+    private(set) var clearPreviewGridCount = 0
+    var onPreviewGridSize: ((TmuxGridSize) -> Void)?
+    var onClearPreviewGrid: (() -> Void)?
 
     init(
         launchError: Error? = nil,
@@ -717,6 +724,19 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
         self.launchError = launchError
         self.launchFailureIsRetryable = launchFailureIsRetryable
         self.closeOnRegistrationCode = closeOnRegistrationCode
+    }
+
+    @discardableResult
+    func sizeForPreviewGrid(columns: Int, rows: Int) -> Bool {
+        let gridSize = TmuxGridSize(columns: columns, rows: rows)
+        previewGridSizes.append(gridSize)
+        onPreviewGridSize?(gridSize)
+        return true
+    }
+
+    func clearPreviewGridSize() {
+        clearPreviewGridCount += 1
+        onClearPreviewGrid?()
     }
 
     func registerSurfaceCloseObserver(

--- a/Tests/App/TmuxBinaryResolverTests.swift
+++ b/Tests/App/TmuxBinaryResolverTests.swift
@@ -2,6 +2,7 @@ import GhosthubTransport
 import Darwin
 import Foundation
 import GhosthubTmux
+import GhosthubWorkspace
 import Testing
 @testable import GhosthubApp
 
@@ -446,8 +447,8 @@ struct TmuxBinaryResolverTests {
                 stdout: """
                 /opt/homebrew/bin/tmux
                 tmux 3.7b
-                GHOSTHUB_TMUX_SESSION\t2\t101\t$1\t1783344091\t\tdocbank
-                GHOSTHUB_TMUX_SESSION\t4\t101\t$2\t1783344092\towner-token\tGhosthub\twork
+                GHOSTHUB_TMUX_SESSION\t2\t101\t$1\t1783344091\t120\t36\ton\t\tproject-a
+                GHOSTHUB_TMUX_SESSION\t4\t101\t$2\t1783344092\t200\t50\t3\towner-token\tGhosthub\twork
 
                 """
             )
@@ -456,14 +457,20 @@ struct TmuxBinaryResolverTests {
         #expect(
             try resolver.discoverSessions().get() == [
                 DiscoveredTmuxSession(
-                    name: "docbank", windowCount: 2,
+                    name: "project-a", windowCount: 2,
                     serverPID: "101",
-                    sessionID: "$1", createdAt: "1783344091", managed: false
+                    sessionID: "$1", createdAt: "1783344091",
+                    activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+                    previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+                    managed: false
                 ),
                 DiscoveredTmuxSession(
                     name: "Ghosthub\twork", windowCount: 4,
                     serverPID: "101",
-                    sessionID: "$2", createdAt: "1783344092", managed: true
+                    sessionID: "$2", createdAt: "1783344092",
+                    activeWindowSize: TmuxGridSize(columns: 200, rows: 50),
+                    previewClientSize: TmuxGridSize(columns: 200, rows: 53),
+                    managed: true
                 ),
             ]
         )
@@ -509,7 +516,7 @@ struct TmuxBinaryResolverTests {
                     stdout: """
                     /usr/local/bin/tmux
                     tmux 3.6
-                    GHOSTHUB_TMUX_SESSION\t3\t202\t$7\t99\t\tremote-work
+                    GHOSTHUB_TMUX_SESSION\t3\t202\t$7\t99\t132\t42\toff\t\tremote-work
 
                     """,
 
@@ -523,7 +530,10 @@ struct TmuxBinaryResolverTests {
                 == [DiscoveredTmuxSession(
                     name: "remote-work", windowCount: 3,
                     serverPID: "202",
-                    sessionID: "$7", createdAt: "99", managed: false
+                    sessionID: "$7", createdAt: "99",
+                    activeWindowSize: TmuxGridSize(columns: 132, rows: 42),
+                    previewClientSize: TmuxGridSize(columns: 132, rows: 42),
+                    managed: false
                 )]
         )
     }
@@ -550,7 +560,7 @@ struct TmuxBinaryResolverTests {
                     stdout: "C:\\Tools\\psmux\\tmux.exe\r\n"
                         + "tmux 3.6.7\r\n"
                         + "GHOSTHUB_TMUX_SESSION\t2\t202\t$7"
-                        + "\t1783344091\t\twindows-work\r\n",
+                        + "\t1783344091\t160\t48\t\t\twindows-work\r\n",
                     stderr: ""
                 )
             }
@@ -564,6 +574,7 @@ struct TmuxBinaryResolverTests {
                     serverPID: "202",
                     sessionID: "$7",
                     createdAt: "1783344091",
+                    activeWindowSize: TmuxGridSize(columns: 160, rows: 48),
                     managed: false
                 )]
         )
@@ -1050,6 +1061,141 @@ struct TmuxPathCacheTests {
         #expect(try cache.resolveTmuxBinary().get() == expected)
         #expect(try cache.resolveTmuxBinary().get() == expected)
         #expect(counter.count == 1)
+    }
+
+    @Test("concurrent successful resolutions share one probe")
+    func coalescesConcurrentSuccess() async throws {
+        let counter = Counter()
+        let gate = BlockingGate()
+        let cache = TmuxPathCache {
+            _ = counter.increment()
+            gate.block()
+            return .success(ResolvedTmuxBinary(
+                path: "/opt/homebrew/bin/tmux",
+                version: "tmux 3.4a"
+            ))
+        }
+
+        let first = Task.detached { cache.resolveTmuxBinary() }
+        await gate.waitUntilBlocked()
+        let secondStarted = LockedValue(false)
+        let second = Task.detached {
+            secondStarted.store(true)
+            return cache.resolveTmuxBinary()
+        }
+        await waitUntil { secondStarted.load() }
+        #expect(counter.count == 1)
+
+        gate.open()
+        #expect(try await first.value.get().path == "/opt/homebrew/bin/tmux")
+        #expect(try await second.value.get().path == "/opt/homebrew/bin/tmux")
+        #expect(counter.count == 1)
+    }
+
+    @Test("concurrent failed resolutions share one probe but later calls retry")
+    func coalescesConcurrentFailure() async throws {
+        let counter = Counter()
+        let gate = BlockingGate()
+        let cache = TmuxPathCache {
+            if counter.increment() == 1 {
+                gate.block()
+                return .failure(.notFound(shell: "/bin/zsh"))
+            }
+            return .success(ResolvedTmuxBinary(
+                path: "/opt/homebrew/bin/tmux",
+                version: "tmux 3.4"
+            ))
+        }
+
+        let first = Task.detached { cache.resolveTmuxBinary() }
+        await gate.waitUntilBlocked()
+        let secondStarted = LockedValue(false)
+        let second = Task.detached {
+            secondStarted.store(true)
+            return cache.resolveTmuxBinary()
+        }
+        await waitUntil { secondStarted.load() }
+
+        gate.open()
+        #expect(
+            await first.value
+                == .failure(.notFound(shell: "/bin/zsh"))
+        )
+        #expect(
+            await second.value
+                == .failure(.notFound(shell: "/bin/zsh"))
+        )
+        #expect(counter.count == 1)
+        #expect(
+            try cache.resolveTmuxBinary().get().path
+                == "/opt/homebrew/bin/tmux"
+        )
+        #expect(counter.count == 2)
+    }
+
+    @Test("a non-cancelled waiter retries a cancelled shared resolution")
+    func waiterRetriesCancelledResolution() async throws {
+        let counter = Counter()
+        let gate = BlockingGate()
+        let cache = TmuxPathCache(cancellationShell: "Build Host") {
+            if counter.increment() == 1 {
+                gate.block()
+                #expect(Task.isCancelled)
+                return .failure(.probeCancelled(shell: "Build Host"))
+            }
+            return .success(ResolvedTmuxBinary(
+                path: "/opt/homebrew/bin/tmux",
+                version: "tmux 3.4"
+            ))
+        }
+
+        let first = Task.detached { cache.resolveTmuxBinary() }
+        await gate.waitUntilBlocked()
+        let secondStarted = LockedValue(false)
+        let second = Task.detached {
+            secondStarted.store(true)
+            return cache.resolveTmuxBinary()
+        }
+        await waitUntil { secondStarted.load() }
+        for _ in 0 ..< 100 {
+            await Task.yield()
+        }
+
+        first.cancel()
+        gate.open()
+
+        #expect(
+            await first.value
+                == .failure(.probeCancelled(shell: "Build Host"))
+        )
+        #expect(
+            try await second.value.get().path
+                == "/opt/homebrew/bin/tmux"
+        )
+        #expect(counter.count == 2)
+    }
+
+    @Test("a cancelled caller does not start a probe")
+    func cancellationSkipsProbe() async {
+        let counter = Counter()
+        let cache = TmuxPathCache(cancellationShell: "Build Host") {
+            _ = counter.increment()
+            return .failure(.notFound(shell: "/bin/zsh"))
+        }
+        let task = Task.detached {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            return cache.resolveTmuxBinary()
+        }
+
+        task.cancel()
+
+        #expect(
+            await task.value
+                == .failure(.probeCancelled(shell: "Build Host"))
+        )
+        #expect(counter.count == 0)
     }
 
     @Test("a failed resolution is not cached, so a later install recovers without a restart")

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -70,7 +70,7 @@ private func publishedClientTTY(
     throw PublishedClientTTYError.timedOut
 }
 
-private final class TestTmuxClient {
+final class TestTmuxClient {
     let process = Process()
     private let input = Pipe()
     private let tokenPath: URL
@@ -80,7 +80,8 @@ private final class TestTmuxClient {
         socketName: String,
         sessionName: String,
         clientToken: String,
-        clientTTYDirectory: URL? = nil
+        clientTTYDirectory: URL? = nil,
+        ignoresClientSize: Bool = false
     ) throws {
         tokenPath = try testClientTokenPath(
             clientToken,
@@ -90,7 +91,8 @@ private final class TestTmuxClient {
             sessionName: sessionName,
             host: .local,
             socketName: socketName,
-            launchMode: .attachOnly
+            launchMode: .attachOnly,
+            ignoresClientSize: ignoresClientSize
         ).attachCommand(
             tmuxPath: tmuxPath,
             clientTTYToken: clientToken,
@@ -214,6 +216,54 @@ private func nativePaneSplitsAreAvailable(_ tmuxPath: String) -> Bool {
 
 @Suite("tmux pane splitting", .serialized)
 struct TmuxPaneSplitterTests {
+    @Test("a preview client preserves the existing tmux window size")
+    func previewClientPreservesWindowSize() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "preview-size",
+            sessions: ["preview"]
+        )
+        defer { server.stop() }
+        let resized = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName,
+                "resize-window", "-t", "preview:", "-x", "180", "-y", "50",
+            ],
+            timeout: 5
+        )
+        #expect(resized.status == 0)
+        let token = UUID().uuidString.lowercased()
+        let client = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: server.socketName,
+            sessionName: "preview",
+            clientToken: token,
+            ignoresClientSize: true
+        )
+        defer { client.stop() }
+
+        _ = try await client.publishedTTY()
+        let measured = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName,
+                "display-message", "-p", "-t", "preview:",
+                "#{window_width}x#{window_height}",
+            ],
+            timeout: 5
+        )
+
+        #expect(measured.status == 0)
+        #expect(measured.stdout.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) == "180x50")
+    }
+
     @Test("version capability requires tmux 3.4")
     func versionCapabilityRequiresTmux34() {
         #expect(TmuxPaneSplitter.supportsPaneSplitting(
@@ -968,6 +1018,48 @@ struct TmuxPaneSplitterTests {
         #expect(commands.load().count == 2)
     }
 
+    @Test("cancellation removes an installed sizing hook")
+    func cancellationRemovesInstalledSizingHook() async {
+        let hookInstalled = LockedValue(false)
+        let sizingStarted = LockedValue(false)
+        let commands = LockedValue<[String]>([])
+        let splitter = TmuxPaneSplitter { _, _, command in
+            commands.withLock { $0.append(command) }
+            if command.contains("'refresh-client'") {
+                hookInstalled.store(true)
+                sizingStarted.store(true)
+                while !withUnsafeCurrentTask(body: {
+                    $0?.isCancelled == true
+                }) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+            } else if command.contains("'set-hook' '-gu'") {
+                hookInstalled.store(false)
+            }
+            return (0, "")
+        }
+        let task = Task {
+            await splitter.enableSizing(
+                target: TmuxPaneSplitTarget(
+                    host: .local,
+                    tmuxPath: "/usr/bin/tmux",
+                    sessionName: "cancelled-sizing",
+                    socketName: nil,
+                    sshConnectionArguments: [],
+                    expectedIdentity: testSplitClient.sessionIdentity,
+                    expectedClient: testSplitClient
+                )
+            )
+        }
+
+        await waitUntil { sizingStarted.load() }
+        task.cancel()
+        _ = await task.value
+
+        #expect(!hookInstalled.load())
+        #expect(commands.load().count == 2)
+    }
+
     @Test("validation and split share one exact-client tmux queue")
     func posixCommands() {
         let right = TmuxPaneSplitter.command(
@@ -1016,6 +1108,96 @@ struct TmuxPaneSplitterTests {
         #expect(down.contains("split-window"))
         #expect(down.contains("-v"))
         #expect(!down.contains("=review"))
+    }
+
+    @Test("client sizing promotion keeps the exact client attached")
+    func sizingPromotionPreservesDestroyUnattachedSession() async throws {
+        guard case let .success(tmuxPath) =
+            TmuxBinaryResolver().resolveTmuxPath()
+        else { return }
+        guard nativePaneSplitsAreAvailable(tmuxPath) else { return }
+        let server = try makeTestTmuxServer(
+            tmuxPath: tmuxPath,
+            purpose: "sizing-promotion",
+            sessions: ["promoted"]
+        )
+        defer { server.stop() }
+        let token = UUID().uuidString.lowercased()
+        let clientProcess = try TestTmuxClient(
+            tmuxPath: tmuxPath,
+            socketName: server.socketName,
+            sessionName: "promoted",
+            clientToken: token,
+            ignoresClientSize: true
+        )
+        defer { clientProcess.stop() }
+        _ = try await clientProcess.publishedTTY()
+        let splitter = TmuxPaneSplitter()
+        let target = TmuxPaneSplitTarget(
+            host: .local,
+            tmuxPath: tmuxPath,
+            sessionName: "promoted",
+            socketName: server.socketName,
+            sshConnectionArguments: [],
+            clientToken: token
+        )
+        let client = try await splitter.clientIdentity(target: target).get()
+        let destroyUnattached = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName, "set-option", "-g",
+                "destroy-unattached", "on",
+            ],
+            timeout: 5
+        )
+        #expect(destroyUnattached.status == 0)
+
+        var verifiedTarget = target
+        verifiedTarget.expectedIdentity = client.sessionIdentity
+        verifiedTarget.expectedClient = client
+        let failure = await splitter.enableSizing(target: verifiedTarget)
+
+        #expect(failure == nil)
+        let session = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName, "has-session", "-t", "=promoted:",
+            ],
+            timeout: 5
+        )
+        #expect(session.status == 0)
+        let clients = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName, "list-clients", "-F",
+                "#{client_tty}\t#{client_flags}",
+            ],
+            timeout: 5
+        )
+        let promotedFlags = clients.stdout.split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .first { $0.hasPrefix(client.clientTTY + "\t") }
+        #expect(promotedFlags != nil)
+        #expect(promotedFlags?.contains("ignore-size") == false)
+
+        let restoreFailure = await splitter.disableSizing(
+            target: verifiedTarget
+        )
+        #expect(restoreFailure == nil)
+        let restoredClients = AccountCommandRunner.runProcess(
+            executable: tmuxPath,
+            arguments: [
+                "-L", server.socketName, "list-clients", "-F",
+                "#{client_tty}\t#{client_flags}",
+            ],
+            timeout: 5
+        )
+        let restoredFlags = restoredClients.stdout.split(
+            whereSeparator: \.isNewline
+        ).map(String.init).first {
+            $0.hasPrefix(client.clientTTY + "\t")
+        }
+        #expect(restoredFlags?.contains("ignore-size") == true)
     }
 
     @Test("atomic validation rejects a replacement on the expected TTY")

--- a/Tests/App/TmuxSessionPreviewCoordinatorTests.swift
+++ b/Tests/App/TmuxSessionPreviewCoordinatorTests.swift
@@ -53,6 +53,205 @@ struct TmuxSessionPreviewCoordinatorTests {
         )
     }
 
+    @Test("Always Live renders every expanded inactive presentation")
+    func alwaysLiveBypassesInactiveBudget() async {
+        let harness = PreviewCoordinatorHarness(
+            mode: .alwaysLive,
+            budgetLimit: 0
+        )
+        let first = harness.presentation(index: 0, isActive: false)
+        let second = harness.presentation(index: 1, isActive: false)
+        for item in [first, second] {
+            harness.coordinator.register(item)
+            harness.coordinator.setExpanded(true, for: item.key)
+        }
+
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+
+        #expect(Set(harness.parks) == [first.key, second.key])
+        #expect(Set(harness.captures) == [first.key, second.key])
+        #expect(harness.budget.granted.isEmpty)
+    }
+
+    @Test("Always Live rejects a switched client's changed frame")
+    func alwaysLiveRejectsChangedFrameAfterClientSwitch() async throws {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        let authorizedFrame = try #require(
+            harness.coordinator.viewState(for: presentation.key)?.frame
+        )
+        #expect(harness.identityRefreshes == 1)
+
+        harness.setRefreshedIdentity(
+            TmuxSessionIdentity(
+                serverPID: "101",
+                sessionID: "$replacement",
+                createdAt: "1001"
+            ),
+            for: presentation.key
+        )
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        #expect(harness.identityRefreshes == 2)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame
+                === authorizedFrame
+        )
+
+        harness.coordinator.remove(
+            presentation.key,
+            reason: .identityMismatch
+        )
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame
+                === authorizedFrame
+        )
+
+        harness.coordinator.setMode(.off)
+        #expect(harness.coordinator.viewState(for: presentation.key) == nil)
+    }
+
+    @Test("a replacement registration clears a mismatched session's frame")
+    func replacementRegistrationClearsMismatchedFrame() async throws {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        let staleFrame = try #require(
+            harness.coordinator.viewState(for: presentation.key)?.frame
+        )
+
+        harness.coordinator.remove(
+            presentation.key,
+            reason: .identityMismatch
+        )
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame
+                === staleFrame
+        )
+
+        let replacement = TmuxSessionPreviewCoordinator.Presentation(
+            key: presentation.key,
+            surface: { nil },
+            handleID: {
+                UUID(uuidString: "00000000-0000-0000-0000-0000000000FF")!
+            },
+            generation: { "generation-replacement" },
+            identity: { nil },
+            connectionState: { .connecting },
+            isActive: { false },
+            activate: {}
+        )
+        harness.coordinator.register(replacement, identityIsResolved: false)
+
+        let state = try #require(
+            harness.coordinator.viewState(for: presentation.key)
+        )
+        #expect(state.frame == nil)
+        #expect(state.placeholder == .awaitingFirstFrame)
+    }
+
+    @Test("a failed identity probe suppresses changed frames until recovery")
+    func failedIdentityProbeSuppressesFramesUntilRecovery() async {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+        harness.setRefreshedIdentity(nil, for: presentation.key)
+
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        #expect(harness.identityRefreshes == 1)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
+        )
+
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        #expect(harness.identityRefreshes == 2)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
+        )
+
+        harness.setRefreshedIdentity(
+            presentation.identity(),
+            for: presentation.key
+        )
+        await harness.coordinator.refreshLivePreviews()
+        await harness.coordinator.waitForPendingWork()
+        #expect(harness.identityRefreshes == 3)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
+        )
+    }
+
+    @Test("Always Live waits for staged surface launch before parking")
+    func alwaysLiveWaitsForSurfaceLaunchBeforeParking() {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        var hasLaunched = false
+        let key = TmuxPreviewKey(
+            hostID: UUID(),
+            name: "session-0",
+            socketName: nil
+        )
+        let presentation = TmuxSessionPreviewCoordinator.Presentation(
+            key: key,
+            surface: { nil },
+            handleID: { UUID() },
+            generation: { "generation" },
+            identity: { nil },
+            connectionState: { .connecting },
+            hasLaunched: { hasLaunched },
+            isActive: { false },
+            activate: {}
+        )
+        harness.coordinator.register(
+            presentation,
+            identityIsResolved: false
+        )
+
+        harness.coordinator.setExpanded(true, for: key)
+
+        #expect(harness.parks.isEmpty)
+
+        hasLaunched = true
+        harness.coordinator.presentationDidChange(key)
+
+        #expect(harness.parks == [key])
+        #expect(harness.captures.isEmpty)
+    }
+
+    @Test("Always Live leaves unavailable identities unmounted")
+    func alwaysLiveLeavesUnavailableIdentityUnmounted() {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(
+            presentation,
+            identityIsUnavailable: true
+        )
+
+        harness.coordinator.setExpanded(true, for: presentation.key)
+
+        #expect(harness.parks.isEmpty)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.placeholder
+                == .unavailable
+        )
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == false
+        )
+    }
+
     @Test("Live scheduling never exceeds two frames per second")
     func liveRateIsCapped() async {
         let recorder = PreviewIntervalRecorder()
@@ -118,7 +317,7 @@ struct TmuxSessionPreviewCoordinatorTests {
             "unpark:0",
         ])
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -136,7 +335,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         #expect(harness.unparks == [presentation.key])
         #expect(harness.budget.granted.isEmpty)
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
         #expect(
             harness.coordinator.viewState(for: presentation.key)?.capturedAt == nil
@@ -234,7 +433,7 @@ struct TmuxSessionPreviewCoordinatorTests {
 
         #expect(harness.captures == [presentation.key])
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -346,14 +545,17 @@ struct TmuxSessionPreviewCoordinatorTests {
         harness.coordinator.register(presentation)
         harness.coordinator.setExpanded(true, for: presentation.key)
         await harness.coordinator.waitForPendingWork()
-        let image = harness.coordinator.viewState(for: presentation.key)?.image
+        let capturedAt = harness.coordinator.viewState(
+            for: presentation.key
+        )?.capturedAt
         harness.captureShouldFail = true
 
         harness.coordinator.captureActiveIfNeeded(presentation.key)
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image === image
+            harness.coordinator.viewState(for: presentation.key)?.capturedAt
+                == capturedAt
         )
     }
 
@@ -375,7 +577,7 @@ struct TmuxSessionPreviewCoordinatorTests {
 
         #expect(harness.captures == [presentation.key])
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -390,7 +592,7 @@ struct TmuxSessionPreviewCoordinatorTests {
 
         #expect(harness.captures == [presentation.key])
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -443,7 +645,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(harness.captures == [key])
-        #expect(harness.coordinator.viewState(for: key)?.image != nil)
+        #expect(harness.coordinator.viewState(for: key)?.frame != nil)
     }
 
     @Test("Deferred identity capture starts after deactivation finishes")
@@ -504,7 +706,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(harness.captures == [key])
-        #expect(harness.coordinator.viewState(for: key)?.image != nil)
+        #expect(harness.coordinator.viewState(for: key)?.frame != nil)
     }
 
     @Test(
@@ -587,7 +789,7 @@ struct TmuxSessionPreviewCoordinatorTests {
 
         #expect(harness.captures == [presentation.key])
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -607,7 +809,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -657,7 +859,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         #expect(harness.captures == [presentation.key, presentation.key])
         #expect(didCompleteNavigationCapture)
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
@@ -706,12 +908,12 @@ struct TmuxSessionPreviewCoordinatorTests {
         #expect(captureAttempts == [presentation.key, presentation.key])
         #expect(didFinishDeactivation)
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image != nil
+            harness.coordinator.viewState(for: presentation.key)?.frame != nil
         )
     }
 
-    @Test("sidebar hiding and app deactivation release only this scene")
-    func visibilityAndActivityReleaseScene() {
+    @Test("sidebar hiding releases parking but app deactivation retains it")
+    func visibilityReleasesAndApplicationDeactivationRetainsParking() {
         let harness = PreviewCoordinatorHarness(mode: .live)
         let presentation = harness.presentation(index: 0, isActive: false)
         harness.coordinator.register(presentation)
@@ -722,8 +924,99 @@ struct TmuxSessionPreviewCoordinatorTests {
         #expect(harness.budget.granted.isEmpty)
 
         harness.coordinator.setSidebarVisible(true)
+        harness.unparks.removeAll()
         harness.coordinator.applicationDidResignActive()
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.unparks.isEmpty)
+        #expect(harness.budget.granted.count == 1)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == false
+        )
+
+        harness.coordinator.applicationDidBecomeActive()
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.unparks.isEmpty)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == true
+        )
+    }
+
+    @Test("non-key app reactivation releases retained preview budget")
+    func nonKeyApplicationReactivationReleasesParking() {
+        let harness = PreviewCoordinatorHarness(mode: .live)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+        harness.coordinator.applicationDidResignActive()
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.budget.granted.count == 1)
+
+        harness.keyWindow = false
+        harness.coordinator.applicationDidBecomeActive()
+
+        #expect(harness.parks.isEmpty)
+        #expect(harness.unparks == [presentation.key])
         #expect(harness.budget.granted.isEmpty)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == false
+        )
+    }
+
+    @Test("removed Always Live rows can clear expansion before re-registering")
+    func removedAlwaysLiveRowsClearExpansion() async {
+        let harness = PreviewCoordinatorHarness(mode: .alwaysLive)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+        #expect(harness.parks == [presentation.key])
+
+        harness.coordinator.remove(presentation.key, reason: .replacement)
+        harness.coordinator.setExpanded(false, for: presentation.key)
+        harness.coordinator.register(presentation)
+        await harness.coordinator.refreshLivePreviews()
+
+        #expect(harness.parks.isEmpty)
+        #expect(harness.captures.isEmpty)
+    }
+
+    @Test("non-key scenes release and reacquire parked preview budget")
+    func nonKeySceneReleasesParkedPreviewBudget() async {
+        let harness = PreviewCoordinatorHarness(
+            mode: .live,
+            activationDelay: .milliseconds(20)
+        )
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.budget.granted.count == 1)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == true
+        )
+
+        harness.keyWindow = false
+        harness.coordinator.sceneWindowFocusDidChange(isKey: false)
+
+        #expect(harness.parks.isEmpty)
+        #expect(harness.unparks == [presentation.key])
+        #expect(harness.budget.granted.isEmpty)
+        #expect(
+            harness.coordinator.viewState(for: presentation.key)?.isLive
+                == false
+        )
+
+        harness.keyWindow = true
+        harness.coordinator.sceneWindowFocusDidChange(isKey: true)
+        await waitUntilMainActor {
+            harness.parks == [presentation.key]
+        }
+
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.budget.granted.count == 1)
     }
 
     @Test("reconnect releases parking without immediately reacquiring it")
@@ -773,12 +1066,16 @@ struct TmuxSessionPreviewCoordinatorTests {
         harness.coordinator.setExpanded(true, for: presentation.key)
         await harness.coordinator.waitForPendingWork()
         harness.captures.removeAll()
+        let viewModel = harness.coordinator.viewModel(for: presentation.key)
 
         harness.coordinator.remove(presentation.key, reason: .replacement)
         harness.coordinator.register(presentation)
         await harness.coordinator.waitForPendingWork()
 
         #expect(harness.captures == [presentation.key])
+        #expect(
+            harness.coordinator.viewModel(for: presentation.key) === viewModel
+        )
     }
 
     @Test("removing the parking host cannot repark during slot release")
@@ -838,10 +1135,9 @@ struct TmuxSessionPreviewCoordinatorTests {
             activationDelay: .milliseconds(20)
         )
         let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.applicationDidResignActive()
         harness.coordinator.register(presentation)
         harness.coordinator.setExpanded(true, for: presentation.key)
-        harness.coordinator.applicationDidResignActive()
-        harness.parks.removeAll()
 
         harness.coordinator.applicationDidBecomeActive()
         harness.coordinator.applicationDidResignActive()
@@ -858,10 +1154,9 @@ struct TmuxSessionPreviewCoordinatorTests {
             activationDelay: .milliseconds(20)
         )
         let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.applicationDidResignActive()
         harness.coordinator.register(presentation)
         harness.coordinator.setExpanded(true, for: presentation.key)
-        harness.coordinator.applicationDidResignActive()
-        harness.parks.removeAll()
         harness.keyWindow = false
 
         harness.coordinator.applicationDidBecomeActive()
@@ -886,9 +1181,9 @@ struct TmuxSessionPreviewCoordinatorTests {
             activationDelay: .milliseconds(20)
         )
         let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.applicationDidResignActive()
         harness.coordinator.register(presentation)
         harness.coordinator.setExpanded(true, for: presentation.key)
-        harness.coordinator.applicationDidResignActive()
         harness.keyWindow = false
         harness.coordinator.applicationDidBecomeActive()
         try? await Task.sleep(for: .milliseconds(50))
@@ -957,6 +1252,32 @@ struct TmuxSessionPreviewCoordinatorTests {
         #expect(await recorder.count == 1)
     }
 
+    @Test("activation parks one terminal surface per main-thread turn")
+    func activationParksIncrementally() async {
+        let harness = PreviewCoordinatorHarness(
+            mode: .alwaysLive,
+            activationDelay: .zero,
+            parkingInterval: .seconds(60)
+        )
+        let presentations = (0 ..< 3).map {
+            harness.presentation(index: $0, isActive: false)
+        }
+        harness.coordinator.applicationDidResignActive()
+        for presentation in presentations {
+            harness.coordinator.register(presentation)
+            harness.coordinator.setExpanded(true, for: presentation.key)
+        }
+
+        harness.coordinator.applicationDidBecomeActive()
+        await waitUntilMainActor { harness.parks.count == 1 }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(harness.parks.count == 1)
+        harness.coordinator.applicationDidResignActive()
+    }
+
     @Test("invalidating a suspended capture prevents stale publication")
     func suspendedCaptureCannotPublishAfterOff() async {
         let harness = PreviewCoordinatorHarness(mode: .efficient)
@@ -971,7 +1292,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
     }
 
@@ -1006,7 +1327,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
     }
 
@@ -1028,7 +1349,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
     }
 
@@ -1050,7 +1371,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         await harness.coordinator.waitForPendingWork()
 
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
     }
 
@@ -1108,13 +1429,51 @@ struct TmuxSessionPreviewCoordinatorTests {
         harness.coordinator.register(presentation)
         harness.events.removeAll()
         var publications = 0
-        let observation = harness.coordinator.$viewStates
+        let observation = harness.coordinator
+            .viewModel(for: presentation.key).$state
             .dropFirst()
             .sink { _ in publications += 1 }
 
         harness.coordinator.prepareToActivate(presentation.key)
 
         #expect(harness.events == ["activate:0"])
+        #expect(publications == 0)
+        withExtendedLifetime(observation) {}
+    }
+
+    @Test("one live frame does not publish sibling tile state")
+    func liveFramePublicationIsTileScoped() async {
+        let harness = PreviewCoordinatorHarness(mode: .efficient)
+        let active = harness.presentation(index: 0, isActive: true)
+        let sibling = harness.presentation(index: 1, isActive: false)
+        harness.coordinator.register(active)
+        harness.coordinator.register(sibling)
+        var siblingPublications = 0
+        let observation = harness.coordinator.viewModel(for: sibling.key)
+            .$state.dropFirst()
+            .sink { _ in siblingPublications += 1 }
+
+        harness.coordinator.setExpanded(true, for: active.key)
+        await harness.coordinator.waitForPendingWork()
+
+        #expect(harness.captures == [active.key])
+        #expect(siblingPublications == 0)
+        withExtendedLifetime(observation) {}
+    }
+
+    @Test("unchanged preview state does not republish its tile")
+    func unchangedPreviewStateIsNotRepublished() {
+        let harness = PreviewCoordinatorHarness(mode: .efficient)
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        var publications = 0
+        let observation = harness.coordinator
+            .viewModel(for: presentation.key).$state
+            .dropFirst()
+            .sink { _ in publications += 1 }
+
+        harness.coordinator.register(presentation)
+
         #expect(publications == 0)
         withExtendedLifetime(observation) {}
     }
@@ -1163,7 +1522,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         harness.resumeCapture()
         await harness.coordinator.waitForPendingWork()
         #expect(
-            harness.coordinator.viewState(for: presentation.key)?.image == nil
+            harness.coordinator.viewState(for: presentation.key)?.frame == nil
         )
     }
 
@@ -1216,8 +1575,60 @@ struct TmuxSessionPreviewCoordinatorTests {
 
         model.handleApplicationDidResignActiveForResourceMonitoring()
 
-        #expect(harness.parks.isEmpty)
-        #expect(harness.budget.granted.isEmpty)
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.budget.granted.count == 1)
+    }
+
+    @Test("will-resign activity reaches previews before window focus loss")
+    func applicationResignationPrecedesWindowFocusLoss() async throws {
+        let workspace = try seededWorkspace()
+        let harness = PreviewCoordinatorHarness(mode: .live)
+        let model = try makeModel(
+            database: workspace.database,
+            localHostID: workspace.hostID,
+            sessionPreviewCoordinator: harness.coordinator
+        )
+        model.subscribeAppActivity()
+        model.isFocusedWindow = true
+        let presentation = harness.presentation(index: 0, isActive: false)
+        harness.coordinator.register(presentation)
+        harness.coordinator.setExpanded(true, for: presentation.key)
+        #expect(harness.parks == [presentation.key])
+
+        NotificationCenter.default.post(
+            name: NSApplication.willResignActiveNotification,
+            object: NSApp
+        )
+        #expect(model.isAppActive == false)
+        model.isFocusedWindow = false
+
+        #expect(harness.parks == [presentation.key])
+        #expect(harness.unparks.isEmpty)
+        #expect(harness.budget.granted.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("rapid activation and resignation preserve inactive state")
+    func rapidApplicationActivityPreservesLatestState() async throws {
+        let workspace = try seededWorkspace()
+        let model = try makeModel(
+            database: workspace.database,
+            localHostID: workspace.hostID
+        )
+        model.subscribeAppActivity()
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification,
+            object: NSApp
+        )
+        NotificationCenter.default.post(
+            name: NSApplication.willResignActiveNotification,
+            object: NSApp
+        )
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(model.isAppActive == false)
+        await model.shutdown()
     }
 }
 
@@ -1243,12 +1654,9 @@ private final class PreviewCoordinatorHarness {
                 }
             }
             captureSequence &+= 1
-            return TerminalSurfaceSnapshot(
-                image: NSImage(size: CGSize(width: 32, height: 20)),
-                captureToken: TerminalSurfaceCaptureToken(
-                    surfaceID: UInt32(Self.index(of: presentation) + 1),
-                    seed: captureSequence
-                )
+            return try makePreviewSnapshot(
+                surfaceID: UInt32(Self.index(of: presentation) + 1),
+                seed: captureSequence
             )
         },
         park: { [weak self] presentation in
@@ -1268,11 +1676,13 @@ private final class PreviewCoordinatorHarness {
         isKeyWindow: { [weak self] in self?.keyWindow == true },
         sleep: { duration in try await Task.sleep(for: duration) },
         activationDelay: activationDelay,
+        parkingInterval: parkingInterval,
         liveInterval: .seconds(60)
     )
 
     private let initialMode: SessionPreviewMode
     private let activationDelay: Duration
+    private let parkingInterval: Duration
     var captures: [TmuxPreviewKey] = []
     var parks: Set<TmuxPreviewKey> = []
     var unparks: [TmuxPreviewKey] = []
@@ -1282,22 +1692,25 @@ private final class PreviewCoordinatorHarness {
     var keyWindow = true
     var parkShouldFail = false
     var parkAttempts = 0
+    var identityRefreshes = 0
     private var captureContinuations: [CheckedContinuation<Void, Never>] = []
     private var captureSequence: UInt32 = 0
     private var activeByKey: [TmuxPreviewKey: Bool] = [:]
     private var connectionByKey: [TmuxPreviewKey: ConnectionState] = [:]
     private var identityByKey: [TmuxPreviewKey: TmuxSessionIdentity] = [:]
     private var refreshedIdentityByKey:
-        [TmuxPreviewKey: TmuxSessionIdentity] = [:]
+        [TmuxPreviewKey: TmuxSessionIdentity?] = [:]
 
     init(
         mode: SessionPreviewMode,
         budgetLimit: Int = 4,
-        activationDelay: Duration = .milliseconds(250)
+        activationDelay: Duration = .milliseconds(250),
+        parkingInterval: Duration = .milliseconds(10)
     ) {
         initialMode = mode
         budget = LivePreviewBudget(limit: budgetLimit)
         self.activationDelay = activationDelay
+        self.parkingInterval = parkingInterval
     }
 
     func presentation(
@@ -1331,6 +1744,7 @@ private final class PreviewCoordinatorHarness {
             },
             refreshIdentity: { [weak self] in
                 guard let self else { return nil }
+                identityRefreshes += 1
                 if let refreshed = refreshedIdentityByKey[key] {
                     return refreshed
                 }
@@ -1363,7 +1777,7 @@ private final class PreviewCoordinatorHarness {
         _ identity: TmuxSessionIdentity?,
         for key: TmuxPreviewKey
     ) {
-        refreshedIdentityByKey[key] = identity
+        refreshedIdentityByKey.updateValue(identity, forKey: key)
     }
 
     private static func index(

--- a/Tests/App/TmuxSessionPreviewStateTests.swift
+++ b/Tests/App/TmuxSessionPreviewStateTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import GhosthubSettings
 import GhosthubTerminal
 import GhosthubTmux
+import GhosthubTransport
 import Testing
 @testable import GhosthubApp
 
@@ -13,6 +14,15 @@ struct TmuxSessionPreviewStateTests {
         createdAt: "1000"
     )
     private let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("connecting status takes precedence over the empty preview")
+    func connectingStatus() {
+        #expect(TmuxSessionPreviewStatus.text(
+            connectionState: .connecting,
+            placeholder: .awaitingFirstFrame,
+            capturedAt: nil
+        ) == "Connecting")
+    }
 
     @Test("new state awaits its first frame")
     func emptyState() {

--- a/Tests/App/TmuxSessionPreviewTileRenderTests.swift
+++ b/Tests/App/TmuxSessionPreviewTileRenderTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import CoreVideo
+import GhosthubTerminal
+import GhosthubTerminalSupport
+import GhosthubTransport
+import IOSurface
+import SwiftUI
+import Testing
+@testable import GhosthubApp
+
+@Suite("Tmux session preview tile rendering")
+struct TmuxSessionPreviewTileRenderTests {
+    @Test("extreme terminal shapes use bounded preview canvases", arguments: [
+        (CGSize(width: 1_000_000, height: 1), CGSize(width: 320, height: 1)),
+        (CGSize(width: 1, height: 1_000_000), CGSize(width: 320, height: 1_024)),
+    ])
+    func extremeTerminalShapesUseBoundedCanvases(
+        sourceSize: CGSize,
+        expectedSize: CGSize
+    ) {
+        #expect(TerminalPreviewGeometry.thumbnailSize(
+            sourceSize: sourceSize,
+            outputWidth: 320
+        ) == expectedSize)
+    }
+
+    @MainActor
+    @Test("GPU frames size each tile to the terminal aspect")
+    func GPUFramesUseTerminalAspect() throws {
+        let viewModel = TmuxPreviewViewModel()
+
+        for (sourceSize, expectedHeight) in [
+            (CGSize(width: 320, height: 160), 160),
+            (CGSize(width: 320, height: 240), 240),
+            (CGSize(width: 320, height: 320), 320),
+            (CGSize(width: 320, height: 100), 100),
+        ] {
+            let ioSurface = try #require(IOSurfaceCreate([
+                kIOSurfaceWidth: Int(sourceSize.width),
+                kIOSurfaceHeight: Int(sourceSize.height),
+                kIOSurfaceBytesPerElement: 4,
+                kIOSurfaceBytesPerRow: Int(sourceSize.width) * 4,
+                kIOSurfacePixelFormat: kCVPixelFormatType_32BGRA,
+            ] as CFDictionary))
+            viewModel.setState(TmuxPreviewViewState(
+                frame: TerminalSurfacePreviewFrame(
+                    ioSurface: ioSurface,
+                    pixelSize: sourceSize
+                ),
+                capturedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                placeholder: nil,
+                connectionState: .connected,
+                isLive: true
+            ))
+            let renderer = ImageRenderer(content: TmuxSessionPreviewTile(
+                viewModel: viewModel,
+                sessionName: "release-work",
+                onActivate: {}
+            ).frame(width: 320))
+            renderer.proposedSize = ProposedViewSize(width: 320, height: nil)
+            renderer.scale = 1
+            let rendered = try #require(renderer.cgImage)
+
+            #expect(CGSize(
+                width: rendered.width,
+                height: rendered.height
+            ) == CGSize(width: 320, height: expectedHeight))
+        }
+    }
+}

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -13,6 +13,1808 @@ import Testing
 
 @Suite("Workspace tmux discovery", .serialized)
 struct WorkspaceTmuxDiscoveryTests {
+    @Test("Always Live activation waits for exact-client verification")
+    @MainActor
+    func alwaysLiveActivationWaitsForExactClientVerification() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let identityReads = Counter()
+        let promotionIdentityGate = BlockingGate()
+        defer { promotionIdentityGate.release() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            if identityReads.increment() == 2 {
+                promotionIdentityGate.wait()
+            }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+        let host = try #require(
+            environment.snapshot.host(id: environment.host.id)
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 1 && identityReads.count == 1
+        }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionIdentityGate.didStart }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        #expect(model.borrowedTmuxSessionView(
+            host: host,
+            sessionName: session.name,
+            defersTerminalResize: false
+        ) == nil)
+
+        promotionIdentityGate.release()
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection == selection
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(model.borrowedTmuxSessionView(
+            host: host,
+            sessionName: session.name,
+            defersTerminalResize: false
+        ) != nil)
+        await model.shutdown()
+    }
+
+    @Test("late route publication does not dismiss Always Live activation")
+    @MainActor
+    func lateRoutePublicationKeepsAlwaysLiveActivation() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let promotionStarted = LockedValue(false)
+        let promotionFinished = LockedValue(false)
+        let restoreCount = LockedValue(0)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionStarted.withLock { $0 = true }
+                releasePromotion.wait()
+                promotionFinished.withLock { $0 = true }
+                return (0, "")
+            }
+            if command.contains("ignore-size"),
+               !command.contains("!ignore-size") {
+                restoreCount.withLock { $0 += 1 }
+                return (0, "")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionStarted.load() }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) != nil)
+
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        releasePromotion.signal()
+        await waitUntilMainActor { promotionFinished.load() }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(restoreCount.load() == 0)
+        await model.shutdown()
+    }
+
+    @Test("failed Always Live promotion retries an interactive attachment")
+    @MainActor
+    func failedAlwaysLivePromotionRetriesInteractiveAttachment() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                return (1, "promotion rejected")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return model.activeBorrowedTmuxSelection == selection
+                && surfaceStore.requestCount == 2
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.count == 1)
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == false)
+        await model.shutdown()
+    }
+
+    @Test("host changes immediately detach Always Live clients")
+    @MainActor
+    func hostChangesDetachAlwaysLiveClients() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let removedHost = HostSummary(
+            id: UUID(),
+            configKey: "removed-builder",
+            name: "Removed Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "user@removed-builder",
+            preferredTransport: .ssh
+        )
+        var snapshot = environment.snapshot
+        snapshot.hosts.append(removedHost)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$1",
+                    createdAt: "1001"
+                )),
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { host in
+                host.isRemote ? .success([session]) : .success([])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 2
+                && surfaceStore.requestCount == 2
+        }
+
+        var updatedSnapshot = model.snapshot
+        updatedSnapshot.hosts.removeAll { $0.id == removedHost.id }
+        let changedIndex = try #require(updatedSnapshot.hosts.firstIndex {
+            $0.id == environment.remoteHost.id
+        })
+        updatedSnapshot.hosts[changedIndex].sshDestination =
+            "user@replacement-builder"
+        model.snapshot = updatedSnapshot
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaceStore.removedKeys.count == 2)
+        await model.shutdown()
+    }
+
+    @Test("Always Live replaces a retained client when identity changes")
+    @MainActor
+    func alwaysLiveReplacesMismatchedRetainedIdentity() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionID = LockedValue("$1")
+        let identityReads = Counter()
+        let splitter = TmuxPaneSplitter { _, _, command in
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            let currentSessionID = sessionID.load()
+            _ = identityReads.increment()
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001"
+                    + "\t\(currentSessionID)"
+                    + "\t\(currentSessionID == "$1" ? "1001" : "2002")"
+                    + "\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in
+                let currentSessionID = sessionID.load()
+                return .success([DiscoveredTmuxSession(
+                    name: "build",
+                    windowCount: 1,
+                    serverPID: "101",
+                    sessionID: currentSessionID,
+                    createdAt: currentSessionID == "$1" ? "1001" : "2002",
+                    activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+                    previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+                    managed: false
+                )])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 1 && identityReads.count >= 1
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        let initialHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+
+        sessionID.withLock { $0 = "$2" }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.retainedBorrowedTmuxHandle(for: selection)
+                != initialHandle
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("Always Live replaces a pending client when identity changes")
+    @MainActor
+    func alwaysLiveReplacesMismatchedPendingIdentity() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionID = LockedValue("$1")
+        let identityReads = Counter()
+        let initialIdentityGate = BlockingGate()
+        defer { initialIdentityGate.release() }
+        let splitter = TmuxPaneSplitter { _, _, command in
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            let currentSessionID = sessionID.load()
+            if identityReads.increment() == 1 {
+                initialIdentityGate.wait()
+            }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001"
+                    + "\t\(currentSessionID)"
+                    + "\t\(currentSessionID == "$1" ? "1001" : "2002")"
+                    + "\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in
+                let currentSessionID = sessionID.load()
+                return .success([DiscoveredTmuxSession(
+                    name: "pending-identity",
+                    windowCount: 1,
+                    serverPID: "101",
+                    sessionID: currentSessionID,
+                    createdAt: currentSessionID == "$1" ? "1001" : "2002",
+                    activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+                    previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+                    managed: false
+                )])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 1 && initialIdentityGate.didStart
+        }
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "pending-identity"
+        )
+        let initialHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+
+        sessionID.withLock { $0 = "$2" }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxSessions.first?.sessionID == "$2"
+        }
+        model.tmuxAttachedSessionIdentityBecameUnavailable(initialHandle)
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            surfaceStore.requestCount == 2
+                && model.retainedBorrowedTmuxHandle(for: selection)
+                != initialHandle
+        }
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.count == 1)
+        initialIdentityGate.release()
+        await model.shutdown()
+    }
+
+    @Test("Always Live retries an excluded name when identity changes")
+    @MainActor
+    func alwaysLiveRetriesExcludedReplacementIdentity() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionID = LockedValue("$1")
+        let resolutionCount = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                let attempt = resolutionCount.load()
+                resolutionCount.withLock { $0 += 1 }
+                return attempt == 0
+                    ? .failure(.notFound(shell: "/bin/zsh"))
+                    : successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$2",
+                    createdAt: "2002"
+                )),
+            tmuxSessionDiscovery: { _ in
+                let currentSessionID = sessionID.load()
+                return .success([DiscoveredTmuxSession(
+                    name: "retry",
+                    windowCount: 1,
+                    serverPID: "101",
+                    sessionID: currentSessionID,
+                    createdAt: currentSessionID == "$1" ? "1001" : "2002",
+                    activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+                    previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+                    managed: false
+                )])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolutionCount.load() == 1
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+
+        sessionID.withLock { $0 = "$2" }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolutionCount.load() == 2
+                && model.retainedBorrowedTmuxPresentationCount == 1
+                && surfaceStore.requestCount == 1
+        }
+
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+        await model.shutdown()
+    }
+
+    @Test("Always Live detaches unavailable identity and recovers a replacement")
+    @MainActor
+    func alwaysLiveDetachesUnavailableIdentity() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionID = LockedValue("$1")
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "identity-retry"
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            let currentSessionID = sessionID.load()
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY\t101\t789\t321"
+                    + "\t/dev/ttys001\t\(currentSessionID)"
+                    + "\t\(currentSessionID == "$1" ? "1001" : "2002")"
+                    + "\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in
+                let currentSessionID = sessionID.load()
+                return .success([DiscoveredTmuxSession(
+                    name: "identity-retry",
+                    windowCount: 1,
+                    serverPID: "101",
+                    sessionID: currentSessionID,
+                    createdAt: currentSessionID == "$1" ? "1001" : "2002",
+                    activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+                    previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+                    managed: false
+                )])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+        }
+        let initialHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: selection)
+        )
+        model.tmuxAttachedSessionIdentityBecameUnavailable(initialHandle)
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaceStore.removedKeys.count == 1)
+
+        sessionID.withLock { $0 = "$2" }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+                && model.retainedBorrowedTmuxHandle(for: selection)
+                != initialHandle
+        }
+
+        await model.shutdown()
+    }
+
+    @Test("stale Always Live promotion cannot activate after navigation")
+    @MainActor
+    func staleAlwaysLivePromotionRestoresPreviewSizing() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let promotionStarted = LockedValue(false)
+        let restoreCount = LockedValue(0)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionStarted.withLock { $0 = true }
+                releasePromotion.wait()
+                return (0, "")
+            }
+            if command.contains("ignore-size"),
+               !command.contains("!ignore-size") {
+                restoreCount.withLock { $0 += 1 }
+                return (0, "")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        model.openBorrowedTmuxSession(WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        ))
+        await waitUntilMainActor { promotionStarted.load() }
+
+        model.hideBorrowedTmuxSession(WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        ))
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        releasePromotion.signal()
+        await waitUntilMainActor { restoreCount.load() == 1 }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(surfaceStore.surface.clearPreviewGridCount == 2)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("reopening during stale promotion restoration serializes sizing")
+    @MainActor
+    func reopeningDuringPromotionRestorationSerializesSizing() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let promotionCount = LockedValue(0)
+        let restoreStarted = LockedValue(false)
+        let restoreFinished = LockedValue(false)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        let releaseRestore = DispatchSemaphore(value: 0)
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        defer {
+            releasePromotion.signal()
+            releaseRestore.signal()
+        }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionCount.withLock { $0 += 1 }
+                if promotionCount.load() == 1 {
+                    releasePromotion.wait()
+                }
+                return (0, "")
+            }
+            if command.contains("ignore-size"),
+               !command.contains("!ignore-size") {
+                restoreStarted.withLock { $0 = true }
+                releaseRestore.wait()
+                restoreFinished.withLock { $0 = true }
+                return (0, "")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionCount.load() == 1 }
+
+        model.hideBorrowedTmuxSession(selection)
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        releasePromotion.signal()
+        await waitUntilMainActor { restoreStarted.load() }
+
+        model.openBorrowedTmuxSession(selection)
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(promotionCount.load() == 1)
+
+        mode.send(.live)
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        releaseRestore.signal()
+        await waitUntilMainActor { restoreFinished.load() }
+        await waitUntilMainActor {
+            promotionCount.load() == 2
+                && surfaceStore.surface.clearPreviewGridCount == 4
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(promotionCount.load() == 2)
+        #expect(surfaceStore.surface.clearPreviewGridCount == 4)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("failed stale promotion restoration detaches the hidden client")
+    @MainActor
+    func failedStalePromotionRestorationDetachesClient() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let promotionStarted = LockedValue(false)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionStarted.withLock { $0 = true }
+                releasePromotion.wait()
+                return (0, "")
+            }
+            if command.contains("ignore-size"),
+               !command.contains("!ignore-size") {
+                return (1, "restore rejected")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionStarted.load() }
+
+        model.hideBorrowedTmuxSession(selection)
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        releasePromotion.signal()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 0
+                && surfaceStore.removedKeys.count == 1
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.previewableTmuxSessionIDs.isEmpty)
+        model.refreshTmuxSessionDiscovery()
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(surfaceStore.requestCount == 1)
+        await model.shutdown()
+    }
+
+    @Test("Always Live promotes an opened client to normal sizing in place")
+    @MainActor
+    func alwaysLiveConnectsEveryDiscoveredSession() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        let previewCoordinator = TmuxSessionPreviewCoordinator(
+            mode: .alwaysLive,
+            budget: LivePreviewBudget(limit: 0),
+            capture: { _, _ in nil }
+        )
+        let sessions = ["build", "review"].enumerated().map { index, name in
+            DiscoveredTmuxSession(
+                name: name,
+                windowCount: index + 1,
+                serverPID: "101",
+                sessionID: "$\(index + 1)",
+                createdAt: "100\(index)",
+                activeWindowSize: TmuxGridSize(
+                    columns: 120 + index * 20,
+                    rows: 36 + index * 4
+                ),
+                previewClientSize: TmuxGridSize(
+                    columns: 120 + index * 20,
+                    rows: 37 + index * 4
+                ),
+                managed: false
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$1",
+                    createdAt: "1000"
+                )),
+            tmuxSessionDiscovery: { _ in .success(sessions) },
+            sessionPreviewCoordinator: previewCoordinator,
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 2
+                && surfaceStore.requestCount == 2
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.previewableTmuxSessionIDs.count == 2)
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .tmuxSessions.map(\.activeWindowSize) == [
+                TmuxGridSize(columns: 120, rows: 36),
+                TmuxGridSize(columns: 140, rows: 40),
+            ])
+
+        let opened = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "build"
+        )
+        model.openBorrowedTmuxSession(opened)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return model.activeBorrowedTmuxSelection == opened
+                && surfaceStore.surface.clearPreviewGridCount == 2
+        }
+
+        #expect(surfaceStore.requestCount == 2)
+        #expect(surfaceStore.removedKeys.isEmpty)
+
+        mode.send(.live)
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+        }
+
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("leaving Always Live preserves an active sizing promotion")
+    @MainActor
+    func leavingAlwaysLivePreservesActivePromotion() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        let promotionStarted = LockedValue(false)
+        let promotionFinished = LockedValue(false)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionStarted.withLock { $0 = true }
+                releasePromotion.wait()
+                promotionFinished.withLock { $0 = true }
+                return (0, "")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionStarted.load() }
+
+        mode.send(.live)
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.removedKeys.isEmpty)
+
+        releasePromotion.signal()
+        await waitUntilMainActor { promotionFinished.load() }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.surface.clearPreviewGridCount == 2)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test("leaving Always Live releases an inactive sizing promotion")
+    @MainActor
+    func leavingAlwaysLiveReleasesInactivePromotion() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        let promotionStarted = LockedValue(false)
+        let releasePromotion = DispatchSemaphore(value: 0)
+        defer { releasePromotion.signal() }
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            if command.contains("'!ignore-size'") {
+                promotionStarted.withLock { $0 = true }
+                releasePromotion.wait()
+                return (0, "")
+            }
+            guard command.contains(
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+            ) else { return (0, "") }
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t101\t789\t321\t/dev/ttys001\t$1\t1001\t%9\n"
+            )
+        }
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { promotionStarted.load() }
+
+        model.hideBorrowedTmuxSession(selection)
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+        mode.send(.live)
+        releasePromotion.signal()
+        await waitUntilMainActor {
+            surfaceStore.surface.clearPreviewGridCount == 2
+        }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("restoration promotes a policy-owned preview client before activation")
+    @MainActor
+    func restorationPromotesAlwaysLiveClient() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let session = DiscoveredTmuxSession(
+            name: "review",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$1",
+                    createdAt: "1001"
+                )),
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+
+        model.beginRestoration(WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(hostKey: environment.host.configKey),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: session.name,
+                socketName: nil,
+                owner: .unbound
+            )
+        ))
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return model.activeBorrowedTmuxSelection?.name == session.name
+                && surfaceStore.surface.clearPreviewGridCount == 2
+        }
+
+        #expect(surfaceStore.requestCount == 1)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        await model.shutdown()
+    }
+
+    @Test(
+        "Always Live leaves a closed client detached until identity changes",
+        arguments: [false, true]
+    )
+    @MainActor
+    func alwaysLiveClosedClientRelaunchesOnlyForNewIdentity(
+        explicitClose: Bool
+    ) async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let discoveries = Counter()
+        let sessionID = LockedValue("$1")
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in
+                _ = discoveries.increment()
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "review",
+                        windowCount: 1,
+                        serverPID: "101",
+                        sessionID: sessionID.load(),
+                        createdAt: sessionID.load() == "$1"
+                            ? "1001"
+                            : "2002",
+                        activeWindowSize: TmuxGridSize(
+                            columns: 120,
+                            rows: 36
+                        ),
+                        previewClientSize: TmuxGridSize(
+                            columns: 120,
+                            rows: 37
+                        ),
+                        managed: false
+                    ),
+                ])
+            },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 1
+                && !surfaceStore.surface.closeObservers.isEmpty
+        }
+
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "review"
+        )
+        if explicitClose {
+            model.closeBorrowedTmuxSession(selection)
+        } else {
+            surfaceStore.surface.closeObservers.values.first?(false, 0)
+        }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor { discoveries.count >= 2 }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(surfaceStore.requestCount == 1)
+
+        sessionID.withLock { $0 = "$2" }
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 2 }
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @Test("removing a preview client preserves unrelated pending restoration")
+    @MainActor
+    func previewRemovalPreservesPendingRestoration() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let session = DiscoveredTmuxSession(
+            name: "review",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let discoveries = TmuxDiscoveryResultQueue([
+            .success([session]),
+            .success([]),
+        ])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+        let pending = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(hostKey: "unavailable-host"),
+            tmux: nil
+        )
+        model.beginRestoration(pending)
+
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            discoveries.count == 2
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+
+        #expect(model.restorationState(windowID: pending.windowID) == pending)
+        await model.shutdown()
+    }
+
+    @Test("Always Live waits for a display before creating terminal surfaces")
+    @MainActor
+    func alwaysLiveWaitsForDisplayBeforeCreatingSurfaces() async throws {
+        let environment = try setupStandardEnvironment()
+        let displays = Mutex(0)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        let session = DiscoveredTmuxSession(
+            name: "build",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 120, rows: 36),
+            previewClientSize: TmuxGridSize(columns: 120, rows: 37),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            activeDisplayCount: { displays.withLock { $0 } },
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+                && model.snapshot.host(id: environment.host.id)?
+                .tmuxInventoryIsAuthoritative == true
+        }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(surfaceStore.requestCount == 0)
+
+        displays.withLock { $0 = 1 }
+        model.handleDisplayParametersChanged()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+
+        await model.shutdown()
+    }
+
+    @Test("Always Live does not attach Windows psmux sessions")
+    @MainActor
+    func alwaysLiveExcludesWindowsSessions() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].platform = .windows
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let session = DiscoveredTmuxSession(
+            name: "windows-work",
+            windowCount: 1,
+            createdAt: "1001",
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("C:\\tools\\psmux.exe")
+            },
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.snapshot.host(id: environment.host.id)?
+                .tmuxInventoryIsAuthoritative == true
+        }
+
+        #expect(model.snapshot.host(id: environment.host.id)?
+            .tmuxSessions.map(\.name) == [session.name])
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.previewableTmuxSessionIDs.isEmpty)
+        #expect(surfaceStore.requestCount == 0)
+        await model.shutdown()
+    }
+
+    @Test("Always Live excludes tmux clients without safe identity support")
+    @MainActor
+    func alwaysLiveExcludesUnsupportedTmuxBeforeLaunch() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let resolutionCount = LockedValue(0)
+        let session = DiscoveredTmuxSession(
+            name: "legacy",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                resolutionCount.withLock { $0 += 1 }
+                return successfulTmuxResolution(
+                    "/usr/bin/tmux",
+                    version: "tmux 3.3a"
+                )
+            },
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolutionCount.load() == 1
+                && model.retainedBorrowedTmuxPresentationCount == 0
+        }
+        #expect(surfaceStore.requestCount == 0)
+
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return model.activeBorrowedTmuxSelection == selection
+                && surfaceStore.requestCount == 1
+        }
+
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == false)
+        await model.shutdown()
+    }
+
+    @Test("entering Always Live adopts previews without touching the active client")
+    @MainActor
+    func enteringAlwaysLiveKeepsActiveClientSizing() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.off)
+        let sessions = [
+            DiscoveredTmuxSession(
+                name: "opened",
+                windowCount: 1,
+                serverPID: "101",
+                sessionID: "$1",
+                createdAt: "1001",
+                activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+                previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+                managed: false
+            ),
+            DiscoveredTmuxSession(
+                name: "fleet",
+                windowCount: 1,
+                serverPID: "101",
+                sessionID: "$2",
+                createdAt: "1002",
+                activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+                previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+                managed: false
+            ),
+        ]
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in .success(sessions) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .off,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+
+        model.startTmuxSessionDiscovery()
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "opened"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 1
+        }
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == false)
+
+        mode.send(.alwaysLive)
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 2
+                && surfaceStore.requestCount == 2
+        }
+
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "fleet"
+        ) == true)
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(Set(surfaceStore.requestedKeys).count == 2)
+        await model.shutdown()
+    }
+
+    @Test("opening during resolution keeps a tmux 3.3 session interactive")
+    @MainActor
+    func pendingOpenSurvivesUnsupportedPreviewResolution() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let resolution = DelayedTmuxPathState(version: "tmux 3.3")
+        defer { resolution.release() }
+        let session = DiscoveredTmuxSession(
+            name: "legacy",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: resolution.resolve,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolution.didStart
+                && model.retainedBorrowedTmuxPresentationCount == 1
+        }
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "legacy"
+        )
+        model.openBorrowedTmuxSession(selection)
+        resolution.release()
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 1
+        }
+
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == false)
+        await model.shutdown()
+    }
+
+    @Test("display loss during preview launch retries when a display returns")
+    @MainActor
+    func surfaceUnavailablePreviewRetriesAfterDisplayReturns() async throws {
+        struct DisplayGoneError: Error {}
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        surfaceStore.surface.launchError = DisplayGoneError()
+        surfaceStore.surface.launchFailureIsRetryable = true
+        let session = DiscoveredTmuxSession(
+            name: "flapped",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+
+        surfaceStore.surface.launchError = nil
+        model.refreshTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+                && surfaceStore.requestCount == 2
+        }
+
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+        await model.shutdown()
+    }
+
+    @Test("failed Always Live setup does not strand a later manual open")
+    @MainActor
+    func alwaysLiveProvisioningFailureAllowsManualRetry() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let resolutionCount = LockedValue(0)
+        let firstResolutionGate = BlockingGate()
+        let failureDelivered = LockedValue(false)
+        let mode = CurrentValueSubject<SessionPreviewMode, Never>(.alwaysLive)
+        defer { firstResolutionGate.release() }
+        let session = DiscoveredTmuxSession(
+            name: "retry",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                let attempt = resolutionCount.load()
+                resolutionCount.withLock { $0 += 1 }
+                guard attempt == 0 else {
+                    return successfulTmuxResolution("/usr/bin/tmux")
+                }
+                firstResolutionGate.wait()
+                failureDelivered.store(true)
+                return .failure(.notFound(shell: "/bin/zsh"))
+            },
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            ),
+            sessionPreviewModePublisher: mode.eraseToAnyPublisher()
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolutionCount.load() == 1
+                && firstResolutionGate.didStart
+                && model.retainedBorrowedTmuxPresentationCount == 1
+        }
+
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+        model.openBorrowedTmuxSession(selection)
+        #expect(model.activeBorrowedTmuxSelection == selection)
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        mode.send(.live)
+        firstResolutionGate.release()
+        await waitUntilMainActor { failureDelivered.load() }
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 0
+        }
+
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return resolutionCount.load() == 2
+                && model.activeBorrowedTmuxSelection == selection
+                && surfaceStore.requestCount == 1
+        }
+
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == false)
+        await model.shutdown()
+    }
+
+    @Test("stale pending promotion restores preview sizing before launch")
+    @MainActor
+    func stalePendingPromotionRestoresPreviewSizing() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let resolution = DelayedTmuxPathState()
+        defer { resolution.release() }
+        let session = DiscoveredTmuxSession(
+            name: "pending",
+            windowCount: 1,
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1001",
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: resolution.resolve,
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                budget: LivePreviewBudget(limit: 0),
+                capture: { _, _ in nil }
+            )
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: session.name
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            resolution.didStart
+                && model.retainedBorrowedTmuxPresentationCount == 1
+        }
+        model.openBorrowedTmuxSession(selection)
+        model.hideBorrowedTmuxSession(selection)
+        model.selectFromUser(WorkspaceSelection(
+            selectedHostID: environment.host.id
+        ))
+
+        resolution.release()
+        await waitUntilMainActor { surfaceStore.requestCount == 1 }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.lastConfiguration?.command?.contains(
+            "ignore-size"
+        ) == true)
+        await model.shutdown()
+    }
+
     @Test("application activation does not refresh tmux inventory")
     @MainActor
     func applicationActivationDoesNotRefreshTmuxInventory() async throws {
@@ -908,8 +2710,10 @@ struct WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("authoritative inventory latches a retained canonical generation")
-    func authoritativeInventoryLatchesRetainedGeneration() async throws {
+    @Test(
+        "authoritative inventory enriches missing generation and invalidates changes"
+    )
+    func authoritativeInventoryReconcilesRetainedGeneration() async throws {
         let environment = try setupStandardEnvironment()
         let firstGeneration = "0123456789abcdef0123456789abcdef"
         let replacementGeneration = "fedcba9876543210fedcba9876543210"
@@ -974,8 +2778,10 @@ struct WorkspaceTmuxDiscoveryTests {
         model.refreshKwtInventory()
         await waitUntilMainActor {
             model.snapshot.worktrees[0].generation == replacementGeneration
+                && model.activeBorrowedTmuxSelection == nil
                 && model.retainedBorrowedTmuxPresentationCount == 0
         }
+        #expect(model.retainedBorrowedTmuxHandle(for: enriched) == nil)
         await model.shutdown()
     }
 
@@ -986,10 +2792,6 @@ struct WorkspaceTmuxDiscoveryTests {
             (
                 "kwt-ghosthub-replacement",
                 "0123456789abcdef0123456789abcdef"
-            ),
-            (
-                "kwt-ghosthub-main",
-                "fedcba9876543210fedcba9876543210"
             ),
         ]
     )
@@ -1272,14 +3074,19 @@ struct WorkspaceTmuxDiscoveryTests {
     final class DelayedTmuxPathState: @unchecked Sendable {
         private let lock = NSLock()
         private let gate = DispatchSemaphore(value: 0)
+        private let version: String
         private var started = false
+
+        init(version: String = "tmux 3.4") {
+            self.version = version
+        }
 
         func resolve() -> Result<ResolvedTmuxBinary, TmuxBinaryError> {
             lock.lock()
             started = true
             lock.unlock()
             gate.wait()
-            return successfulTmuxResolution("/usr/bin/tmux")
+            return successfulTmuxResolution("/usr/bin/tmux", version: version)
         }
 
         var didStart: Bool {

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -159,7 +159,8 @@ extension WorkspaceTmuxDiscoveryTests {
                 events.append(
                     "unpark:\(weakModel?.activeBorrowedTmuxSelection?.name ?? "none")"
                 )
-            }
+            },
+            isKeyWindow: { true }
         )
         let model = try makeModel(
             database: environment.database,
@@ -607,13 +608,7 @@ extension WorkspaceTmuxDiscoveryTests {
             budget: LivePreviewBudget(limit: 4),
             capture: { _, _ in
                 _ = captures.increment()
-                return TerminalSurfaceSnapshot(
-                    image: NSImage(size: CGSize(width: 32, height: 20)),
-                    captureToken: TerminalSurfaceCaptureToken(
-                        surfaceID: 1,
-                        seed: 1
-                    )
-                )
+                return try makePreviewSnapshot()
             }
         )
         let surfaceStore = SceneTmuxSurfaceStoreStub()
@@ -759,11 +754,6 @@ extension WorkspaceTmuxDiscoveryTests {
                 Optional("replacement-socket"),
                 "0123456789abcdef0123456789abcdef"
             ),
-            (
-                "kwt-ghosthub-main",
-                String?.none,
-                "fedcba9876543210fedcba9876543210"
-            ),
         ]
     )
     func returningToReplacedWorktreeInvalidatesRetainedClient(
@@ -820,6 +810,60 @@ extension WorkspaceTmuxDiscoveryTests {
             #expect(model.retainedBorrowedTmuxHandle(for: worktree) == nil)
         }
         #expect(model.activeBorrowedTmuxSelection == replacement)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 2)
+        #expect(surfaceStore.removedKeys.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("returning after a generation refresh replaces the retained client")
+    func returningAfterGenerationRefreshReplacesRetainedClient() async throws {
+        let environment = try setupStandardEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+        let worktree = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef"
+        )
+        let other = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "other"
+        )
+        model.openBorrowedTmuxSession(worktree)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let originalHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: worktree)
+        )
+        model.openBorrowedTmuxSession(other)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+
+        var refreshed = worktree
+        refreshed.worktreeGeneration =
+            "fedcba9876543210fedcba9876543210"
+        model.openBorrowedTmuxSession(refreshed)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 3
+        }
+
+        #expect(
+            model.retainedBorrowedTmuxHandle(for: refreshed) != originalHandle
+        )
+        #expect(model.activeBorrowedTmuxSelection == refreshed)
         #expect(model.retainedBorrowedTmuxPresentationCount == 2)
         #expect(surfaceStore.removedKeys.count == 1)
         await model.shutdown()

--- a/Tests/App/WorkspaceTmuxPreviewTests.swift
+++ b/Tests/App/WorkspaceTmuxPreviewTests.swift
@@ -86,13 +86,7 @@ extension WorkspaceTmuxDiscoveryTests {
             budget: LivePreviewBudget(limit: 4),
             capture: { _, _ in
                 _ = captures.increment()
-                return TerminalSurfaceSnapshot(
-                    image: NSImage(size: CGSize(width: 32, height: 20)),
-                    captureToken: TerminalSurfaceCaptureToken(
-                        surfaceID: 1,
-                        seed: 1
-                    )
-                )
+                return try makePreviewSnapshot()
             }
         )
         let model = try makeModel(
@@ -137,11 +131,11 @@ extension WorkspaceTmuxDiscoveryTests {
         previewCoordinator.setExpanded(true, for: key)
         await waitUntilMainActor {
             captures.count == 1
-                && previewCoordinator.viewState(for: key)?.image != nil
+                && previewCoordinator.viewState(for: key)?.frame != nil
         }
 
         #expect(identityReads.count == 0)
-        #expect(previewCoordinator.viewState(for: key)?.image != nil)
+        #expect(previewCoordinator.viewState(for: key)?.frame != nil)
         await model.shutdown()
     }
 
@@ -181,13 +175,7 @@ extension WorkspaceTmuxDiscoveryTests {
             budget: LivePreviewBudget(limit: 4),
             capture: { _, _ in
                 _ = captures.increment()
-                return TerminalSurfaceSnapshot(
-                    image: NSImage(size: CGSize(width: 32, height: 20)),
-                    captureToken: TerminalSurfaceCaptureToken(
-                        surfaceID: 1,
-                        seed: 1
-                    )
-                )
+                return try makePreviewSnapshot()
             }
         )
         let model = try makeModel(
@@ -221,11 +209,142 @@ extension WorkspaceTmuxDiscoveryTests {
         }
 
         #expect(captures.count == 1)
-        #expect(previewCoordinator.viewState(for: key)?.image == nil)
+        #expect(previewCoordinator.viewState(for: key)?.frame == nil)
         #expect(
             previewCoordinator.viewState(for: key)?.placeholder
                 == .unavailable
         )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test(
+        "a switched managed client retains only an identity-bound frame",
+        arguments: SwitchedClientDisposition.allCases
+    )
+    func switchedManagedClientRetainsOnlyAuthorizedFrame(
+        _ disposition: SwitchedClientDisposition
+    ) async throws {
+        let environment = try setupHostEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let sessionID = LockedValue("$1")
+        let captures = Counter()
+        let originalIdentity = TmuxSessionIdentity(
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1000"
+        )
+        let switchedIdentity = TmuxSessionIdentity(
+            serverPID: "101",
+            sessionID: "$2",
+            createdAt: "2000"
+        )
+        let splitter = TmuxPaneSplitter { _, _, command in
+            guard command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY")
+            else { return (0, "") }
+            let identity = sessionID.load() == "$1"
+                ? originalIdentity : switchedIdentity
+            return (
+                0,
+                "GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"
+                    + "\t\(identity.serverPID)\t789\t321"
+                    + "\t/dev/ttys001\t\(identity.sessionID)"
+                    + "\t\(identity.createdAt)\t%9\n"
+            )
+        }
+        let previewCoordinator = TmuxSessionPreviewCoordinator(
+            mode: .alwaysLive,
+            budget: LivePreviewBudget(limit: 0),
+            capture: { _, _ in
+                let sequence = captures.increment()
+                return try makePreviewSnapshot(seed: UInt32(sequence))
+            },
+            park: { _ in },
+            unpark: { _ in },
+            isKeyWindow: { true },
+            liveInterval: .seconds(60)
+        )
+        let session = DiscoveredTmuxSession(
+            name: "fleet",
+            windowCount: 1,
+            serverPID: originalIdentity.serverPID,
+            sessionID: originalIdentity.sessionID,
+            createdAt: originalIdentity.createdAt,
+            activeWindowSize: TmuxGridSize(columns: 100, rows: 30),
+            previewClientSize: TmuxGridSize(columns: 100, rows: 31),
+            managed: false
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            nativeTmuxPaneSplitter: splitter,
+            tmuxSessionDiscovery: { _ in
+                let identity = sessionID.load() == "$1"
+                    ? originalIdentity : switchedIdentity
+                return .success([DiscoveredTmuxSession(
+                    name: session.name,
+                    windowCount: session.windowCount,
+                    serverPID: identity.serverPID,
+                    sessionID: identity.sessionID,
+                    createdAt: identity.createdAt,
+                    activeWindowSize: session.activeWindowSize,
+                    previewClientSize: session.previewClientSize,
+                    managed: session.managed
+                )])
+            },
+            sessionPreviewCoordinator: previewCoordinator
+        )
+        let key = TmuxPreviewKey(
+            hostID: environment.host.id,
+            name: session.name,
+            socketName: nil
+        )
+
+        model.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 1
+                && surfaceStore.requestCount == 1
+        }
+        previewCoordinator.setExpanded(true, for: key)
+        await waitUntilMainActor {
+            await previewCoordinator.refreshLivePreviews()
+            return captures.count >= 1
+        }
+        await previewCoordinator.waitForPendingWork()
+        let authorizedFrame = try #require(
+            previewCoordinator.viewState(for: key)?.frame
+        )
+
+        sessionID.withLock { $0 = "$2" }
+        await previewCoordinator.refreshLivePreviews()
+        await previewCoordinator.waitForPendingWork()
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxPresentationCount == 0
+        }
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(
+            previewCoordinator.viewState(for: key)?.frame
+                === authorizedFrame
+        )
+
+        switch disposition {
+        case .replacementIdentity:
+            model.refreshTmuxSessionDiscovery()
+            await waitUntilMainActor {
+                model.retainedBorrowedTmuxPresentationCount == 1
+                    && surfaceStore.requestCount == 2
+            }
+        case .removedHost:
+            var snapshot = model.snapshot
+            snapshot.hosts.removeAll { $0.id == environment.host.id }
+            model.snapshot = snapshot
+        }
+        #expect(previewCoordinator.viewState(for: key)?.frame == nil)
         await model.shutdown()
     }
 
@@ -245,13 +364,7 @@ extension WorkspaceTmuxDiscoveryTests {
             budget: LivePreviewBudget(limit: 4),
             capture: { _, _ in
                 let sequence = captures.increment()
-                return TerminalSurfaceSnapshot(
-                    image: NSImage(size: CGSize(width: 32, height: 20)),
-                    captureToken: TerminalSurfaceCaptureToken(
-                        surfaceID: 1,
-                        seed: UInt32(sequence)
-                    )
-                )
+                return try makePreviewSnapshot(seed: UInt32(sequence))
             }
         )
         let model = try makeModel(
@@ -288,8 +401,13 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(captures.count == 2)
         #expect(model.activeBorrowedTmuxSelection == nil)
         #expect(model.previewableTmuxSessionIDs == [selection.id])
-        #expect(previewCoordinator.viewState(for: key)?.image != nil)
+        #expect(previewCoordinator.viewState(for: key)?.frame != nil)
         await model.shutdown()
     }
 
+}
+
+enum SwitchedClientDisposition: CaseIterable, Sendable {
+    case replacementIdentity
+    case removedHost
 }

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -1362,12 +1362,14 @@ extension WorkspaceTmuxDiscoveryTests {
 
         await waitUntilMainActor {
             probe.didCancel
-                && attempts.count == 2
                 && surfaceStore.requestCount == 2
                 && model.activeBorrowedTmuxSessionIsConnected
         }
 
-        #expect(attempts.count == 2)
+        // A slow scheduler can let the deadline cancel a second probe
+        // before its instant success lands, so the retry count is a
+        // lower bound rather than an exact value.
+        #expect(attempts.count >= 2)
         #expect(surfaceStore.requestCount == 2)
         #expect(model.activeBorrowedTmuxSessionIsConnected)
         #expect(model.activeBorrowedTmuxRecoveryState == nil)

--- a/Tests/App/WorkspaceTmuxTestSupport.swift
+++ b/Tests/App/WorkspaceTmuxTestSupport.swift
@@ -125,6 +125,11 @@ final class SceneTmuxPaneSurfaceStub: NativeSessionPaneSurfacing {
     var childExitCode: UInt32?
     private(set) var closeObservers: [UUID: (Bool, UInt32?) -> Void] = [:]
     private(set) var lastObserverID: UUID?
+    private(set) var clearPreviewGridCount = 0
+
+    func clearPreviewGridSize() {
+        clearPreviewGridCount += 1
+    }
 
     func registerSurfaceCloseObserver(
         id: UUID,
@@ -163,6 +168,12 @@ final class SceneTmuxSurfaceStoreStub: NativeSessionSurfaceStoring {
         lastConfiguration = configuration
         requestedKeys.append(key)
         return returnsSurface ? surface : nil
+    }
+
+    func paneSurfaceIfPresent(
+        for key: SurfaceKey
+    ) -> (any NativeSessionPaneSurfacing)? {
+        retainedKeys.contains(key) ? surface : nil
     }
 
     func removeSurface(for key: SurfaceKey) {

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1400,6 +1400,25 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         )
     }
 
+    func testFontZoomReappliesParkedPreviewGrid() throws {
+        let (coordinator, config) = try makeCoordinator()
+        defer { coordinator.removeAll() }
+        let key = SurfaceKey.fixture()
+        let view = try XCTUnwrap(coordinator.surface(
+            for: key,
+            configuration: config
+        ))
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        XCTAssertTrue(view.sizeForPreviewGrid(columns: 120, rows: 41))
+
+        coordinator.applyFontZoom(.increase)
+
+        let size = try XCTUnwrap(view.surfaceSize)
+        XCTAssertEqual(Int(size.columns), 120)
+        XCTAssertEqual(Int(size.rows), 41)
+    }
+
     func testSurfaceIdentityLookupResolvesLiveView() throws {
         let (coordinator, config) = try makeCoordinator()
         let key = SurfaceKey.fixture()

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -1024,6 +1024,43 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(view.frame, originalFrame)
     }
 
+    func testPreviewSizingConvergesAfterRejectedInitialApply() throws {
+        let view = try makeSurface()
+        let realSizeSetter = TerminalSurfaceView.sizeSetter
+        defer { TerminalSurfaceView.sizeSetter = realSizeSetter }
+        // Simulate libghostty not adopting the resize while the surface is
+        // still initializing.
+        TerminalSurfaceView.sizeSetter = { _, _, _ in }
+
+        XCTAssertFalse(view.sizeForPreviewGrid(columns: 123, rows: 41))
+
+        TerminalSurfaceView.sizeSetter = realSizeSetter
+        view.ensurePreviewGridSize()
+
+        let converged = try XCTUnwrap(view.surfaceSize)
+        XCTAssertEqual(Int(converged.columns), 123)
+        XCTAssertEqual(Int(converged.rows), 41)
+    }
+
+    func testEnsurePreviewGridSizeIsIdleOnceAdopted() throws {
+        let view = try makeSurface()
+        XCTAssertTrue(view.sizeForPreviewGrid(columns: 96, rows: 28))
+        let realSizeSetter = TerminalSurfaceView.sizeSetter
+        defer { TerminalSurfaceView.sizeSetter = realSizeSetter }
+        var resizeCount = 0
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            resizeCount += 1
+            realSizeSetter(surface, width, height)
+        }
+
+        view.ensurePreviewGridSize()
+
+        XCTAssertEqual(resizeCount, 0)
+        let size = try XCTUnwrap(view.surfaceSize)
+        XCTAssertEqual(Int(size.columns), 96)
+        XCTAssertEqual(Int(size.rows), 28)
+    }
+
     func testPromotionPreservesPreviewGridUntilInteractiveMount() throws {
         let view = try makeSurface()
         XCTAssertTrue(view.sizeForPreviewGrid(columns: 100, rows: 30))

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -20,7 +20,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         try skipUnlessLibghosttyReady()
     }
 
-    func testSnapshotCopiesAThumbnailWithoutMutatingSurface() async throws {
+    func testSnapshotProducesGPUFrameWithoutMutatingSurface() async throws {
         let view = try makeSurface()
         let window = hostInWindow(view)
         defer { window.orderOut(nil) }
@@ -28,6 +28,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let originalSuperview = view.superview
         let originalFrame = view.frame
         let originalSurfaceSize = try XCTUnwrap(view.surfaceSize)
+        let ioSurface = try XCTUnwrap(view.layer?.contents as? IOSurface)
         let snapshotter = TerminalSurfaceSnapshotter()
 
         let captured = try await snapshotter.snapshot(
@@ -36,24 +37,24 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             previousCaptureToken: nil
         )
         let snapshot = try XCTUnwrap(captured)
-        let expectedThumbnailSize = TerminalPreviewGeometry.thumbnailSize(
-            sourceSize: CGSize(
-                width: Int(originalSurfaceSize.width_px),
-                height: Int(originalSurfaceSize.height_px)
-            ),
-            outputWidth: 320
-        )
+        let previewFrame = try XCTUnwrap(snapshot.frame)
 
-        XCTAssertEqual(snapshot.image.size, expectedThumbnailSize)
-        let image = try XCTUnwrap(
-            snapshot.image.cgImage(
-                forProposedRect: nil,
-                context: nil,
-                hints: nil
+        XCTAssertEqual(snapshot.captureToken.surfaceID, IOSurfaceGetID(ioSurface))
+        XCTAssertEqual(IOSurfaceGetWidth(previewFrame.ioSurface), 320)
+        XCTAssertNotNil(
+            IOSurfaceCopyValue(previewFrame.ioSurface, kIOSurfaceColorSpace)
+        )
+        XCTAssertEqual(
+            previewFrame.pixelSize,
+            TerminalPreviewGeometry.thumbnailSize(
+                sourceSize: CGSize(
+                    width: IOSurfaceGetWidth(ioSurface),
+                    height: IOSurfaceGetHeight(ioSurface)
+                ),
+                outputWidth: 320
             )
         )
-        XCTAssertEqual(image.width, 320)
-        XCTAssertEqual(image.height, Int(expectedThumbnailSize.height))
+        XCTAssertFalse(previewFrame.ioSurface === ioSurface)
         XCTAssertTrue(view.superview === originalSuperview)
         XCTAssertEqual(view.frame, originalFrame)
         XCTAssertEqual(view.surfaceSize?.width_px, originalSurfaceSize.width_px)
@@ -61,17 +62,122 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertNotNil(view.surfaceHandle)
     }
 
-    func testSnapshotPreservesInRangeSourceAspectRatio() async throws {
+    func testPreviewDisplaysGPUFramesThroughCoreAnimation() throws {
+        let firstSurface = try makeIOSurface(width: 400, height: 300)
+        let replacementSurface = try makeIOSurface(width: 800, height: 400)
+        let firstFrame = TerminalSurfacePreviewFrame(
+            ioSurface: firstSurface,
+            pixelSize: CGSize(width: 400, height: 300)
+        )
+        let replacementFrame = TerminalSurfacePreviewFrame(
+            ioSurface: replacementSurface,
+            pixelSize: CGSize(width: 800, height: 400)
+        )
+        let preview = TerminalSurfacePreviewView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 200
+        ))
+
+        preview.display(firstFrame)
+
+        XCTAssertTrue(
+            preview.layer?.contents as? IOSurface === firstSurface
+        )
+        XCTAssertEqual(preview.layer?.contentsGravity, .resize)
+        XCTAssertTrue(preview.layer?.actions?["contents"] is NSNull)
+
+        preview.display(replacementFrame)
+
+        XCTAssertTrue(
+            preview.layer?.contents as? IOSurface === replacementSurface
+        )
+    }
+
+    func testSnapshotPreservesSourceAspectAcrossPreviewShapes() async throws {
         let view = try makeSurface()
-        view.layer?.contents = try makeIOSurface(width: 400, height: 300)
+        view.layer?.backgroundColor = NSColor.black.cgColor
+        let snapshotter = TerminalSurfaceSnapshotter()
+
+        for (sourceSize, expectedOutputSize) in [
+            (CGSize(width: 400, height: 300), CGSize(width: 320, height: 240)),
+            (CGSize(width: 800, height: 400), CGSize(width: 320, height: 160)),
+            (CGSize(width: 320, height: 400), CGSize(width: 320, height: 400)),
+            (CGSize(width: 800, height: 200), CGSize(width: 320, height: 80)),
+        ] {
+            let sourceSurface = try makeIOSurface(
+                width: Int(sourceSize.width),
+                height: Int(sourceSize.height)
+            )
+            XCTAssertEqual(IOSurfaceLock(sourceSurface, [], nil), kIOReturnSuccess)
+            memset(
+                try XCTUnwrap(IOSurfaceGetBaseAddress(sourceSurface)),
+                0xFF,
+                IOSurfaceGetAllocSize(sourceSurface)
+            )
+            XCTAssertEqual(IOSurfaceUnlock(sourceSurface, [], nil), kIOReturnSuccess)
+            view.layer?.contents = sourceSurface
+            let captured = try await snapshotter.snapshot(
+                of: view,
+                outputWidth: 320,
+                previousCaptureToken: nil
+            )
+            let frame = try XCTUnwrap(captured?.frame)
+
+            XCTAssertEqual(frame.pixelSize, expectedOutputSize)
+            XCTAssertEqual(IOSurfaceGetWidth(frame.ioSurface), 320)
+            XCTAssertEqual(
+                IOSurfaceGetHeight(frame.ioSurface),
+                Int(expectedOutputSize.height)
+            )
+            XCTAssertEqual(IOSurfaceLock(frame.ioSurface, [.readOnly], nil), kIOReturnSuccess)
+            let pixels = try XCTUnwrap(IOSurfaceGetBaseAddress(frame.ioSurface))
+                .assumingMemoryBound(to: UInt8.self)
+            let rowBytes = IOSurfaceGetBytesPerRow(frame.ioSurface)
+            let corner = pixels
+            let center = pixels
+                + Int(expectedOutputSize.height / 2) * rowBytes
+                + 160 * 4
+            XCTAssertGreaterThan(Int(corner[0]) + Int(corner[1]) + Int(corner[2]), 700)
+            XCTAssertGreaterThan(Int(center[0]) + Int(center[1]) + Int(center[2]), 700)
+            XCTAssertEqual(
+                IOSurfaceUnlock(frame.ioSurface, [.readOnly], nil),
+                kIOReturnSuccess
+            )
+        }
+    }
+
+    func testSnapshotUsesMetalCompatibleStrideForOddOutputWidth() async throws {
+        let view = try makeSurface()
+        let sourceSurface = try makeIOSurface(width: 400, height: 300)
+        XCTAssertEqual(IOSurfaceLock(sourceSurface, [], nil), kIOReturnSuccess)
+        memset(
+            try XCTUnwrap(IOSurfaceGetBaseAddress(sourceSurface)),
+            0xFF,
+            IOSurfaceGetAllocSize(sourceSurface)
+        )
+        XCTAssertEqual(IOSurfaceUnlock(sourceSurface, [], nil), kIOReturnSuccess)
+        view.layer?.contents = sourceSurface
 
         let captured = try await TerminalSurfaceSnapshotter().snapshot(
             of: view,
-            outputWidth: 320,
+            outputWidth: 301,
             previousCaptureToken: nil
         )
-
-        XCTAssertEqual(captured?.image.size, CGSize(width: 320, height: 240))
+        let frame = try XCTUnwrap(captured?.frame)
+        XCTAssertEqual(frame.pixelSize, CGSize(width: 301, height: 226))
+        XCTAssertEqual(IOSurfaceGetBytesPerRow(frame.ioSurface) % 16, 0)
+        XCTAssertEqual(IOSurfaceLock(frame.ioSurface, [.readOnly], nil), kIOReturnSuccess)
+        let center = try XCTUnwrap(IOSurfaceGetBaseAddress(frame.ioSurface))
+            .assumingMemoryBound(to: UInt8.self)
+            + 113 * IOSurfaceGetBytesPerRow(frame.ioSurface)
+            + 150 * 4
+        XCTAssertGreaterThan(Int(center[0]) + Int(center[1]) + Int(center[2]), 700)
+        XCTAssertEqual(
+            IOSurfaceUnlock(frame.ioSurface, [.readOnly], nil),
+            kIOReturnSuccess
+        )
     }
 
     func testSnapshotSkipsAnUnchangedIOSurfaceToken() async throws {
@@ -245,7 +351,10 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             )
             XCTFail("Expected invalid output size failure")
         } catch {
-            XCTAssertEqual(error as? TerminalSurfaceSnapshotError, .invalidOutputSize)
+            XCTAssertEqual(
+                error as? TerminalSurfaceSnapshotError,
+                .invalidOutputSize
+            )
         }
     }
 
@@ -691,13 +800,27 @@ final class TerminalSurfacePreviewTests: XCTestCase {
 
     func testParkingHostIsNoninteractiveAndPreservesSurfaceSize() throws {
         let originalOcclusionSetter = TerminalSurfaceView.occlusionSetter
+        let originalSizeSetter = TerminalSurfaceView.sizeSetter
+        let originalContentScaleSetter = TerminalSurfaceView.contentScaleSetter
         var occlusionStates: [Bool] = []
+        var surfaceSizes: [(UInt32, UInt32)] = []
+        var contentScales: [(Double, Double)] = []
         TerminalSurfaceView.occlusionSetter = { surface, visible in
             occlusionStates.append(visible)
             originalOcclusionSetter(surface, visible)
         }
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            surfaceSizes.append((width, height))
+            originalSizeSetter(surface, width, height)
+        }
+        TerminalSurfaceView.contentScaleSetter = { surface, xScale, yScale in
+            contentScales.append((xScale, yScale))
+            originalContentScaleSetter(surface, xScale, yScale)
+        }
         defer {
             TerminalSurfaceView.occlusionSetter = originalOcclusionSetter
+            TerminalSurfaceView.sizeSetter = originalSizeSetter
+            TerminalSurfaceView.contentScaleSetter = originalContentScaleSetter
         }
         let view = try makeSurface()
         let window = hostInWindow(view)
@@ -710,8 +833,11 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         window.contentView = root
         let host = LivePreviewParkingHost(frame: root.bounds)
         root.addSubview(host)
+        surfaceSizes.removeAll()
+        contentScales.removeAll()
 
         try host.park(view)
+        view.viewDidChangeBackingProperties()
 
         XCTAssertTrue(host.contains(view))
         XCTAssertTrue(view.superview === host)
@@ -721,6 +847,10 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(view.surfaceSize?.height_px, originalSurfaceSize.height_px)
         XCTAssertEqual(view.surfaceSize?.columns, originalSurfaceSize.columns)
         XCTAssertEqual(view.surfaceSize?.rows, originalSurfaceSize.rows)
+        XCTAssertTrue(surfaceSizes.isEmpty)
+        XCTAssertEqual(contentScales.count, 1)
+        XCTAssertEqual(contentScales.first?.0, window.backingScaleFactor)
+        XCTAssertEqual(contentScales.first?.1, window.backingScaleFactor)
         XCTAssertNil(host.hitTest(CGPoint(x: 10, y: 10)))
         XCTAssertEqual(host.accessibilityChildren()?.count, 0)
         XCTAssertFalse(host.isAccessibilityElement())
@@ -734,6 +864,235 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertEqual(view.frame, originalFrame)
         XCTAssertEqual(view.bounds, originalBounds)
         XCTAssertEqual(occlusionStates.last, false)
+    }
+
+    func testInteractiveRemountRepublishesWindowContentScale() throws {
+        let originalContentScaleSetter = TerminalSurfaceView.contentScaleSetter
+        var contentScales: [(Double, Double)] = []
+        TerminalSurfaceView.contentScaleSetter = { surface, xScale, yScale in
+            contentScales.append((xScale, yScale))
+            originalContentScaleSetter(surface, xScale, yScale)
+        }
+        defer {
+            TerminalSurfaceView.contentScaleSetter = originalContentScaleSetter
+        }
+        let view = try makeSurface()
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        try waitForIOSurface(in: view)
+        let root = NSView(frame: try XCTUnwrap(window.contentView).bounds)
+        window.contentView = root
+        let host = LivePreviewParkingHost(frame: root.bounds)
+        root.addSubview(host)
+        try host.park(view)
+
+        contentScales.removeAll()
+        host.unpark(view)
+        root.addSubview(view)
+
+        XCTAssertEqual(contentScales.last?.0, window.backingScaleFactor)
+        XCTAssertEqual(contentScales.last?.1, window.backingScaleFactor)
+    }
+
+    func testUnparkingOccludesSurfaceBeforeReparenting() throws {
+        let originalOcclusionSetter = TerminalSurfaceView.occlusionSetter
+        let view = try makeSurface()
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        let root = NSView(frame: try XCTUnwrap(window.contentView).bounds)
+        window.contentView = root
+        let host = LivePreviewParkingHost(frame: root.bounds)
+        root.addSubview(host)
+        try host.park(view)
+        var occlusionEvents: [(visible: Bool, wasParked: Bool)] = []
+        TerminalSurfaceView.occlusionSetter = { surface, visible in
+            occlusionEvents.append((visible, view.superview === host))
+            originalOcclusionSetter(surface, visible)
+        }
+        defer {
+            TerminalSurfaceView.occlusionSetter = originalOcclusionSetter
+        }
+
+        host.unpark(view)
+
+        XCTAssertEqual(occlusionEvents.first?.visible, false)
+        XCTAssertEqual(occlusionEvents.first?.wasParked, true)
+        XCTAssertNil(view.superview)
+    }
+
+    func testApplicationActivitySuspendsAndRestoresParkedSurfaceRendering()
+        throws {
+        let originalOcclusionSetter = TerminalSurfaceView.occlusionSetter
+        var occlusionStates: [Bool] = []
+        TerminalSurfaceView.occlusionSetter = { surface, visible in
+            occlusionStates.append(visible)
+            originalOcclusionSetter(surface, visible)
+        }
+        defer {
+            TerminalSurfaceView.occlusionSetter = originalOcclusionSetter
+        }
+
+        let surface = try makeSurface()
+        surface.frame = NSRect(x: 0, y: 0, width: 640, height: 400)
+        let root = NSView(frame: surface.frame)
+        let window = NSWindow(
+            contentRect: root.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        let parkingHost = LivePreviewParkingHost(frame: root.bounds)
+        root.addSubview(parkingHost)
+        let key = TmuxPreviewKey(
+            hostID: UUID(),
+            name: "parked-activity",
+            socketName: nil
+        )
+        let coordinator = TmuxSessionPreviewCoordinator(
+            mode: .live,
+            budget: LivePreviewBudget(limit: 1),
+            capture: { _, _ in nil },
+            isKeyWindow: { true }
+        )
+        defer { coordinator.shutdown() }
+        coordinator.installParkingHost(parkingHost)
+        coordinator.register(.init(
+            key: key,
+            surface: { surface },
+            handleID: { UUID() },
+            generation: { nil },
+            identity: {
+                TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$1",
+                    createdAt: "1000"
+                )
+            },
+            connectionState: { .connected },
+            isActive: { false },
+            activate: {}
+        ))
+        coordinator.setExpanded(true, for: key)
+        XCTAssertTrue(parkingHost.contains(surface))
+        occlusionStates.removeAll()
+
+        coordinator.applicationDidResignActive()
+
+        XCTAssertTrue(parkingHost.contains(surface))
+        XCTAssertEqual(occlusionStates.last, false)
+        let resignationEventCount = occlusionStates.count
+
+        coordinator.applicationDidBecomeActive()
+
+        XCTAssertTrue(parkingHost.contains(surface))
+        XCTAssertGreaterThan(occlusionStates.count, resignationEventCount)
+        XCTAssertEqual(
+            occlusionStates.last,
+            TerminalSurfaceView.resolvedOcclusionVisibility(for: window)
+        )
+    }
+
+    func testParkingAppliesTheRequestedTmuxGridAndRestoresGeometry() throws {
+        let view = try makeSurface()
+        let originalFrame = view.frame
+        XCTAssertTrue(view.sizeForPreviewGrid(columns: 100, rows: 30))
+        XCTAssertTrue(view.sizeForPreviewGrid(columns: 100, rows: 30))
+        let root = NSView(frame: originalFrame)
+        let window = NSWindow(
+            contentRect: root.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        let host = LivePreviewParkingHost(frame: root.bounds)
+        root.addSubview(host)
+
+        try host.park(view)
+
+        let previewSize = try XCTUnwrap(view.surfaceSize)
+        XCTAssertEqual(Int(previewSize.columns), 100)
+        XCTAssertEqual(Int(previewSize.rows), 30)
+        XCTAssertEqual(view.frame, originalFrame)
+        XCTAssertEqual(view.bounds.size, originalFrame.size)
+        host.unpark(view)
+        XCTAssertEqual(view.frame, originalFrame)
+    }
+
+    func testPromotionPreservesPreviewGridUntilInteractiveMount() throws {
+        let view = try makeSurface()
+        XCTAssertTrue(view.sizeForPreviewGrid(columns: 100, rows: 30))
+        let previewSize = try XCTUnwrap(view.surfaceSize)
+
+        view.clearPreviewGridSize()
+
+        XCTAssertEqual(view.surfaceSize?.width_px, previewSize.width_px)
+        XCTAssertEqual(view.surfaceSize?.height_px, previewSize.height_px)
+        XCTAssertEqual(view.surfaceSize?.columns, previewSize.columns)
+        XCTAssertEqual(view.surfaceSize?.rows, previewSize.rows)
+
+        let interactiveBounds = NSRect(
+            x: 0,
+            y: 0,
+            width: 960,
+            height: 640
+        )
+        let root = NSView(frame: interactiveBounds)
+        let window = NSWindow(
+            contentRect: interactiveBounds,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        view.frame = .zero
+        view.bounds = .zero
+        root.addSubview(view)
+        view.frame = interactiveBounds
+        view.sizeDidChange(interactiveBounds.size)
+        view.refreshGridSize()
+        defer { window.orderOut(nil) }
+        let interactiveSize = try XCTUnwrap(
+            SurfacePixelSize(view.convertToBacking(view.bounds.size))
+        )
+        XCTAssertEqual(view.surfaceSize?.width_px, interactiveSize.width)
+        XCTAssertEqual(view.surfaceSize?.height_px, interactiveSize.height)
+    }
+
+    func testUnparkingAnUnopenedZeroSizeSurfaceDoesNotPublishInvalidScale()
+        throws {
+        let view = try makeSurface()
+        view.frame = .zero
+        view.bounds = .zero
+        let root = NSView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: 640,
+            height: 400
+        ))
+        let window = NSWindow(
+            contentRect: root.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        let host = LivePreviewParkingHost(frame: root.bounds)
+        root.addSubview(host)
+
+        try host.park(view)
+        host.unpark(view)
+
+        XCTAssertNil(view.superview)
+        XCTAssertEqual(view.frame, .zero)
+        XCTAssertEqual(view.bounds, .zero)
     }
 
     func testParkingRejectsAStillMountedSurface() throws {
@@ -776,7 +1135,8 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let coordinator = TmuxSessionPreviewCoordinator(
             mode: .live,
             budget: LivePreviewBudget(limit: 1),
-            capture: { _, _ in nil }
+            capture: { _, _ in nil },
+            isKeyWindow: { true }
         )
         coordinator.installParkingHost(parkingHost)
         coordinator.register(.init(
@@ -809,6 +1169,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
     func testPreviewActivationUnparksBeforeTheNormalTmuxMount() async throws {
         let surface = try makeSurface()
         surface.frame = NSRect(x: 0, y: 0, width: 640, height: 400)
+        XCTAssertTrue(surface.sizeForPreviewGrid(columns: 116, rows: 94))
         let root = NSView(frame: surface.frame)
         let window = NSWindow(
             contentRect: root.frame,
@@ -843,13 +1204,20 @@ final class TerminalSurfacePreviewTests: XCTestCase {
                     presentation.surface()?.superview === parkingHost
                 )
                 return TerminalSurfaceSnapshot(
-                    image: NSImage(size: CGSize(width: 32, height: 20)),
+                    frame: TerminalSurfacePreviewFrame(
+                        ioSurface: try self.makeIOSurface(
+                            width: 32,
+                            height: 20
+                        ),
+                        pixelSize: CGSize(width: 32, height: 20)
+                    ),
                     captureToken: TerminalSurfaceCaptureToken(
                         surfaceID: 1,
                         seed: 1
                     )
                 )
-            }
+            },
+            isKeyWindow: { true }
         )
         coordinator.installParkingHost(parkingHost)
         coordinator.register(.init(
@@ -871,6 +1239,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         coordinator.setExpanded(true, for: key)
         XCTAssertTrue(surface.superview === parkingHost)
         XCTAssertTrue(surface.isParkedForPreview)
+        surface.clearPreviewGridSize()
 
         coordinator.prepareToActivate(key) {
             XCTAssertNil(surface.superview)
@@ -900,6 +1269,23 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertFalse(surface.isParkedForPreview)
         XCTAssertFalse(surface.suppressAutoFocus)
         XCTAssertTrue(isActive)
+        let interactiveSize = try XCTUnwrap(
+            SurfacePixelSize(surface.convertToBacking(surface.bounds.size))
+        )
+        XCTAssertEqual(surface.surfaceSize?.width_px, interactiveSize.width)
+        XCTAssertEqual(surface.surfaceSize?.height_px, interactiveSize.height)
+        try waitForIOSurface(in: surface, matching: interactiveSize)
+        let interactiveIOSurface = try XCTUnwrap(
+            surface.layer?.contents as? IOSurface
+        )
+        XCTAssertEqual(
+            IOSurfaceGetWidth(interactiveIOSurface),
+            Int(interactiveSize.width)
+        )
+        XCTAssertEqual(
+            IOSurfaceGetHeight(interactiveIOSurface),
+            Int(interactiveSize.height)
+        )
     }
 
     func testParkingAdapterWaitsForAVisibleWorkspaceWindow() throws {
@@ -913,7 +1299,8 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         let coordinator = TmuxSessionPreviewCoordinator(
             mode: .live,
             budget: LivePreviewBudget(limit: 1),
-            capture: { _, _ in nil }
+            capture: { _, _ in nil },
+            isKeyWindow: { true }
         )
         coordinator.register(.init(
             key: key,
@@ -1025,14 +1412,21 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         return window
     }
 
-    private func waitForIOSurface(in view: TerminalSurfaceView) throws {
+    private func waitForIOSurface(
+        in view: TerminalSurfaceView,
+        matching pixelSize: SurfacePixelSize? = nil
+    ) throws {
         let deadline = Date().addingTimeInterval(10)
-        while !(view.layer?.contents is IOSurface), Date() < deadline {
+        while Date() < deadline {
+            if let ioSurface = view.layer?.contents as? IOSurface {
+                guard let pixelSize else { return }
+                if IOSurfaceGetWidth(ioSurface) == Int(pixelSize.width),
+                   IOSurfaceGetHeight(ioSurface) == Int(pixelSize.height) {
+                    return
+                }
+            }
             RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         }
-        _ = try XCTUnwrap(
-            view.layer?.contents as? IOSurface,
-            "libghostty did not render an IOSurface before the deadline"
-        )
+        XCTFail("libghostty did not render the expected IOSurface before the deadline")
     }
 }

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -2023,6 +2023,37 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         XCTAssertEqual(appliedSizes.last?.height, UInt32(expectedSize.height))
     }
 
+    func testOversizedSurfaceResizeNeverReachesLibghostty() throws {
+        let appHandle = try requireAppHandle()
+        let previousSetter = TerminalSurfaceView.sizeSetter
+        var appliedSizes: [(width: UInt32, height: UInt32)] = []
+        TerminalSurfaceView.sizeSetter = { surface, width, height in
+            appliedSizes.append((width, height))
+            ghostty_surface_set_size(surface, width, height)
+        }
+        defer {
+            TerminalSurfaceView.sizeSetter = previousSetter
+        }
+
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        let window = hostInWindow(view)
+        defer { window.orderOut(nil) }
+        appliedSizes.removeAll()
+
+        view.sizeDidChange(CGSize(
+            width: SurfacePixelSize.maximumDimension + 1,
+            height: 480
+        ))
+
+        XCTAssertTrue(
+            appliedSizes.isEmpty,
+            "A size that can overflow libghostty's grid must be rejected before its C boundary."
+        )
+    }
+
     func testPresentationResizeAppliesOnlyTheFinalSurfaceSize() throws {
         let appHandle = try requireAppHandle()
         let previousSetter = TerminalSurfaceView.sizeSetter

--- a/Tests/TerminalSupport/SurfacePixelSizeTests.swift
+++ b/Tests/TerminalSupport/SurfacePixelSizeTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import GhosthubTerminalSupport
+
+@Suite("Surface pixel size")
+struct SurfacePixelSizeTests {
+    @Test("valid dimensions convert to libghostty pixels")
+    func convertsValidDimensions() {
+        #expect(
+            SurfacePixelSize(CGSize(width: 1_200.75, height: 800.5))
+                == SurfacePixelSize(CGSize(width: 1_200, height: 800))
+        )
+    }
+
+    @Test(
+        "invalid dimensions cannot reach libghostty",
+        arguments: [
+            CGSize(width: 0, height: 800),
+            CGSize(width: 1_200, height: 0),
+            CGSize(width: CGFloat.nan, height: 800),
+            CGSize(width: 1_200, height: CGFloat.infinity),
+            CGSize(
+                width: SurfacePixelSize.maximumDimension + 1,
+                height: 800
+            ),
+            CGSize(
+                width: 1_200,
+                height: SurfacePixelSize.maximumDimension + 1
+            ),
+        ]
+    )
+    func rejectsInvalidDimensions(_ size: CGSize) {
+        #expect(SurfacePixelSize(size) == nil)
+    }
+}

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -7,6 +7,89 @@ import Testing
 
 @Suite("Native tmux attachment")
 struct TmuxAttachmentInfoTests {
+    @Test("preview attachments do not participate in tmux window sizing")
+    func previewAttachmentsIgnoreClientSize() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "release-work",
+            host: .local,
+            launchMode: .attachOnly,
+            ignoresClientSize: true,
+            initialClientSize: TmuxClientSize(columns: 200, rows: 51)
+        ).attachCommand(tmuxPath: "/opt/homebrew/bin/tmux")
+
+        #expect(command.contains("attach-session"))
+        #expect(command.contains("ignore-size"))
+        #expect(command.contains("stty columns 200 rows 51"))
+    }
+
+    @Test("a sole preview client preserves the detached tmux window size")
+    func solePreviewClientPreservesWindowSize() throws {
+        let tmuxPath = ProcessInfo.processInfo.environment["PATH"]?
+            .split(separator: ":")
+            .map { String($0) + "/tmux" }
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+        guard let tmuxPath else { return }
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "preview-size")
+        )
+        defer { server.stop() }
+        let command = TmuxAttachmentInfo(
+            sessionName: "stable-preview",
+            host: .local,
+            socketName: server.socketName,
+            launchMode: .attachOnly,
+            ignoresClientSize: true,
+            initialClientSize: TmuxClientSize(columns: 200, rows: 51)
+        ).attachCommand(tmuxPath: tmuxPath)
+        let tmux = shellQuotedCommandArgument(tmuxPath)
+        let socket = shellQuotedCommandArgument(server.socketName)
+        let attach = shellQuotedCommandArgument(command)
+        let probe = Process()
+        let output = Pipe()
+        probe.executableURL = URL(fileURLWithPath: "/bin/sh")
+        probe.arguments = ["-c", """
+        set -eu
+        \(tmux) -f /dev/null -L \(socket) new-session -d -x 200 -y 50 -s stable-preview
+        /bin/sleep 5 | /usr/bin/script -q /dev/null /bin/sh -c \(attach) >/dev/null 2>&1 &
+        preview_pid=$!
+        trap 'kill "$preview_pid" 2>/dev/null || :' EXIT HUP INT TERM
+        attached=
+        attempts=0
+        while [ "$attempts" -lt 100 ]; do
+            if \(tmux) -L \(socket) list-clients >/dev/null 2>&1; then
+                attached=1
+                break
+            fi
+            attempts=$((attempts + 1))
+            sleep 0.01
+        done
+        [ -n "$attached" ]
+        attempts=0
+        while [ "$attempts" -lt 10 ]; do
+            size=$(\(tmux) -L \(
+                socket
+            ) display-message -p -t stable-preview '#{window_width}x#{window_height}')
+            [ "$size" = 200x50 ] || {
+                printf 'unexpected window size: %s\n' "$size" >&2
+                exit 1
+            }
+            attempts=$((attempts + 1))
+            sleep 0.02
+        done
+        """]
+        probe.standardOutput = output
+        probe.standardError = output
+        try probe.run()
+        probe.waitUntilExit()
+        let diagnostic = String(
+            decoding: output.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+
+        #expect(probe.terminationStatus == 0, Comment(rawValue: diagnostic))
+    }
+
     @Test("POSIX attachments publish their client TTY under a unique token")
     func posixAttachmentsPublishClientTTY() {
         let token = "attachment-01234567"

--- a/Tests/UI/WorkspaceSidebarViewTests.swift
+++ b/Tests/UI/WorkspaceSidebarViewTests.swift
@@ -27,24 +27,6 @@ struct WorkspaceSidebarViewTests {
             sessionID: sessionID,
             previewableSessionIDs: []
         ))
-        #expect(TmuxSessionPreviewRowPresentation.placeholderAspectRatio == 1.6)
-    }
-
-    @Test("tmux preview height follows captured geometry within limits")
-    func tmuxPreviewAdaptiveAspectRatio() {
-        #expect(TmuxSessionPreviewRowPresentation.aspectRatio(
-            for: CGSize(width: 4, height: 3)
-        ) == CGFloat(4) / 3)
-        #expect(TmuxSessionPreviewRowPresentation.aspectRatio(
-            for: CGSize(width: 16, height: 9)
-        ) == CGFloat(16) / 9)
-        #expect(TmuxSessionPreviewRowPresentation.aspectRatio(
-            for: CGSize(width: 1, height: 1)
-        ) == CGFloat(4) / 3)
-        #expect(TmuxSessionPreviewRowPresentation.aspectRatio(
-            for: CGSize(width: 3, height: 1)
-        ) == 2)
-        #expect(TmuxSessionPreviewRowPresentation.aspectRatio(for: nil) == 1.6)
     }
 
     @Test("Off hides previews without discarding scene expansion")
@@ -66,6 +48,31 @@ struct WorkspaceSidebarViewTests {
             previewableSessionIDs: [sessionID],
             expansion: state
         ))
+    }
+
+    @Test("Always Live expands by default and honors a collapsed override")
+    func alwaysLivePreviewCanCollapse() {
+        let sessionID = "host:default:opened"
+        var state = TmuxSessionPreviewExpansionState()
+
+        #expect(TmuxSessionPreviewRowPresentation.isExpanded(
+            mode: .alwaysLive,
+            sessionID: sessionID,
+            expansion: state
+        ))
+
+        state.setExpanded(
+            false,
+            sessionID: sessionID,
+            defaultExpanded: true
+        )
+
+        #expect(!TmuxSessionPreviewRowPresentation.isExpanded(
+            mode: .alwaysLive,
+            sessionID: sessionID,
+            expansion: state
+        ))
+        #expect(!state.isExpanded(sessionID))
     }
 
     @MainActor
@@ -153,11 +160,15 @@ struct WorkspaceSidebarViewTests {
         )
         var opened: [WorkspaceTmuxSessionSelection] = []
         var activationRoutes: [WorkspaceSelection] = []
+        let selectionBinding = Binding(
+            get: { selection },
+            set: { selection = $0 }
+        )
 
         WorkspaceSidebarView.activateTmuxSession(
             session,
             rowTarget: .tmuxSession(hostID: hostID, name: session.name),
-            selection: &selection,
+            selection: selectionBinding,
             snapshot: snapshot,
             visibility: .default,
             onOpen: { openedSession, route in
@@ -171,6 +182,44 @@ struct WorkspaceSidebarViewTests {
         #expect(selection.selectedHostID == hostID)
         #expect(selection.selectedProjectID == nil)
         #expect(selection.selectedWorktreeID == nil)
+    }
+
+    @MainActor
+    @Test("tmux activation commits its route before opening")
+    func tmuxActivationCommitsRouteBeforeOpening() {
+        let hostID = UUID()
+        let session = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "opened"
+        )
+        let snapshot = WorkspaceSnapshot.fixture(hosts: [
+            .fixture(
+                id: hostID,
+                tmuxSessions: [
+                    .init(name: session.name, managed: false, windows: []),
+                ]
+            ),
+        ])
+        var storedSelection = WorkspaceSelection(selectedHostID: hostID)
+        var events: [String] = []
+        let selection = Binding(
+            get: { storedSelection },
+            set: {
+                storedSelection = $0
+                events.append("selected")
+            }
+        )
+
+        WorkspaceSidebarView.activateTmuxSession(
+            session,
+            rowTarget: .tmuxSession(hostID: hostID, name: session.name),
+            selection: selection,
+            snapshot: snapshot,
+            visibility: .default,
+            onOpen: { _, _ in events.append("opened") }
+        )
+
+        #expect(events == ["selected", "opened"])
     }
 
     @MainActor

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,8 +51,12 @@ Tmux, Herdr, and Zellij sessions are each presented through their ordinary
 native whole-session client. The selected backend alone owns its internal
 layout. Each scene has at most one active interactive presentation.
 Already-opened tmux clients may remain retained and noninteractive, and may
-render only when the user explicitly enables session previews. A preview never
-creates another client or reconstructs tmux panes, layout, or history.
+render when the user explicitly enables session previews. On POSIX hosts, the
+Always Live mode may also connect every freshly discovered tmux session without
+activating it. Windows/psmux inventory remains unattached until the user opens
+the session because psmux has no non-sizing preview-client mode.
+Preview rendering reuses that session's retained client rather than creating a
+second client or reconstructing tmux panes, layout, or history.
 
 After an attachment reaches the connected state, Ghosthub keeps that exact
 session warm for the remainder of the app launch. One app-scoped, in-memory
@@ -757,9 +761,11 @@ remain visible, and explicit reloads publish a user-visible result.
 Each scene owns one active interactive presentation slot shared by tmux, Herdr,
 and Zellij. Selecting Herdr or Zellij hides any active retained tmux client
 before opening the peer presentation; selecting another tmux session hides the
-previous retained tmux client. Already-opened retained tmux clients may render
-as noninteractive previews when the user enables them, but previewing never
-opens another client.
+previous retained tmux client. Retained tmux clients may render as
+noninteractive previews when the user enables them. On POSIX hosts, Always
+Live deliberately creates one ordinary retained client for each freshly
+discovered session;
+previewing never creates a second client for the same session.
 Herdr discovery and attachment are supported on the local Mac and configured
 remote POSIX hosts, not experimental Windows/psmux hosts. Ghosthub shows
 running and stopped sessions. Ordinary open and restoration are attach-only;
@@ -812,31 +818,70 @@ client. Ghosthub never projects tmux windows or panes into a Swift split tree.
 Changing selection only hides the previous retained client. Pressing Cmd-W
 closes the active client, while closing its workspace window or the app closes
 every client retained by that scene; none of these paths runs `kill-session`.
-Optional sidebar previews copy width-bounded bitmap frames from these retained
-clients. A tile follows its terminal's aspect ratio between 4:3 and 2:1 and
-letterboxes only content outside those limits. Efficient mode captures on
-disclosure and whenever the active tmux presentation navigates away, even when
-its tile is collapsed. Live mode
-may keep an inactive surface mounted behind the visible workspace content and
-polls at no more than two frames per second. A process-wide budget permits at
-most four such inactive live surfaces. Parked surfaces preserve their terminal
-size and cannot receive focus, pointer input, or accessibility actions. The
-active surface stays in the detail area and is copied without reparenting.
+Optional sidebar previews are GPU-native. Libghostty renders each retained
+client into its Metal-backed IOSurface; Ghosthub uses a Metal-backed Core Image
+context to scale a changed frame into a width-bounded preview IOSurface, then
+presents that surface directly through Core Animation. The path performs no CPU
+pixel readback and creates no `Data`, `CGImage`, or `NSImage` copy. Each tile
+uses the terminal's aspect ratio so the tile shows the complete viewport
+without cropping; only degenerate terminal shapes hit the bounded preview
+canvas (height clamped to 1024 pixels) and scale to fit it. The placeholder is 16:10 until the first frame
+arrives. Frame replacement disables Core Animation transitions, and parked
+surfaces do not publish transient size changes during app activation. Efficient
+mode captures on disclosure and
+whenever the active tmux
+presentation navigates away, even when its tile is collapsed. Live mode may keep
+an inactive surface mounted behind the visible workspace content and refreshes
+at no more than two frames per second.
+A process-wide budget permits at most four such inactive live surfaces. Always
+Live attaches every freshly discovered tmux session on every reachable POSIX
+host, defaults every preview tile to expanded, and bypasses that budget. A tile
+may still be collapsed to stop its rendering work while its policy-owned
+client remains connected. Leaving Always Live detaches only clients created by
+that policy; a client the user explicitly opened remains retained. Always Live
+launches those clients incrementally so early tiles can render while a large
+fleet is still connecting. Before a hidden client attaches with tmux's
+`ignore-size` flag, Ghosthub sizes its PTY to the active window dimensions plus
+the discovered tmux status rows. This exact client grid is also reapplied after
+font and backing-scale changes. The client therefore starts at the server's
+existing size even when it is the only attached client and does not resize the
+tmux window. Opening one atomically clears `ignore-size` on that exact verified
+client before activating its retained surface. The client never detaches during
+this promotion, so servers using `destroy-unattached` cannot destroy the session
+between preview and interactive presentation. A promotion that finishes after
+newer navigation restores `ignore-size` on the same verified client and never
+activates the stale surface. If the attachment changes during promotion,
+Ghosthub retries the exact-client mutation against the replacement before it
+can activate. If stale sizing cannot be restored, Ghosthub marks the preview
+ineligible and detaches it instead of retaining a hidden sizing client. Parked
+surfaces cannot receive focus, pointer input, or accessibility actions. Parking applies the destination
+window's stable backing scale and ignores hidden-host layout changes; only an
+explicit Always Live preview-grid update may change its pixel size. AppKit reparenting
+callbacks never publish transient DPI or resize values to libghostty. App
+deactivation stops capture work but leaves retained surfaces parked, avoiding a
+fleet-wide unpark/repark cycle when Ghosthub becomes active again. The active
+surface stays in the detail area and its IOSurface is sampled without
+reparenting the terminal view.
 Preview pixels are published only after the attachment's token-bound tmux
 client identity is available; a name-based session lookup never authorizes a
-cached frame. Ghosthub revalidates that attached client after copying each
-changed frame and rejects the copy if the client switched sessions. Attachments
-that cannot supply this safe identity, including psmux and tmux older than 3.4,
-show an unavailable placeholder instead of retaining unverified pixels.
+cached frame. Ghosthub revalidates that attached client after rendering each
+changed preview IOSurface and rejects the frame if the client switched
+sessions. Always Live abandons policy attachment setup before launching a client
+when binary resolution fails or the resolved tmux version cannot supply this
+safe identity. The session remains available for an ordinary manual open.
+Windows/psmux sessions are also excluded from automatic attachment.
 Reconnect identity binding uses bounded background retries only after a preview
 requests identity. Reconnecting keeps the last frame quarantined until the new
 attachment binds to the same server and session identity, while replacement
 clears the frame without collapsing the tile.
 Off and Efficient modes schedule no preview work when a window becomes key,
-and Off does not mount the hidden parking host. Live coalesces its delayed
-parking reconciliation for the key scene. Selecting a parked preview unparks
-and activates its retained surface synchronously; snapshot and identity work
-never delay that pane-activation path.
+and Off does not mount the hidden parking host. Live and Always Live coalesce
+delayed parking reconciliation for newly available surfaces in the key scene;
+already parked surfaces remain mounted across application deactivation.
+Selecting an ordinary parked
+preview unparks and activates its retained surface synchronously. Selecting an
+Always Live client promotes its verified retained attachment to normal sizing
+before activation.
 An explicit, confirmed Kill Session action
 targets the exact session (`=<name>:`) on its selected default or protected
 socket only when discovery or a currently connected active attachment

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -153,7 +153,15 @@ state, and the processes inside each session. Ghosthub owns discovery,
 whole-session lifecycle requests, and the disposable client presentation. Each
 scene has at most one active interactive tmux, Herdr, or Zellij presentation.
 Already-opened tmux clients may remain retained and noninteractive for
-explicitly enabled previews; previews never create another client.
+explicitly enabled previews. On POSIX hosts, Always Live may connect one
+ordinary retained client for each freshly discovered tmux session without
+activating it. Preview
+rendering never creates a second client for the same session. These hidden
+clients ignore tmux window sizing and render at the dimensions discovery
+reported for the session's active window; selecting one promotes that retained
+client in place by clearing `ignore-size` before interaction. Windows/psmux
+sessions are not attached automatically because psmux has no non-sizing client
+mode.
 Navigating away, pressing Cmd-W, closing a window, or quitting closes only the
 client. Ghosthub never reconstructs or otherwise controls Herdr themes,
 workspaces, tabs, panes, agents, plugins, installation, updates, configuration,

--- a/website/README.md
+++ b/website/README.md
@@ -61,7 +61,10 @@ shows real project or host details, and `shoot.sh` drives the exact staged
 process through every documented UI state:
 
     cd website/demo
-    ./stage.sh && ./run.sh && ./shoot.sh /tmp/ghosthub-website-assets
+    ./stage.sh && ./run.sh
+    GHOSTHUB_DEMO_SKIP_SESSION_PREVIEWS=1 ./shoot.sh /tmp/ghosthub-website-assets
+    GHOSTHUB_DEMO_SESSION_PREVIEW_MODE=always-live ./run.sh
+    GHOSTHUB_DEMO_ALWAYS_LIVE_PREVIEW_ONLY=1 ./shoot.sh /tmp/ghosthub-website-assets
     GHOSTHUB_DEMO_EXE_ACCOUNTS=1 ./run.sh
     GHOSTHUB_DEMO_EXE_ONLY=1 ./shoot.sh /tmp/ghosthub-website-assets
     ./teardown.sh   # always run: stops demo processes and removes scratch state

--- a/website/demo/launch.swift
+++ b/website/demo/launch.swift
@@ -53,6 +53,12 @@ let exeAccountsHex = CommandLine.arguments[6]
 let demoRoot = CommandLine.arguments[7]
 let scratch = CommandLine.arguments[8]
 let sshAuthSocket = CommandLine.arguments[9]
+let sessionPreviewMode = ProcessInfo.processInfo.environment[
+    "GHOSTHUB_DEMO_SESSION_PREVIEW_MODE"
+] ?? "live"
+guard ["live", "always-live"].contains(sessionPreviewMode) else {
+    fail("unsupported demo session preview mode: \(sessionPreviewMode)")
+}
 
 // Once LaunchServices has created the application, this helper must run until
 // it either publishes the exact PID or terminates that exact application. The
@@ -66,7 +72,7 @@ configuration.arguments = [
     "-ApplePersistenceIgnoreState", "YES",
     "-ghosthub.settings.hosts.ssh", "<\(hostsHex)>",
     "-ghosthub.settings.hosts.exeAccounts", "<\(exeAccountsHex)>",
-    "-ghosthub.settings.terminal.sessionPreviewMode", "live",
+    "-ghosthub.settings.terminal.sessionPreviewMode", sessionPreviewMode,
 ]
 configuration.createsNewApplicationInstance = true
 configuration.environment = [

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -173,6 +173,14 @@ capture_state() {
   sips -g pixelWidth -g pixelHeight "$out_dir/$name" | tail -2
 }
 
+if [[ "${GHOSTHUB_DEMO_ALWAYS_LIVE_PREVIEW_ONLY:-}" == "1" ]]; then
+  echo "==> guide: Always Live tmux session previews"
+  sleep 1
+  capture_state guide-session-previews.png
+  echo "captured Always Live website asset -> $out_dir"
+  exit 0
+fi
+
 process_matrix_capture() {
   local raw="$1" destination="$2"
   local temporary
@@ -365,23 +373,25 @@ demo_input escape
 demo_input click "32,489"
 sleep 0.5
 
-echo "==> guide: opened tmux session previews"
-palette "add-session-filters"
-sleep 3
-palette "scratch"
-sleep 3
-palette "add-session-filters"
-sleep 3
-# The demo window is fixed at 1600x1000. SwiftUI does not expose this
-# disclosure button to the injected accessibility tree, so click the stable
-# scratch-row chevron in window coordinates.
-demo_input click "31,746"
-sleep 5
-demo_input expect-text "Live"
-capture_state guide-session-previews.png
-# Keep later settings and palette captures focused on their own workflows.
-demo_input click "31,746"
-sleep 0.5
+if [[ "${GHOSTHUB_DEMO_SKIP_SESSION_PREVIEWS:-}" != "1" ]]; then
+  echo "==> guide: opened tmux session previews"
+  palette "add-session-filters"
+  sleep 3
+  palette "scratch"
+  sleep 3
+  palette "add-session-filters"
+  sleep 3
+  # The demo window is fixed at 1600x1000. SwiftUI does not expose this
+  # disclosure button to the injected accessibility tree, so click the stable
+  # scratch-row chevron in window coordinates.
+  demo_input click "31,746"
+  sleep 5
+  demo_input expect-text "Live"
+  capture_state guide-session-previews.png
+  # Keep later settings and palette captures focused on their own workflows.
+  demo_input click "31,746"
+  sleep 0.5
+fi
 
 echo "==> guide: remote host settings"
 capture_host_settings

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -85,35 +85,53 @@ launch-profile command.
 
 ## Preview opened tmux sessions
 
-Choose **Settings → Terminal → Session previews**, then select **Efficient** or
-**Live**. A disclosure control appears only beside tmux sessions that you have
-already opened in that workspace. Expand it to show a bitmap preview. The tile
-adapts to the terminal's shape between 4:3 and 2:1; only
-taller or wider frames need minimal letterboxing, and content is never cropped.
+Choose **Settings → Terminal → Session previews**, then select **Efficient**,
+**Live**, or **Always Live**. Efficient and Live add a disclosure control beside
+tmux sessions that you have already opened in that workspace. Expand it to show
+a GPU-rendered preview. Always Live connects every freshly discovered tmux
+session on every reachable POSIX host and expands its tile automatically. Each
+tile follows its terminal's aspect ratio, preserving the complete frame
+without cropping.
 Selecting the preview follows the same route as selecting its session row.
 
-![Ghosthub sidebar showing an expanded live preview for an already-opened tmux session](assets/guide-session-previews.png)
+![Ghosthub sidebar showing Always Live previews expanded for discovered tmux sessions](assets/guide-session-previews.png)
 
 The modes trade resource use for freshness:
 
 - **Off** is the default. It hides preview controls, clears cached frames, and
   avoids preview GPU work.
 - **Efficient** captures when you expand a preview and when its tmux
-  presentation stops being active. It does not poll in the background.
+  presentation stops being active. It does not refresh in the background.
 - **Live** refreshes expanded previews at no more than two frames per second.
   Across the app, at most four inactive tmux surfaces can render live at once;
   an additional tile reports that the live-preview limit was reached.
+- **Always Live** connects every freshly discovered tmux session on POSIX
+  hosts, expands its preview automatically, and refreshes all expanded tiles
+  without the four-surface limit. This can use substantial CPU, GPU, memory,
+  and SSH capacity. Collapse a tile to stop rendering it while keeping its
+  client connected. Ghosthub starts the clients incrementally, so earlier
+  tiles can appear while a large session fleet is still connecting.
 
 Expansion choices stay in memory for each workspace window, including while
-the mode is Off, and reset when that window closes. Hiding the sidebar releases
-that window's live slots. Briefly switching away from Ghosthub releases all
-live slots until the app is active again.
+the mode is Off, and reset when that window closes. Hiding the sidebar or
+briefly switching away from Ghosthub stops live rendering until it is visible
+and active again. Always Live keeps its policy-owned clients connected during
+that pause.
 
-Previews never attach to unopened sessions and never add a tmux or SSH client.
-They require a token-bound client identity, which is available for tmux 3.4 or
-newer on POSIX hosts. Other attachments, including psmux, show a **Preview
-unavailable** placeholder rather than displaying pixels that Ghosthub cannot
-verify.
+Efficient and Live never attach to unopened sessions. Always Live deliberately
+adds one ordinary retained tmux or SSH client per discovered POSIX session;
+switching away from it detaches only clients created by that policy. Every mode
+reuses a session's retained client for rendering and never creates a second
+preview client. Before a hidden Always Live client attaches, Ghosthub matches
+its terminal grid to the active tmux window and status rows. This keeps the
+server-side window unchanged even when the preview is its only client; the
+sidebar tile never dictates the session size. Opening one promotes its hidden
+non-sizing client to normal interactive sizing. Previews require a token-bound
+client identity, which is available for tmux 3.4 or newer on POSIX hosts.
+Always Live skips automatic attachment when tmux cannot provide that identity
+or setup fails; the session can still be opened normally.
+Windows/psmux sessions are not attached automatically because psmux has no
+non-sizing client mode.
 During reconnect, Ghosthub hides the cached frame behind a reconnecting
 placeholder until the replacement client proves the same tmux server, session,
 and creation identity. Closing the presentation, or detecting a replacement

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -48,26 +48,38 @@ can unexpectedly change zsh keymaps. It sets `TERM_PROGRAM` to `ghosthub`.
 ## Session previews
 
 **Settings → Terminal → Session previews** controls optional sidebar previews
-for tmux presentations you have already opened in a workspace:
+for tmux presentations in each workspace window:
 
 - **Off** is the default and performs no preview rendering.
-- **Efficient** keeps a bitmap of the latest frame captured on disclosure or
-  when you navigate away. It does not poll.
-- **Live** polls expanded tiles at no more than two frames per second. Ghosthub
-  limits live rendering to four inactive previews across all windows.
+- **Efficient** keeps the latest GPU-rendered frame captured on disclosure or
+  when you navigate away. It does not refresh in the background.
+- **Live** refreshes expanded tiles at no more than two frames per second.
+  Ghosthub limits live rendering to four inactive previews across all windows.
+- **Always Live** attaches every freshly discovered tmux session on every
+  reachable POSIX host, expands its tile by default, and removes the
+  four-preview limit. Individual tiles can still be collapsed without
+  disconnecting them.
+  Clients start incrementally. Ghosthub matches each hidden client's terminal
+  grid to the tmux window and status rows before attachment, so even a sole
+  preview client leaves the server-side window size unchanged.
+  Expect substantially higher CPU, GPU, memory, and SSH use.
 
 The preference takes effect when you close Settings. Each workspace window
 remembers its own expanded rows in memory, even while previews are Off. A tile
-follows the captured terminal's aspect ratio between 4:3 and 2:1. More extreme
-shapes use minimal letterboxing so the complete frame remains visible.
+follows its terminal's aspect ratio, preserving the complete
+frame without cropping.
 Reconnecting sessions show a placeholder until Ghosthub verifies that the
 replacement client is attached to the same server-side session.
-If an attachment cannot provide a safe client identity, such as psmux or tmux
-older than 3.4, its tile reports that the preview is unavailable.
+Tmux older than 3.4 cannot provide a safe client identity, so Always Live skips
+its automatic attachment. You can still open that session normally. Windows/
+psmux sessions are not attached automatically because psmux has no non-sizing
+client mode.
 
-Previews reuse retained tmux clients only. They do not open sessions, create an
-extra tmux or SSH client, persist terminal pixels to disk, or reconstruct tmux
-panes and layout.
+Efficient and Live preview only clients you opened. Always Live deliberately
+opens one retained tmux or SSH client for each discovered POSIX session.
+Preview rendering never adds a second client, persists terminal pixels to
+disk, copies terminal pixels through the CPU, or reconstructs tmux panes and
+layout.
 
 ## Tmux themes
 

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -89,10 +89,11 @@ when no review is pending.
 
 ## A tmux session preview is unavailable
 
-Preview controls appear only after you open a tmux session in that workspace
-and choose **Efficient** or **Live** under **Settings → Terminal → Session
-previews**. They are not available for Herdr, Zellij, unopened sessions, or
-native Windows/psmux attachments.
+With **Efficient** or **Live**, preview controls appear only after you open a
+tmux session in that workspace. **Always Live** connects and expands freshly
+discovered tmux sessions on POSIX hosts automatically. Choose the mode under
+**Settings → Terminal → Session previews**. Previews are not available for
+Herdr, Zellij, or native Windows/psmux attachments.
 
 On a POSIX host, run `tmux -V`. Verified previews require tmux 3.4 or newer so
 Ghosthub can bind captured pixels to the exact attached client. An older tmux

--- a/website/src/pages/overview.astro
+++ b/website/src/pages/overview.astro
@@ -24,7 +24,7 @@ const imageAlt = {
   sessions:
     'Ghosthub workspace showing Tmux, Herdr, and Zellij sessions for local and remote hosts',
   sessionPreviews:
-    'Ghosthub sidebar with an expanded live bitmap preview for an already-opened tmux session',
+    'Ghosthub sidebar with Always Live previews expanded for discovered tmux sessions',
   hosts: 'Ghosthub Hosts settings with a configured remote GPU host',
   worktree:
     'Ghosthub new worktree sheet listing available local and remote branches',
@@ -124,10 +124,11 @@ const imageAlt = {
         <div>
           <h2>Glance at opened tmux sessions</h2>
           <p>
-            Expand optional bitmap previews beside tmux sessions you already
-            opened. Efficient mode keeps the latest captured frame; Live mode
-            refreshes a bounded set without creating another client or taking
-            focus from your active terminal.
+            Expand optional GPU-rendered previews beside tmux sessions you
+            already opened. Efficient mode keeps the latest captured frame;
+            Live mode refreshes a bounded set. Always Live can connect and
+            expand every discovered tmux session on POSIX hosts for an
+            at-a-glance fleet view without taking focus from your active terminal.
           </p>
           <p><a href="/docs/sessions/#preview-opened-tmux-sessions">Explore session previews</a>.</p>
         </div>


### PR DESCRIPTION
Fleet users can opt into an at-a-glance view of every tmux session without letting hidden clients resize server-side windows or destabilize app activation.

- Adds **Always Live** for freshly discovered tmux sessions on reachable POSIX hosts. Tiles start expanded; collapsing one stops rendering while its retained client stays connected.
- Sizes each hidden PTY to the tmux window plus status rows before attaching with `ignore-size`, so even a sole preview client preserves the session grid. Opening a tile replaces it with a normal interactive client.
- Keeps previews GPU-native from libghostty's IOSurface through Metal-backed Core Image to Core Animation, with no CPU pixel copy. Tiles preserve terminal shape between 4:3 and 2:1 without stretching or animated frame swaps.
- Stages client launch and parking, waits for an available display, and preserves stable grid and backing scale. Non-key scenes release parked surfaces and Live-budget grants.
- Keeps token-bound tmux identity checks and reconnect quarantine. Canonical worktree-generation changes discard retained clients; missing generation metadata can be enriched in place.
- Disabling the mode detaches only policy-created clients. Windows/psmux stays on demand because it has no non-sizing client mode.
- Bypasses the four-preview Live budget only in this explicit mode and warns about its CPU, GPU, memory, and SSH cost.

![Always Live tmux previews expanded in the sidebar](https://raw.githubusercontent.com/kenn-io/ghosthub/4ee43dadc5ccb65377a44f70bc9bb5ba06d6d15f/guide-session-previews.png)