### PR TITLE
Stop sandbox policy from blocking unrelated merges

### DIFF
--- a/.github/workflows/sandbox-image-promote.yml
+++ b/.github/workflows/sandbox-image-promote.yml
@@ -365,7 +365,7 @@ jobs:
               default_branch and
               any(.rules[]?;
                 .type == "required_status_checks" and
-                .parameters.strict_required_status_checks_policy == true and
+                .parameters.strict_required_status_checks_policy == false and
                 any(.parameters.required_status_checks[]?;
                   .context == "sandbox-image-promotion" and
                   .integration_id == $app_id)) and

--- a/docs/release.md
+++ b/docs/release.md
@@ -187,7 +187,9 @@ successful run of the exact trusted promotion workflow for that pull-request
 head. The gate verifies that run through the GitHub API; the status alone is
 not promotion authority. An active default-branch ruleset provisioned with no
 bypass actors or ref exclusions requires the status from a dedicated
-status-only GitHub App with strict checking. Its
+status-only GitHub App. Global up-to-date enforcement is disabled so unrelated
+pull requests remain mergeable when `main` advances; reconciliation separately
+invalidates stale promotion evidence. Its
 key is available only through a
 no-reviewer environment restricted to `main`; no `GITHUB_TOKEN` receives
 status-write or package-write authority. Candidate publication and production

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -48,8 +48,8 @@ Never use `latest`.
   an exact branch policy to the `main` branch (not a same-named tag), containing
   that app's client ID and private key
 - an active default-branch ruleset with no bypass actors or ref exclusions that
-  requires `sandbox-image-promotion`, enables strict required-status-check
-  policy, and binds the context to that dedicated app's numeric integration ID
+  requires `sandbox-image-promotion`, binds the context to that dedicated app's
+  numeric integration ID, and leaves global up-to-date enforcement disabled
 - approval authority, or an available reviewer, for that environment
 
 The promotion preflight reads the live rulesets through the GitHub API and
@@ -281,9 +281,10 @@ run expires before retag or merge, rerun
 `sandbox-image-promote` and approve the idempotent promotion again.
 
 The repository ruleset is provisioned with no bypass actors and must require
-this status from the dedicated app with strict checking enabled and an empty
-exclusion list. Merge the authorized pull-request head through the repository's
-normal squash-merge path.
+this status from the dedicated app with an empty exclusion list. Its global
+up-to-date option stays disabled so unrelated `main` changes never force every
+open pull request through another rebase. Merge the authorized pull-request
+head through the repository's normal squash-merge path.
 Trusted-main code checks out the proposed merge tree without executing it,
 structurally audits every proposed workflow, and requires every workflow that
 can reference a credential-bearing environment to remain byte-identical to
@@ -293,8 +294,10 @@ executable post-approval vulnerability policy is part of the same
 byte-identical authority closure, and changing it is promotion-relevant.
 It then rechecks the complete App, environment, ruleset, file, base,
 promotion-run, and freshness authority before the dedicated App authorizes that
-pull-request head. Strict checking also makes the current `main` revision part
-of authorization. Any push creates a new head without authorization.
+pull-request head. Reconciliation makes the current `main` revision part of
+promotion authorization without turning ordinary branch freshness into a
+repository-wide merge requirement. Any push creates a new head without
+authorization.
 Trusted promotion verifies the same live authority before it can write a
 production tag.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -453,8 +453,10 @@ also fingerprints the full reviewer, deployment, and branch policy and the
 status-signing environment. The approved runner requires exact matches and an
 unchanged trusted-main workflow authority immediately before registry mutation.
 A repository ruleset provisioned with no bypass actors or ref exclusions
-requires that status from a dedicated status-only GitHub App with strict
-checking. The app private key exists only in a
+requires that status from a dedicated status-only GitHub App. Global up-to-date
+enforcement stays disabled; trusted reconciliation invalidates stale promotion
+evidence without forcing unrelated pull requests to rebase after every `main`
+change. The app private key exists only in a
 no-reviewer
 environment restricted by an exact branch policy to the `main` branch, never a
 same-named tag. A pinned token action consumes that key; repository Python

