### PR TITLE
Accept digest-preserving sandbox candidates

### DIFF
--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -1296,9 +1296,20 @@ def verify_candidate_identity(
     )
     try:
         payload = json.loads(result.stdout)
-        if set(payload) not in ({"linux/arm64"}, {"linux/arm64/v8"}):
-            raise ValueError("candidate image must contain only linux/arm64")
-        config = next(iter(payload.values()))["config"]
+        if not isinstance(payload, dict):
+            raise TypeError
+        if "os" in payload or "architecture" in payload:
+            if (
+                payload.get("os") != "linux"
+                or payload.get("architecture") != "arm64"
+                or payload.get("variant") not in (None, "", "v8")
+            ):
+                raise ValueError("candidate image must contain only linux/arm64")
+            config = payload["config"]
+        else:
+            if set(payload) not in ({"linux/arm64"}, {"linux/arm64/v8"}):
+                raise ValueError("candidate image must contain only linux/arm64")
+            config = next(iter(payload.values()))["config"]
         labels = config["Labels"]
     except (json.JSONDecodeError, KeyError, StopIteration, TypeError) as error:
         raise ValueError("candidate image metadata is invalid") from error

--- a/tools/tests/test_sandbox_image_github.py
+++ b/tools/tests/test_sandbox_image_github.py
@@ -140,6 +140,42 @@ class EvidenceRunner:
         return CompletedCommand(call, 0, self.responses[call], "")
 
 
+def test_candidate_identity_accepts_single_arm64_manifest() -> None:
+    image = ImageReference.parse(
+        f"ghcr.io/kenn-io/ghosthub-sandbox:candidate-{SOURCE}@{DIGEST}"
+    )
+    command = (
+        "docker",
+        "buildx",
+        "imagetools",
+        "inspect",
+        image.canonical,
+        "--format",
+        "{{json .Image}}",
+    )
+    runner = EvidenceRunner(
+        {
+            command: json.dumps(
+                {
+                    "architecture": "arm64",
+                    "config": {
+                        "Labels": {
+                            "org.opencontainers.image.url": (
+                                "https://github.com/kenn-io/ghosthub"
+                            ),
+                            "org.opencontainers.image.revision": SOURCE,
+                            "org.opencontainers.image.version": "0.1.0",
+                        }
+                    },
+                    "os": "linux",
+                }
+            )
+        }
+    )
+
+    github.verify_candidate_identity(image, SOURCE, "0.1.0", runner)
+
+
 def test_evidence_reader_rejects_symlink_entry() -> None:
     commit = "c" * 40
     path = Path("SANDBOX_IMAGE")


### PR DESCRIPTION
Production promotion rejected the published candidate because its identity check only understood a multi-platform index. The publisher intentionally preserves the vetted digest as one `linux/arm64` manifest.

- accept Buildx's direct image metadata for a single arm64 manifest
- retain support for an arm64-only index
- continue rejecting other operating systems, architectures, variants, labels, tags, and source commits

The verifier accepts the live candidate that failed promotion. The focused regression test uses that provider response shape, and all 407 Python tests plus lint and type checks pass.
