### PR TITLE
Restore retained tmux previews with isolated state homes

### DIFF
--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -63,6 +63,7 @@ private struct NativeTmuxAttachment {
     var sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
     var sessionIdentity: TmuxSessionIdentity?
     var paneSplitClientToken: String
+    var clientTTYDirectory: String?
     var supportsPaneSplitting: Bool
     var remoteExitStatusURL: URL?
 }
@@ -383,6 +384,10 @@ final class NativeTmuxSessionCoordinator {
                 sshConnectionSnapshot: sshConnectionSnapshot,
                 sessionIdentity: sessionIdentity,
                 paneSplitClientToken: attachmentID.uuidString.lowercased(),
+                clientTTYDirectory: host.isRemote ? nil : StateHome.resolved()
+                    .appendingPathComponent(
+                        "tmux-clients", isDirectory: true
+                    ).path,
                 supportsPaneSplitting: TmuxPaneSplitter
                     .supportsPaneSplitting(
                         version: resolved.version,
@@ -517,7 +522,8 @@ final class NativeTmuxSessionCoordinator {
                     attachment.sshConnectionSnapshot.arguments,
                     remoteExitStatusPath:
                     attachment.remoteExitStatusURL?.path,
-                    clientTTYToken: attachment.paneSplitClientToken
+                    clientTTYToken: attachment.paneSplitClientToken,
+                    localClientTTYDirectory: attachment.clientTTYDirectory
                 )
             )
         )
@@ -550,6 +556,7 @@ final class NativeTmuxSessionCoordinator {
             sshConnectionArguments: attachment.sshConnectionSnapshot.arguments,
             expectedIdentity: attachment.sessionIdentity,
             clientToken: attachment.paneSplitClientToken,
+            clientTTYDirectory: attachment.clientTTYDirectory,
             expectedClient: paneSplitClients[handle.id]
         )
         if attachment.supportsPaneSplitting {
@@ -650,6 +657,7 @@ final class NativeTmuxSessionCoordinator {
             sshConnectionArguments: attachment.sshConnectionSnapshot.arguments,
             expectedIdentity: expectedIdentity,
             clientToken: attachment.paneSplitClientToken,
+            clientTTYDirectory: attachment.clientTTYDirectory,
             expectedClient: paneSplitClients[handle.id]
         )
     }

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -11,6 +11,7 @@ struct TmuxPaneSplitTarget: Sendable {
     var sshConnectionArguments: [String]
     var expectedIdentity: TmuxSessionIdentity?
     var clientToken: String?
+    var clientTTYDirectory: String?
     var expectedClient: TmuxPaneSplitClientIdentity?
 }
 
