### PR TITLE
Fix Apple image vetting and restore normal merges

### DIFF
--- a/.github/workflows/sandbox-image-promote.yml
+++ b/.github/workflows/sandbox-image-promote.yml
@@ -369,18 +369,7 @@ jobs:
                 any(.parameters.required_status_checks[]?;
                   .context == "sandbox-image-promotion" and
                   .integration_id == $app_id)) and
-              any(.rules[]?; .type == "pull_request") and
-              any(.rules[]?;
-                .type == "merge_queue" and
-                .parameters == {
-                  check_response_timeout_minutes: 60,
-                  grouping_strategy: "ALLGREEN",
-                  max_entries_to_build: 1,
-                  max_entries_to_merge: 1,
-                  merge_method: "SQUASH",
-                  min_entries_to_merge: 1,
-                  min_entries_to_merge_wait_minutes: 0
-                });
+              any(.rules[]?; .type == "pull_request");
             def merge_signal:
               default_branch and
               .source_type == "Organization" and

--- a/docs/release.md
+++ b/docs/release.md
@@ -187,7 +187,7 @@ successful run of the exact trusted promotion workflow for that pull-request
 head. The gate verifies that run through the GitHub API; the status alone is
 not promotion authority. An active default-branch ruleset provisioned with no
 bypass actors or ref exclusions requires the status from a dedicated
-status-only GitHub App with strict checking and a single-entry merge queue. Its
+status-only GitHub App with strict checking. Its
 key is available only through a
 no-reviewer environment restricted to `main`; no `GITHUB_TOKEN` receives
 status-write or package-write authority. Candidate publication and production
@@ -195,19 +195,12 @@ retagging use a separate package-writer credential available only through
 exact-`main` environments, and the GHCR package does not inherit repository
 Actions access. Trusted promotion and every reconciliation audit the
 environment, parsed workflow authority, app integration ID, and repository
-policy. An organization ruleset requires the merge-signal workflow from the
-protected `sandbox-merge-signal-v1` tag in the separate public
-`kenn-io/ghosthub-nightly` repository, so merge-queue code cannot select its
-own signal logic. Promotion preflight and reconciliation verify the source
-identity, reviewed commit, and the workflow's restricted
-trigger, permissions, and environment authority.
-Reconciliation fences all open heads before file inspection. The merge queue
-generates a fresh SHA with its own reconciliation lane; trusted-main
-tooling audits the proposed workflow tree without executing it, refuses changes
-to the credential-bearing status workflow, and rechecks promotion and freshness
-before authorizing it. A GitHub or API failure therefore leaves the merge
-blocked. This makes the exact PR head, current `main` base, and a current
-merge-time evaluation part of authorization. Main changes invalidate the
+policy. Reconciliation fences all open heads before file inspection.
+Trusted-main tooling audits the proposed workflow tree without executing it,
+refuses changes to the credential-bearing status workflow, and rechecks
+promotion and freshness before authorizing the exact pull-request head. A
+GitHub or API failure therefore leaves the merge blocked. This makes the exact
+PR head and current `main` base part of authorization. Main changes invalidate the
 status, and successful promotion evidence expires after 24 hours.
 
 The scheduled and manually dispatchable maintenance workflow rescans the

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -49,13 +49,7 @@ Never use `latest`.
   that app's client ID and private key
 - an active default-branch ruleset with no bypass actors or ref exclusions that
   requires `sandbox-image-promotion`, enables strict required-status-check
-  policy, binds the context to that dedicated app's numeric integration ID,
-  and requires the merge queue with one pull request per group
-- an organization-owned ruleset with no bypass actors or ref exclusions that
-  targets Ghosthub's default branch and requires
-  `.github/workflows/sandbox-image-merge-signal.yml` from
-  the protected `sandbox-merge-signal-v1` tag of
-  `kenn-io/ghosthub-nightly`
+  policy, and binds the context to that dedicated app's numeric integration ID
 - approval authority, or an available reviewer, for that environment
 
 The promotion preflight reads the live rulesets through the GitHub API and
@@ -63,8 +57,8 @@ fails before registry mutation if that exact required-check policy is absent.
 The operator-side enable path creates and verifies an empty bypass-actor list.
 GitHub redacts that field as `null` from installation-token responses, so
 recurring App audits accept either visible empty actors or the redacted value;
-they still verify the exact enforcement, ref, status, App, merge-queue, and
-workflow requirements. Repository and organization administrators remain
+they still verify the exact enforcement, ref, status, and App requirements.
+Repository and organization administrators remain
 trusted to preserve the provisioned bypass policy.
 Every reconciliation also audits both credential-bearing environments, their
 exact secret sets and `main` branch policies, the status App variables, the