--- a/tools/sandbox_image/authority.py
+++ b/tools/sandbox_image/authority.py
@@ -305,7 +305,7 @@ def promotion_ruleset_payload(value: object, app_id: int) -> dict[str, object]:
             {
                 "type": "required_status_checks",
                 "parameters": {
-                    "strict_required_status_checks_policy": True,
+                    "strict_required_status_checks_policy": False,
                     "do_not_enforce_on_create": False,
                     "required_status_checks": [required],
                 },

--- a/tools/sandbox_image/github.py
+++ b/tools/sandbox_image/github.py
@@ -896,7 +896,10 @@ def verify_required_promotion_status(
         )
         if _ruleset_requires_promotion_status(ruleset, expected_integration_id):
             return
-    raise ValueError("main must require the strict sandbox-image-promotion check")
+    raise ValueError(
+        "main must require the App-bound sandbox-image-promotion check "
+        "without global up-to-date enforcement"
+    )
 
 
 def verify_required_merge_signal(runner: Runner) -> None:
@@ -1074,7 +1077,7 @@ def _rule_requires_promotion_status(
         return False
     checks = parameters.get("required_status_checks")
     return (
-        parameters.get("strict_required_status_checks_policy") is True
+        parameters.get("strict_required_status_checks_policy") is False
         and isinstance(checks, list)
         and any(
             isinstance(check, dict)

--- a/tools/tests/test_sandbox_image_authority.py
+++ b/tools/tests/test_sandbox_image_authority.py
@@ -256,7 +256,7 @@ def test_promotion_ruleset_is_narrow_and_pins_app() -> None:
     assert isinstance(required_rule, dict)
     required = required_rule["parameters"]
     assert isinstance(required, dict)
-    assert required["strict_required_status_checks_policy"] is True
+    assert required["strict_required_status_checks_policy"] is False
     assert required["required_status_checks"] == [
         {
             "context": "sandbox-image-promotion",

--- a/tools/tests/test_sandbox_image_commands.py
+++ b/tools/tests/test_sandbox_image_commands.py
@@ -1005,7 +1005,7 @@ def test_image_inputs_digest_covers_every_reviewed_input(tmp_path: Path) -> None
         path.write_bytes(before)
 
 
-def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> None:
+def test_required_promotion_status_is_non_strict_and_bound_to_dedicated_app() -> None:
     ruleset_pages = [[{"id": 41}], [{"id": 42}]]
     detail = {
         "target": "branch",
@@ -1017,7 +1017,7 @@ def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> Non
             {
                 "type": "required_status_checks",
                 "parameters": {
-                    "strict_required_status_checks_policy": True,
+                    "strict_required_status_checks_policy": False,
                     "required_status_checks": [
                         {
                             "context": "sandbox-image-promotion",
@@ -1048,9 +1048,9 @@ def test_required_promotion_status_is_strict_and_bound_to_dedicated_app() -> Non
 @pytest.mark.parametrize(
     ("strict", "integration_id", "exclude"),
     [
-        (False, 424242, []),
-        (True, None, []),
-        (True, 424242, ["refs/heads/main"]),
+        (True, 424242, []),
+        (False, None, []),
+        (False, 424242, ["refs/heads/main"]),
     ],
 )
 def test_required_promotion_status_rejects_weak_policy(
@@ -1099,7 +1099,7 @@ def test_required_promotion_status_rejects_weak_policy(
         }
     )
 
-    with pytest.raises(ValueError, match="strict.*check"):
+    with pytest.raises(ValueError, match="without global up-to-date enforcement"):
         verify_required_promotion_status(runner, 424242)
 
 


### PR DESCRIPTION
The sandbox promotion ruleset forced every pull request to rebase whenever `main` advanced, even when the pull request did not touch sandbox evidence. Normal Ghosthub work can now merge without that unrelated freshness requirement.

- continue requiring the dedicated App-bound promotion status
- disable repository-wide up-to-date enforcement in provisioning and live audits
- keep promotion evidence tied to the current base through trusted reconciliation

The live rule was corrected first and immediately unblocked #169. The owned payload and validation behavior is covered directly; all 407 Python tests and the workflow, documentation, lint, and type gates pass.