@@ -283,6 +284,7 @@ struct TmuxPaneSplitter: Sendable {
             tmuxPath: target.tmuxPath,
             socketName: target.socketName,
             clientToken: clientToken,
+            clientTTYDirectory: target.clientTTYDirectory,
             platform: Self.platform(for: target.host)
         )
         let result = await run(
@@ -337,6 +339,7 @@ struct TmuxPaneSplitter: Sendable {
         tmuxPath: String,
         socketName: String?,
         clientToken: String,
+        clientTTYDirectory: String?,
         platform: SSHHostInfo.Platform
     ) -> String {
         guard platform == .posix,
@@ -379,7 +382,15 @@ struct TmuxPaneSplitter: Sendable {
                 + "\"$ghosthub_identity_session_id\" "
                 + "\"$ghosthub_identity_session_created\" "
                 + "\"$ghosthub_identity_pane_id\"; break; done"
-        let path = "\"$HOME/.ghosthub/tmux-clients/\(clientToken)\""
+        let path: String
+        if let clientTTYDirectory {
+            let separator = clientTTYDirectory.hasSuffix("/") ? "" : "/"
+            path = shellQuotedCommandArgument(
+                clientTTYDirectory + separator + clientToken
+            )
+        } else {
+            path = "\"$HOME/.ghosthub/tmux-clients/\(clientToken)\""
+        }
         return "ghosthub_client_tty=; "
             + "for ghosthub_client_probe_delay in "
             + "0.01 0.02 0.04 0.08 0.16 0.32 0.64 1 1 1 1; do "

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -49,7 +49,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         workingDirectory: String? = nil,
         sshConnectionArguments: [String] = demoSSHIsolationArguments(),
         remoteExitStatusPath: String? = nil,
-        clientTTYToken: String? = nil
+        clientTTYToken: String? = nil,
+        localClientTTYDirectory: String? = nil
     ) -> String {
         switch host {
         case .local:
@@ -60,7 +61,8 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             )
             return recordedClientTTYCommand(
                 command,
-                token: clientTTYToken
+                token: clientTTYToken,
+                directory: localClientTTYDirectory
             )
         case let .ssh(info):
             let command: String
@@ -674,21 +676,24 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
 
     private func recordedClientTTYCommand(
         _ command: String,
-        token: String?
+        token: String?,
+        directory: String? = nil
     ) -> String {
         guard let token else { return command }
         return shellCommand([
             "/bin/sh", "-c",
             recordedClientTTYBody(
                 command,
-                token: token
+                token: token,
+                directory: directory
             ),
         ])
     }
 
     private func recordedClientTTYBody(
         _ command: String,
-        token: String?
+        token: String?,
+        directory: String? = nil
     ) -> String {
         guard let token,
               !token.isEmpty,
@@ -699,9 +704,11 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
               })
         else { return command }
         let nestedCommand = shellCommand(["/bin/sh", "-c", command])
+        let clientTTYDirectory = directory.map(shellQuotedCommandArgument)
+            ?? "\"$HOME/.ghosthub/tmux-clients\""
         return [
             "unset TMUX TMUX_PANE",
-            "ghosthub_client_tty_dir=\"$HOME/.ghosthub/tmux-clients\"",
+            "ghosthub_client_tty_dir=\(clientTTYDirectory)",
             "ghosthub_client_tty_path=\"$ghosthub_client_tty_dir/\(token)\"",
             "ghosthub_client_tty_tmp=\"$ghosthub_client_tty_path.$$\"",
             "ghosthub_client_pid=",

--- a/Tests/App/TmuxPaneSplitterTests.swift
+++ b/Tests/App/TmuxPaneSplitterTests.swift
@@ -16,7 +16,13 @@ private let testSplitClient = TmuxPaneSplitClientIdentity(
     paneID: "%9"
 )
 
-private func testClientTokenPath(_ token: String) throws -> URL {
+private func testClientTokenPath(
+    _ token: String,
+    directory: URL? = nil
+) throws -> URL {
+    if let directory {
+        return directory.appendingPathComponent(token)
+    }
     let shellHome = try #require(
         ProcessInfo.processInfo.environment["HOME"]
     )
@@ -73,9 +79,13 @@ private final class TestTmuxClient {
         tmuxPath: String,
         socketName: String,
         sessionName: String,
-        clientToken: String
+        clientToken: String,
+        clientTTYDirectory: URL? = nil
     ) throws {
-        tokenPath = try testClientTokenPath(clientToken)
+        tokenPath = try testClientTokenPath(
+            clientToken,
+            directory: clientTTYDirectory
+        )
         let command = TmuxAttachmentInfo(
             sessionName: sessionName,
             host: .local,
@@ -83,7 +93,8 @@ private final class TestTmuxClient {
             launchMode: .attachOnly
         ).attachCommand(
             tmuxPath: tmuxPath,
-            clientTTYToken: clientToken
+            clientTTYToken: clientToken,
+            localClientTTYDirectory: clientTTYDirectory?.path
         )
         process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
         process.arguments = [
@@ -503,14 +514,21 @@ struct TmuxPaneSplitterTests {
         defer { server.stop() }
         let socketName = server.socketName
 
+        let stateDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: stateDirectory) }
         let token = UUID().uuidString.lowercased()
+        let clientTTYDirectory = stateDirectory.appendingPathComponent(
+            "isolated-state/tmux-clients", isDirectory: true
+        )
         let target = TmuxPaneSplitTarget(
             host: .local,
             tmuxPath: tmuxPath,
             sessionName: "token-race",
             socketName: socketName,
             sshConnectionArguments: [],
-            clientToken: token
+            clientToken: token,
+            clientTTYDirectory: clientTTYDirectory.path
         )
         let runnerStarted = LockedValue(false)
         let releaseRunner = DispatchSemaphore(value: 0)
@@ -537,7 +555,8 @@ struct TmuxPaneSplitterTests {
             tmuxPath: tmuxPath,
             socketName: socketName,
             sessionName: "token-race",
-            clientToken: token
+            clientToken: token,
+            clientTTYDirectory: clientTTYDirectory
         )
         defer { clientProcess.stop() }
         let client = try await pendingIdentity.get()

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -997,7 +997,9 @@ final class TerminalSurfacePreviewTests: XCTestCase {
                 at: pipeline.paths.configDirectory,
                 withIntermediateDirectories: true
             )
-            try! "shell = /bin/zsh\n".write(
+            let config = LibghosttyConfigPipeline.defaultGlobalConfigContents
+                + "\nshell = /bin/zsh\n"
+            try! config.write(
                 to: pipeline.paths.globalConfigFile,
                 atomically: true,
                 encoding: .utf8

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -54,17 +54,19 @@ struct TmuxAttachmentInfoTests {
             ofItemAtPath: tmux.path
         )
         let token = "slow-\(UUID().uuidString.lowercased())"
-        let shellHome = try #require(
-            ProcessInfo.processInfo.environment["HOME"]
+        let clientTTYDirectory = directory.appendingPathComponent(
+            "isolated-state/tmux-clients", isDirectory: true
         )
-        let tokenPath = URL(fileURLWithPath: shellHome, isDirectory: true)
-            .appendingPathComponent(".ghosthub/tmux-clients/\(token)")
-        defer { try? FileManager.default.removeItem(at: tokenPath) }
+        let tokenPath = clientTTYDirectory.appendingPathComponent(token)
         let command = TmuxAttachmentInfo(
             sessionName: "unpublished",
             host: .local,
             launchMode: .attachOnly
-        ).attachCommand(tmuxPath: tmux.path, clientTTYToken: token)
+        ).attachCommand(
+            tmuxPath: tmux.path,
+            clientTTYToken: token,
+            localClientTTYDirectory: clientTTYDirectory.path
+        )
         let process = Process()
         let input = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/script")


### PR DESCRIPTION
Retained local tmux previews could remain in **Reconnecting** when Ghosthub used a non-default application state directory. The tmux client published its identity token under the account home while the identity probe searched the configured state home.

- Resolves the local identity-token directory once during attachment provisioning and gives the same exact path to the client publisher and probe.
- Leaves remote attachment behavior unchanged.
- Adds real-tmux coverage for publishing and resolving identity through a non-default state directory.
- Keeps activation, focus, rendering, polling, and window-switching paths unchanged; the activation work gate remains green.

The exact isolated demo sequence that exposed the bug now restores the retained preview to **Live**, and its token files remain inside the isolated state directory.
