### PR TITLE
Rust Port: Add durable appearance settings

### DIFF
--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1122,11 +1122,15 @@ Slice 1 reads font family, font size, and theme through:
 config → workspace projection → UI-facing state → GPUI
 ~~~
 
-The Settings shell exposes durable Appearance and Hosts panes. Appearance edits
-the validated terminal font and default colors, previews the draft, persists
-the complete configuration atomically, and publishes the saved projection to
-the running GPUI workspace. Existing terminal clients keep the palette they
-negotiated until reopened; new clients use the saved defaults. Hosts owns only
+The Settings shell exposes durable Appearance and Hosts panes. Appearance
+offers the same built-in terminal color families as Swift plus a Custom
+fallback, enumerates installed fixed-pitch fonts, offers standard terminal font
+sizes, and renders a substantial live preview before saving. Theme selection
+is persisted by name; custom colors are stored only for Custom. Older
+color-only configuration loads as Custom. Saves persist the complete
+configuration atomically and publish the projection to the running GPUI
+workspace. Existing terminal clients keep the palette they negotiated until
+reopened; new clients use the saved defaults. Hosts owns only
 `[[ssh-host]]` records. The shell's stable navigation, page header, list, and
 detail regions are the permanent container for the remaining Swift settings
 domains.
@@ -1135,7 +1139,7 @@ The parity inventory is:
 | Swift domain | Rust state |
 | --- | --- |
 | Hosts | Native add, edit, remove, explicit connect, and SSH prompt UI |
-| Appearance | Native font and default-color editor with preview and atomic persistence |
+| Appearance | Built-in themes, Custom colors, installed-font and size pickers, live preview, and atomic persistence |
 | Terminal | Startup configuration only; pane not yet implemented |
 | Keyboard | Runtime shortcuts exist; pane not yet implemented |
 | Worktrees | Project/worktree workflows exist; preferences pane not yet implemented |

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1125,12 +1125,13 @@ config → workspace projection → UI-facing state → GPUI
 The Settings shell exposes durable Appearance and Hosts panes. Appearance
 offers the same built-in terminal color families as Swift plus a Custom
 fallback, enumerates installed fixed-pitch fonts, offers standard terminal font
-sizes, and renders a substantial live preview before saving. Theme selection
-is persisted by name; custom colors are stored only for Custom. Older
-color-only configuration loads as Custom. Saves persist the complete
-configuration atomically and publish the projection to the running GPUI
+sizes, and renders a substantial live preview. Valid appearance changes apply
+and persist immediately; incomplete Custom color input remains editable until
+it forms a valid color. Theme selection is persisted by name, and custom colors
+are stored only for Custom. Older color-only configuration loads as Custom.
+Each persisted change atomically publishes the projection to the running GPUI
 workspace. Existing terminal clients keep the palette they negotiated until
-reopened; new clients use the saved defaults. Hosts owns only
+reopened; new clients use the current defaults. Hosts owns only
 `[[ssh-host]]` records. The shell's stable navigation, page header, list, and
 detail regions are the permanent container for the remaining Swift settings
 domains.

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1122,15 +1122,20 @@ Slice 1 reads font family, font size, and theme through:
 config → workspace projection → UI-facing state → GPUI
 ~~~
 
-The Settings shell currently exposes the Hosts pane, and that pane owns only
-`[[ssh-host]]` records. Its stable navigation, page header, list, and detail
-regions are the permanent container for the remaining Swift settings domains.
+The Settings shell exposes durable Appearance and Hosts panes. Appearance edits
+the validated terminal font and default colors, previews the draft, persists
+the complete configuration atomically, and publishes the saved projection to
+the running GPUI workspace. Existing terminal clients keep the palette they
+negotiated until reopened; new clients use the saved defaults. Hosts owns only
+`[[ssh-host]]` records. The shell's stable navigation, page header, list, and
+detail regions are the permanent container for the remaining Swift settings
+domains.
 The parity inventory is:
 
 | Swift domain | Rust state |
 | --- | --- |
 | Hosts | Native add, edit, remove, explicit connect, and SSH prompt UI |
-| Appearance | Startup configuration only; pane not yet implemented |
+| Appearance | Native font and default-color editor with preview and atomic persistence |
 | Terminal | Startup configuration only; pane not yet implemented |
 | Keyboard | Runtime shortcuts exist; pane not yet implemented |
 | Worktrees | Project/worktree workflows exist; preferences pane not yet implemented |
@@ -1138,8 +1143,8 @@ The parity inventory is:
 | Privacy | Clipboard policy exists in configuration; pane not yet implemented |
 | Integrations | Not yet implemented |
 
-Adding these panes extends the existing shell rather than replacing it. WSL
-and terminal appearance remain startup configuration until their panes land.
+Adding the remaining panes extends the existing shell rather than replacing
+it. WSL configuration remains startup-only until its settings surface lands.
 
 Read-only configuration may select a distro name, an absolute POSIX tmux
 binary, and an absolute POSIX `TMUX_TMPDIR`. Defaults are the current WSL
@@ -1149,10 +1154,11 @@ sessions use another binary or socket directory must configure it explicitly;
 the empty state names the resolved distro and whether the default or configured
 socket environment was queried.
 
-The Rust app reads `<resolved config root>/config.toml` once at startup. A
-missing file uses defaults; malformed TOML, unknown fields, relative WSL
-paths, empty names, zero font size, and non-`#RRGGBB` colors produce a visible
-startup diagnostic rather than silent fallback. The read-only schema is:
+The Rust app reads `<resolved config root>/config.toml` at startup and rewrites
+it atomically when supported Settings panes save changes. A missing file uses
+defaults; malformed TOML, unknown fields, relative WSL paths, empty names, zero
+font size, and non-`#RRGGBB` colors produce a visible startup diagnostic rather
+than silent fallback. The schema is:
 
 ~~~toml
 [wsl]

--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1130,8 +1130,10 @@ and persist immediately; incomplete Custom color input remains editable until
 it forms a valid color. Theme selection is persisted by name, and custom colors
 are stored only for Custom. Older color-only configuration loads as Custom.
 Each persisted change atomically publishes the projection to the running GPUI