@@ -287,46 +281,33 @@ run expires before retag or merge, rerun
 `sandbox-image-promote` and approve the idempotent promotion again.
 
 The repository ruleset is provisioned with no bypass actors and must require
-this status from the dedicated app with strict checking enabled, an empty
-exclusion list, and a single-entry merge queue. Queue the pull request with
-**Merge when ready** rather than merging its head directly. The organization
-ruleset separately
-requires the merge-signal workflow from the protected
-`sandbox-merge-signal-v1` tag of the public source repository. The queue
-creates a fresh synthetic SHA; that workflow requests a SHA-specific
-reconciliation.
+this status from the dedicated app with strict checking enabled and an empty
+exclusion list. Merge the authorized pull-request head through the repository's
+normal squash-merge path.
 Trusted-main code checks out the proposed merge tree without executing it,
 structurally audits every proposed workflow, and requires every workflow that
 can reference a credential-bearing environment to remain byte-identical to
 trusted `main`. The audit rejects job-level reusable workflows except the
-exact repository-owned `ci.yml@main` call. The organization ruleset binds the
-merge-signal path, repository identity, and protected source tag outside the
-candidate tree. Live preflight resolves the tag to its reviewed commit,
-then requires the workflow's `pull_request` and `merge_group` triggers, empty
-permissions, and absence of environment or reusable
-workflow authority; reconciliation accepts only runs with the expected name
-and path. The
+exact repository-owned `ci.yml@main` call. The
 executable post-approval vulnerability policy is part of the same
 byte-identical authority closure, and changing it is promotion-relevant.
 It then rechecks the complete App, environment, ruleset, file, base,
 promotion-run, and freshness authority before the dedicated App authorizes that
-queue SHA. If GitHub cannot run reconciliation, the queue SHA never succeeds
-and times out closed. Strict checking also makes the current `main` revision
-part of authorization. Any push creates a new head without authorization.
+pull-request head. Strict checking also makes the current `main` revision part
+of authorization. Any push creates a new head without authorization.
 Trusted promotion verifies the same live authority before it can write a
 production tag.
 
 The pull-request gate runs only for pull requests targeting `main`. Every open,
 head update, reopen, ready-for-review transition, or edit fences every open head
 pending before it inspects file metadata. Push, schedule, workflow completion,
-and manual events perform the same full reconciliation. Merge-signal events use
-an isolated lane that fences and reconciles only their own queue SHA. Recurring
-reconciliation also fences prior queue SHAs and restores only a recently
+and manual events perform the same full reconciliation. Recurring
+reconciliation restores only a recently
 audited authorization that still satisfies current policy. A pull request whose file list exceeds
 GitHub's 3,000-file API limit remains pending without preventing other pull
 requests from being reconciled. Only current evidence from the trusted
 default-branch promotion workflow may cause the dedicated App to record success
-on either a pull-request head or its fresh merge-group SHA.
+on a pull-request head.
 
 ## Status, Recovery, and Maintenance
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -454,7 +454,7 @@ status-signing environment. The approved runner requires exact matches and an
 unchanged trusted-main workflow authority immediately before registry mutation.
 A repository ruleset provisioned with no bypass actors or ref exclusions
 requires that status from a dedicated status-only GitHub App with strict
-checking and a single-entry merge queue. The app private key exists only in a
+checking. The app private key exists only in a
 no-reviewer
 environment restricted by an exact branch policy to the `main` branch, never a
 same-named tag. A pinned token action consumes that key; repository Python
@@ -471,14 +471,7 @@ selection is
 rejected, every workflow declares explicit top-level permissions, the job
 refuses non-`main` effective refs, and no
 `GITHUB_TOKEN` has status-write or package-write authority. The GHCR package
-does not inherit repository Actions access. An organization ruleset requires
-the merge-signal workflow from the protected `sandbox-merge-signal-v1` tag of
-the separate public `kenn-io/ghosthub-nightly` repository. Trusted promotion
-and every reconciliation verify that source repository, protected tag,
-reviewed commit, workflow path, required `pull_request` and `merge_group`
-triggers, empty token permissions, absence of environment use, live
-environments, parsed workflow authority, app integration ID, and ruleset. The
-organization tag policy is trusted infrastructure. At the final production-tag
+does not inherit repository Actions access. At the final production-tag
 mutation boundary,
 trusted promotion authenticates the App owner, slug, permissions, private key,
 and complete single-repository installation scope, then rechecks both required
