### PR TITLE
Let workspace windows keep custom titles

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -218,6 +218,15 @@ struct GhosthubApp: App {
             SessionMenuCommands()
             ViewMenuCommands()
             CommandGroup(after: .windowArrangement) {
+                Button("Rename Window…") {
+                    NotificationCenter.default.post(
+                        name: .ghosthubRenameWorkspaceWindow,
+                        object: NSApplication.shared.keyWindow
+                    )
+                }
+
+                Divider()
+
                 Button("Previous Tab") {
                     NativeTabCommands.selectPrevious()
                 }

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -244,17 +244,7 @@ private struct WindowFocusTracker: NSViewRepresentable {
 @MainActor
 private final class DraggableTitlebarHostingView:
     NSHostingView<AnyView> {
-    var onDoubleClick: () -> Void = {}
-
     override var mouseDownCanMoveWindow: Bool { true }
-
-    override func mouseDown(with event: NSEvent) {
-        guard event.clickCount == 2 else {
-            super.mouseDown(with: event)
-            return
-        }
-        onDoubleClick()
-    }
 }
 
 @MainActor
@@ -493,7 +483,6 @@ final class CompactWorkspaceTitlebarController {
         self.onSettings = onSettings
         self.onNewWorktree = onNewWorktree
         self.onRenameWindow = onRenameWindow
-        titleHost.onDoubleClick = onRenameWindow
         refreshHosts()
         let titleLeadingOffset = Self.titleLeadingOffset(
             isSidebarVisible: isSidebarVisible,
@@ -578,24 +567,21 @@ private struct EditableWindowTitleView: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 5) {
-            title
-            if isHovered {
-                Button(action: onRename) {
+        Button(action: onRename) {
+            HStack(spacing: 5) {
+                title
+                if isHovered {
                     Image(systemName: "pencil")
                         .font(.system(size: 10, weight: .medium))
                         .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
+                        .transition(.opacity)
                 }
-                .buttonStyle(.plain)
-                .help("Rename Window")
-                .accessibilityLabel("Rename Window")
-                .transition(.opacity)
             }
+            .contentShape(Rectangle())
         }
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+        .help("Rename Window")
         .onHover { isHovered = $0 }
-        .accessibilityAction(named: "Rename Window", onRename)
     }
 
     @ViewBuilder

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -581,6 +581,7 @@ private struct EditableWindowTitleView: View {
         }
         .buttonStyle(.plain)
         .help("Rename Window")
+        .accessibilityLabel("Rename Window")
         .onHover { isHovered = $0 }
     }
 

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -84,6 +84,7 @@ private struct WindowFocusTracker: NSViewRepresentable {
     var onQuickLaunch: () -> Void
     var onSettings: () -> Void
     var onNewWorktree: () -> Void
+    var onRenameWindow: () -> Void
     var onWindowChanged: (NSWindow?) -> Void
 
     func makeNSView(context: Context) -> NSView {
@@ -115,7 +116,8 @@ private struct WindowFocusTracker: NSViewRepresentable {
             onToggleSidebar: onToggleSidebar,
             onQuickLaunch: onQuickLaunch,
             onSettings: onSettings,
-            onNewWorktree: onNewWorktree
+            onNewWorktree: onNewWorktree,
+            onRenameWindow: onRenameWindow
         )
         if let window = view.window {
             view.titlebarController.install(on: window)
@@ -242,7 +244,17 @@ private struct WindowFocusTracker: NSViewRepresentable {
 @MainActor
 private final class DraggableTitlebarHostingView:
     NSHostingView<AnyView> {
+    var onDoubleClick: () -> Void = {}
+
     override var mouseDownCanMoveWindow: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        guard event.clickCount == 2 else {
+            super.mouseDown(with: event)
+            return
+        }
+        onDoubleClick()
+    }
 }
 
 @MainActor
@@ -353,6 +365,7 @@ final class CompactWorkspaceTitlebarController {
     private var onQuickLaunch: () -> Void = {}
     private var onSettings: () -> Void = {}
     private var onNewWorktree: () -> Void = {}
+    private var onRenameWindow: () -> Void = {}
 
     init(applicationDelegate: ApplicationDelegate? = nil) {
         closeDelegate.applicationDelegate = applicationDelegate
@@ -463,7 +476,8 @@ final class CompactWorkspaceTitlebarController {
         onToggleSidebar: @escaping () -> Void,
         onQuickLaunch: @escaping () -> Void,
         onSettings: @escaping () -> Void,
-        onNewWorktree: @escaping () -> Void
+        onNewWorktree: @escaping () -> Void,
+        onRenameWindow: @escaping () -> Void = {}
     ) {
         let sidebarVisibilityChanged = self.isSidebarVisible
             != isSidebarVisible
@@ -478,6 +492,8 @@ final class CompactWorkspaceTitlebarController {
         self.onQuickLaunch = onQuickLaunch
         self.onSettings = onSettings
         self.onNewWorktree = onNewWorktree
+        self.onRenameWindow = onRenameWindow
+        titleHost.onDoubleClick = onRenameWindow
         refreshHosts()
         let titleLeadingOffset = Self.titleLeadingOffset(
             isSidebarVisible: isSidebarVisible,
@@ -538,8 +554,52 @@ final class CompactWorkspaceTitlebarController {
         }
     }
 
-    @ViewBuilder
     private var titleView: some View {
+        EditableWindowTitleView(
+            customTitle: customTitle,
+            sessionTitle: sessionTitle,
+            onRename: onRenameWindow
+        )
+    }
+
+    private func removeControlsFromInstalledWindow() {
+        titleLeadingConstraint = nil
+        sidebarHost.removeFromSuperview()
+        titleHost.removeFromSuperview()
+        actionsHost.removeFromSuperview()
+    }
+}
+
+private struct EditableWindowTitleView: View {
+    let customTitle: String?
+    let sessionTitle: SessionTitlebarPresentation?
+    let onRename: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 5) {
+            title
+            if isHovered {
+                Button(action: onRename) {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 10, weight: .medium))
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Rename Window")
+                .accessibilityLabel("Rename Window")
+                .transition(.opacity)
+            }
+        }
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .accessibilityAction(named: "Rename Window", onRename)
+    }
+
+    @ViewBuilder
+    private var title: some View {
         if let customTitle {
             Text(customTitle)
                 .font(.system(size: 12, weight: .semibold))
@@ -573,13 +633,6 @@ final class CompactWorkspaceTitlebarController {
                 .foregroundStyle(.secondary)
                 .accessibilityLabel("Ghosthub")
         }
-    }
-
-    private func removeControlsFromInstalledWindow() {
-        titleLeadingConstraint = nil
-        sidebarHost.removeFromSuperview()
-        titleHost.removeFromSuperview()
-        actionsHost.removeFromSuperview()
     }
 }
 
@@ -1205,6 +1258,7 @@ struct WorkspaceWindow: View {
                         object: nil
                     )
                 },
+                onRenameWindow: requestWindowTitleRename,
                 onWindowChanged: { window in
                     sceneModel.workspaceWindow = window
                 }
@@ -1214,14 +1268,9 @@ struct WorkspaceWindow: View {
             for: .ghosthubRenameWorkspaceWindow
         )) { notification in
             guard let requestedWindow = notification.object as? NSWindow,
-                  requestedWindow === sceneModel.workspaceWindow,
-                  requestedWindow.isKeyWindow,
-                  requestedWindow.attachedSheet == nil
+                  requestedWindow === sceneModel.workspaceWindow
             else { return }
-            windowTitleRenameRequest = WorkspaceWindowTitleRenameRequest(
-                currentTitle: customWindowTitle ?? "",
-                automaticTitle: automaticWindowTitle
-            )
+            requestWindowTitleRename()
         }
         .sheet(item: $windowTitleRenameRequest) { request in
             RenameWorkspaceWindowSheet(
@@ -1422,6 +1471,17 @@ struct WorkspaceWindow: View {
             activeZellijSession: sceneModel.activeBorrowedZellijSelection,
             in: sceneModel.snapshot
         )?.title ?? "Ghosthub"
+    }
+
+    private func requestWindowTitleRename() {
+        guard let window = sceneModel.workspaceWindow,
+              window.isKeyWindow,
+              window.attachedSheet == nil
+        else { return }
+        windowTitleRenameRequest = WorkspaceWindowTitleRenameRequest(
+            currentTitle: customWindowTitle ?? "",
+            automaticTitle: automaticWindowTitle
+        )
     }
 }
 

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -79,6 +79,7 @@ private struct WindowFocusTracker: NSViewRepresentable {
     var sidebarWidth: CGFloat
     var canCreateWorktree: Bool
     var sessionTitle: SessionTitlebarPresentation?
+    var customTitle: String?
     var onToggleSidebar: () -> Void
     var onQuickLaunch: () -> Void
     var onSettings: () -> Void
@@ -110,6 +111,7 @@ private struct WindowFocusTracker: NSViewRepresentable {
             sidebarWidth: sidebarWidth,
             canCreateWorktree: canCreateWorktree,
             sessionTitle: sessionTitle,
+            customTitle: customTitle,
             onToggleSidebar: onToggleSidebar,
             onQuickLaunch: onQuickLaunch,
             onSettings: onSettings,
@@ -346,6 +348,7 @@ final class CompactWorkspaceTitlebarController {
     private var sidebarWidth = WorkspaceSidebarWidthPolicy.defaultWidth
     private var canCreateWorktree = false
     private var sessionTitle: SessionTitlebarPresentation?
+    private var customTitle: String?
     private var onToggleSidebar: () -> Void = {}
     private var onQuickLaunch: () -> Void = {}
     private var onSettings: () -> Void = {}
@@ -367,7 +370,7 @@ final class CompactWorkspaceTitlebarController {
 
     func install(on window: NSWindow) {
         WorkspaceWindowChrome.apply(to: window)
-        window.title = sessionTitle?.title ?? "Ghosthub"
+        window.title = customTitle ?? sessionTitle?.title ?? "Ghosthub"
         titleHost.isHidden = !Self.showsTitle(
             tabCount: window.tabbedWindows?.count ?? 1
         )
@@ -456,6 +459,7 @@ final class CompactWorkspaceTitlebarController {
         sidebarWidth: CGFloat = WorkspaceSidebarWidthPolicy.defaultWidth,
         canCreateWorktree: Bool,
         sessionTitle: SessionTitlebarPresentation?,
+        customTitle: String? = nil,
         onToggleSidebar: @escaping () -> Void,
         onQuickLaunch: @escaping () -> Void,
         onSettings: @escaping () -> Void,
@@ -469,6 +473,7 @@ final class CompactWorkspaceTitlebarController {
         )
         self.canCreateWorktree = canCreateWorktree
         self.sessionTitle = sessionTitle
+        self.customTitle = customTitle
         self.onToggleSidebar = onToggleSidebar
         self.onQuickLaunch = onQuickLaunch
         self.onSettings = onSettings
@@ -535,7 +540,14 @@ final class CompactWorkspaceTitlebarController {
 
     @ViewBuilder
     private var titleView: some View {
-        if let sessionTitle {
+        if let customTitle {
+            Text(customTitle)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(customTitle)
+                .accessibilityLabel(customTitle)
+        } else if let sessionTitle {
             HStack(spacing: 5) {
                 Image(systemName: sessionTitle.icon.systemImageName)
                     .font(.system(size: 11, weight: .medium))
@@ -611,6 +623,9 @@ struct WorkspaceWindow: View {
         LibghosttyConfigReloadNotice?
     @State private var titlebarSidebarWidth =
         WorkspaceSidebarWidthPolicy.defaultWidth
+    @State private var customWindowTitle: String?
+    @State private var windowTitleRenameRequest:
+        WorkspaceWindowTitleRenameRequest?
     private let registry = WindowRegistry.shared
 
     #if canImport(AppKit)
@@ -1168,6 +1183,7 @@ struct WorkspaceWindow: View {
                     sceneModel.activeBorrowedZellijSelection,
                     in: sceneModel.snapshot
                 ),
+                customTitle: customWindowTitle,
                 onToggleSidebar: {
                     NotificationCenter.default.post(
                         name: .ghosthubToggleSidebar,
@@ -1194,11 +1210,40 @@ struct WorkspaceWindow: View {
                 }
             )
         )
+        .onReceive(NotificationCenter.default.publisher(
+            for: .ghosthubRenameWorkspaceWindow
+        )) { notification in
+            guard let requestedWindow = notification.object as? NSWindow,
+                  requestedWindow === sceneModel.workspaceWindow,
+                  requestedWindow.isKeyWindow,
+                  requestedWindow.attachedSheet == nil
+            else { return }
+            windowTitleRenameRequest = WorkspaceWindowTitleRenameRequest(
+                currentTitle: customWindowTitle ?? "",
+                automaticTitle: automaticWindowTitle
+            )
+        }
+        .sheet(item: $windowTitleRenameRequest) { request in
+            RenameWorkspaceWindowSheet(
+                initialTitle: request.currentTitle,
+                automaticTitle: request.automaticTitle,
+                onSave: { title in
+                    customWindowTitle = WorkspaceWindowTitle.normalized(title)
+                    windowTitleRenameRequest = nil
+                    refreshWindowState()
+                },
+                onCancel: {
+                    windowTitleRenameRequest = nil
+                }
+            )
+        }
         #endif
         .onChange(of: sceneModel.restorationState(
             windowID: resolvedWindowState.wrappedValue.windowID
         )) { _, state in
-            resolvedWindowState.wrappedValue = state
+            resolvedWindowState.wrappedValue = state.withCustomTitle(
+                customWindowTitle
+            )
         }
         .onChange(of: windowState) { _, state in
             #if canImport(AppKit)
@@ -1229,7 +1274,7 @@ struct WorkspaceWindow: View {
                    presented: state,
                    current: sceneModel.restorationState(
                        windowID: updateRelaunchWindowID
-                   )
+                   ).withCustomTitle(customWindowTitle)
                ) {
                 resolvedWindowState.wrappedValue = replacement
                 return
@@ -1310,6 +1355,9 @@ struct WorkspaceWindow: View {
     }
 
     private func beginRestoration(_ state: WorkspaceWindowState) {
+        customWindowTitle = WorkspaceWindowTitle.normalized(
+            state.customTitle
+        )
         sceneModel.beginRestoration(
             state,
             launchIntent: applicationDelegate
@@ -1338,7 +1386,7 @@ struct WorkspaceWindow: View {
     private func captureWindowState() -> WorkspaceWindowState {
         let state = sceneModel.restorationState(
             windowID: resolvedWindowState.wrappedValue.windowID
-        )
+        ).withCustomTitle(customWindowTitle)
         resolvedWindowState.wrappedValue = state
         return state
     }
@@ -1365,6 +1413,68 @@ struct WorkspaceWindow: View {
             selection: sceneModel.selection
         ) else { return false }
         return sceneModel.snapshot.canCreateWorktree(in: project)
+    }
+
+    private var automaticWindowTitle: String {
+        SessionTitlebarPresentation.resolve(
+            activeTmuxSession: sceneModel.activeBorrowedTmuxSelection,
+            activeHerdrSession: sceneModel.activeBorrowedHerdrSelection,
+            activeZellijSession: sceneModel.activeBorrowedZellijSelection,
+            in: sceneModel.snapshot
+        )?.title ?? "Ghosthub"
+    }
+}
+
+private struct WorkspaceWindowTitleRenameRequest: Identifiable {
+    let id = UUID()
+    let currentTitle: String
+    let automaticTitle: String
+}
+
+private struct RenameWorkspaceWindowSheet: View {
+    let automaticTitle: String
+    let onSave: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var title: String
+    @FocusState private var titleIsFocused: Bool
+
+    init(
+        initialTitle: String,
+        automaticTitle: String,
+        onSave: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _title = State(initialValue: initialTitle)
+        self.automaticTitle = automaticTitle
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Rename window")
+                .font(.headline)
+            TextField("Custom title", text: $title)
+                .focused($titleIsFocused)
+                .onSubmit { onSave(title) }
+            Text("Leave blank to use “\(automaticTitle)”.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") {
+                    onSave(title)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+        .onAppear { titleIsFocused = true }
     }
 }
 

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -70,12 +70,24 @@ enum WorkspaceWindowLaunchIntent: Hashable, Sendable {
     case openWorktree
 }
 
+enum WorkspaceWindowTitle {
+    static func normalized(_ value: String?) -> String? {
+        guard let title = value?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !title.isEmpty else {
+            return nil
+        }
+        return title
+    }
+}
+
 struct WorkspaceWindowState: Codable, Hashable, Sendable {
     var windowID: UUID
     var navigation: WorkspaceNavigationDescriptor?
     var tmux: WorkspaceTmuxDescriptor?
     var herdr: WorkspaceHerdrDescriptor? = nil
     var zellij: WorkspaceZellijDescriptor? = nil
+    var customTitle: String? = nil
 
     static func fresh(windowID: UUID = UUID()) -> Self {
         Self(windowID: windowID, navigation: nil, tmux: nil)
@@ -217,6 +229,12 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
             herdr: herdr,
             zellij: zellij
         )
+    }
+
+    func withCustomTitle(_ value: String?) -> Self {
+        var copy = self
+        copy.customTitle = WorkspaceWindowTitle.normalized(value)
+        return copy
     }
 }
 

--- a/Sources/UI/WorkspaceMenuNotifications.swift
+++ b/Sources/UI/WorkspaceMenuNotifications.swift
@@ -9,6 +9,8 @@ extension Notification.Name {
         Notification.Name("ghosthubCommandPalette")
     public static let ghosthubToggleSidebar =
         Notification.Name("ghosthubToggleSidebar")
+    public static let ghosthubRenameWorkspaceWindow =
+        Notification.Name("ghosthubRenameWorkspaceWindow")
     public static let ghosthubApplyThemeToCurrentSession =
         Notification.Name("ghosthubApplyThemeToCurrentSession")
     public static let ghosthubApplicationShortcutRequest =

--- a/Tests/App/ApplicationDelegateTests.swift
+++ b/Tests/App/ApplicationDelegateTests.swift
@@ -1043,6 +1043,24 @@ final class ApplicationDelegateTests: XCTestCase {
             "ghosthub / feature/api · studio-mac"
         )
         XCTAssertEqual(window.titleVisibility, .hidden)
+
+        controller.update(
+            isSidebarVisible: true,
+            canCreateWorktree: true,
+            sessionTitle: SessionTitlebarPresentation(
+                displayName: "ghosthub / feature/api",
+                hostname: "studio-mac",
+                icon: .tmuxSession
+            ),
+            customTitle: "Review logs",
+            onToggleSidebar: {},
+            onQuickLaunch: {},
+            onSettings: {},
+            onNewWorktree: {}
+        )
+        controller.install(on: window)
+
+        XCTAssertEqual(window.title, "Review logs")
     }
 
 }

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -5,6 +5,21 @@ import GhosthubWorkspace
 import Testing
 @testable import GhosthubApp
 
+@Suite("Workspace window titles")
+struct WorkspaceWindowTitleTests {
+    @Test("Custom titles trim and blank titles restore automatic naming")
+    func normalization() {
+        let state = WorkspaceWindowState.fresh()
+
+        #expect(
+            state.withCustomTitle("  Review logs  ").customTitle
+                == "Review logs"
+        )
+        #expect(state.withCustomTitle(" \n ").customTitle == nil)
+        #expect(state.customTitle == nil)
+    }
+}
+
 private struct RestorationFixture {
     static let worktreeGeneration =
         "0123456789abcdef0123456789abcdef"

--- a/tools/tests/test_demo_scripts.py
+++ b/tools/tests/test_demo_scripts.py
@@ -32,6 +32,7 @@ WEBSITE_ASSET_NAMES = (
     "guide-terminal.png",
     "guide-command-center.png",
     "guide-native-tabs.png",
+    "guide-window-title.png",
 )
 
 

--- a/website/demo/assets/demohost.m
+++ b/website/demo/assets/demohost.m
@@ -828,6 +828,12 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                               : [NSString stringWithFormat:
                                   @"expected %@ but active title is %@",
                                   text, activeTitle]];
+    } else if ([action isEqualToString:@"expect-sheet"]) {
+      BOOL found = DemoRootWindow().attachedSheet != nil;
+      [self acknowledge:requestID
+                success:found
+                message:found ? @"sheet is visible"
+                              : @"no workspace sheet is visible"];
     } else if ([action isEqualToString:@"click"]) {
       NSArray<NSString *> *parts =
           [text componentsSeparatedByString:@","];
@@ -839,6 +845,20 @@ static void DemoCapture(NSString *path, BOOL matrix, BOOL exactWindow) {
                 success:clicked
                 message:clicked ? @"click sent"
                                 : @"click requires x,y and a workspace window"];
+    } else if ([action isEqualToString:@"rename-window"]) {
+      NSWindow *window = DemoRootWindow();
+      NSView *title = DemoTitlebarView(
+          window, @"GhosthubCompactSessionTitle");
+      NSPoint point = title == nil
+          ? NSZeroPoint
+          : [title convertPoint:NSMakePoint(
+              NSMidX(title.bounds), NSMidY(title.bounds))
+                            toView:nil];
+      BOOL clicked = title != nil && DemoClickWindow(window, point);
+      [self acknowledge:requestID
+                success:clicked
+                message:clicked ? @"window title clicked"
+                                : @"workspace title was not available"];
     } else if ([action isEqualToString:@"scroll-detail"]) {
       BOOL scrolled = text.length > 0 && DemoScrollDetail(text.doubleValue);
       [self acknowledge:requestID

--- a/website/demo/shoot.sh
+++ b/website/demo/shoot.sh
@@ -252,6 +252,21 @@ capture_worktree_window_counts() {
   sleep 0.5
 }
 
+capture_window_title() {
+  demo_input rename-window
+  sleep 1
+  demo_input expect-sheet
+  capture_state guide-window-title.png
+  demo_input escape
+  sleep 1
+}
+
+if [[ "${GHOSTHUB_DEMO_WINDOW_TITLE_ONLY:-}" == "1" ]]; then
+  echo "==> guide: editable workspace title"
+  capture_window_title
+  exit 0
+fi
+
 if [[ "${GHOSTHUB_DEMO_WORKTREE_COUNTS_ONLY:-}" == "1" ]]; then
   echo "==> guide: worktree window counts"
   capture_worktree_window_counts
@@ -290,6 +305,9 @@ capture_worktree_window_counts
 
 echo "==> guide: project removal"
 capture_project_removal
+
+echo "==> guide: editable workspace title"
+capture_window_title
 
 echo "==> hero: active coding-agent worktree"
 palette "fix-reconnect-backoff"

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -53,8 +53,8 @@ To give one workspace window or tab its own label, choose
 and returns after restoration or an update relaunch. Save an empty title to
 return to the automatic session and host title. Renaming Ghosthub chrome never
 renames a tmux session or window, a Herdr or Zellij session, or a worktree.
-You can also hover the compact title and select its pencil, or double-click the
-title, to open the same editor.
+You can also hover the compact title and select either the title or its pencil
+to open the same editor.
 
 ## Close a presentation
 

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -56,6 +56,8 @@ renames a tmux session or window, a Herdr or Zellij session, or a worktree.
 You can also hover the compact title and select either the title or its pencil
 to open the same editor.
 
+![Ghosthub's editor for a workspace window or tab title](assets/guide-window-title.png)
+
 ## Close a presentation
 
 ++cmd+w++ closes and detaches only the active session presentation. Other

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -48,6 +48,12 @@ tab group. If a numbered shortcut is beyond the end of the current group, it
 selects the group's last tab. The tab bar shows the available numbered
 shortcuts and updates them when you reorder tabs.
 
+To give one workspace window or tab its own label, choose
+**Window → Rename Window…**. The label belongs only to that Ghosthub workspace
+and returns after restoration or an update relaunch. Save an empty title to
+return to the automatic session and host title. Renaming Ghosthub chrome never
+renames a tmux session or window, a Herdr or Zellij session, or a worktree.
+
 ## Close a presentation
 
 ++cmd+w++ closes and detaches only the active session presentation. Other

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -53,6 +53,8 @@ To give one workspace window or tab its own label, choose
 and returns after restoration or an update relaunch. Save an empty title to
 return to the automatic session and host title. Renaming Ghosthub chrome never
 renames a tmux session or window, a Herdr or Zellij session, or a worktree.
+You can also hover the compact title and select its pencil, or double-click the
+title, to open the same editor.
 
 ## Close a presentation
 

--- a/website/scripts/sync-assets.sh
+++ b/website/scripts/sync-assets.sh
@@ -28,6 +28,7 @@ assets=(
   guide-terminal.png
   guide-command-center.png
   guide-native-tabs.png
+  guide-window-title.png
 )
 raw_root="https://raw.githubusercontent.com/kenn-io/ghosthub/website-assets"
 fetched_ref=""


### PR DESCRIPTION
Automatic session names do not always describe the task represented by a Ghosthub workspace.

- Adds **Window → Rename Window…** and a hover pencil on the compact title; the full title and pencil share one click target.
- Stores the trimmed label per native workspace window or tab and restores it after ordinary and update relaunches. Saving an empty value returns to automatic session and host naming.
- Keeps labels app-owned: tmux, Herdr, Zellij, and worktree identity never change, and two windows attached to the same session can use different labels.
- Keeps all rename work behind explicit user input; activation, focus, rendering, polling, and libghostty paths are unchanged. The activation work gate remains green.

![Ghosthub's editable workspace title sheet](https://raw.githubusercontent.com/kenn-io/ghosthub/refs/heads/website-assets/guide-window-title.png)