-workspace. Existing terminal clients keep the palette they negotiated until
-reopened; new clients use the current defaults. Hosts owns only
+workspace. Terminal palettes never recolor Ghosthub's application chrome;
+interface appearance remains a separate settings concern. Existing terminal
+clients keep the palette they negotiated until reopened; new clients use the
+current defaults. Hosts owns only
 `[[ssh-host]]` records. The shell's stable navigation, page header, list, and
 detail regions are the permanent container for the remaining Swift settings
 domains.

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -323,6 +323,7 @@ struct WslFile {
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 struct TerminalFile {
+    theme: Option<TerminalTheme>,
     font_family: Option<String>,
     font_size: Option<u16>,
     background: Option<String>,
@@ -382,32 +383,40 @@ impl TryFrom<ConfigFile> for ApplicationConfig {
             .collect::<Result<Vec<_>, ConfigError>>()?;
         validate_unique_ssh_hosts(&ssh_hosts)?;
 
-        let font_family = file
-            .terminal
+        let terminal = file.terminal;
+        let has_configured_colors = terminal.background.is_some() || terminal.foreground.is_some();
+        let font_family = terminal
             .font_family
             .unwrap_or_else(|| defaults.terminal.font_family.clone());
         require_nonempty("terminal.font-family", &font_family)?;
-        let font_size = file
-            .terminal
-            .font_size
-            .unwrap_or(defaults.terminal.font_size);
+        let font_size = terminal.font_size.unwrap_or(defaults.terminal.font_size);
         if font_size == 0 {
             return Err(ConfigError::new(
                 "terminal.font-size must be greater than zero",
             ));
         }
-        let background = file
-            .terminal
+        let configured_background = terminal
             .background
             .map_or(Ok(defaults.terminal.background), |value| {
                 parse_rgb("terminal.background", &value)
             })?;
-        let foreground = file
-            .terminal
+        let configured_foreground = terminal
             .foreground
             .map_or(Ok(defaults.terminal.foreground), |value| {
                 parse_rgb("terminal.foreground", &value)
             })?;
+
+        let theme = terminal.theme.unwrap_or_else(|| {
+            if has_configured_colors {
+                TerminalTheme::from_colors(configured_background, configured_foreground)
+                    .unwrap_or(TerminalTheme::Custom)
+            } else {
+                defaults.terminal.theme
+            }
+        });
+        let (background, foreground) = theme
+            .colors()
+            .unwrap_or((configured_background, configured_foreground));
 
         Ok(Self {
             wsl: WslSettings {
@@ -416,12 +425,12 @@ impl TryFrom<ConfigFile> for ApplicationConfig {
                 socket_directory: file.wsl.socket_directory,
             },
             terminal: TerminalAppearance {
+                theme,
                 font_family,
                 font_size,
                 background,
                 foreground,
-                allow_remote_clipboard_write: file
-                    .terminal
+                allow_remote_clipboard_write: terminal
                     .clipboard_write
                     .unwrap_or(defaults.terminal.allow_remote_clipboard_write),
             },
@@ -439,10 +448,13 @@ impl From<&ApplicationConfig> for ConfigFile {
                 socket_directory: config.wsl.socket_directory.clone(),
             },
             terminal: TerminalFile {
+                theme: Some(config.terminal.theme),
                 font_family: Some(config.terminal.font_family.clone()),
                 font_size: Some(config.terminal.font_size),
-                background: Some(format!("#{:06x}", config.terminal.background)),
-                foreground: Some(format!("#{:06x}", config.terminal.foreground)),
+                background: (config.terminal.theme == TerminalTheme::Custom)
+                    .then(|| format!("#{:06x}", config.terminal.background)),
+                foreground: (config.terminal.theme == TerminalTheme::Custom)
+                    .then(|| format!("#{:06x}", config.terminal.foreground)),
                 clipboard_write: Some(config.terminal.allow_remote_clipboard_write),
             },
             ssh_hosts: config
@@ -550,8 +562,87 @@ fn current_roots() -> Result<Roots, ConfigError> {
     .map_err(|error| ConfigError::new(error.to_string()))
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminalTheme {
+    Pro,
+    Homebrew,
+    ClearDark,
+    ClearLight,
+    Novel,
+    Ocean,
+    Custom,
+}
+
+impl TerminalTheme {
+    pub const ALL: [Self; 7] = [
+        Self::Pro,
+        Self::Homebrew,
+        Self::ClearDark,
+        Self::ClearLight,
+        Self::Novel,
+        Self::Ocean,
+        Self::Custom,
+    ];
+
+    #[must_use]
+    pub const fn title(self) -> &'static str {
+        match self {
+            Self::Pro => "Pro",
+            Self::Homebrew => "Homebrew",
+            Self::ClearDark => "Clear Dark",
+            Self::ClearLight => "Clear Light",
+            Self::Novel => "Novel",
+            Self::Ocean => "Ocean",
+            Self::Custom => "Custom",
+        }
+    }
+
+    #[must_use]
+    pub const fn summary(self) -> &'static str {
+        match self {
+            Self::Pro => "Black glass with bright monochrome text.",
+            Self::Homebrew => "Classic green-on-black terminal colors.",
+            Self::ClearDark => "A subtle blue-black palette.",
+            Self::ClearLight => "An airy light palette with steel-blue text.",
+            Self::Novel => "Paper-like sepia colors for long reading.",
+            Self::Ocean => "Bright ocean blue with white text.",
+            Self::Custom => "Choose your own foreground and background colors.",
+        }
+    }
+
+    #[must_use]
+    pub const fn colors(self) -> Option<(u32, u32)> {
+        match self {
+            Self::Pro => Some((0x00_00_00, 0xf4_f4_f4)),
+            Self::Homebrew => Some((0x00_00_00, 0x28_fe_14)),
+            Self::ClearDark => Some((0x21_27_34, 0xe6_e6_e6)),
+            Self::ClearLight => Some((0xff_ff_ff, 0x3a_48_51)),
+            Self::Novel => Some((0xdf_db_c3, 0x4d_2f_2d)),
+            Self::Ocean => Some((0x2b_66_c9, 0xff_ff_ff)),
+            Self::Custom => None,
+        }
+    }
+
+    const fn from_colors(background: u32, foreground: u32) -> Option<Self> {
+        let mut index = 0;
+        while index < Self::ALL.len() {
+            let theme = Self::ALL[index];
+            if let Some((theme_background, theme_foreground)) = theme.colors()
+                && theme_background == background
+                && theme_foreground == foreground
+            {
+                return Some(theme);
+            }
+            index += 1;
+        }
+        None
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct TerminalAppearance {
+    theme: TerminalTheme,
     font_family: String,
     font_size: u16,
     background: u32,
@@ -581,12 +672,55 @@ impl TerminalAppearance {
             ));
         }
         Ok(Self {
+            theme: TerminalTheme::Custom,
             font_family,
             font_size,
             background: parse_rgb("terminal.background", background)?,
             foreground: parse_rgb("terminal.foreground", foreground)?,
             allow_remote_clipboard_write,
         })
+    }
+
+    /// Build a validated appearance from a built-in theme or custom colors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid font settings or invalid custom colors.
+    pub fn themed(
+        theme: TerminalTheme,
+        font_family: impl Into<String>,
+        font_size: u16,
+        custom_background: &str,
+        custom_foreground: &str,
+        allow_remote_clipboard_write: bool,
+    ) -> Result<Self, ConfigError> {
+        let font_family = font_family.into();
+        require_nonempty("terminal.font-family", &font_family)?;
+        if font_size == 0 {
+            return Err(ConfigError::new(
+                "terminal.font-size must be greater than zero",
+            ));
+        }
+        let (background, foreground) = match theme.colors() {
+            Some(colors) => colors,
+            None => (
+                parse_rgb("terminal.background", custom_background)?,
+                parse_rgb("terminal.foreground", custom_foreground)?,
+            ),
+        };
+        Ok(Self {
+            theme,
+            font_family,
+            font_size,
+            background,
+            foreground,
+            allow_remote_clipboard_write,
+        })
+    }
+
+    #[must_use]
+    pub const fn theme(&self) -> TerminalTheme {
+        self.theme
     }
 
     #[must_use]
@@ -624,10 +758,11 @@ impl TerminalAppearance {
 impl Default for TerminalAppearance {
     fn default() -> Self {
         Self {
+            theme: TerminalTheme::ClearDark,
             font_family: "Cascadia Mono".to_owned(),
             font_size: 14,
-            background: 0x0c_0f_14,
-            foreground: 0xd8_de_e9,
+            background: 0x21_27_34,
+            foreground: 0xe6_e6_e6,
             allow_remote_clipboard_write: true,
         }
     }

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -226,6 +226,24 @@ impl ApplicationConfig {
         Ok(())
     }
 
+    /// Replace the terminal appearance and persist the complete validated
+    /// application configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be written.
+    pub fn replace_terminal_appearance(
+        &mut self,
+        roots: &Roots,
+        appearance: TerminalAppearance,
+    ) -> Result<(), ConfigError> {
+        let mut candidate = self.clone();
+        candidate.terminal = appearance;
+        candidate.save(roots)?;
+        *self = candidate;
+        Ok(())
+    }
+
     /// Persist the current configuration to its resolved location.
     ///
     /// # Errors
@@ -542,6 +560,35 @@ pub struct TerminalAppearance {
 }
 
 impl TerminalAppearance {
+    /// Validate user-authored terminal appearance values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty font family, zero font size, or colors
+    /// outside the `#RRGGBB` format.
+    pub fn new(
+        font_family: impl Into<String>,
+        font_size: u16,
+        background: &str,
+        foreground: &str,
+        allow_remote_clipboard_write: bool,
+    ) -> Result<Self, ConfigError> {
+        let font_family = font_family.into();
+        require_nonempty("terminal.font-family", &font_family)?;
+        if font_size == 0 {
+            return Err(ConfigError::new(
+                "terminal.font-size must be greater than zero",
+            ));
+        }
+        Ok(Self {
+            font_family,
+            font_size,
+            background: parse_rgb("terminal.background", background)?,
+            foreground: parse_rgb("terminal.foreground", foreground)?,
+            allow_remote_clipboard_write,
+        })
+    }
+
     #[must_use]
     pub fn font_family(&self) -> &str {
         &self.font_family

--- a/rust/config/tests/appearance.rs
+++ b/rust/config/tests/appearance.rs
@@ -1,4 +1,4 @@
-use config::TerminalAppearance;
+use config::{TerminalAppearance, TerminalTheme};
 
 #[test]
 fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
@@ -6,8 +6,9 @@ fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
 
     assert_eq!(appearance.font_family(), "Cascadia Mono");
     assert_eq!(appearance.font_size(), 14);
-    assert_eq!(appearance.background(), 0x0c_0f_14);
-    assert_eq!(appearance.foreground(), 0xd8_de_e9);
+    assert_eq!(appearance.theme(), TerminalTheme::ClearDark);
+    assert_eq!(appearance.background(), 0x21_27_34);
+    assert_eq!(appearance.foreground(), 0xe6_e6_e6);
 }
 
 #[test]
@@ -17,6 +18,7 @@ fn user_authored_terminal_appearance_is_validated() {
 
     assert_eq!(appearance.font_family(), "Iosevka Term");
     assert_eq!(appearance.font_size(), 16);
+    assert_eq!(appearance.theme(), TerminalTheme::Custom);
     assert_eq!(appearance.background(), 0x10_20_30);
     assert_eq!(appearance.foreground(), 0xf0_e0_d0);
     assert!(!appearance.allow_remote_clipboard_write());
@@ -29,4 +31,21 @@ fn user_authored_terminal_appearance_is_validated() {
     ] {
         assert!(invalid.is_err());
     }
+}
+
+#[test]
+fn built_in_themes_supply_their_own_colors() {
+    let appearance = TerminalAppearance::themed(
+        TerminalTheme::Ocean,
+        "Cascadia Mono",
+        14,
+        "not-a-color",
+        "also-not-a-color",
+        true,
+    )
+    .expect("built-in themes do not require custom colors");
+
+    assert_eq!(appearance.theme(), TerminalTheme::Ocean);
+    assert_eq!(appearance.background(), 0x2b_66_c9);
+    assert_eq!(appearance.foreground(), 0xff_ff_ff);
 }

--- a/rust/config/tests/appearance.rs
+++ b/rust/config/tests/appearance.rs
@@ -9,3 +9,24 @@ fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
     assert_eq!(appearance.background(), 0x0c_0f_14);
     assert_eq!(appearance.foreground(), 0xd8_de_e9);
 }
+
+#[test]
+fn user_authored_terminal_appearance_is_validated() {
+    let appearance = TerminalAppearance::new("Iosevka Term", 16, "#102030", "#f0e0d0", false)
+        .expect("valid terminal appearance");
+
+    assert_eq!(appearance.font_family(), "Iosevka Term");
+    assert_eq!(appearance.font_size(), 16);
+    assert_eq!(appearance.background(), 0x10_20_30);
+    assert_eq!(appearance.foreground(), 0xf0_e0_d0);
+    assert!(!appearance.allow_remote_clipboard_write());
+
+    for invalid in [
+        TerminalAppearance::new("", 16, "#102030", "#f0e0d0", true),
+        TerminalAppearance::new("Iosevka Term", 0, "#102030", "#f0e0d0", true),
+        TerminalAppearance::new("Iosevka Term", 16, "102030", "#f0e0d0", true),
+        TerminalAppearance::new("Iosevka Term", 16, "#102030", "#nope00", true),
+    ] {
+        assert!(invalid.is_err());
+    }
+}

--- a/rust/config/tests/application.rs
+++ b/rust/config/tests/application.rs
@@ -4,7 +4,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use config::{ApplicationConfig, Roots, SshHostSettings};
+use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance};
 
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -248,6 +248,47 @@ fn failed_ssh_host_persistence_preserves_the_loaded_configuration() {
         config.ssh_hosts().is_empty(),
         "failed persistence must not change the in-memory settings"
     );
+    fs::remove_file(root).expect("remove blocking config file");
+}
+
+#[test]
+fn terminal_appearance_round_trips_without_changing_other_settings() {
+    let root = temporary_root("appearance-round-trip");
+    let roots = roots_at(&root);
+    let mut config = ApplicationConfig::from_toml("[wsl]\ndistro = \"Ubuntu\"\n")
+        .expect("valid starting configuration");
+    let appearance = TerminalAppearance::new("Berkeley Mono", 15, "#111820", "#e4e8ef", false)
+        .expect("valid appearance");
+
+    config
+        .replace_terminal_appearance(&roots, appearance)
+        .expect("persist appearance");
+    let loaded = ApplicationConfig::load(&roots).expect("reload appearance");
+
+    assert_eq!(loaded.wsl().distro(), Some("Ubuntu"));
+    assert_eq!(loaded.terminal().font_family(), "Berkeley Mono");
+    assert_eq!(loaded.terminal().font_size(), 15);
+    assert_eq!(loaded.terminal().background(), 0x11_18_20);
+    assert_eq!(loaded.terminal().foreground(), 0xe4_e8_ef);
+    assert!(!loaded.terminal().allow_remote_clipboard_write());
+    fs::remove_dir_all(root).expect("remove temporary config root");
+}
+
+#[test]
+fn failed_appearance_persistence_preserves_the_loaded_configuration() {
+    let root = temporary_root("appearance-write-failure");
+    fs::write(&root, "not a directory").expect("create blocking config file");
+    let roots = roots_at(&root);
+    let mut config = ApplicationConfig::default();
+    let appearance = TerminalAppearance::new("Berkeley Mono", 15, "#111820", "#e4e8ef", true)
+        .expect("valid appearance");
+
+    let error = config
+        .replace_terminal_appearance(&roots, appearance)
+        .expect_err("persistence must fail when the config root is a file");
+
+    assert!(error.to_string().contains("create"));
+    assert_eq!(config.terminal(), &TerminalAppearance::default());
     fs::remove_file(root).expect("remove blocking config file");
 }
 

--- a/rust/config/tests/application.rs
+++ b/rust/config/tests/application.rs
@@ -4,7 +4,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance};
+use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance, TerminalTheme};
 
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -20,8 +20,9 @@ fn missing_application_config_uses_documented_defaults() {
     assert_eq!(loaded.wsl().socket_directory(), None);
     assert_eq!(loaded.terminal().font_family(), "Cascadia Mono");
     assert_eq!(loaded.terminal().font_size(), 14);
-    assert_eq!(loaded.terminal().background(), 0x0c_0f_14);
-    assert_eq!(loaded.terminal().foreground(), 0xd8_de_e9);
+    assert_eq!(loaded.terminal().theme(), TerminalTheme::ClearDark);
+    assert_eq!(loaded.terminal().background(), 0x21_27_34);
+    assert_eq!(loaded.terminal().foreground(), 0xe6_e6_e6);
     assert!(loaded.terminal().allow_remote_clipboard_write());
 }
 
@@ -272,6 +273,48 @@ fn terminal_appearance_round_trips_without_changing_other_settings() {
     assert_eq!(loaded.terminal().foreground(), 0xe4_e8_ef);
     assert!(!loaded.terminal().allow_remote_clipboard_write());
     fs::remove_dir_all(root).expect("remove temporary config root");
+}
+
+#[test]
+fn built_in_terminal_theme_round_trips_without_redundant_color_overrides() {
+    let root = temporary_root("built-in-appearance-round-trip");
+    let roots = roots_at(&root);
+    let mut config = ApplicationConfig::default();
+    let appearance = TerminalAppearance::themed(
+        TerminalTheme::Novel,
+        "Cascadia Mono",
+        15,
+        "#000000",
+        "#ffffff",
+        true,
+    )
+    .expect("valid built-in appearance");
+
+    config
+        .replace_terminal_appearance(&roots, appearance)
+        .expect("persist built-in appearance");
+    let contents = fs::read_to_string(root.join("config.toml")).expect("read saved config");
+    let loaded = ApplicationConfig::load(&roots).expect("reload built-in appearance");
+
+    assert_eq!(loaded.terminal().theme(), TerminalTheme::Novel);
+    assert_eq!(loaded.terminal().background(), 0xdf_db_c3);
+    assert_eq!(loaded.terminal().foreground(), 0x4d_2f_2d);
+    assert!(contents.contains("theme = \"novel\""));
+    assert!(!contents.contains("background ="));
+    assert!(!contents.contains("foreground ="));
+    fs::remove_dir_all(root).expect("remove temporary config root");
+}
+
+#[test]
+fn color_only_configuration_is_preserved_as_custom() {
+    let config = ApplicationConfig::from_toml(
+        "[terminal]\nfont-family = \"Iosevka Term\"\nbackground = \"#102030\"\nforeground = \"#f0e0d0\"\n",
+    )
+    .expect("load legacy color-only appearance");
+
+    assert_eq!(config.terminal().theme(), TerminalTheme::Custom);
+    assert_eq!(config.terminal().background(), 0x10_20_30);
+    assert_eq!(config.terminal().foreground(), 0xf0_e0_d0);
 }
 
 #[test]

--- a/rust/terminal/src/lib.rs
+++ b/rust/terminal/src/lib.rs
@@ -762,19 +762,22 @@ fn convert_color(
     }
     match color {
         Color::Spec(color) => Rgb::new(color.r, color.g, color.b),
-        Color::Indexed(index) => indexed_color(index),
+        Color::Indexed(index) => indexed_color(index, default_colors),
         Color::Named(NamedColor::Foreground | NamedColor::BrightForeground) => {
             default_colors.foreground()
         }
         Color::Named(NamedColor::Background | NamedColor::Cursor) => default_colors.background(),
         Color::Named(NamedColor::DimForeground) => default_colors.foreground(),
-        Color::Named(named) if standard_named_index(named).is_some() => {
-            indexed_color(standard_named_index(named).expect("standard color has an index"))
-        }
-        Color::Named(named) => dim_named_color(named).unwrap_or(if foreground {
-            default_colors.foreground()
-        } else {
-            default_colors.background()
+        Color::Named(named) if standard_named_index(named).is_some() => indexed_color(
+            standard_named_index(named).expect("standard color has an index"),
+            default_colors,
+        ),
+        Color::Named(named) => dim_named_color(named, default_colors).unwrap_or({
+            if foreground {
+                default_colors.foreground()
+            } else {
+                default_colors.background()
+            }
         }),
     }
 }
@@ -801,7 +804,7 @@ fn standard_named_index(color: NamedColor) -> Option<u8> {
     }
 }
 
-fn dim_named_color(color: NamedColor) -> Option<Rgb> {
+fn dim_named_color(color: NamedColor, default_colors: DefaultColors) -> Option<Rgb> {
     let index = match color {
         NamedColor::DimBlack => 0,
         NamedColor::DimRed => 1,
@@ -813,11 +816,11 @@ fn dim_named_color(color: NamedColor) -> Option<Rgb> {
         NamedColor::DimWhite => 7,
         _ => return None,
     };
-    Some(indexed_color(index))
+    Some(indexed_color(index, default_colors))
 }
 
-fn indexed_color(index: u8) -> Rgb {
-    const ANSI: [Rgb; 16] = [
+fn indexed_color(index: u8, default_colors: DefaultColors) -> Rgb {
+    const DARK_ANSI: [Rgb; 16] = [
         Rgb::new(0x11, 0x13, 0x18),
         Rgb::new(0xcc, 0x66, 0x66),
         Rgb::new(0x7e, 0xc6, 0x99),
@@ -835,8 +838,35 @@ fn indexed_color(index: u8) -> Rgb {
         Rgb::new(0x88, 0xd1, 0xd8),
         Rgb::new(0xee, 0xf0, 0xf4),
     ];
+    const LIGHT_ANSI: [Rgb; 16] = [
+        Rgb::new(0x1e, 0x1e, 0x1e),
+        Rgb::new(0xb5, 0x20, 0x20),
+        Rgb::new(0x12, 0x6a, 0x00),
+        Rgb::new(0x70, 0x58, 0x00),
+        Rgb::new(0x04, 0x51, 0xa5),
+        Rgb::new(0x8f, 0x2a, 0x8f),
+        Rgb::new(0x00, 0x66, 0x6d),
+        Rgb::new(0x55, 0x59, 0x5e),
+        Rgb::new(0x45, 0x49, 0x4f),
+        Rgb::new(0x9c, 0x1c, 0x1c),
+        Rgb::new(0x00, 0x64, 0x00),
+        Rgb::new(0x5f, 0x51, 0x00),
+        Rgb::new(0x00, 0x3e, 0xaa),
+        Rgb::new(0x76, 0x20, 0x76),
+        Rgb::new(0x00, 0x5f, 0x66),
+        Rgb::new(0x3a, 0x48, 0x51),
+    ];
     if index < 16 {
-        return ANSI[usize::from(index)];
+        let background = default_colors.background();
+        let brightness = 299 * u32::from(background.red)
+            + 587 * u32::from(background.green)
+            + 114 * u32::from(background.blue);
+        let palette = if brightness >= 128_000 {
+            LIGHT_ANSI
+        } else {
+            DARK_ANSI
+        };
+        return palette[usize::from(index)];
     }
     if index < 232 {
         let value = index - 16;

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -617,6 +617,23 @@ fn appearance_preview_color(value: &str, fallback: u32) -> u32 {
         .unwrap_or(fallback)
 }
 
+fn appearance_draft_is_persistable(draft: &AppearanceSettingsDraft) -> bool {
+    let valid_font_size = draft
+        .font_size
+        .trim()
+        .parse::<u16>()
+        .is_ok_and(|size| size > 0);
+    let valid_color = |value: &str| {
+        value
+            .strip_prefix('#')
+            .is_some_and(|digits| digits.len() == 6 && u32::from_str_radix(digits, 16).is_ok())
+    };
+    !draft.font_family.trim().is_empty()
+        && valid_font_size
+        && (draft.theme != TerminalTheme::Custom
+            || (valid_color(&draft.background) && valid_color(&draft.foreground)))
+}
+
 fn appearance_preview_colors(draft: &AppearanceSettingsDraft) -> (u32, u32) {
     draft.theme.colors().unwrap_or_else(|| {
         (
@@ -1685,22 +1702,18 @@ impl RootView {
         cx.notify();
     }
 
-    fn save_appearance(&mut self, cx: &mut Context<Self>) {
-        let Some(draft) = self
-            .settings_dialog
-            .as_ref()
-            .map(|dialog| dialog.appearance_editor.draft.clone())
-        else {
+    fn persist_appearance(&mut self, draft: &AppearanceSettingsDraft, cx: &mut Context<Self>) {
+        if !appearance_draft_is_persistable(draft) {
+            if let Some(dialog) = &mut self.settings_dialog {
+                dialog.appearance_editor.error = None;
+            }
+            cx.notify();
             return;
-        };
-        match self.workspace.save_appearance(&draft) {
+        }
+        match self.workspace.save_appearance(draft) {
             Ok(()) => {
                 if let Some(dialog) = &mut self.settings_dialog {
-                    let font_families = std::mem::take(&mut dialog.appearance_editor.font_families);
-                    dialog.appearance_editor = AppearanceEditor::new(
-                        self.workspace.configured_appearance(),
-                        font_families,
-                    );
+                    dialog.appearance_editor.error = None;
                 }
             }
             Err(error) => {
@@ -1770,7 +1783,8 @@ impl RootView {
                 _ => {}
             }
             editor.open_picker = None;
-            cx.notify();
+            let draft = editor.draft.clone();
+            self.persist_appearance(&draft, cx);
             cx.stop_propagation();
             return;
         }
@@ -1796,7 +1810,8 @@ impl RootView {
         {
             append_non_control_characters(value, text, SETTINGS_FIELD_CHARACTER_LIMIT);
         }
-        cx.notify();
+        let draft = editor.draft.clone();
+        self.persist_appearance(&draft, cx);
         cx.stop_propagation();
     }
 
@@ -1890,7 +1905,8 @@ impl RootView {
         }
         if key == "enter" && !event.is_held {
             if pane == SettingsPane::Appearance {
-                self.save_appearance(cx);
+                cx.stop_propagation();
+                return;
             } else if self
                 .settings_dialog
                 .as_ref()
@@ -4717,7 +4733,13 @@ impl RootView {
                     dialog.appearance_editor.error = None;
                 }
                 window.focus(&this.settings_focus);
-                cx.notify();
+                let draft = this
+                    .settings_dialog
+                    .as_ref()
+                    .map(|dialog| dialog.appearance_editor.draft.clone());
+                if let Some(draft) = draft {
+                    this.persist_appearance(&draft, cx);
+                }
             }))
             .into_any_element()
     }
@@ -4812,7 +4834,13 @@ impl RootView {
                             dialog.appearance_editor.open_picker = None;
                             dialog.appearance_editor.error = None;
                         }
-                        cx.notify();
+                        let draft = this
+                            .settings_dialog
+                            .as_ref()
+                            .map(|dialog| dialog.appearance_editor.draft.clone());
+                        if let Some(draft) = draft {
+                            this.persist_appearance(&draft, cx);
+                        }
                     })),
             );
         }
@@ -4853,7 +4881,13 @@ impl RootView {
                             dialog.appearance_editor.open_picker = None;
                             dialog.appearance_editor.error = None;
                         }
-                        cx.notify();
+                        let draft = this
+                            .settings_dialog
+                            .as_ref()
+                            .map(|dialog| dialog.appearance_editor.draft.clone());
+                        if let Some(draft) = draft {
+                            this.persist_appearance(&draft, cx);
+                        }
                     })),
             );
         }
@@ -5018,25 +5052,6 @@ impl RootView {
             .into_any_element()
     }
 
-    fn appearance_save_controls(cx: &mut Context<Self>) -> gpui::AnyElement {
-        div()
-            .pb_2()
-            .flex()
-            .justify_end()
-            .child(
-                div()
-                    .id("save-appearance")
-                    .px_4()
-                    .py_2()
-                    .rounded_md()
-                    .cursor_pointer()
-                    .bg(rgb(0x1d_5f9a))
-                    .child("Save")
-                    .on_click(cx.listener(|this, _, _, cx| this.save_appearance(cx))),
-            )
-            .into_any_element()
-    }
-
     fn settings_appearance_editor(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let Some(editor) = self
             .settings_dialog
@@ -5066,8 +5081,6 @@ impl RootView {
                     .child(error.clone()),
             );
         }
-        form = form.child(Self::appearance_save_controls(cx));
-
         div()
             .id("settings-appearance-editor")
             .flex_1()
@@ -5575,6 +5588,31 @@ impl RootView {
                 .child(self.settings_host_editor(cx))
                 .into_any_element(),
         };
+        let pane_header = div()
+            .px_6()
+            .py_4()
+            .flex_none()
+            .flex()
+            .items_center()
+            .justify_between()
+            .border_b_1()
+            .border_color(rgb(0x2a_2f39))
+            .child(
+                div()
+                    .child(
+                        div()
+                            .text_2xl()
+                            .font_weight(FontWeight::BOLD)
+                            .child(pane.title()),
+                    )
+                    .child(
+                        div()
+                            .pt_1()
+                            .text_sm()
+                            .text_color(rgb(0x8f_96_a3))
+                            .child(pane.subtitle()),
+                    ),
+            );
         let confirmation = self.settings_remove_confirmation(cx);
 
         Some(
@@ -5644,27 +5682,7 @@ impl RootView {
                                         .min_w_0()
                                         .flex()
                                         .flex_col()
-                                        .child(
-                                            div()
-                                                .px_6()
-                                                .py_4()
-                                                .flex_none()
-                                                .border_b_1()
-                                                .border_color(rgb(0x2a_2f39))
-                                                .child(
-                                                    div()
-                                                        .text_2xl()
-                                                        .font_weight(FontWeight::BOLD)
-                                                        .child(pane.title()),
-                                                )
-                                                .child(
-                                                    div()
-                                                        .pt_1()
-                                                        .text_sm()
-                                                        .text_color(rgb(0x8f_96_a3))
-                                                        .child(pane.subtitle()),
-                                                ),
-                                        )
+                                        .child(pane_header)
                                         .child(detail),
                                 ),
                         )
@@ -8764,18 +8782,19 @@ mod tests {
         UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority, WorktreeHostAccess, WorktreeOpenContext,
         WorktreeOpenMode, WorktreeOpenTarget, WorktreePresentation, WorktreeRemoveTarget,
         WorktreeSessionPresence, WorktreeSocket, active_session_selection,
-        adjacent_appearance_field, appearance_preview_color, application_navigation_width,
-        apply_new_worktree_failure, apply_worktree_removal_failure, available_herdr_row_actions,
-        can_create_worktree, can_kill_worktree, canonical_terminal_key_with,
-        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
-        coalesce_last_resize, coalesce_last_wheel, has_ambiguous_worktree_source,
-        herdr_row_actions, herdr_session_menu_actions, host_header_action, host_landing_text,
-        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
-        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
-        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
-        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
-        session_action_menu_position, session_backend_id, session_creation_available,
-        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        adjacent_appearance_field, appearance_draft_is_persistable, appearance_preview_color,
+        application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
+        available_herdr_row_actions, can_create_worktree, can_kill_worktree,
+        canonical_terminal_key_with, clear_terminal_input_state, clears_after_input_delivery,
+        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
+        has_ambiguous_worktree_source, herdr_row_actions, herdr_session_menu_actions,
+        host_header_action, host_landing_text, input_queue_has_capacity,
+        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
+        kwt_operation_failure_owns_dialog, named_key, new_session_validation, normalize_cell_width,
+        owns_created_worktree_navigation, pull_request_import_selector,
+        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
+        session_backend_id, session_creation_available, session_group_visibility,
+        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
         terminal_line_height, terminal_wheel_steps, tmux_row_actions, toggle_session_group_state,
         transitioned_presentation, tree_herdr_sessions, tree_sessions, tree_zellij_sessions,
@@ -8875,6 +8894,25 @@ mod tests {
         );
         assert_eq!(appearance_preview_color("#102030", 0), 0x10_20_30);
         assert_eq!(appearance_preview_color("102030", 0x12_34_56), 0x12_34_56);
+    }
+
+    #[test]
+    fn appearance_auto_persistence_waits_for_complete_custom_colors() {
+        let mut draft = AppearanceSettingsDraft {
+            theme: TerminalTheme::ClearDark,
+            font_family: "Cascadia Mono".to_owned(),
+            font_size: "14".to_owned(),
+            background: "#12".to_owned(),
+            foreground: "#d8dee9".to_owned(),
+        };
+
+        assert!(appearance_draft_is_persistable(&draft));
+        draft.theme = TerminalTheme::Custom;
+        assert!(!appearance_draft_is_persistable(&draft));
+        draft.background = "#102030".to_owned();
+        assert!(appearance_draft_is_persistable(&draft));
+        draft.font_size = "0".to_owned();
+        assert!(!appearance_draft_is_persistable(&draft));
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -28,6 +28,7 @@ pub const WINDOW_TITLE: &str = "Ghosthub";
 const APP_NAVIGATION_WIDTH: f32 = 224.0;
 const APP_TITLEBAR_HEIGHT: f32 = 32.0;
 const APP_CHROME_BACKGROUND: u32 = 0x0f_1116;
+const APP_CHROME_FOREGROUND: u32 = 0xd8_de_e9;
 const NAVIGATION_HEADER_HEIGHT: f32 = 32.0;
 const HOST_ROW_HEIGHT: f32 = 28.0;
 const SESSION_GROUP_ROW_HEIGHT: f32 = 24.0;
@@ -641,6 +642,10 @@ fn appearance_preview_colors(draft: &AppearanceSettingsDraft) -> (u32, u32) {
             appearance_preview_color(&draft.foreground, 0xd8_de_e9),
         )
     })
+}
+
+fn chrome_palette_for_terminal_theme(_theme: TerminalTheme) -> (u32, u32) {
+    (APP_CHROME_BACKGROUND, APP_CHROME_FOREGROUND)
 }
 
 fn terminal_font_families(cx: &Context<RootView>, configured: &str) -> Vec<String> {
@@ -8084,12 +8089,14 @@ impl Render for RootView {
         let session_action_menu = self.session_action_menu_overlay(window, cx);
         let kill_overlay = self.pending_session_kill_overlay(window, cx);
         let herdr_lifecycle_overlay = self.pending_herdr_lifecycle_overlay(window, cx);
+        let (chrome_background, chrome_foreground) =
+            chrome_palette_for_terminal_theme(snapshot.appearance().theme());
         let mut root = div()
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(snapshot.appearance().background()))
-            .text_color(rgb(snapshot.appearance().foreground()))
+            .bg(rgb(chrome_background))
+            .text_color(rgb(chrome_foreground))
             .on_action(cx.listener(|this, _: &ToggleSidebar, window, cx| {
                 this.toggle_sidebar(window, cx);
             }))
@@ -8785,16 +8792,16 @@ mod tests {
         adjacent_appearance_field, appearance_draft_is_persistable, appearance_preview_color,
         application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
         available_herdr_row_actions, can_create_worktree, can_kill_worktree,
-        canonical_terminal_key_with, clear_terminal_input_state, clears_after_input_delivery,
-        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
-        has_ambiguous_worktree_source, herdr_row_actions, herdr_session_menu_actions,
-        host_header_action, host_landing_text, input_queue_has_capacity,
-        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
-        kwt_operation_failure_owns_dialog, named_key, new_session_validation, normalize_cell_width,
-        owns_created_worktree_navigation, pull_request_import_selector,
-        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
-        session_backend_id, session_creation_available, session_group_visibility,
-        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        canonical_terminal_key_with, chrome_palette_for_terminal_theme, clear_terminal_input_state,
+        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
+        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
+        herdr_session_menu_actions, host_header_action, host_landing_text,
+        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
+        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
+        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
+        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
+        session_action_menu_position, session_backend_id, session_creation_available,
+        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
         terminal_line_height, terminal_wheel_steps, tmux_row_actions, toggle_session_group_state,
         transitioned_presentation, tree_herdr_sessions, tree_sessions, tree_zellij_sessions,
@@ -8913,6 +8920,16 @@ mod tests {
         assert!(appearance_draft_is_persistable(&draft));
         draft.font_size = "0".to_owned();
         assert!(!appearance_draft_is_persistable(&draft));
+    }
+
+    #[test]
+    fn terminal_themes_never_recolor_application_chrome() {
+        for theme in TerminalTheme::ALL {
+            assert_eq!(
+                chrome_palette_for_terminal_theme(theme),
+                (super::APP_CHROME_BACKGROUND, super::APP_CHROME_FOREGROUND)
+            );
+        }
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -557,6 +557,7 @@ impl SshHostEditor {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SettingsDialog {
     pane: SettingsPane,
+    sidebar_focus: Option<SettingsPane>,
     appearance_editor: AppearanceEditor,
     selected_host_id: Option<String>,
     host_editor: Option<SshHostEditor>,
@@ -573,6 +574,7 @@ impl SettingsDialog {
         let selected = hosts.first();
         Self {
             pane: SettingsPane::Appearance,
+            sidebar_focus: Some(SettingsPane::Appearance),
             appearance_editor: AppearanceEditor::new(appearance, font_families),
             selected_host_id: selected.map(|host| host.id().to_owned()),
             host_editor: selected.map(|host| SshHostEditor::new(Some(host))),
@@ -580,6 +582,117 @@ impl SettingsDialog {
             error: None,
         }
     }
+}
+
+fn focus_settings_detail(dialog: &mut SettingsDialog, reverse: bool) -> bool {
+    match dialog.pane {
+        SettingsPane::Appearance => {
+            let custom = dialog.appearance_editor.draft.theme == TerminalTheme::Custom;
+            dialog.appearance_editor.field = if reverse && custom {
+                AppearanceField::Foreground
+            } else if reverse {
+                AppearanceField::FontSize
+            } else {
+                AppearanceField::Theme
+            };
+            true
+        }
+        SettingsPane::Hosts => {
+            let Some(editor) = &mut dialog.host_editor else {
+                return false;
+            };
+            editor.field = if reverse {
+                SshField::SocketDirectory
+            } else {
+                SshField::Name
+            };
+            true
+        }
+    }
+}
+
+fn advance_settings_focus(dialog: &mut SettingsDialog, reverse: bool) {
+    if let Some(pane) = dialog.sidebar_focus {
+        match (pane, reverse) {
+            (SettingsPane::Appearance, false) => {
+                dialog.sidebar_focus = Some(SettingsPane::Hosts);
+            }
+            (SettingsPane::Hosts, true) => {
+                dialog.sidebar_focus = Some(SettingsPane::Appearance);
+            }
+            (SettingsPane::Hosts, false) | (SettingsPane::Appearance, true) => {
+                if focus_settings_detail(dialog, reverse) {
+                    dialog.sidebar_focus = None;
+                } else {
+                    dialog.sidebar_focus = Some(if reverse {
+                        SettingsPane::Hosts
+                    } else {
+                        SettingsPane::Appearance
+                    });
+                }
+            }
+        }
+        return;
+    }
+
+    match dialog.pane {
+        SettingsPane::Appearance => {
+            let custom = dialog.appearance_editor.draft.theme == TerminalTheme::Custom;
+            let first = AppearanceField::Theme;
+            let last = if custom {
+                AppearanceField::Foreground
+            } else {
+                AppearanceField::FontSize
+            };
+            let at_edge = if reverse {
+                dialog.appearance_editor.field == first
+            } else {
+                dialog.appearance_editor.field == last
+            };
+            if at_edge {
+                dialog.sidebar_focus = Some(if reverse {
+                    SettingsPane::Hosts
+                } else {
+                    SettingsPane::Appearance
+                });
+            } else {
+                dialog.appearance_editor.field =
+                    adjacent_appearance_field(dialog.appearance_editor.field, reverse, custom);
+            }
+            dialog.appearance_editor.open_picker = None;
+            dialog.appearance_editor.error = None;
+        }
+        SettingsPane::Hosts => {
+            let Some(editor) = &mut dialog.host_editor else {
+                dialog.sidebar_focus = Some(SettingsPane::Appearance);
+                return;
+            };
+            let at_edge = if reverse {
+                editor.field == SshField::Name
+            } else {
+                editor.field == SshField::SocketDirectory
+            };
+            if at_edge {
+                dialog.sidebar_focus = Some(if reverse {
+                    SettingsPane::Hosts
+                } else {
+                    SettingsPane::Appearance
+                });
+            } else {
+                editor.field = editor.field.adjacent(reverse);
+            }
+            editor.error = None;
+        }
+    }
+}
+
+fn activate_settings_sidebar_pane(dialog: &mut SettingsDialog) -> bool {
+    let Some(pane) = dialog.sidebar_focus else {
+        return false;
+    };
+    dialog.pane = pane;
+    dialog.error = None;
+    true
 }
 
 #[derive(Clone)]
@@ -1641,6 +1754,7 @@ impl RootView {
         cx: &mut Context<Self>,
     ) {
         if let Some(dialog) = &mut self.settings_dialog {
+            dialog.sidebar_focus = None;
             dialog.selected_host_id = Some(host.id().to_owned());
             dialog.host_editor = Some(SshHostEditor::new(Some(host)));
             dialog.pending_remove = None;
@@ -1652,6 +1766,7 @@ impl RootView {
 
     fn add_ssh_host(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(dialog) = &mut self.settings_dialog {
+            dialog.sidebar_focus = None;
             dialog.selected_host_id = None;
             dialog.host_editor = Some(SshHostEditor::new(None));
             dialog.pending_remove = None;
@@ -1929,6 +2044,17 @@ impl RootView {
             cx.stop_propagation();
             return;
         }
+        if matches!(key.as_str(), "enter" | "space")
+            && !event.is_held
+            && self
+                .settings_dialog
+                .as_mut()
+                .is_some_and(activate_settings_sidebar_pane)
+        {
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
         if key == "enter" && !event.is_held {
             if pane == SettingsPane::Appearance {
                 cx.stop_propagation();
@@ -1947,21 +2073,17 @@ impl RootView {
         }
         if key == "tab" {
             if let Some(dialog) = &mut self.settings_dialog {
-                if pane == SettingsPane::Appearance {
-                    let custom = dialog.appearance_editor.draft.theme == TerminalTheme::Custom;
-                    dialog.appearance_editor.field = adjacent_appearance_field(
-                        dialog.appearance_editor.field,
-                        event.keystroke.modifiers.shift,
-                        custom,
-                    );
-                    dialog.appearance_editor.open_picker = None;
-                    dialog.appearance_editor.error = None;
-                } else if let Some(editor) = &mut dialog.host_editor {
-                    editor.field = editor.field.adjacent(event.keystroke.modifiers.shift);
-                    editor.error = None;
-                }
+                advance_settings_focus(dialog, event.keystroke.modifiers.shift);
                 cx.notify();
             }
+            cx.stop_propagation();
+            return;
+        }
+        if self
+            .settings_dialog
+            .as_ref()
+            .is_some_and(|dialog| dialog.sidebar_focus.is_some())
+        {
             cx.stop_propagation();
             return;
         }
@@ -4645,6 +4767,7 @@ impl RootView {
         let selected = self
             .settings_dialog
             .as_ref()
+            .filter(|dialog| dialog.sidebar_focus.is_none())
             .and_then(|dialog| dialog.host_editor.as_ref())
             .is_some_and(|editor| editor.field == field);
         let value = ssh_draft_field(draft, field);
@@ -4686,12 +4809,11 @@ impl RootView {
                     }))
                     .child(display)
                     .on_click(cx.listener(move |this, _, window, cx| {
-                        if let Some(editor) = this
-                            .settings_dialog
-                            .as_mut()
-                            .and_then(|dialog| dialog.host_editor.as_mut())
-                        {
-                            editor.field = field;
+                        if let Some(dialog) = &mut this.settings_dialog {
+                            dialog.sidebar_focus = None;
+                            if let Some(editor) = &mut dialog.host_editor {
+                                editor.field = field;
+                            }
                         }
                         window.focus(&this.settings_focus);
                         cx.notify();
@@ -4753,6 +4875,7 @@ impl RootView {
             )
             .on_click(cx.listener(move |this, _, window, cx| {
                 if let Some(dialog) = &mut this.settings_dialog {
+                    dialog.sidebar_focus = None;
                     dialog.appearance_editor.draft.theme = theme;
                     dialog.appearance_editor.field = AppearanceField::Theme;
                     dialog.appearance_editor.open_picker = None;
@@ -4779,10 +4902,9 @@ impl RootView {
         open: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let selected = self
-            .settings_dialog
-            .as_ref()
-            .is_some_and(|dialog| dialog.appearance_editor.field == field);
+        let selected = self.settings_dialog.as_ref().is_some_and(|dialog| {
+            dialog.sidebar_focus.is_none() && dialog.appearance_editor.field == field
+        });
         div()
             .flex()
             .flex_col()
@@ -4807,6 +4929,7 @@ impl RootView {
                     .child(if open { "▴" } else { "▾" })
                     .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
+                            dialog.sidebar_focus = None;
                             let editor = &mut dialog.appearance_editor;
                             editor.field = field;
                             editor.open_picker =
@@ -4927,10 +5050,9 @@ impl RootView {
         field: AppearanceField,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
-        let selected = self
-            .settings_dialog
-            .as_ref()
-            .is_some_and(|dialog| dialog.appearance_editor.field == field);
+        let selected = self.settings_dialog.as_ref().is_some_and(|dialog| {
+            dialog.sidebar_focus.is_none() && dialog.appearance_editor.field == field
+        });
         let display = if selected {
             format!("{value}▏")
         } else {
@@ -4957,6 +5079,7 @@ impl RootView {
                     .child(display)
                     .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
+                            dialog.sidebar_focus = None;
                             dialog.appearance_editor.field = field;
                             dialog.appearance_editor.open_picker = None;
                             dialog.appearance_editor.error = None;
@@ -5216,8 +5339,13 @@ impl RootView {
             .settings_dialog
             .as_ref()
             .map_or(SettingsPane::Appearance, |dialog| dialog.pane);
+        let focused = self
+            .settings_dialog
+            .as_ref()
+            .and_then(|dialog| dialog.sidebar_focus);
         let mut panes = div().flex().flex_col().gap_1();
         for (index, pane) in SettingsPane::ALL.into_iter().enumerate() {
+            let keyboard_focused = focused == Some(pane);
             panes = panes.child(
                 div()
                     .id(("settings-pane", index))
@@ -5230,13 +5358,18 @@ impl RootView {
                     .cursor_pointer()
                     .bg(rgb(if pane == active { 0x25_2d3a } else { 0x13_161c }))
                     .text_color(rgb(if pane == active { 0xe1_e5ec } else { 0xa0_a7b3 }))
+                    .when(keyboard_focused, |element| {
+                        element.border_1().border_color(rgb(0x4a_8f_cf))
+                    })
                     .child("▣")
                     .child(pane.title())
-                    .on_click(cx.listener(move |this, _, _, cx| {
+                    .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
                             dialog.pane = pane;
+                            dialog.sidebar_focus = Some(pane);
                             dialog.error = None;
                         }
+                        window.focus(&this.settings_focus);
                         cx.notify();
                     })),
             );
@@ -8818,20 +8951,21 @@ mod tests {
         TerminalKeyboard, TerminalPointer, TerminalResize, TransientNotice, UI_INPUT_BYTE_CAPACITY,
         UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority, WorktreeHostAccess, WorktreeOpenContext,
         WorktreeOpenMode, WorktreeOpenTarget, WorktreePresentation, WorktreeRemoveTarget,
-        WorktreeSessionPresence, WorktreeSocket, active_session_selection,
-        adjacent_appearance_field, appearance_draft_is_persistable, appearance_preview_color,
-        application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
-        available_herdr_row_actions, can_create_worktree, can_kill_worktree,
-        canonical_terminal_key_with, chrome_palette_for_terminal_theme, clear_terminal_input_state,
-        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
-        herdr_session_menu_actions, host_header_action, host_landing_text,
-        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
-        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
-        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
-        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
-        session_action_menu_position, session_backend_id, session_creation_available,
-        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        WorktreeSessionPresence, WorktreeSocket, activate_settings_sidebar_pane,
+        active_session_selection, adjacent_appearance_field, advance_settings_focus,
+        appearance_draft_is_persistable, appearance_preview_color, application_navigation_width,
+        apply_new_worktree_failure, apply_worktree_removal_failure, available_herdr_row_actions,
+        can_create_worktree, can_kill_worktree, canonical_terminal_key_with,
+        chrome_palette_for_terminal_theme, clear_terminal_input_state, clears_after_input_delivery,
+        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
+        has_ambiguous_worktree_source, herdr_row_actions, herdr_session_menu_actions,
+        host_header_action, host_landing_text, input_queue_has_capacity,
+        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
+        kwt_operation_failure_owns_dialog, named_key, new_session_validation, normalize_cell_width,
+        owns_created_worktree_navigation, pull_request_import_selector,
+        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
+        session_backend_id, session_creation_available, session_group_visibility,
+        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_font_changed, terminal_key_input,
         terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
         tmux_row_actions, toggle_session_group_state, transitioned_presentation,
@@ -8909,10 +9043,47 @@ mod tests {
             [SettingsPane::Appearance, SettingsPane::Hosts]
         );
         assert_eq!(dialog.pane, SettingsPane::Appearance);
+        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
         assert_eq!(dialog.appearance_editor.draft, appearance);
         assert!(dialog.selected_host_id.is_none());
         assert!(dialog.host_editor.is_none());
         assert!(dialog.pending_remove.is_none());
+    }
+
+    #[test]
+    fn settings_sidebar_and_detail_fields_share_keyboard_focus_order() {
+        let appearance = AppearanceSettingsDraft {
+            theme: TerminalTheme::ClearDark,
+            font_family: "Cascadia Mono".to_owned(),
+            font_size: "14".to_owned(),
+            background: "#212734".to_owned(),
+            foreground: "#e6e6e6".to_owned(),
+        };
+        let mut dialog = SettingsDialog::new(&[], appearance, vec!["Cascadia Mono".to_owned()]);
+
+        advance_settings_focus(&mut dialog, false);
+        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Hosts));
+        assert!(activate_settings_sidebar_pane(&mut dialog));
+        assert_eq!(dialog.pane, SettingsPane::Hosts);
+
+        advance_settings_focus(&mut dialog, false);
+        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
+        assert!(activate_settings_sidebar_pane(&mut dialog));
+        assert_eq!(dialog.pane, SettingsPane::Appearance);
+
+        advance_settings_focus(&mut dialog, false);
+        advance_settings_focus(&mut dialog, false);
+        assert_eq!(dialog.sidebar_focus, None);
+        assert_eq!(dialog.appearance_editor.field, AppearanceField::Theme);
+
+        advance_settings_focus(&mut dialog, false);
+        advance_settings_focus(&mut dialog, false);
+        advance_settings_focus(&mut dialog, false);
+        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
+
+        advance_settings_focus(&mut dialog, true);
+        assert_eq!(dialog.sidebar_focus, None);
+        assert_eq!(dialog.appearance_editor.field, AppearanceField::FontSize);
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -21,7 +21,7 @@ use workspace::{
     AppearanceSettingsDraft, ConfiguredSshHost, HerdrSessionState, HostConnectionState, HostItem,
     KeyEvent as InputKeyEvent, KeyInput, KwtProjectAction, Modifiers as InputModifiers,
     MouseAction, MouseButton, MouseInput, NamedKey, SessionName, SessionSelection, SshHostDraft,
-    SshPromptRequest, Workspace, WorkspaceContent, WorkspaceEvent,
+    SshPromptRequest, TerminalTheme, Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -43,6 +43,7 @@ const MOUSE_RELEASE_RESERVE: usize = 3;
 const MAX_WHEEL_EVENTS_PER_CALLBACK: usize = 64;
 const UI_INPUT_BYTE_CAPACITY: usize = 512 * 1024;
 const SETTINGS_FIELD_CHARACTER_LIMIT: usize = 4 * 1024;
+const TERMINAL_FONT_SIZES: [u16; 10] = [10, 11, 12, 13, 14, 15, 16, 18, 20, 24];
 const SSH_PROMPT_CHARACTER_LIMIT: usize = 64 * 1024;
 const INPUT_BUFFERED_DIAGNOSTIC: &str = "Terminal is busy; input is buffered.";
 const INPUT_BUFFER_FULL_DIAGNOSTIC: &str =
@@ -452,7 +453,7 @@ impl SettingsPane {
 
     const fn subtitle(self) -> &'static str {
         match self {
-            Self::Appearance => "Choose the font and colors used by terminal presentations.",
+            Self::Appearance => "Choose a terminal theme and installed monospace font.",
             Self::Hosts => "Connect the machines and tmux sessions in your SSH network.",
         }
     }
@@ -460,6 +461,7 @@ impl SettingsPane {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AppearanceField {
+    Theme,
     FontFamily,
     FontSize,
     Background,
@@ -470,34 +472,63 @@ impl AppearanceField {
     const fn adjacent(self, reverse: bool) -> Self {
         if reverse {
             match self {
-                Self::FontFamily => Self::Foreground,
+                Self::Theme => Self::Foreground,
+                Self::FontFamily => Self::Theme,
                 Self::FontSize => Self::FontFamily,
                 Self::Background => Self::FontSize,
                 Self::Foreground => Self::Background,
             }
         } else {
             match self {
+                Self::Theme => Self::FontFamily,
                 Self::FontFamily => Self::FontSize,
                 Self::FontSize => Self::Background,
                 Self::Background => Self::Foreground,
-                Self::Foreground => Self::FontFamily,
+                Self::Foreground => Self::Theme,
             }
         }
     }
+}
+
+fn adjacent_appearance_field(
+    field: AppearanceField,
+    reverse: bool,
+    custom_theme: bool,
+) -> AppearanceField {
+    let mut adjacent = field.adjacent(reverse);
+    while !custom_theme
+        && matches!(
+            adjacent,
+            AppearanceField::Background | AppearanceField::Foreground
+        )
+    {
+        adjacent = adjacent.adjacent(reverse);
+    }
+    adjacent
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AppearancePicker {
+    FontFamily,
+    FontSize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct AppearanceEditor {
     draft: AppearanceSettingsDraft,
     field: AppearanceField,
+    open_picker: Option<AppearancePicker>,
+    font_families: Vec<String>,
     error: Option<String>,
 }
 
 impl AppearanceEditor {
-    fn new(draft: AppearanceSettingsDraft) -> Self {
+    fn new(draft: AppearanceSettingsDraft, font_families: Vec<String>) -> Self {
         Self {
             draft,
-            field: AppearanceField::FontFamily,
+            field: AppearanceField::Theme,
+            open_picker: None,
+            font_families,
             error: None,
         }
     }
@@ -533,11 +564,15 @@ struct SettingsDialog {
 }
 
 impl SettingsDialog {
-    fn new(hosts: &[ConfiguredSshHost], appearance: AppearanceSettingsDraft) -> Self {
+    fn new(
+        hosts: &[ConfiguredSshHost],
+        appearance: AppearanceSettingsDraft,
+        font_families: Vec<String>,
+    ) -> Self {
         let selected = hosts.first();
         Self {
             pane: SettingsPane::Appearance,
-            appearance_editor: AppearanceEditor::new(appearance),
+            appearance_editor: AppearanceEditor::new(appearance, font_families),
             selected_host_id: selected.map(|host| host.id().to_owned()),
             host_editor: selected.map(|host| SshHostEditor::new(Some(host))),
             pending_remove: None,
@@ -566,21 +601,11 @@ fn ssh_draft_field_mut(draft: &mut SshHostDraft, field: SshField) -> &mut String
 fn appearance_draft_field_mut(
     draft: &mut AppearanceSettingsDraft,
     field: AppearanceField,
-) -> &mut String {
+) -> Option<&mut String> {
     match field {
-        AppearanceField::FontFamily => &mut draft.font_family,
-        AppearanceField::FontSize => &mut draft.font_size,
-        AppearanceField::Background => &mut draft.background,
-        AppearanceField::Foreground => &mut draft.foreground,
-    }
-}
-
-fn appearance_draft_field(draft: &AppearanceSettingsDraft, field: AppearanceField) -> &str {
-    match field {
-        AppearanceField::FontFamily => &draft.font_family,
-        AppearanceField::FontSize => &draft.font_size,
-        AppearanceField::Background => &draft.background,
-        AppearanceField::Foreground => &draft.foreground,
+        AppearanceField::Background => Some(&mut draft.background),
+        AppearanceField::Foreground => Some(&mut draft.foreground),
+        AppearanceField::Theme | AppearanceField::FontFamily | AppearanceField::FontSize => None,
     }
 }
 
@@ -590,6 +615,42 @@ fn appearance_preview_color(value: &str, fallback: u32) -> u32 {
         .filter(|digits| digits.len() == 6)
         .and_then(|digits| u32::from_str_radix(digits, 16).ok())
         .unwrap_or(fallback)
+}
+
+fn appearance_preview_colors(draft: &AppearanceSettingsDraft) -> (u32, u32) {
+    draft.theme.colors().unwrap_or_else(|| {
+        (
+            appearance_preview_color(&draft.background, 0x0c_0f_14),
+            appearance_preview_color(&draft.foreground, 0xd8_de_e9),
+        )
+    })
+}
+
+fn terminal_font_families(cx: &Context<RootView>, configured: &str) -> Vec<String> {
+    let text_system = cx.text_system();
+    let mut families = text_system
+        .all_font_names()
+        .into_iter()
+        .filter(|family| !family.starts_with('.'))
+        .filter(|family| {
+            let font_id = text_system.resolve_font(&font(family.clone()));
+            let advances = ['i', 'W', '0', 'm', ' '].map(|character| {
+                text_system
+                    .advance(font_id, px(14.0), character)
+                    .map(|advance| f32::from(advance.width))
+                    .unwrap_or_default()
+            });
+            let minimum = advances.iter().copied().fold(f32::INFINITY, f32::min);
+            let maximum = advances.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            minimum > 0.0 && maximum - minimum < 0.1
+        })
+        .collect::<Vec<_>>();
+    if !configured.trim().is_empty() && !families.iter().any(|family| family == configured) {
+        families.push(configured.to_owned());
+    }
+    families.sort_by_key(|family| family.to_ascii_lowercase());
+    families.dedup_by(|left, right| left.eq_ignore_ascii_case(right));
+    families
 }
 
 fn ssh_draft_field(draft: &SshHostDraft, field: SshField) -> &str {
@@ -1538,7 +1599,8 @@ impl RootView {
     fn open_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let hosts = self.workspace.configured_ssh_hosts();
         let appearance = self.workspace.configured_appearance();
-        self.settings_dialog = Some(SettingsDialog::new(&hosts, appearance));
+        let font_families = terminal_font_families(cx, &appearance.font_family);
+        self.settings_dialog = Some(SettingsDialog::new(&hosts, appearance, font_families));
         self.session_action_menu = None;
         window.focus(&self.settings_focus);
         cx.notify();
@@ -1634,8 +1696,11 @@ impl RootView {
         match self.workspace.save_appearance(&draft) {
             Ok(()) => {
                 if let Some(dialog) = &mut self.settings_dialog {
-                    dialog.appearance_editor =
-                        AppearanceEditor::new(self.workspace.configured_appearance());
+                    let font_families = std::mem::take(&mut dialog.appearance_editor.font_families);
+                    dialog.appearance_editor = AppearanceEditor::new(
+                        self.workspace.configured_appearance(),
+                        font_families,
+                    );
                 }
             }
             Err(error) => {
@@ -1656,8 +1721,65 @@ impl RootView {
         else {
             return;
         };
-        let value = appearance_draft_field_mut(&mut editor.draft, editor.field);
         editor.error = None;
+        if !event.is_held && matches!(key.as_str(), "up" | "down" | "left" | "right") {
+            let reverse = matches!(key.as_str(), "up" | "left");
+            match editor.field {
+                AppearanceField::Theme => {
+                    let current = TerminalTheme::ALL
+                        .iter()
+                        .position(|theme| *theme == editor.draft.theme)
+                        .unwrap_or_default();
+                    let offset = if reverse {
+                        TerminalTheme::ALL.len() - 1
+                    } else {
+                        1
+                    };
+                    editor.draft.theme =
+                        TerminalTheme::ALL[(current + offset) % TerminalTheme::ALL.len()];
+                }
+                AppearanceField::FontFamily if !editor.font_families.is_empty() => {
+                    let current = editor
+                        .font_families
+                        .iter()
+                        .position(|family| family == &editor.draft.font_family)
+                        .unwrap_or_default();
+                    let offset = if reverse {
+                        editor.font_families.len() - 1
+                    } else {
+                        1
+                    };
+                    editor.draft.font_family = editor.font_families
+                        [(current + offset) % editor.font_families.len()]
+                    .clone();
+                }
+                AppearanceField::FontSize => {
+                    let current = TERMINAL_FONT_SIZES
+                        .iter()
+                        .position(|size| size.to_string() == editor.draft.font_size)
+                        .unwrap_or_default();
+                    let offset = if reverse {
+                        TERMINAL_FONT_SIZES.len() - 1
+                    } else {
+                        1
+                    };
+                    editor.draft.font_size = TERMINAL_FONT_SIZES
+                        [(current + offset) % TERMINAL_FONT_SIZES.len()]
+                    .to_string();
+                }
+                _ => {}
+            }
+            editor.open_picker = None;
+            cx.notify();
+            cx.stop_propagation();
+            return;
+        }
+        if editor.draft.theme != TerminalTheme::Custom {
+            return;
+        }
+        let Some(value) = appearance_draft_field_mut(&mut editor.draft, editor.field) else {
+            return;
+        };
         if is_paste_shortcut(&event.keystroke) {
             if !event.is_held
                 && let Some(text) = cx.read_from_clipboard().and_then(|item| item.text())
@@ -1784,10 +1906,13 @@ impl RootView {
         if key == "tab" {
             if let Some(dialog) = &mut self.settings_dialog {
                 if pane == SettingsPane::Appearance {
-                    dialog.appearance_editor.field = dialog
-                        .appearance_editor
-                        .field
-                        .adjacent(event.keystroke.modifiers.shift);
+                    let custom = dialog.appearance_editor.draft.theme == TerminalTheme::Custom;
+                    dialog.appearance_editor.field = adjacent_appearance_field(
+                        dialog.appearance_editor.field,
+                        event.keystroke.modifiers.shift,
+                        custom,
+                    );
+                    dialog.appearance_editor.open_picker = None;
                     dialog.appearance_editor.error = None;
                 } else if let Some(editor) = &mut dialog.host_editor {
                     editor.field = editor.field.adjacent(event.keystroke.modifiers.shift);
@@ -4533,26 +4658,220 @@ impl RootView {
             .into_any_element()
     }
 
-    fn appearance_field_row(
+    fn appearance_theme_card(
+        theme: TerminalTheme,
+        draft: &AppearanceSettingsDraft,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let selected = draft.theme == theme;
+        let (background, foreground) = theme
+            .colors()
+            .unwrap_or_else(|| appearance_preview_colors(draft));
+        div()
+            .id(("appearance-theme", theme as usize))
+            .w(px(154.0))
+            .h(px(88.0))
+            .p_2()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(if selected { 0x4a_8f_cf } else { 0x34_3a46 }))
+            .bg(rgb(if selected { 0x20_2b3a } else { 0x11_141a }))
+            .cursor_pointer()
+            .child(
+                div()
+                    .h(px(34.0))
+                    .px_2()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .rounded_sm()
+                    .bg(rgb(background))
+                    .child(
+                        div()
+                            .font_family(draft.font_family.clone())
+                            .text_sm()
+                            .text_color(rgb(foreground))
+                            .child("$ _"),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .text_sm()
+                    .text_color(rgb(if selected { 0xe8_ec_f3 } else { 0xb8_be_c9 }))
+                    .child(theme.title())
+                    .when(selected, |element| {
+                        element.child(div().text_color(rgb(0x79_b8_f3)).child("✓"))
+                    }),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                if let Some(dialog) = &mut this.settings_dialog {
+                    dialog.appearance_editor.draft.theme = theme;
+                    dialog.appearance_editor.field = AppearanceField::Theme;
+                    dialog.appearance_editor.open_picker = None;
+                    dialog.appearance_editor.error = None;
+                }
+                window.focus(&this.settings_focus);
+                cx.notify();
+            }))
+            .into_any_element()
+    }
+
+    fn appearance_select(
         &self,
         label: &'static str,
+        value: String,
         field: AppearanceField,
-        draft: &AppearanceSettingsDraft,
+        picker: AppearancePicker,
+        open: bool,
         cx: &mut Context<Self>,
     ) -> gpui::AnyElement {
         let selected = self
             .settings_dialog
             .as_ref()
             .is_some_and(|dialog| dialog.appearance_editor.field == field);
-        let value = appearance_draft_field(draft, field);
-        let placeholder = match field {
-            AppearanceField::FontFamily => "Font family",
-            AppearanceField::FontSize => "14",
-            AppearanceField::Background | AppearanceField::Foreground => "#RRGGBB",
-        };
-        let display = if value.is_empty() {
-            if selected { "▏" } else { placeholder }.to_owned()
-        } else if selected {
+        div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .child(div().text_xs().text_color(rgb(0x8f_96_a3)).child(label))
+            .child(
+                div()
+                    .id(("appearance-select", field as usize))
+                    .h(px(38.0))
+                    .px_3()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(rgb(if selected { 0x4a_8f_cf } else { 0x3a_404c }))
+                    .bg(rgb(0x0f_1218))
+                    .cursor_pointer()
+                    .text_sm()
+                    .text_color(rgb(0xe1_e5ec))
+                    .child(value)
+                    .child(if open { "▴" } else { "▾" })
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        if let Some(dialog) = &mut this.settings_dialog {
+                            let editor = &mut dialog.appearance_editor;
+                            editor.field = field;
+                            editor.open_picker =
+                                (editor.open_picker != Some(picker)).then_some(picker);
+                            editor.error = None;
+                        }
+                        window.focus(&this.settings_focus);
+                        cx.notify();
+                    })),
+            )
+            .into_any_element()
+    }
+
+    fn appearance_font_options(
+        editor: &AppearanceEditor,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let mut options = div()
+            .id("appearance-font-options")
+            .max_h(px(220.0))
+            .overflow_y_scroll()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(0x3a_404c))
+            .bg(rgb(0x0f_1218));
+        for (index, family) in editor.font_families.iter().enumerate() {
+            let selected = family == &editor.draft.font_family;
+            let selected_family = family.clone();
+            options = options.child(
+                div()
+                    .id(("appearance-font-option", index))
+                    .h(px(30.0))
+                    .px_3()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .cursor_pointer()
+                    .bg(rgb(if selected { 0x25_3448 } else { 0x0f_1218 }))
+                    .font_family(family.clone())
+                    .text_sm()
+                    .text_color(rgb(0xd8_dd_e6))
+                    .child(family.clone())
+                    .when(selected, |element| element.child("✓"))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        if let Some(dialog) = &mut this.settings_dialog {
+                            dialog
+                                .appearance_editor
+                                .draft
+                                .font_family
+                                .clone_from(&selected_family);
+                            dialog.appearance_editor.open_picker = None;
+                            dialog.appearance_editor.error = None;
+                        }
+                        cx.notify();
+                    })),
+            );
+        }
+        options.into_any_element()
+    }
+
+    fn appearance_size_options(
+        editor: &AppearanceEditor,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let mut options = div()
+            .flex()
+            .flex_wrap()
+            .gap_1()
+            .p_2()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(0x3a_404c))
+            .bg(rgb(0x0f_1218));
+        for size in TERMINAL_FONT_SIZES {
+            let selected = editor.draft.font_size == size.to_string();
+            options = options.child(
+                div()
+                    .id(("appearance-size-option", usize::from(size)))
+                    .w(px(54.0))
+                    .h(px(30.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .bg(rgb(if selected { 0x2b_6495 } else { 0x19_1d25 }))
+                    .text_sm()
+                    .child(format!("{size} pt"))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        if let Some(dialog) = &mut this.settings_dialog {
+                            dialog.appearance_editor.draft.font_size = size.to_string();
+                            dialog.appearance_editor.open_picker = None;
+                            dialog.appearance_editor.error = None;
+                        }
+                        cx.notify();
+                    })),
+            );
+        }
+        options.into_any_element()
+    }
+
+    fn appearance_color_field(
+        &self,
+        label: &'static str,
+        value: &str,
+        field: AppearanceField,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let selected = self
+            .settings_dialog
+            .as_ref()
+            .is_some_and(|dialog| dialog.appearance_editor.field == field);
+        let display = if selected {
             format!("{value}▏")
         } else {
             value.to_owned()
@@ -4564,8 +4883,8 @@ impl RootView {
             .child(div().text_xs().text_color(rgb(0x8f_96_a3)).child(label))
             .child(
                 div()
-                    .id(("appearance-setting-field", field as usize))
-                    .h(px(36.0))
+                    .id(("appearance-color-field", field as usize))
+                    .h(px(38.0))
                     .px_3()
                     .flex()
                     .items_center()
@@ -4575,20 +4894,145 @@ impl RootView {
                     .bg(rgb(0x0f_1218))
                     .cursor_text()
                     .text_sm()
-                    .text_color(rgb(if value.is_empty() && !selected {
-                        0x72_7986
-                    } else {
-                        0xe1_e5ec
-                    }))
                     .child(display)
                     .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
                             dialog.appearance_editor.field = field;
+                            dialog.appearance_editor.open_picker = None;
                             dialog.appearance_editor.error = None;
                         }
                         window.focus(&this.settings_focus);
                         cx.notify();
                     })),
+            )
+            .into_any_element()
+    }
+
+    fn appearance_theme_section(
+        draft: &AppearanceSettingsDraft,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let mut themes = div().flex().flex_wrap().gap_2();
+        for theme in TerminalTheme::ALL {
+            themes = themes.child(Self::appearance_theme_card(theme, draft, cx));
+        }
+        div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .text_base()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child("Terminal theme"),
+            )
+            .child(themes)
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(rgb(0x8f_96_a3))
+                    .child(draft.theme.summary()),
+            )
+            .into_any_element()
+    }
+
+    fn appearance_font_section(
+        &self,
+        editor: &AppearanceEditor,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let draft = &editor.draft;
+        let font_open = editor.open_picker == Some(AppearancePicker::FontFamily);
+        let size_open = editor.open_picker == Some(AppearancePicker::FontSize);
+        let mut section = div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .text_base()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child("Terminal font"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(div().flex_1().child(self.appearance_select(
+                        "Font family",
+                        draft.font_family.clone(),
+                        AppearanceField::FontFamily,
+                        AppearancePicker::FontFamily,
+                        font_open,
+                        cx,
+                    )))
+                    .child(div().w(px(170.0)).child(self.appearance_select(
+                        "Font size",
+                        format!("{} pt", draft.font_size),
+                        AppearanceField::FontSize,
+                        AppearancePicker::FontSize,
+                        size_open,
+                        cx,
+                    ))),
+            );
+        if font_open {
+            section = section.child(Self::appearance_font_options(editor, cx));
+        } else if size_open {
+            section = section.child(Self::appearance_size_options(editor, cx));
+        }
+        section.into_any_element()
+    }
+
+    fn appearance_custom_color_section(
+        &self,
+        draft: &AppearanceSettingsDraft,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .text_base()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child("Custom colors"),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(div().flex_1().child(self.appearance_color_field(
+                        "Background",
+                        &draft.background,
+                        AppearanceField::Background,
+                        cx,
+                    )))
+                    .child(div().flex_1().child(self.appearance_color_field(
+                        "Foreground",
+                        &draft.foreground,
+                        AppearanceField::Foreground,
+                        cx,
+                    ))),
+            )
+            .into_any_element()
+    }
+
+    fn appearance_save_controls(cx: &mut Context<Self>) -> gpui::AnyElement {
+        div()
+            .pb_2()
+            .flex()
+            .justify_end()
+            .child(
+                div()
+                    .id("save-appearance")
+                    .px_4()
+                    .py_2()
+                    .rounded_md()
+                    .cursor_pointer()
+                    .bg(rgb(0x1d_5f9a))
+                    .child("Save")
+                    .on_click(cx.listener(|this, _, _, cx| this.save_appearance(cx))),
             )
             .into_any_element()
     }
@@ -4604,45 +5048,16 @@ impl RootView {
         let draft = &editor.draft;
         let mut form = div()
             .w_full()
-            .max_w(px(680.0))
+            .max_w(px(1080.0))
             .flex()
             .flex_col()
-            .gap_4()
-            .child(
-                div()
-                    .flex()
-                    .gap_3()
-                    .child(div().flex_1().child(self.appearance_field_row(
-                        "Font family",
-                        AppearanceField::FontFamily,
-                        draft,
-                        cx,
-                    )))
-                    .child(div().w(px(150.0)).child(self.appearance_field_row(
-                        "Font size",
-                        AppearanceField::FontSize,
-                        draft,
-                        cx,
-                    ))),
-            )
-            .child(
-                div()
-                    .flex()
-                    .gap_3()
-                    .child(div().flex_1().child(self.appearance_field_row(
-                        "Background",
-                        AppearanceField::Background,
-                        draft,
-                        cx,
-                    )))
-                    .child(div().flex_1().child(self.appearance_field_row(
-                        "Foreground",
-                        AppearanceField::Foreground,
-                        draft,
-                        cx,
-                    ))),
-            )
-            .child(Self::appearance_preview(draft));
+            .gap_6()
+            .child(Self::appearance_theme_section(draft, cx))
+            .child(self.appearance_font_section(editor, cx));
+        if draft.theme == TerminalTheme::Custom {
+            form = form.child(self.appearance_custom_color_section(draft, cx));
+        }
+        form = form.child(Self::appearance_preview(draft));
         if let Some(error) = &editor.error {
             form = form.child(
                 div()
@@ -4651,19 +5066,7 @@ impl RootView {
                     .child(error.clone()),
             );
         }
-        form = form.child(
-            div().pt_1().flex().justify_end().child(
-                div()
-                    .id("save-appearance")
-                    .px_4()
-                    .py_2()
-                    .rounded_md()
-                    .cursor_pointer()
-                    .bg(rgb(0x1d_5f9a))
-                    .child("Save Appearance")
-                    .on_click(cx.listener(|this, _, _, cx| this.save_appearance(cx))),
-            ),
-        );
+        form = form.child(Self::appearance_save_controls(cx));
 
         div()
             .id("settings-appearance-editor")
@@ -4678,8 +5081,7 @@ impl RootView {
     }
 
     fn appearance_preview(draft: &AppearanceSettingsDraft) -> gpui::AnyElement {
-        let background = appearance_preview_color(&draft.background, 0x0c_0f_14);
-        let foreground = appearance_preview_color(&draft.foreground, 0xd8_de_e9);
+        let (background, foreground) = appearance_preview_colors(draft);
         let font_size = draft
             .font_size
             .parse::<f32>()
@@ -4692,24 +5094,80 @@ impl RootView {
         } else {
             draft.font_family.clone()
         };
+        let red = (foreground >> 16) & 0xff;
+        let green = (foreground >> 8) & 0xff;
+        let blue = foreground & 0xff;
+        let light_foreground = red + green + blue > 0x17f;
+        let accent = if light_foreground {
+            0x78_b5_ff
+        } else {
+            0x1d_5f_9a
+        };
         div()
             .flex()
             .flex_col()
-            .gap_1()
-            .child(div().text_xs().text_color(rgb(0x8f_96_a3)).child("Preview"))
+            .gap_2()
             .child(
                 div()
-                    .h(px(132.0))
-                    .px_4()
-                    .py_3()
+                    .text_base()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child("Preview"),
+            )
+            .child(
+                div()
+                    .h(px(230.0))
                     .rounded_md()
                     .border_1()
                     .border_color(rgb(0x3a_404c))
                     .bg(rgb(background))
-                    .text_color(rgb(foreground))
-                    .font_family(font_family)
-                    .text_size(px(font_size))
-                    .child("Ghosthub terminal\n$ cargo test --workspace\nAll checks passed"),
+                    .overflow_hidden()
+                    .child(
+                        div()
+                            .h(px(34.0))
+                            .px_3()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .border_b_1()
+                            .border_color(rgba(0xff_ff_ff_18))
+                            .text_xs()
+                            .text_color(rgb(foreground))
+                            .child("ghosthub — workspace")
+                            .child(draft.theme.title()),
+                    )
+                    .child(
+                        div()
+                            .px_4()
+                            .py_3()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .font_family(font_family)
+                            .text_size(px(font_size))
+                            .text_color(rgb(foreground))
+                            .child(
+                                div()
+                                    .flex()
+                                    .gap_2()
+                                    .child(div().text_color(rgb(accent)).child("~/ghosthub"))
+                                    .child("on rust-port"),
+                            )
+                            .child("❯ cargo test --workspace")
+                            .child(
+                                div()
+                                    .text_color(rgb(accent))
+                                    .child("   Compiling ghosthub-ui v0.0.0"),
+                            )
+                            .child("   Finished test profile in 2.14s")
+                            .child("   248 tests passed")
+                            .child(
+                                div()
+                                    .flex()
+                                    .gap_1()
+                                    .child(div().text_color(rgb(accent)).child("❯"))
+                                    .child("▏"),
+                            ),
+                    ),
             )
             .into_any_element()
     }
@@ -8306,12 +8764,12 @@ mod tests {
         UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority, WorktreeHostAccess, WorktreeOpenContext,
         WorktreeOpenMode, WorktreeOpenTarget, WorktreePresentation, WorktreeRemoveTarget,
         WorktreeSessionPresence, WorktreeSocket, active_session_selection,
-        appearance_preview_color, application_navigation_width, apply_new_worktree_failure,
-        apply_worktree_removal_failure, available_herdr_row_actions, can_create_worktree,
-        can_kill_worktree, canonical_terminal_key_with, clear_terminal_input_state,
-        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
-        herdr_session_menu_actions, host_header_action, host_landing_text,
+        adjacent_appearance_field, appearance_preview_color, application_navigation_width,
+        apply_new_worktree_failure, apply_worktree_removal_failure, available_herdr_row_actions,
+        can_create_worktree, can_kill_worktree, canonical_terminal_key_with,
+        clear_terminal_input_state, clears_after_input_delivery, clears_when_input_queue_is_empty,
+        coalesce_last_resize, coalesce_last_wheel, has_ambiguous_worktree_source,
+        herdr_row_actions, herdr_session_menu_actions, host_header_action, host_landing_text,
         input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
         kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
         new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
@@ -8332,7 +8790,7 @@ mod tests {
         AppearanceSettingsDraft, HerdrSessionItem, HerdrSessionState, HostConnectionState,
         HostDiagnostic, HostItem, KeyEvent, KeyInput, KwtBranchItem, KwtPullRequestItem, Modifiers,
         MouseAction, MouseButton, MouseInput, NamedKey, ProjectItem, SessionItem, SessionSelection,
-        SshHostDraft, WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
+        SshHostDraft, TerminalTheme, WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
     };
 
     #[test]
@@ -8382,12 +8840,13 @@ mod tests {
     #[test]
     fn settings_shell_opens_the_appearance_pane_without_a_transient_host_editor() {
         let appearance = AppearanceSettingsDraft {
+            theme: TerminalTheme::Custom,
             font_family: "Cascadia Mono".to_owned(),
             font_size: "14".to_owned(),
             background: "#0c0f14".to_owned(),
             foreground: "#d8dee9".to_owned(),
         };
-        let dialog = SettingsDialog::new(&[], appearance.clone());
+        let dialog = SettingsDialog::new(&[], appearance.clone(), vec!["Cascadia Mono".to_owned()]);
 
         assert_eq!(
             SettingsPane::ALL,
@@ -8403,11 +8862,15 @@ mod tests {
     #[test]
     fn appearance_fields_follow_tab_order_and_preview_only_accepts_rgb_hex() {
         assert_eq!(
-            AppearanceField::FontFamily.adjacent(false),
+            adjacent_appearance_field(AppearanceField::Theme, false, false),
+            AppearanceField::FontFamily
+        );
+        assert_eq!(
+            adjacent_appearance_field(AppearanceField::Theme, true, false),
             AppearanceField::FontSize
         );
         assert_eq!(
-            AppearanceField::FontFamily.adjacent(true),
+            adjacent_appearance_field(AppearanceField::Theme, true, true),
             AppearanceField::Foreground
         );
         assert_eq!(appearance_preview_color("#102030", 0), 0x10_20_30);

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -18,10 +18,10 @@ use gpui::{
 use model::PortStatus;
 use surface::{CellStyle, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
 use workspace::{
-    ConfiguredSshHost, HerdrSessionState, HostConnectionState, HostItem, KeyEvent as InputKeyEvent,
-    KeyInput, KwtProjectAction, Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput,
-    NamedKey, SessionName, SessionSelection, SshHostDraft, SshPromptRequest, Workspace,
-    WorkspaceContent, WorkspaceEvent,
+    AppearanceSettingsDraft, ConfiguredSshHost, HerdrSessionState, HostConnectionState, HostItem,
+    KeyEvent as InputKeyEvent, KeyInput, KwtProjectAction, Modifiers as InputModifiers,
+    MouseAction, MouseButton, MouseInput, NamedKey, SessionName, SessionSelection, SshHostDraft,
+    SshPromptRequest, Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -436,21 +436,69 @@ impl SshField {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SettingsPane {
+    Appearance,
     Hosts,
 }
 
 impl SettingsPane {
-    const ALL: [Self; 1] = [Self::Hosts];
+    const ALL: [Self; 2] = [Self::Appearance, Self::Hosts];
 
     const fn title(self) -> &'static str {
         match self {
+            Self::Appearance => "Appearance",
             Self::Hosts => "Hosts",
         }
     }
 
     const fn subtitle(self) -> &'static str {
         match self {
+            Self::Appearance => "Choose the font and colors used by terminal presentations.",
             Self::Hosts => "Connect the machines and tmux sessions in your SSH network.",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AppearanceField {
+    FontFamily,
+    FontSize,
+    Background,
+    Foreground,
+}
+
+impl AppearanceField {
+    const fn adjacent(self, reverse: bool) -> Self {
+        if reverse {
+            match self {
+                Self::FontFamily => Self::Foreground,
+                Self::FontSize => Self::FontFamily,
+                Self::Background => Self::FontSize,
+                Self::Foreground => Self::Background,
+            }
+        } else {
+            match self {
+                Self::FontFamily => Self::FontSize,
+                Self::FontSize => Self::Background,
+                Self::Background => Self::Foreground,
+                Self::Foreground => Self::FontFamily,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AppearanceEditor {
+    draft: AppearanceSettingsDraft,
+    field: AppearanceField,
+    error: Option<String>,
+}
+
+impl AppearanceEditor {
+    fn new(draft: AppearanceSettingsDraft) -> Self {
+        Self {
+            draft,
+            field: AppearanceField::FontFamily,
+            error: None,
         }
     }
 }
@@ -477,6 +525,7 @@ impl SshHostEditor {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SettingsDialog {
     pane: SettingsPane,
+    appearance_editor: AppearanceEditor,
     selected_host_id: Option<String>,
     host_editor: Option<SshHostEditor>,
     pending_remove: Option<ConfiguredSshHost>,
@@ -484,10 +533,11 @@ struct SettingsDialog {
 }
 
 impl SettingsDialog {
-    fn new(hosts: &[ConfiguredSshHost]) -> Self {
+    fn new(hosts: &[ConfiguredSshHost], appearance: AppearanceSettingsDraft) -> Self {
         let selected = hosts.first();
         Self {
-            pane: SettingsPane::Hosts,
+            pane: SettingsPane::Appearance,
+            appearance_editor: AppearanceEditor::new(appearance),
             selected_host_id: selected.map(|host| host.id().to_owned()),
             host_editor: selected.map(|host| SshHostEditor::new(Some(host))),
             pending_remove: None,
@@ -511,6 +561,35 @@ fn ssh_draft_field_mut(draft: &mut SshHostDraft, field: SshField) -> &mut String
         SshField::TmuxBinary => &mut draft.tmux_binary,
         SshField::SocketDirectory => &mut draft.socket_directory,
     }
+}
+
+fn appearance_draft_field_mut(
+    draft: &mut AppearanceSettingsDraft,
+    field: AppearanceField,
+) -> &mut String {
+    match field {
+        AppearanceField::FontFamily => &mut draft.font_family,
+        AppearanceField::FontSize => &mut draft.font_size,
+        AppearanceField::Background => &mut draft.background,
+        AppearanceField::Foreground => &mut draft.foreground,
+    }
+}
+
+fn appearance_draft_field(draft: &AppearanceSettingsDraft, field: AppearanceField) -> &str {
+    match field {
+        AppearanceField::FontFamily => &draft.font_family,
+        AppearanceField::FontSize => &draft.font_size,
+        AppearanceField::Background => &draft.background,
+        AppearanceField::Foreground => &draft.foreground,
+    }
+}
+
+fn appearance_preview_color(value: &str, fallback: u32) -> u32 {
+    value
+        .strip_prefix('#')
+        .filter(|digits| digits.len() == 6)
+        .and_then(|digits| u32::from_str_radix(digits, 16).ok())
+        .unwrap_or(fallback)
 }
 
 fn ssh_draft_field(draft: &SshHostDraft, field: SshField) -> &str {
@@ -1458,7 +1537,8 @@ impl RootView {
 
     fn open_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let hosts = self.workspace.configured_ssh_hosts();
-        self.settings_dialog = Some(SettingsDialog::new(&hosts));
+        let appearance = self.workspace.configured_appearance();
+        self.settings_dialog = Some(SettingsDialog::new(&hosts, appearance));
         self.session_action_menu = None;
         window.focus(&self.settings_focus);
         cx.notify();
@@ -1543,6 +1623,61 @@ impl RootView {
         cx.notify();
     }
 
+    fn save_appearance(&mut self, cx: &mut Context<Self>) {
+        let Some(draft) = self
+            .settings_dialog
+            .as_ref()
+            .map(|dialog| dialog.appearance_editor.draft.clone())
+        else {
+            return;
+        };
+        match self.workspace.save_appearance(&draft) {
+            Ok(()) => {
+                if let Some(dialog) = &mut self.settings_dialog {
+                    dialog.appearance_editor =
+                        AppearanceEditor::new(self.workspace.configured_appearance());
+                }
+            }
+            Err(error) => {
+                if let Some(dialog) = &mut self.settings_dialog {
+                    dialog.appearance_editor.error = Some(error.to_string());
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    fn edit_appearance_field(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        let key = event.keystroke.key.to_ascii_lowercase();
+        let Some(editor) = self
+            .settings_dialog
+            .as_mut()
+            .map(|dialog| &mut dialog.appearance_editor)
+        else {
+            return;
+        };
+        let value = appearance_draft_field_mut(&mut editor.draft, editor.field);
+        editor.error = None;
+        if is_paste_shortcut(&event.keystroke) {
+            if !event.is_held
+                && let Some(text) = cx.read_from_clipboard().and_then(|item| item.text())
+            {
+                append_non_control_characters(value, &text, SETTINGS_FIELD_CHARACTER_LIMIT);
+            }
+        } else if key == "backspace" {
+            value.pop();
+        } else if !event.keystroke.modifiers.control
+            && !event.keystroke.modifiers.alt
+            && !event.keystroke.modifiers.platform
+            && !event.keystroke.modifiers.function
+            && let Some(text) = &event.keystroke.key_char
+        {
+            append_non_control_characters(value, text, SETTINGS_FIELD_CHARACTER_LIMIT);
+        }
+        cx.notify();
+        cx.stop_propagation();
+    }
+
     fn remove_ssh_host(&mut self, cx: &mut Context<Self>) {
         let Some(host) = self
             .settings_dialog
@@ -1610,6 +1745,10 @@ impl RootView {
         cx: &mut Context<Self>,
     ) {
         let key = event.keystroke.key.to_ascii_lowercase();
+        let pane = self
+            .settings_dialog
+            .as_ref()
+            .map_or(SettingsPane::Appearance, |dialog| dialog.pane);
         if key == "escape" && !event.is_held {
             if self
                 .settings_dialog
@@ -1628,7 +1767,9 @@ impl RootView {
             return;
         }
         if key == "enter" && !event.is_held {
-            if self
+            if pane == SettingsPane::Appearance {
+                self.save_appearance(cx);
+            } else if self
                 .settings_dialog
                 .as_ref()
                 .is_some_and(|dialog| dialog.pending_remove.is_some())
@@ -1641,16 +1782,24 @@ impl RootView {
             return;
         }
         if key == "tab" {
-            if let Some(editor) = self
-                .settings_dialog
-                .as_mut()
-                .and_then(|dialog| dialog.host_editor.as_mut())
-            {
-                editor.field = editor.field.adjacent(event.keystroke.modifiers.shift);
-                editor.error = None;
+            if let Some(dialog) = &mut self.settings_dialog {
+                if pane == SettingsPane::Appearance {
+                    dialog.appearance_editor.field = dialog
+                        .appearance_editor
+                        .field
+                        .adjacent(event.keystroke.modifiers.shift);
+                    dialog.appearance_editor.error = None;
+                } else if let Some(editor) = &mut dialog.host_editor {
+                    editor.field = editor.field.adjacent(event.keystroke.modifiers.shift);
+                    editor.error = None;
+                }
                 cx.notify();
             }
             cx.stop_propagation();
+            return;
+        }
+        if pane == SettingsPane::Appearance {
+            self.edit_appearance_field(event, cx);
             return;
         }
         let Some(editor) = self
@@ -4384,11 +4533,192 @@ impl RootView {
             .into_any_element()
     }
 
+    fn appearance_field_row(
+        &self,
+        label: &'static str,
+        field: AppearanceField,
+        draft: &AppearanceSettingsDraft,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let selected = self
+            .settings_dialog
+            .as_ref()
+            .is_some_and(|dialog| dialog.appearance_editor.field == field);
+        let value = appearance_draft_field(draft, field);
+        let placeholder = match field {
+            AppearanceField::FontFamily => "Font family",
+            AppearanceField::FontSize => "14",
+            AppearanceField::Background | AppearanceField::Foreground => "#RRGGBB",
+        };
+        let display = if value.is_empty() {
+            if selected { "▏" } else { placeholder }.to_owned()
+        } else if selected {
+            format!("{value}▏")
+        } else {
+            value.to_owned()
+        };
+        div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .child(div().text_xs().text_color(rgb(0x8f_96_a3)).child(label))
+            .child(
+                div()
+                    .id(("appearance-setting-field", field as usize))
+                    .h(px(36.0))
+                    .px_3()
+                    .flex()
+                    .items_center()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(rgb(if selected { 0x4a_8f_cf } else { 0x3a_404c }))
+                    .bg(rgb(0x0f_1218))
+                    .cursor_text()
+                    .text_sm()
+                    .text_color(rgb(if value.is_empty() && !selected {
+                        0x72_7986
+                    } else {
+                        0xe1_e5ec
+                    }))
+                    .child(display)
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        if let Some(dialog) = &mut this.settings_dialog {
+                            dialog.appearance_editor.field = field;
+                            dialog.appearance_editor.error = None;
+                        }
+                        window.focus(&this.settings_focus);
+                        cx.notify();
+                    })),
+            )
+            .into_any_element()
+    }
+
+    fn settings_appearance_editor(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let Some(editor) = self
+            .settings_dialog
+            .as_ref()
+            .map(|dialog| &dialog.appearance_editor)
+        else {
+            return div().into_any_element();
+        };
+        let draft = &editor.draft;
+        let mut form = div()
+            .w_full()
+            .max_w(px(680.0))
+            .flex()
+            .flex_col()
+            .gap_4()
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(div().flex_1().child(self.appearance_field_row(
+                        "Font family",
+                        AppearanceField::FontFamily,
+                        draft,
+                        cx,
+                    )))
+                    .child(div().w(px(150.0)).child(self.appearance_field_row(
+                        "Font size",
+                        AppearanceField::FontSize,
+                        draft,
+                        cx,
+                    ))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_3()
+                    .child(div().flex_1().child(self.appearance_field_row(
+                        "Background",
+                        AppearanceField::Background,
+                        draft,
+                        cx,
+                    )))
+                    .child(div().flex_1().child(self.appearance_field_row(
+                        "Foreground",
+                        AppearanceField::Foreground,
+                        draft,
+                        cx,
+                    ))),
+            )
+            .child(Self::appearance_preview(draft));
+        if let Some(error) = &editor.error {
+            form = form.child(
+                div()
+                    .text_xs()
+                    .text_color(rgb(0xd0_7070))
+                    .child(error.clone()),
+            );
+        }
+        form = form.child(
+            div().pt_1().flex().justify_end().child(
+                div()
+                    .id("save-appearance")
+                    .px_4()
+                    .py_2()
+                    .rounded_md()
+                    .cursor_pointer()
+                    .bg(rgb(0x1d_5f9a))
+                    .child("Save Appearance")
+                    .on_click(cx.listener(|this, _, _, cx| this.save_appearance(cx))),
+            ),
+        );
+
+        div()
+            .id("settings-appearance-editor")
+            .flex_1()
+            .min_w_0()
+            .h_full()
+            .overflow_y_scroll()
+            .px_6()
+            .py_5()
+            .child(form)
+            .into_any_element()
+    }
+
+    fn appearance_preview(draft: &AppearanceSettingsDraft) -> gpui::AnyElement {
+        let background = appearance_preview_color(&draft.background, 0x0c_0f_14);
+        let foreground = appearance_preview_color(&draft.foreground, 0xd8_de_e9);
+        let font_size = draft
+            .font_size
+            .parse::<f32>()
+            .ok()
+            .filter(|size| *size > 0.0)
+            .unwrap_or(14.0)
+            .clamp(8.0, 32.0);
+        let font_family = if draft.font_family.trim().is_empty() {
+            "monospace".to_owned()
+        } else {
+            draft.font_family.clone()
+        };
+        div()
+            .flex()
+            .flex_col()
+            .gap_1()
+            .child(div().text_xs().text_color(rgb(0x8f_96_a3)).child("Preview"))
+            .child(
+                div()
+                    .h(px(132.0))
+                    .px_4()
+                    .py_3()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(rgb(0x3a_404c))
+                    .bg(rgb(background))
+                    .text_color(rgb(foreground))
+                    .font_family(font_family)
+                    .text_size(px(font_size))
+                    .child("Ghosthub terminal\n$ cargo test --workspace\nAll checks passed"),
+            )
+            .into_any_element()
+    }
+
     fn settings_sidebar(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let active = self
             .settings_dialog
             .as_ref()
-            .map_or(SettingsPane::Hosts, |dialog| dialog.pane);
+            .map_or(SettingsPane::Appearance, |dialog| dialog.pane);
         let mut panes = div().flex().flex_col().gap_1();
         for (index, pane) in SettingsPane::ALL.into_iter().enumerate() {
             panes = panes.child(
@@ -4778,6 +5108,7 @@ impl RootView {
         let dialog = self.settings_dialog.as_ref()?;
         let pane = dialog.pane;
         let detail = match pane {
+            SettingsPane::Appearance => self.settings_appearance_editor(cx),
             SettingsPane::Hosts => div()
                 .flex_1()
                 .min_h_0()
@@ -7966,7 +8297,7 @@ mod tests {
     use std::collections::{HashSet, VecDeque};
 
     use super::{
-        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, HerdrRowAccess, HerdrRowAction,
+        APP_NAVIGATION_WIDTH, APP_TITLEBAR_HEIGHT, AppearanceField, HerdrRowAccess, HerdrRowAction,
         HostHeaderAction, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC, InputRefusal,
         LayoutKey, NewSessionDraft, NewSessionKind, NewWorktreeMode, PendingUiInput, ProjectDialog,
         QueuedUiInput, SessionGroup, SessionGroupKey, SessionRowAction, SettingsDialog,
@@ -7975,18 +8306,18 @@ mod tests {
         UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority, WorktreeHostAccess, WorktreeOpenContext,
         WorktreeOpenMode, WorktreeOpenTarget, WorktreePresentation, WorktreeRemoveTarget,
         WorktreeSessionPresence, WorktreeSocket, active_session_selection,
-        application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
-        available_herdr_row_actions, can_create_worktree, can_kill_worktree,
-        canonical_terminal_key_with, clear_terminal_input_state, clears_after_input_delivery,
-        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
-        has_ambiguous_worktree_source, herdr_row_actions, herdr_session_menu_actions,
-        host_header_action, host_landing_text, input_queue_has_capacity,
-        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
-        kwt_operation_failure_owns_dialog, named_key, new_session_validation, normalize_cell_width,
-        owns_created_worktree_navigation, pull_request_import_selector,
-        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
-        session_backend_id, session_creation_available, session_group_visibility,
-        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        appearance_preview_color, application_navigation_width, apply_new_worktree_failure,
+        apply_worktree_removal_failure, available_herdr_row_actions, can_create_worktree,
+        can_kill_worktree, canonical_terminal_key_with, clear_terminal_input_state,
+        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
+        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
+        herdr_session_menu_actions, host_header_action, host_landing_text,
+        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
+        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
+        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
+        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
+        session_action_menu_position, session_backend_id, session_creation_available,
+        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
         terminal_line_height, terminal_wheel_steps, tmux_row_actions, toggle_session_group_state,
         transitioned_presentation, tree_herdr_sessions, tree_sessions, tree_zellij_sessions,
@@ -7998,10 +8329,10 @@ mod tests {
     use std::time::{Duration, Instant};
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
-        HerdrSessionItem, HerdrSessionState, HostConnectionState, HostDiagnostic, HostItem,
-        KeyEvent, KeyInput, KwtBranchItem, KwtPullRequestItem, Modifiers, MouseAction, MouseButton,
-        MouseInput, NamedKey, ProjectItem, SessionItem, SessionSelection, SshHostDraft,
-        WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
+        AppearanceSettingsDraft, HerdrSessionItem, HerdrSessionState, HostConnectionState,
+        HostDiagnostic, HostItem, KeyEvent, KeyInput, KwtBranchItem, KwtPullRequestItem, Modifiers,
+        MouseAction, MouseButton, MouseInput, NamedKey, ProjectItem, SessionItem, SessionSelection,
+        SshHostDraft, WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
     };
 
     #[test]
@@ -8049,14 +8380,38 @@ mod tests {
     }
 
     #[test]
-    fn settings_shell_opens_the_hosts_pane_without_a_transient_editor() {
-        let dialog = SettingsDialog::new(&[]);
+    fn settings_shell_opens_the_appearance_pane_without_a_transient_host_editor() {
+        let appearance = AppearanceSettingsDraft {
+            font_family: "Cascadia Mono".to_owned(),
+            font_size: "14".to_owned(),
+            background: "#0c0f14".to_owned(),
+            foreground: "#d8dee9".to_owned(),
+        };
+        let dialog = SettingsDialog::new(&[], appearance.clone());
 
-        assert_eq!(SettingsPane::ALL, [SettingsPane::Hosts]);
-        assert_eq!(dialog.pane, SettingsPane::Hosts);
+        assert_eq!(
+            SettingsPane::ALL,
+            [SettingsPane::Appearance, SettingsPane::Hosts]
+        );
+        assert_eq!(dialog.pane, SettingsPane::Appearance);
+        assert_eq!(dialog.appearance_editor.draft, appearance);
         assert!(dialog.selected_host_id.is_none());
         assert!(dialog.host_editor.is_none());
         assert!(dialog.pending_remove.is_none());
+    }
+
+    #[test]
+    fn appearance_fields_follow_tab_order_and_preview_only_accepts_rgb_hex() {
+        assert_eq!(
+            AppearanceField::FontFamily.adjacent(false),
+            AppearanceField::FontSize
+        );
+        assert_eq!(
+            AppearanceField::FontFamily.adjacent(true),
+            AppearanceField::Foreground
+        );
+        assert_eq!(appearance_preview_color("#102030", 0), 0x10_20_30);
+        assert_eq!(appearance_preview_color("102030", 0x12_34_56), 0x12_34_56);
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1707,7 +1707,12 @@ impl RootView {
         cx.notify();
     }
 
-    fn persist_appearance(&mut self, draft: &AppearanceSettingsDraft, cx: &mut Context<Self>) {
+    fn persist_appearance(
+        &mut self,
+        draft: &AppearanceSettingsDraft,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) {
         if !appearance_draft_is_persistable(draft) {
             if let Some(dialog) = &mut self.settings_dialog {
                 dialog.appearance_editor.error = None;
@@ -1715,10 +1720,21 @@ impl RootView {
             cx.notify();
             return;
         }
+        let previous = self.workspace.snapshot().appearance().clone();
         match self.workspace.save_appearance(draft) {
             Ok(()) => {
                 if let Some(dialog) = &mut self.settings_dialog {
                     dialog.appearance_editor.error = None;
+                }
+                let appearance = self.workspace.snapshot().appearance().clone();
+                if terminal_font_changed(
+                    previous.font_family(),
+                    previous.font_size(),
+                    appearance.font_family(),
+                    appearance.font_size(),
+                ) {
+                    self.terminal_metrics = measure_terminal_metrics(window, &appearance);
+                    self.resize_for_window(window);
                 }
             }
             Err(error) => {
@@ -1730,7 +1746,12 @@ impl RootView {
         cx.notify();
     }
 
-    fn edit_appearance_field(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+    fn edit_appearance_field(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) {
         let key = event.keystroke.key.to_ascii_lowercase();
         let Some(editor) = self
             .settings_dialog
@@ -1789,7 +1810,7 @@ impl RootView {
             }
             editor.open_picker = None;
             let draft = editor.draft.clone();
-            self.persist_appearance(&draft, cx);
+            self.persist_appearance(&draft, window, cx);
             cx.stop_propagation();
             return;
         }
@@ -1816,7 +1837,7 @@ impl RootView {
             append_non_control_characters(value, text, SETTINGS_FIELD_CHARACTER_LIMIT);
         }
         let draft = editor.draft.clone();
-        self.persist_appearance(&draft, cx);
+        self.persist_appearance(&draft, window, cx);
         cx.stop_propagation();
     }
 
@@ -1945,7 +1966,7 @@ impl RootView {
             return;
         }
         if pane == SettingsPane::Appearance {
-            self.edit_appearance_field(event, cx);
+            self.edit_appearance_field(event, window, cx);
             return;
         }
         let Some(editor) = self
@@ -4743,7 +4764,7 @@ impl RootView {
                     .as_ref()
                     .map(|dialog| dialog.appearance_editor.draft.clone());
                 if let Some(draft) = draft {
-                    this.persist_appearance(&draft, cx);
+                    this.persist_appearance(&draft, window, cx);
                 }
             }))
             .into_any_element()
@@ -4829,7 +4850,7 @@ impl RootView {
                     .text_color(rgb(0xd8_dd_e6))
                     .child(family.clone())
                     .when(selected, |element| element.child("✓"))
-                    .on_click(cx.listener(move |this, _, _, cx| {
+                    .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
                             dialog
                                 .appearance_editor
@@ -4844,7 +4865,7 @@ impl RootView {
                             .as_ref()
                             .map(|dialog| dialog.appearance_editor.draft.clone());
                         if let Some(draft) = draft {
-                            this.persist_appearance(&draft, cx);
+                            this.persist_appearance(&draft, window, cx);
                         }
                     })),
             );
@@ -4880,7 +4901,7 @@ impl RootView {
                     .bg(rgb(if selected { 0x2b_6495 } else { 0x19_1d25 }))
                     .text_sm()
                     .child(format!("{size} pt"))
-                    .on_click(cx.listener(move |this, _, _, cx| {
+                    .on_click(cx.listener(move |this, _, window, cx| {
                         if let Some(dialog) = &mut this.settings_dialog {
                             dialog.appearance_editor.draft.font_size = size.to_string();
                             dialog.appearance_editor.open_picker = None;
@@ -4891,7 +4912,7 @@ impl RootView {
                             .as_ref()
                             .map(|dialog| dialog.appearance_editor.draft.clone());
                         if let Some(draft) = draft {
-                            this.persist_appearance(&draft, cx);
+                            this.persist_appearance(&draft, window, cx);
                         }
                     })),
             );
@@ -8711,6 +8732,15 @@ fn normalize_cell_width(measured: f32) -> f32 {
     measured.max(1.0)
 }
 
+fn terminal_font_changed(
+    previous_family: &str,
+    previous_size: u16,
+    current_family: &str,
+    current_size: u16,
+) -> bool {
+    previous_family != current_family || previous_size != current_size
+}
+
 fn terminal_line_height(font_size: f32, ascent: f32, descent: f32) -> f32 {
     (ascent + descent + CELL_LINE_GAP)
         .max(font_size * 1.3)
@@ -8802,11 +8832,11 @@ mod tests {
         pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
         session_action_menu_position, session_backend_id, session_creation_available,
         session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
-        terminal_cell_at_with_offset, terminal_key_input, terminal_key_input_with_canonical,
-        terminal_line_height, terminal_wheel_steps, tmux_row_actions, toggle_session_group_state,
-        transitioned_presentation, tree_herdr_sessions, tree_sessions, tree_zellij_sessions,
-        visible_kwt_branch_candidates, visible_kwt_pull_requests, workspace_window_title,
-        worktree_open_mode,
+        terminal_cell_at_with_offset, terminal_font_changed, terminal_key_input,
+        terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
+        tmux_row_actions, toggle_session_group_state, transitioned_presentation,
+        tree_herdr_sessions, tree_sessions, tree_zellij_sessions, visible_kwt_branch_candidates,
+        visible_kwt_pull_requests, workspace_window_title, worktree_open_mode,
     };
     use model::DiagnosticKind;
     use std::sync::Arc;
@@ -10979,6 +11009,28 @@ mod tests {
     fn terminal_line_height_keeps_readable_leading() {
         assert!((terminal_line_height(14.0, 10.0, 3.0) - 19.0).abs() < f32::EPSILON);
         assert!((terminal_line_height(14.0, 12.0, 4.0) - 20.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn terminal_font_changes_require_fresh_metrics() {
+        assert!(!terminal_font_changed(
+            "Cascadia Mono",
+            14,
+            "Cascadia Mono",
+            14
+        ));
+        assert!(terminal_font_changed(
+            "Cascadia Mono",
+            14,
+            "Iosevka Term",
+            14
+        ));
+        assert!(terminal_font_changed(
+            "Cascadia Mono",
+            14,
+            "Cascadia Mono",
+            16
+        ));
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -16691,6 +16691,7 @@ fn default_terminal_geometry() -> TerminalGeometry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use terminal::TerminalEngine;
 
     const TEST_REMOTE_ROUTE: &str =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -18446,6 +18447,63 @@ mod tests {
 
         assert_eq!(colors.background(), Rgb::new(0x12, 0x34, 0x56));
         assert_eq!(colors.foreground(), Rgb::new(0x65, 0x43, 0x21));
+    }
+
+    fn relative_luminance(color: Rgb) -> f64 {
+        let linear = |component: u8| {
+            let value = f64::from(component) / 255.0;
+            if value <= 0.040_45 {
+                value / 12.92
+            } else {
+                ((value + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * linear(color.red) + 0.7152 * linear(color.green) + 0.0722 * linear(color.blue)
+    }
+
+    fn contrast_ratio(first: Rgb, second: Rgb) -> f64 {
+        let first = relative_luminance(first);
+        let second = relative_luminance(second);
+        let (lighter, darker) = if first >= second {
+            (first, second)
+        } else {
+            (second, first)
+        };
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
+    #[test]
+    fn light_themes_render_every_ansi_color_with_readable_contrast() {
+        for theme in [TerminalTheme::ClearLight, TerminalTheme::Novel] {
+            let (background, foreground) = theme.colors().expect("built-in theme colors");
+            let appearance = Appearance {
+                theme,
+                font_family: "monospace".to_owned(),
+                font_size: 14,
+                background,
+                foreground,
+            };
+            let colors = default_colors(&appearance);
+            let mut engine = TerminalEngine::with_default_colors(
+                GridSize::new(16, 1).expect("valid grid"),
+                colors,
+            );
+            let mut output = Vec::new();
+            for index in 0_u8..16 {
+                let code = if index < 8 { 30 + index } else { 82 + index };
+                output.extend_from_slice(format!("\x1b[{code}mX").as_bytes());
+            }
+
+            let _events = engine.process(&output);
+            let frame = engine.surface().load();
+            for column in 0..16 {
+                let ratio = contrast_ratio(frame.row(0)[column].foreground, colors.background());
+                assert!(
+                    ratio >= 4.5,
+                    "{theme:?} ANSI color {column} has only {ratio:.2}:1 contrast"
+                );
+            }
+        }
     }
 
     #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -72,6 +72,36 @@ pub struct Appearance {
     foreground: u32,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppearanceSettingsDraft {
+    pub font_family: String,
+    pub font_size: String,
+    pub background: String,
+    pub foreground: String,
+}
+
+impl From<&TerminalAppearance> for AppearanceSettingsDraft {
+    fn from(value: &TerminalAppearance) -> Self {
+        Self {
+            font_family: value.font_family().to_owned(),
+            font_size: value.font_size().to_string(),
+            background: format!("#{:06x}", value.background()),
+            foreground: format!("#{:06x}", value.foreground()),
+        }
+    }
+}
+
+impl From<&Appearance> for AppearanceSettingsDraft {
+    fn from(value: &Appearance) -> Self {
+        Self {
+            font_family: value.font_family().to_owned(),
+            font_size: value.font_size().to_string(),
+            background: format!("#{:06x}", value.background()),
+            foreground: format!("#{:06x}", value.foreground()),
+        }
+    }
+}
+
 impl Appearance {
     #[must_use]
     pub fn font_family(&self) -> &str {
@@ -3237,7 +3267,7 @@ impl AdmissionAttacher for ConptyAdmissionAttacher {
 }
 
 struct Inner {
-    appearance: Appearance,
+    appearance: RwLock<Appearance>,
     host_scoped_inventory: bool,
     wsl_config: Option<WslConfig>,
     wsl_executable: Mutex<Option<WslExecutable>>,
@@ -3893,7 +3923,7 @@ impl Workspace {
         };
         Self {
             inner: Arc::new(Inner {
-                appearance: snapshot.appearance,
+                appearance: RwLock::new(snapshot.appearance),
                 host_scoped_inventory: false,
                 wsl_config: None,
                 wsl_executable: Mutex::new(None),
@@ -4050,7 +4080,7 @@ impl Workspace {
         let wsl_executable = wsl.and_then(|spec| spec.executable);
         Self {
             inner: Arc::new(Inner {
-                appearance: appearance.into(),
+                appearance: RwLock::new(appearance.into()),
                 host_scoped_inventory: true,
                 wsl_config,
                 wsl_executable: Mutex::new(wsl_executable),
@@ -4115,7 +4145,7 @@ impl Workspace {
         let allow_remote_clipboard_write = appearance.allow_remote_clipboard_write();
         let workspace = Self {
             inner: Arc::new(Inner {
-                appearance: appearance.into(),
+                appearance: RwLock::new(appearance.into()),
                 host_scoped_inventory: false,
                 wsl_config: Some(config.clone()),
                 wsl_executable: Mutex::new(None),
@@ -4223,6 +4253,74 @@ impl Workspace {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn configured_appearance(&self) -> AppearanceSettingsDraft {
+        self.inner
+            .settings
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map_or_else(
+                || {
+                    let appearance = self
+                        .inner
+                        .appearance
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    AppearanceSettingsDraft::from(&*appearance)
+                },
+                |settings| AppearanceSettingsDraft::from(settings.config.terminal()),
+            )
+    }
+
+    /// Persist terminal appearance settings and publish them to the running
+    /// workspace. Existing clients keep their negotiated terminal palette;
+    /// the UI and newly opened clients use the saved values immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid values, unavailable settings storage, or
+    /// an I/O failure.
+    pub fn save_appearance(&self, draft: &AppearanceSettingsDraft) -> Result<(), WorkspaceError> {
+        let font_size = draft
+            .font_size
+            .trim()
+            .parse::<u16>()
+            .map_err(|_| WorkspaceError::new("Font size must be a number from 1 to 65535"))?;
+        let appearance = {
+            let mut settings = self
+                .inner
+                .settings
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let settings = settings
+                .as_mut()
+                .ok_or_else(|| WorkspaceError::new("Appearance settings storage is unavailable"))?;
+            let appearance = TerminalAppearance::new(
+                draft.font_family.trim(),
+                font_size,
+                draft.background.trim(),
+                draft.foreground.trim(),
+                settings.config.terminal().allow_remote_clipboard_write(),
+            )
+            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+            let roots = settings.roots.clone();
+            settings
+                .config
+                .replace_terminal_appearance(&roots, appearance.clone())
+                .map_err(|error| WorkspaceError::new(error.to_string()))?;
+            appearance
+        };
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        *self
+            .inner
+            .appearance
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = appearance.into();
+        self.inner.revision.fetch_add(1, Ordering::Release);
+        Ok(())
     }
 
     /// Persist a new or edited SSH host and publish its disconnected row.
@@ -5345,7 +5443,12 @@ impl Workspace {
                 };
                 WorkspaceSnapshot {
                     revision,
-                    appearance: self.inner.appearance.clone(),
+                    appearance: self
+                        .inner
+                        .appearance
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone(),
                     content,
                     hosts,
                     selected_host,
@@ -12560,7 +12663,7 @@ fn prepare_remote_tmux_attachment(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -12710,7 +12813,7 @@ fn prepare_remote_herdr_attachment(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -12887,7 +12990,7 @@ fn prepare_remote_zellij_attachment(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -13225,7 +13328,7 @@ fn create_remote_herdr_fresh(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok(worker)
@@ -13342,7 +13445,7 @@ fn create_remote_zellij_fresh(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok(worker)
@@ -13737,7 +13840,7 @@ fn create_herdr_fresh(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok((worker, geometry))
@@ -13843,7 +13946,7 @@ fn create_zellij_fresh(
         geometry.sequence,
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| WorkspaceError::new(error.to_string()))?;
 
@@ -14106,7 +14209,7 @@ fn create_fresh(
         launch_geometry.sequence,
         launch_geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| WorkspaceError::new(error.to_string()))?;
     let client_identity = request
@@ -15531,7 +15634,7 @@ fn launch_fresh_tmux(
         geometry.sequence,
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
     Ok((
@@ -15740,7 +15843,7 @@ fn launch_fresh_protected_worktree_once(
         geometry.sequence,
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| {
         WorktreeLaunchError::Attach(AttachFreshError::Host(WorkspaceError::new(
@@ -15880,7 +15983,7 @@ fn launch_fresh_worktree_once(
         geometry.sequence,
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| {
         WorktreeLaunchError::Attach(AttachFreshError::Host(WorkspaceError::new(
@@ -16105,7 +16208,7 @@ fn launch_fresh_herdr(
                 geometry.sequence,
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-                default_colors(&inner.appearance),
+                current_default_colors(inner),
             )
             .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
             Ok((worker, geometry))
@@ -16137,7 +16240,7 @@ fn launch_fresh_zellij(
         geometry.sequence,
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
-        default_colors(&inner.appearance),
+        current_default_colors(inner),
     )
     .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
     Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
@@ -16178,6 +16281,14 @@ fn clear_terminal_notice(inner: &Inner) {
 
 fn default_colors(appearance: &Appearance) -> DefaultColors {
     DefaultColors::new(rgb(appearance.foreground()), rgb(appearance.background()))
+}
+
+fn current_default_colors(inner: &Inner) -> DefaultColors {
+    let appearance = inner
+        .appearance
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    default_colors(&appearance)
 }
 
 fn rgb(color: u32) -> Rgb {

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::thread;
 use std::time::{Duration, Instant};
 
+pub use config::TerminalTheme;
 use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance};
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HerdrInventory, HostError,
@@ -66,6 +67,7 @@ const PENDING_KWT_CREATION_LIFETIME: Duration = Duration::from_mins(3);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Appearance {
+    theme: TerminalTheme,
     font_family: String,
     font_size: u16,
     background: u32,
@@ -74,6 +76,7 @@ pub struct Appearance {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AppearanceSettingsDraft {
+    pub theme: TerminalTheme,
     pub font_family: String,
     pub font_size: String,
     pub background: String,
@@ -83,6 +86,7 @@ pub struct AppearanceSettingsDraft {
 impl From<&TerminalAppearance> for AppearanceSettingsDraft {
     fn from(value: &TerminalAppearance) -> Self {
         Self {
+            theme: value.theme(),
             font_family: value.font_family().to_owned(),
             font_size: value.font_size().to_string(),
             background: format!("#{:06x}", value.background()),
@@ -94,6 +98,7 @@ impl From<&TerminalAppearance> for AppearanceSettingsDraft {
 impl From<&Appearance> for AppearanceSettingsDraft {
     fn from(value: &Appearance) -> Self {
         Self {
+            theme: value.theme(),
             font_family: value.font_family().to_owned(),
             font_size: value.font_size().to_string(),
             background: format!("#{:06x}", value.background()),
@@ -103,6 +108,11 @@ impl From<&Appearance> for AppearanceSettingsDraft {
 }
 
 impl Appearance {
+    #[must_use]
+    pub const fn theme(&self) -> TerminalTheme {
+        self.theme
+    }
+
     #[must_use]
     pub fn font_family(&self) -> &str {
         &self.font_family
@@ -127,6 +137,7 @@ impl Appearance {
 impl From<TerminalAppearance> for Appearance {
     fn from(value: TerminalAppearance) -> Self {
         Self {
+            theme: value.theme(),
             font_family: value.font_family().to_owned(),
             font_size: value.font_size(),
             background: value.background(),
@@ -4298,7 +4309,8 @@ impl Workspace {
             let settings = settings
                 .as_mut()
                 .ok_or_else(|| WorkspaceError::new("Appearance settings storage is unavailable"))?;
-            let appearance = TerminalAppearance::new(
+            let appearance = TerminalAppearance::themed(
+                draft.theme,
                 draft.font_family.trim(),
                 font_size,
                 draft.background.trim(),
@@ -18423,6 +18435,7 @@ mod tests {
     #[test]
     fn appearance_projects_terminal_default_colors() {
         let appearance = Appearance {
+            theme: TerminalTheme::Custom,
             font_family: "monospace".to_owned(),
             font_size: 14,
             background: 0x12_34_56,

--- a/rust/workspace/tests/view_state.rs
+++ b/rust/workspace/tests/view_state.rs
@@ -1,10 +1,17 @@
-use config::TerminalAppearance;
+use std::{
+    fs,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use config::{ApplicationConfig, Roots, TerminalAppearance};
 use host::{WslConfig, WslExecutable};
 use model::DiagnosticKind;
 use workspace::{
-    Appearance, HostConnectionState, HostDiagnostic, HostItem, SessionItem, Workspace,
-    WorkspaceContent, WorkspaceSnapshot, WslHostSpec,
+    Appearance, AppearanceSettingsDraft, HostConnectionState, HostDiagnostic, HostItem,
+    SessionItem, Workspace, WorkspaceContent, WorkspaceSnapshot, WslHostSpec,
 };
+
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[test]
 fn host_failure_is_scoped_beside_the_application_shell() {
@@ -132,4 +139,53 @@ fn startup_configuration_errors_are_visible_without_starting_a_host() {
         }
         _ => panic!("startup error must be visible"),
     }
+}
+
+#[test]
+fn saved_appearance_is_persisted_and_published_without_rebuilding_hosts() {
+    let root = std::env::temp_dir().join(format!(
+        "ghosthub-workspace-appearance-{}-{}",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    let value = root.to_string_lossy().into_owned();
+    let roots = Roots {
+        ghosthub_home: value.clone(),
+        config: value.clone(),
+        state: value.clone(),
+        helpers: value,
+    };
+    let workspace = Workspace::application_with_remote_hosts(
+        TerminalAppearance::default(),
+        None,
+        Vec::new(),
+        ApplicationConfig::default(),
+        roots.clone(),
+        None,
+        None,
+    );
+
+    workspace
+        .save_appearance(&AppearanceSettingsDraft {
+            font_family: "Iosevka Term".to_owned(),
+            font_size: "16".to_owned(),
+            background: "#102030".to_owned(),
+            foreground: "#f0e0d0".to_owned(),
+        })
+        .expect("save appearance");
+
+    let snapshot = workspace.snapshot();
+    assert_eq!(snapshot.appearance().font_family(), "Iosevka Term");
+    assert_eq!(snapshot.appearance().font_size(), 16);
+    assert_eq!(snapshot.appearance().background(), 0x10_20_30);
+    assert_eq!(snapshot.appearance().foreground(), 0xf0_e0_d0);
+    assert!(snapshot.hosts().is_empty());
+    assert_eq!(
+        ApplicationConfig::load(&roots)
+            .expect("reload application config")
+            .terminal()
+            .font_family(),
+        "Iosevka Term"
+    );
+    fs::remove_dir_all(root).expect("remove temporary config root");
 }

--- a/rust/workspace/tests/view_state.rs
+++ b/rust/workspace/tests/view_state.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use config::{ApplicationConfig, Roots, TerminalAppearance};
+use config::{ApplicationConfig, Roots, TerminalAppearance, TerminalTheme};
 use host::{WslConfig, WslExecutable};
 use model::DiagnosticKind;
 use workspace::{
@@ -167,6 +167,7 @@ fn saved_appearance_is_persisted_and_published_without_rebuilding_hosts() {
 
     workspace
         .save_appearance(&AppearanceSettingsDraft {
+            theme: TerminalTheme::Custom,
             font_family: "Iosevka Term".to_owned(),
             font_size: "16".to_owned(),
             background: "#102030".to_owned(),


### PR DESCRIPTION
- Adds a permanent Appearance pane to the Rust Settings shell with built-in terminal themes, custom colors, and a live terminal preview.
- Lists installed fixed-pitch fonts and common terminal sizes instead of requiring configuration-file edits.
- Applies and persists valid changes immediately, matching the Swift app without a separate Save action.
- Keeps terminal palettes scoped to terminal surfaces and previews so light and sepia themes do not recolor Ghosthub's application chrome.
- Preserves existing color-only configurations as Custom and writes named-theme settings atomically.
- Applies current defaults to newly opened terminals while existing terminal clients retain their negotiated palette until reopened.
- Passes the full Rust workspace tests, formatting, Clippy with warnings denied, and dependency-policy checks.