@@ -486,15 +479,11 @@ rulesets, pull-request evidence, and tag availability immediately before the
 registry write. The completed run records an App-authenticated production
 environment fingerprint and the exact promotion run; reconciliation requires
 both to match current live authority before restoring merge authorization.
-Reconciliation fences all open heads and prior merge-group SHAs before
-inspecting their metadata. At
-merge time, an unprivileged merge-group signal receives a SHA-specific trusted
-reconciliation. Trusted-main tooling audits the proposed workflow tree without
-executing it and refuses any change to a credential-bearing workflow before
-authorizing the queue's fresh synthetic SHA. The candidate tree cannot change
-the external merge signal or claim its reserved workflow path or
-public name; inability to reconcile
-therefore leaves that SHA blocked rather than preserving an old head status.
+Reconciliation fences all open heads before inspecting their metadata.
+Trusted-main tooling audits the proposed workflow tree without executing it and
+refuses any change to a credential-bearing workflow before authorizing the
+exact pull-request head. Inability to reconcile leaves that head blocked rather
+than preserving an old status.
 Main changes, a new pin PR head SHA, the immutable promotion-plan deadline, and
 the 24-hour run-age limit invalidate authorization. A
 registry, tag, report, workflow-run, environment, ruleset, or attestation

--- a/tools/sandbox_image/apple.py
+++ b/tools/sandbox_image/apple.py
@@ -301,8 +301,6 @@ class AppleVettingHarness:
             )
             if len(values) != 1:
                 raise ValueError("Apple image inspect identity is ambiguous")
-            configuration = values[0]["configuration"]
-            digest = configuration["descriptor"]["digest"]
             variants = values[0]["variants"]
             arm64 = next(
                 variant
@@ -310,6 +308,7 @@ class AppleVettingHarness:
                 if variant["config"]["architecture"] == "arm64"
                 and variant["config"]["os"] == "linux"
             )
+            digest = arm64["digest"]
             labels = arm64["config"]["config"]["Labels"]
             source_commit = labels["org.opencontainers.image.revision"]
             image_version = labels["org.opencontainers.image.version"]

--- a/tools/sandbox_image/authority.py
+++ b/tools/sandbox_image/authority.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from .github import (
-    MERGE_QUEUE_PARAMETERS,
     list_ruleset_summaries,
     verify_package_writer_environment,
     verify_production_environment,
@@ -310,10 +309,6 @@ def promotion_ruleset_payload(value: object, app_id: int) -> dict[str, object]:
                     "do_not_enforce_on_create": False,
                     "required_status_checks": [required],
                 },
-            },
-            {
-                "type": "merge_queue",
-                "parameters": dict(MERGE_QUEUE_PARAMETERS),
             },
         ],
     }

--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -33,15 +33,6 @@ from .report import (
 )
 from .trivy import scan_image, scan_reference
 
-MERGE_QUEUE_PARAMETERS = {
-    "check_response_timeout_minutes": 60,
-    "grouping_strategy": "ALLGREEN",
-    "max_entries_to_build": 1,
-    "max_entries_to_merge": 1,
-    "merge_method": "SQUASH",
-    "min_entries_to_merge": 1,
-    "min_entries_to_merge_wait_minutes": 0,
-}
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
 VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 REVIEWED_IMAGE_INPUTS = (
@@ -1066,17 +1057,11 @@ def _ruleset_requires_promotion_status(
             for rule in rules
         )
     )
-    requires_merge_queue = any(
-        isinstance(rule, dict)
-        and rule.get("type") == "merge_queue"
-        and rule.get("parameters") == MERGE_QUEUE_PARAMETERS
-        for rule in rules
-    )
     requires_pull_request = any(
         isinstance(rule, dict) and rule.get("type") == "pull_request"
         for rule in rules
     )
-    return requires_status and requires_merge_queue and requires_pull_request
+    return requires_status and requires_pull_request
 
 
 def _rule_requires_promotion_status(

--- a/tools/tests/test_sandbox_image_apple.py
+++ b/tools/tests/test_sandbox_image_apple.py
@@ -168,6 +168,40 @@ def test_canonical_report_path_uses_digest_only(tmp_path: Path) -> None:
     )
 
 
