### PR TITLE
Accept GitHub's redacted ruleset field

### DIFF
--- a/.github/workflows/sandbox-image-promote.yml
+++ b/.github/workflows/sandbox-image-promote.yml
@@ -358,7 +358,7 @@ jobs:
             def default_branch:
               .target == "branch" and
               .enforcement == "active" and
-              .bypass_actors == [] and
+              (.bypass_actors == null or .bypass_actors == []) and
               (.conditions.ref_name.include | index("~DEFAULT_BRANCH")) != null and
               .conditions.ref_name.exclude == [];
             def promotion_status:

--- a/docs/release.md
+++ b/docs/release.md
@@ -185,9 +185,10 @@ workflow-enforced immutable policy; GHCR tag settings are not treated as the
 authority. The `sandbox-image-promotion` status points to a completed
 successful run of the exact trusted promotion workflow for that pull-request
 head. The gate verifies that run through the GitHub API; the status alone is
-not promotion authority. An active no-bypass, no-exclusion default-branch
-ruleset requires the status from a dedicated status-only GitHub App with strict
-checking and a single-entry merge queue. Its key is available only through a
+not promotion authority. An active default-branch ruleset provisioned with no
+bypass actors or ref exclusions requires the status from a dedicated
+status-only GitHub App with strict checking and a single-entry merge queue. Its
+key is available only through a
 no-reviewer environment restricted to `main`; no `GITHUB_TOKEN` receives
 status-write or package-write authority. Candidate publication and production
 retagging use a separate package-writer credential available only through

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -60,6 +60,12 @@ Never use `latest`.
 
 The promotion preflight reads the live rulesets through the GitHub API and
 fails before registry mutation if that exact required-check policy is absent.
+The operator-side enable path creates and verifies an empty bypass-actor list.
+GitHub redacts that field as `null` from installation-token responses, so
+recurring App audits accept either visible empty actors or the redacted value;
+they still verify the exact enforcement, ref, status, App, merge-queue, and
+workflow requirements. Repository and organization administrators remain
+trusted to preserve the provisioned bypass policy.
 Every reconciliation also audits both credential-bearing environments, their
 exact secret sets and `main` branch policies, the status App variables, the
 lack of package-writer reviewers, and the parsed structure of both `.yml` and
@@ -280,10 +286,11 @@ cutoff to leave one hour of scheduling margin before the 24-hour limit. If the
 run expires before retag or merge, rerun
 `sandbox-image-promote` and approve the idempotent promotion again.
 
-The repository ruleset must require this status from the dedicated app with
-strict checking enabled, no bypass actors, an empty exclusion list, and a
-single-entry merge queue. Queue the pull request with **Merge when ready**
-rather than merging its head directly. The organization ruleset separately
+The repository ruleset is provisioned with no bypass actors and must require
+this status from the dedicated app with strict checking enabled, an empty
+exclusion list, and a single-entry merge queue. Queue the pull request with
+**Merge when ready** rather than merging its head directly. The organization
+ruleset separately
 requires the merge-signal workflow from the protected
 `sandbox-merge-signal-v1` tag of the public source repository. The queue
 creates a fresh synthetic SHA; that workflow requests a SHA-specific

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -452,10 +452,10 @@ lifetime, while run authorization ends after 23 hours. It
 also fingerprints the full reviewer, deployment, and branch policy and the
 status-signing environment. The approved runner requires exact matches and an
 unchanged trusted-main workflow authority immediately before registry mutation.
-A no-bypass, no-exclusion
-repository ruleset requires
-that status from a dedicated status-only GitHub App with strict checking and a
-single-entry merge queue. The app private key exists only in a no-reviewer
+A repository ruleset provisioned with no bypass actors or ref exclusions
+requires that status from a dedicated status-only GitHub App with strict
+checking and a single-entry merge queue. The app private key exists only in a
+no-reviewer
 environment restricted by an exact branch policy to the `main` branch, never a
 same-named tag. A pinned token action consumes that key; repository Python
 receives only a separately minted read-only installation token and never the

--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -1007,7 +1007,9 @@ def _ruleset_requires_merge_signal(value: object) -> bool:
         or value.get("source") != "kenn-io"
         or value.get("target") != "branch"
         or value.get("enforcement") != "active"
-        or value.get("bypass_actors") != []
+        # GitHub redacts bypass actors as null from installation tokens. The
+        # operator-side provisioning still requires an empty list.
+        or value.get("bypass_actors") not in (None, [])
         or not isinstance(ref_name, dict)
         or "~DEFAULT_BRANCH" not in ref_name.get("include", [])
         or ref_name.get("exclude") != []
@@ -1055,7 +1057,9 @@ def _ruleset_requires_promotion_status(
     requires_status = (
         value.get("target") == "branch"
         and value.get("enforcement") == "active"
-        and value.get("bypass_actors") == []
+        # GitHub redacts bypass actors as null from installation tokens. The
+        # operator-side enable command still requires and writes an empty list.
+        and value.get("bypass_actors") in (None, [])
         and "~DEFAULT_BRANCH" in includes
         and any(
             _rule_requires_promotion_status(rule, expected_integration_id)

--- a/tools/tests/test_sandbox_image_commands.py
+++ b/tools/tests/test_sandbox_image_commands.py
@@ -1010,7 +1010,7 @@ def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> Non
     detail = {
         "target": "branch",
         "enforcement": "active",
-        "bypass_actors": [],
+        "bypass_actors": None,
         "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
         "rules": [
             {"type": "pull_request", "parameters": {}},
@@ -1152,7 +1152,7 @@ def test_required_merge_signal_uses_the_external_protected_tag() -> None:
         "source": "kenn-io",
         "target": "branch",
         "enforcement": "active",
-        "bypass_actors": [],
+        "bypass_actors": None,
         "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
         "rules": [
             {


### PR DESCRIPTION
GitHub App installation tokens return `bypass_actors: null` for both live sandbox rulesets even though operator credentials report the provisioned empty list. The authority audit rejected those valid rules and kept the promotion gate red after bootstrap.

- Accept only the API's redacted `null` or a visible empty actor list.
- Apply the same handling in the final post-approval retag ruleset check.
- Continue requiring the exact enforcement, ref exclusions, dedicated App status, strict checking, single-entry merge queue, and external workflow source.
- Keep operator-side provisioning responsible for creating rulesets without bypass actors and document the observable boundary.

A freshly minted read-only App installation token now validates the live rulesets. All 406 Python tests, focused authority coverage, lint, type checking, and docs build pass.