+def test_image_identity_uses_arm64_manifest_digest(tmp_path: Path) -> None:
+    image = "ghcr.io/kenn-io/ghosthub-sandbox@" + DIGEST
+    inspect_call = ("container", "image", "inspect", image)
+    payload = [
+        {
+            "configuration": {
+                "descriptor": {"digest": "sha256:" + "a" * 64}
+            },
+            "variants": [
+                {
+                    "digest": DIGEST,
+                    "config": {
+                        "architecture": "arm64",
+                        "os": "linux",
+                        "config": {
+                            "Labels": {
+                                "org.opencontainers.image.revision": "c" * 40,
+                                "org.opencontainers.image.version": "0.1.0",
+                            }
+                        },
+                    },
+                }
+            ],
+        }
+    ]
+    runner = ResponseRunner(
+        {inspect_call: response(inspect_call, json.dumps(payload))}
+    )
+
+    identity = AppleVettingHarness(tmp_path, runner)._inspect_image_identity(image)
+
+    assert identity == AppleImageIdentity(DIGEST, "c" * 40, "0.1.0")
+
+
 def test_vetting_rechecks_mount_protection_after_restart(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tools/tests/test_sandbox_image_authority.py
+++ b/tools/tests/test_sandbox_image_authority.py
@@ -263,18 +263,7 @@ def test_promotion_ruleset_is_narrow_and_pins_app() -> None:
             "integration_id": 424242,
         }
     ]
-    assert rules[2] == {
-        "type": "merge_queue",
-        "parameters": {
-            "check_response_timeout_minutes": 60,
-            "grouping_strategy": "ALLGREEN",
-            "max_entries_to_build": 1,
-            "max_entries_to_merge": 1,
-            "merge_method": "SQUASH",
-            "min_entries_to_merge": 1,
-            "min_entries_to_merge_wait_minutes": 0,
-        },
-    }
+    assert len(rules) == 2
 
 
 @pytest.mark.parametrize("existing_id", [None, 99])

--- a/tools/tests/test_sandbox_image_commands.py
+++ b/tools/tests/test_sandbox_image_commands.py
@@ -1015,18 +1015,6 @@ def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> Non
         "rules": [
             {"type": "pull_request", "parameters": {}},
             {
-                "type": "merge_queue",
-                "parameters": {
-                    "check_response_timeout_minutes": 60,
-                    "grouping_strategy": "ALLGREEN",
-                    "max_entries_to_build": 1,
-                    "max_entries_to_merge": 1,
-                    "merge_method": "SQUASH",
-                    "min_entries_to_merge": 1,
-                    "min_entries_to_merge_wait_minutes": 0,
-                },
-            },
-            {
                 "type": "required_status_checks",
                 "parameters": {
                     "strict_required_status_checks_policy": True,
@@ -1058,19 +1046,17 @@ def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> Non
 
 
 @pytest.mark.parametrize(
-    ("strict", "integration_id", "exclude", "include_queue"),
+    ("strict", "integration_id", "exclude"),
     [
-        (False, 424242, [], True),
-        (True, None, [], True),
-        (True, 424242, ["refs/heads/main"], True),
-        (True, 424242, [], False),
+        (False, 424242, []),
+        (True, None, []),
+        (True, 424242, ["refs/heads/main"]),
     ],
 )
 def test_required_promotion_status_rejects_weak_policy(
     strict: bool,
     integration_id: int | None,
     exclude: list[str],
-    include_queue: bool,
 ) -> None:
     rules: list[dict[str, object]] = [
         {"type": "pull_request", "parameters": {}},
@@ -1087,21 +1073,6 @@ def test_required_promotion_status_rejects_weak_policy(
             },
         }
     ]
-    if include_queue:
-        rules.append(
-            {
-                "type": "merge_queue",
-                "parameters": {
-                    "check_response_timeout_minutes": 60,
-                    "grouping_strategy": "ALLGREEN",
-                    "max_entries_to_build": 1,
-                    "max_entries_to_merge": 1,
-                    "merge_method": "SQUASH",
-                    "min_entries_to_merge": 1,
-                    "min_entries_to_merge_wait_minutes": 0,
-                },
-            }
-        )
     runner = ScriptedRunner(
         {
             (


### PR DESCRIPTION
Apple container reports both a local index digest and the requested arm64 registry manifest digest; vetting must bind evidence to the latter. The promotion gate also does not need a merge queue once its dedicated App status is bound to the exact pull-request head.

- select the arm64 manifest digest from Apple image inspection
- keep the App-bound strict promotion status and ordinary pull-request rule, without imposing a repository merge queue
- update the operator, threat-model, and release contracts to use normal squash merges
- cover parser and authority behavior without source-text or configuration-file assertions

The live Apple 1.2.2 vet passed against the published candidate digest. The full 406-test Python suite, image tooling lint/type checks, docs build, and workflow audit pass.