### PR TITLE
Skip signing and publishing jobs outside the canonical repository

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,12 @@ env:
 jobs:
   eligibility:
     name: Check for a changed main revision
-    if: github.ref == 'refs/heads/main'
+    # Only the canonical repository publishes a nightly channel. Forks inherit
+    # the schedule trigger but have neither the signing material nor the
+    # release repository, so every job in this workflow is repository-guarded.
+    if: >-
+      github.repository == 'kenn-io/ghosthub' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -75,7 +80,9 @@ jobs:
 
   macos-nightly:
     name: Build, sign, and notarize
-    if: needs.eligibility.outputs.eligible == 'true'
+    if: >-
+      github.repository == 'kenn-io/ghosthub' &&
+      needs.eligibility.outputs.eligible == 'true'
     needs: eligibility
     runs-on: macos-15
     timeout-minutes: 120
@@ -370,6 +377,7 @@ jobs:
 
   publish-nightly:
     name: Publish verified objects
+    if: github.repository == 'kenn-io/ghosthub'
     needs:
       - eligibility
       - macos-nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ env:
 jobs:
   macos-release:
     name: Build, sign, and notarize
+    # Signing and notarization credentials only exist in the canonical
+    # repository. A fork that pushes a `v*` tag would otherwise fail here.
     if: >-
-      github.event_name == 'push' ||
+      github.repository == 'kenn-io/ghosthub' &&
+      (github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main')
+      github.ref == 'refs/heads/main'))
     runs-on: macos-15
     timeout-minutes: 120
     environment:
@@ -319,7 +322,9 @@ jobs:
 
   publish-release:
     name: Publish GitHub release
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    if: >-
+      github.repository == 'kenn-io/ghosthub' &&
+      github.event_name == 'push' && github.ref_type == 'tag'
     needs: macos-release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/sandbox-image-maintenance.yml
+++ b/.github/workflows/sandbox-image-maintenance.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   inspect:
     name: Inspect pinned production digest
+    # Forks inherit the schedule trigger but do not own the production image.
+    if: github.repository == 'kenn-io/ghosthub'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/docs/release.md
+++ b/docs/release.md
@@ -214,6 +214,15 @@ visibly when operator action is required. The complete developer procedure is
 
 ## Protected signing environment
 
+Signing, notarization, and publishing jobs run only in `kenn-io/ghosthub`.
+Every such job in `.github/workflows/release.yml`, `nightly.yml`, and the
+sandbox image workflows carries a
+`github.repository == 'kenn-io/ghosthub'` condition, so a fork that inherits
+the tag or schedule trigger skips the job instead of failing on absent
+credentials. `tools/tests/test_workflow_fork_guards.py` enforces that contract.
+Validation lanes (`pull_request` and branch pushes) stay unguarded so forks
+can still build and test.
+
 Create a `release-signing` GitHub Actions environment before running the
 workflow. Configure it with:
 

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -1,9 +1,8 @@
-"""Publishing and scheduled workflow jobs must not run outside kenn-io/ghosthub.
+"""Sensitive GitHub Actions jobs must not be runnable in a fork.
 
-Forks inherit `schedule` and tag-push triggers but have none of the signing,
-notarization, or registry credentials, so unguarded jobs fail on every run in
-every fork. Validation lanes (`pull_request`, branch pushes) stay unguarded so
-forks can still build and test their own work.
+Forks inherit scheduled and tag-push workflows but do not have Ghosthub's
+signing, notarization, or publishing authority. Validation lanes remain
+available so forks can still build and test their own work.
 """
 
 from __future__ import annotations
@@ -13,122 +12,257 @@ import re
 
 import pytest
 import yaml
-from workflow_guards import requires
+from workflow_guards import overrides_implicit_success, requires
 
 CANONICAL_GUARD = "github.repository == 'kenn-io/ghosthub'"
-# `secrets.NAME`, `secrets['NAME']`, and reusable-workflow secret forwarding.
-SECRET_REFERENCE = re.compile(r"secrets\s*[.\[]")
-# Any status check function in an `if` replaces the implicit success
-# requirement, so the job can still run once a guarded dependency is skipped
-# and cannot inherit that dependency's guard.
-STATUS_OVERRIDE = re.compile(r"\b(always|success|failure|cancelled)\s*\(")
+SECRET_CONTEXT = re.compile(r"\bsecrets\b", re.IGNORECASE)
 WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 
 def load(path: pathlib.Path) -> dict:
-    return yaml.safe_load(path.read_text())
+    workflow = yaml.safe_load(path.read_text())
+    # PyYAML reads the bare `on` key as the YAML 1.1 boolean True. Normalize it
+    # once so mutated workflow fixtures serialize back to valid Actions YAML.
+    if True in workflow and "on" not in workflow:
+        workflow["on"] = workflow.pop(True)
+    return workflow
 
 
 def triggers(workflow: dict) -> dict:
-    # PyYAML reads the bare `on` key as the YAML 1.1 boolean True.
-    raw = workflow.get("on", workflow.get(True)) or {}
+    raw = workflow.get("on") or {}
     return raw if isinstance(raw, dict) else dict.fromkeys(raw)
 
 
 def guarded(job_name: str, jobs: dict, seen: frozenset[str] = frozenset()) -> bool:
-    """A job is guarded directly, or because every job it needs is guarded."""
+    """A job is guarded directly, or by a dependency that must be skipped."""
     if job_name in seen:
         return False
     job = jobs[job_name]
     condition = str(job.get("if", ""))
     if requires(condition, CANONICAL_GUARD):
         return True
-    if STATUS_OVERRIDE.search(condition):
+    if overrides_implicit_success(condition):
         return False
     needs = job.get("needs") or []
     if isinstance(needs, str):
         needs = [needs]
     return bool(needs) and all(
-        guarded(need, jobs, seen | {job_name}) for need in needs if need in jobs
+        need in jobs and guarded(need, jobs, seen | {job_name}) for need in needs
     )
 
 
-def consumes_secrets(job: dict) -> bool:
-    if "secrets" in job:  # reusable workflow call: `inherit` or an explicit map
+def action_expression_bodies(text: str) -> list[str]:
+    """Return expression bodies with quoted strings replaced by spaces."""
+    expressions = []
+    search_from = 0
+    while True:
+        start = text.find("${{", search_from)
+        if start == -1:
+            return expressions
+
+        body = []
+        index = start + 3
+        quoted = False
+        while index < len(text):
+            char = text[index]
+            if char == "'":
+                if quoted and text[index : index + 2] == "''":
+                    body.extend((" ", " "))
+                    index += 2
+                    continue
+                quoted = not quoted
+                body.append(" ")
+                index += 1
+                continue
+            if not quoted and text[index : index + 2] == "}}":
+                expressions.append("".join(body))
+                search_from = index + 2
+                break
+            body.append(" " if quoted else char)
+            index += 1
+        else:
+            return expressions
+
+
+def references_secret_context(value: object) -> bool:
+    if isinstance(value, str):
+        return any(
+            SECRET_CONTEXT.search(expression)
+            for expression in action_expression_bodies(value)
+        )
+    if isinstance(value, dict):
+        return any(references_secret_context(item) for item in value.values())
+    if isinstance(value, list):
+        return any(references_secret_context(item) for item in value)
+    return False
+
+
+def consumes_secrets(workflow: dict, job: dict) -> bool:
+    return (
+        "secrets" in job
+        or references_secret_context(workflow.get("env"))
+        or references_secret_context(job)
+    )
+
+
+def grants_write_access(workflow: dict, job: dict) -> bool:
+    permissions = job.get("permissions", workflow.get("permissions"))
+    if permissions == "write-all":
         return True
-    return bool(SECRET_REFERENCE.search(yaml.safe_dump(job)))
+    return isinstance(permissions, dict) and "write" in permissions.values()
 
 
-def workflow_files() -> list[pathlib.Path]:
-    return sorted(WORKFLOWS.glob("*.yml"))
+def workflow_files(root: pathlib.Path) -> list[pathlib.Path]:
+    return sorted((*root.glob("*.yml"), *root.glob("*.yaml")))
 
 
-def unguarded_jobs(path: pathlib.Path, *, secrets_only: bool) -> list[str]:
-    workflow = load(path)
-    jobs = workflow.get("jobs") or {}
-    if not secrets_only and "schedule" not in triggers(workflow):
-        return []
+def fork_runnable_sensitive_jobs(root: pathlib.Path) -> list[str]:
     offenders = []
-    for name, job in jobs.items():
-        if secrets_only and not consumes_secrets(job):
-            continue
-        if not guarded(name, jobs):
-            offenders.append(name)
+    for path in workflow_files(root):
+        workflow = load(path)
+        jobs = workflow.get("jobs") or {}
+        scheduled = "schedule" in triggers(workflow)
+        for name, job in jobs.items():
+            sensitive = (
+                scheduled
+                or consumes_secrets(workflow, job)
+                or grants_write_access(workflow, job)
+            )
+            if sensitive and not guarded(name, jobs):
+                offenders.append(f"{path.name}:{name}")
     return offenders
 
 
-@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
-def test_scheduled_jobs_are_repository_guarded(path: pathlib.Path) -> None:
-    assert unguarded_jobs(path, secrets_only=False) == []
-
-
-@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
-def test_secret_consuming_jobs_are_repository_guarded(path: pathlib.Path) -> None:
-    assert unguarded_jobs(path, secrets_only=True) == []
+def test_sensitive_jobs_cannot_run_in_forks() -> None:
+    assert fork_runnable_sensitive_jobs(WORKFLOWS) == []
 
 
 @pytest.mark.parametrize(
-    ("condition", "expected"),
+    ("workflow_name", "job_name", "mutation", "expected"),
     [
-        (CANONICAL_GUARD, True),
-        (f"{CANONICAL_GUARD} && github.ref == 'refs/heads/main'", True),
-        (f"always() && {CANONICAL_GUARD}", True),
-        (f"(github.event_name == 'push' || inputs.force) && {CANONICAL_GUARD}", True),
-        ("'kenn-io/ghosthub' == github.repository", True),
-        (f"{CANONICAL_GUARD} || github.event_name == 'push'", False),
-        (f"!({CANONICAL_GUARD})", False),
-        (
-            f"github.ref == 'refs/heads/main' && !({CANONICAL_GUARD} && inputs.force)",
-            False,
+        pytest.param(
+            "nightly.yml",
+            "eligibility",
+            "remove",
+            "nightly.yml:eligibility",
+            id="scheduled-job-loses-guard",
         ),
-        ("github.repository == 'someone/ghosthub'", False),
-        ("", False),
-        (f"{CANONICAL_GUARD} &&", False),
+        pytest.param(
+            "release.yml",
+            "macos-release",
+            "optional",
+            "release.yml:macos-release",
+            id="signing-job-makes-guard-optional",
+        ),
+        pytest.param(
+            "release.yml",
+            "publish-release",
+            "override",
+            "release.yml:publish-release",
+            id="write-enabled-job-bypasses-skipped-dependency",
+        ),
+        pytest.param(
+            "sandbox-image-maintenance.yml",
+            "inspect",
+            "negate",
+            "sandbox-image-maintenance.yml:inspect",
+            id="scheduled-job-negates-guard",
+        ),
+        pytest.param(
+            "sandbox-image-publish.yml",
+            "prepare",
+            "override",
+            "sandbox-image-publish.yml:publish",
+            id="publishing-job-bypasses-skipped-dependency",
+        ),
+        pytest.param(
+            "sandbox-image-publish.yml",
+            "prepare",
+            "not-cancelled",
+            "sandbox-image-publish.yml:publish",
+            id="publishing-job-replaces-implicit-success-check",
+        ),
+        pytest.param(
+            "website.yml",
+            "build",
+            "workflow-secret-env",
+            "website.yml:build",
+            id="job-inherits-workflow-secret-context",
+        ),
+        pytest.param(
+            "website.yml",
+            "build",
+            "whole-secret-context",
+            "website.yml:build",
+            id="job-uses-whole-secret-context",
+        ),
+        pytest.param(
+            "website.yml",
+            "build",
+            "formatted-secret-context",
+            "website.yml:build",
+            id="secret-follows-braces-in-format-string",
+        ),
     ],
 )
-def test_guard_must_be_mandatory_on_every_path(condition: str, expected: bool) -> None:
-    assert requires(condition, CANONICAL_GUARD) is expected
+def test_audit_catches_jobs_that_a_fork_could_run(
+    tmp_path: pathlib.Path,
+    workflow_name: str,
+    job_name: str,
+    mutation: str,
+    expected: str,
+) -> None:
+    workflow = load(WORKFLOWS / workflow_name)
+    job = workflow["jobs"][job_name]
+    if mutation == "remove":
+        job.pop("if", None)
+    elif mutation == "optional":
+        job["if"] = f"{job['if']} || github.event_name == 'push'"
+    elif mutation == "negate":
+        job["if"] = f"!({job['if']})"
+    elif mutation == "override":
+        job["if"] = "always()"
+    elif mutation == "not-cancelled":
+        job["if"] = "!cancelled()"
+    elif mutation == "workflow-secret-env":
+        workflow["env"] = {"TEST_TOKEN": "${{ secrets.TEST_TOKEN }}"}
+    elif mutation == "whole-secret-context":
+        job.setdefault("env", {})["SECRET_CONTEXT"] = "${{ toJSON(Secrets) }}"
+    elif mutation == "formatted-secret-context":
+        job.setdefault("env", {})["SECRET_CONTEXT"] = (
+            "${{ format('{{{0}}}', secrets.TEST_TOKEN) }}"
+        )
+    else:
+        raise AssertionError(f"unknown workflow mutation: {mutation}")
+
+    (tmp_path / workflow_name).write_text(yaml.safe_dump(workflow, sort_keys=False))
+
+    assert fork_runnable_sensitive_jobs(tmp_path) == [expected]
+
+
+def test_audit_checks_yaml_workflows(tmp_path: pathlib.Path) -> None:
+    workflow = load(WORKFLOWS / "sandbox-image-maintenance.yml")
+    workflow["jobs"]["inspect"].pop("if")
+    (tmp_path / "sandbox-image-maintenance.yaml").write_text(
+        yaml.safe_dump(workflow, sort_keys=False)
+    )
+
+    assert fork_runnable_sensitive_jobs(tmp_path) == [
+        "sandbox-image-maintenance.yaml:inspect"
+    ]
 
 
 @pytest.mark.parametrize(
-    ("condition", "expected"),
+    ("workflow_name", "job_name"),
     [
-        ("", True),
-        ("inputs.force", True),
-        ("success()", False),
-        ("success() || inputs.force", False),
-        ("always()", False),
-        ("failure()", False),
-        ("cancelled()", False),
-        (CANONICAL_GUARD, True),
-        (f"always() && {CANONICAL_GUARD}", True),
+        pytest.param("ci-pr.yml", "run", id="pull-request-dispatch"),
+        pytest.param("ci.yml", "macos-arm64", id="hosted-macos-validation"),
+        pytest.param("sandbox-image.yml", "check", id="sandbox-image-validation"),
     ],
 )
-def test_guard_inheritance_requires_the_implicit_success_check(
-    condition: str, expected: bool
+def test_validation_entry_jobs_do_not_require_the_canonical_repository(
+    workflow_name: str, job_name: str
 ) -> None:
-    jobs = {
-        "upstream": {"if": CANONICAL_GUARD},
-        "downstream": {"needs": "upstream", "if": condition},
-    }
-    assert guarded("downstream", jobs) is expected
+    workflow = load(WORKFLOWS / workflow_name)
+
+    assert not guarded(job_name, workflow["jobs"])

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -18,9 +18,10 @@ from workflow_guards import requires
 CANONICAL_GUARD = "github.repository == 'kenn-io/ghosthub'"
 # `secrets.NAME`, `secrets['NAME']`, and reusable-workflow secret forwarding.
 SECRET_REFERENCE = re.compile(r"secrets\s*[.\[]")
-# A job whose condition overrides the default success requirement still runs
-# when a guarded dependency is skipped, so it cannot inherit that guard.
-STATUS_OVERRIDE = re.compile(r"\b(always|failure|cancelled)\s*\(")
+# Any status check function in an `if` replaces the implicit success
+# requirement, so the job can still run once a guarded dependency is skipped
+# and cannot inherit that dependency's guard.
+STATUS_OVERRIDE = re.compile(r"\b(always|success|failure|cancelled)\s*\(")
 WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 
@@ -107,3 +108,27 @@ def test_secret_consuming_jobs_are_repository_guarded(path: pathlib.Path) -> Non
 )
 def test_guard_must_be_mandatory_on_every_path(condition: str, expected: bool) -> None:
     assert requires(condition, CANONICAL_GUARD) is expected
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected"),
+    [
+        ("", True),
+        ("inputs.force", True),
+        ("success()", False),
+        ("success() || inputs.force", False),
+        ("always()", False),
+        ("failure()", False),
+        ("cancelled()", False),
+        (CANONICAL_GUARD, True),
+        (f"always() && {CANONICAL_GUARD}", True),
+    ],
+)
+def test_guard_inheritance_requires_the_implicit_success_check(
+    condition: str, expected: bool
+) -> None:
+    jobs = {
+        "upstream": {"if": CANONICAL_GUARD},
+        "downstream": {"needs": "upstream", "if": condition},
+    }
+    assert guarded("downstream", jobs) is expected

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -13,6 +13,7 @@ import re
 
 import pytest
 import yaml
+from workflow_guards import requires
 
 CANONICAL_GUARD = "github.repository == 'kenn-io/ghosthub'"
 # `secrets.NAME`, `secrets['NAME']`, and reusable-workflow secret forwarding.
@@ -39,7 +40,7 @@ def guarded(job_name: str, jobs: dict, seen: frozenset[str] = frozenset()) -> bo
         return False
     job = jobs[job_name]
     condition = str(job.get("if", ""))
-    if CANONICAL_GUARD in condition:
+    if requires(condition, CANONICAL_GUARD):
         return True
     if STATUS_OVERRIDE.search(condition):
         return False
@@ -83,3 +84,26 @@ def test_scheduled_jobs_are_repository_guarded(path: pathlib.Path) -> None:
 @pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
 def test_secret_consuming_jobs_are_repository_guarded(path: pathlib.Path) -> None:
     assert unguarded_jobs(path, secrets_only=True) == []
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected"),
+    [
+        (CANONICAL_GUARD, True),
+        (f"{CANONICAL_GUARD} && github.ref == 'refs/heads/main'", True),
+        (f"always() && {CANONICAL_GUARD}", True),
+        (f"(github.event_name == 'push' || inputs.force) && {CANONICAL_GUARD}", True),
+        ("'kenn-io/ghosthub' == github.repository", True),
+        (f"{CANONICAL_GUARD} || github.event_name == 'push'", False),
+        (f"!({CANONICAL_GUARD})", False),
+        (
+            f"github.ref == 'refs/heads/main' && !({CANONICAL_GUARD} && inputs.force)",
+            False,
+        ),
+        ("github.repository == 'someone/ghosthub'", False),
+        ("", False),
+        (f"{CANONICAL_GUARD} &&", False),
+    ],
+)
+def test_guard_must_be_mandatory_on_every_path(condition: str, expected: bool) -> None:
+    assert requires(condition, CANONICAL_GUARD) is expected

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -9,11 +9,17 @@ forks can still build and test their own work.
 from __future__ import annotations
 
 import pathlib
+import re
 
 import pytest
 import yaml
 
 CANONICAL_GUARD = "github.repository == 'kenn-io/ghosthub'"
+# `secrets.NAME`, `secrets['NAME']`, and reusable-workflow secret forwarding.
+SECRET_REFERENCE = re.compile(r"secrets\s*[.\[]")
+# A job whose condition overrides the default success requirement still runs
+# when a guarded dependency is skipped, so it cannot inherit that guard.
+STATUS_OVERRIDE = re.compile(r"\b(always|failure|cancelled)\s*\(")
 WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 
@@ -32,14 +38,23 @@ def guarded(job_name: str, jobs: dict, seen: frozenset[str] = frozenset()) -> bo
     if job_name in seen:
         return False
     job = jobs[job_name]
-    if CANONICAL_GUARD in str(job.get("if", "")):
+    condition = str(job.get("if", ""))
+    if CANONICAL_GUARD in condition:
         return True
+    if STATUS_OVERRIDE.search(condition):
+        return False
     needs = job.get("needs") or []
     if isinstance(needs, str):
         needs = [needs]
     return bool(needs) and all(
         guarded(need, jobs, seen | {job_name}) for need in needs if need in jobs
     )
+
+
+def consumes_secrets(job: dict) -> bool:
+    if "secrets" in job:  # reusable workflow call: `inherit` or an explicit map
+        return True
+    return bool(SECRET_REFERENCE.search(yaml.safe_dump(job)))
 
 
 def workflow_files() -> list[pathlib.Path]:
@@ -53,7 +68,7 @@ def unguarded_jobs(path: pathlib.Path, *, secrets_only: bool) -> list[str]:
         return []
     offenders = []
     for name, job in jobs.items():
-        if secrets_only and "secrets." not in yaml.safe_dump(job):
+        if secrets_only and not consumes_secrets(job):
             continue
         if not guarded(name, jobs):
             offenders.append(name)

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -169,6 +169,13 @@ def test_sensitive_jobs_cannot_run_in_forks() -> None:
             id="scheduled-job-negates-guard",
         ),
         pytest.param(
+            "nightly.yml",
+            "eligibility",
+            "unary-not-precedence",
+            "nightly.yml:eligibility",
+            id="unary-not-binds-before-equality",
+        ),
+        pytest.param(
             "sandbox-image-publish.yml",
             "prepare",
             "override",
@@ -220,6 +227,8 @@ def test_audit_catches_jobs_that_a_fork_could_run(
         job["if"] = f"{job['if']} || github.event_name == 'push'"
     elif mutation == "negate":
         job["if"] = f"!({job['if']})"
+    elif mutation == "unary-not-precedence":
+        job["if"] = "!(!github.repository == 'kenn-io/ghosthub')"
     elif mutation == "override":
         job["if"] = "always()"
     elif mutation == "not-cancelled":

--- a/tools/tests/test_workflow_fork_guards.py
+++ b/tools/tests/test_workflow_fork_guards.py
@@ -1,0 +1,70 @@
+"""Publishing and scheduled workflow jobs must not run outside kenn-io/ghosthub.
+
+Forks inherit `schedule` and tag-push triggers but have none of the signing,
+notarization, or registry credentials, so unguarded jobs fail on every run in
+every fork. Validation lanes (`pull_request`, branch pushes) stay unguarded so
+forks can still build and test their own work.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+CANONICAL_GUARD = "github.repository == 'kenn-io/ghosthub'"
+WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+def load(path: pathlib.Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def triggers(workflow: dict) -> dict:
+    # PyYAML reads the bare `on` key as the YAML 1.1 boolean True.
+    raw = workflow.get("on", workflow.get(True)) or {}
+    return raw if isinstance(raw, dict) else dict.fromkeys(raw)
+
+
+def guarded(job_name: str, jobs: dict, seen: frozenset[str] = frozenset()) -> bool:
+    """A job is guarded directly, or because every job it needs is guarded."""
+    if job_name in seen:
+        return False
+    job = jobs[job_name]
+    if CANONICAL_GUARD in str(job.get("if", "")):
+        return True
+    needs = job.get("needs") or []
+    if isinstance(needs, str):
+        needs = [needs]
+    return bool(needs) and all(
+        guarded(need, jobs, seen | {job_name}) for need in needs if need in jobs
+    )
+
+
+def workflow_files() -> list[pathlib.Path]:
+    return sorted(WORKFLOWS.glob("*.yml"))
+
+
+def unguarded_jobs(path: pathlib.Path, *, secrets_only: bool) -> list[str]:
+    workflow = load(path)
+    jobs = workflow.get("jobs") or {}
+    if not secrets_only and "schedule" not in triggers(workflow):
+        return []
+    offenders = []
+    for name, job in jobs.items():
+        if secrets_only and "secrets." not in yaml.safe_dump(job):
+            continue
+        if not guarded(name, jobs):
+            offenders.append(name)
+    return offenders
+
+
+@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
+def test_scheduled_jobs_are_repository_guarded(path: pathlib.Path) -> None:
+    assert unguarded_jobs(path, secrets_only=False) == []
+
+
+@pytest.mark.parametrize("path", workflow_files(), ids=lambda p: p.name)
+def test_secret_consuming_jobs_are_repository_guarded(path: pathlib.Path) -> None:
+    assert unguarded_jobs(path, secrets_only=True) == []

--- a/tools/workflow_guards.py
+++ b/tools/workflow_guards.py
@@ -1,46 +1,14 @@
-"""Decide whether a GitHub Actions condition truly requires a guard.
-
-Substring matching cannot answer that question: `!(github.repository == 'x')`
-and `github.repository == 'x' || github.event_name == 'push'` both contain the
-guard text while still running elsewhere. This module parses the condition and
-asks whether it can evaluate true while the guard is false. Every other term is
-treated as free, so the answer is conservative: an expression is accepted only
-when the guard is a mandatory conjunct on every path.
-"""
+"""Conservative checks for canonical GitHub Actions job guards."""
 
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
+import ast
 
-_IDENTIFIER_TAIL = re.compile(r"[A-Za-z0-9_.\]']$")
+STATUS_CHECKS = frozenset({"always", "cancelled", "failure", "success"})
 
 
 class ParseError(ValueError):
     """The condition is not an expression this module can reason about."""
-
-
-@dataclass(frozen=True)
-class Atom:
-    text: str
-
-
-@dataclass(frozen=True)
-class Not:
-    operand: Node
-
-
-@dataclass(frozen=True)
-class And:
-    operands: tuple[Node, ...]
-
-
-@dataclass(frozen=True)
-class Or:
-    operands: tuple[Node, ...]
-
-
-Node = Atom | Not | And | Or
 
 
 def normalize(text: str) -> str:
@@ -48,163 +16,104 @@ def normalize(text: str) -> str:
     return " ".join(text.split())
 
 
-def tokenize(condition: str) -> list[str]:
-    tokens: list[str] = []
-    atom = ""
-    index = 0
-    quote = ""
-
-    def flush() -> None:
-        nonlocal atom
-        if atom.strip():
-            tokens.append(normalize(atom))
-        atom = ""
-
-    while index < len(condition):
-        char = condition[index]
-        if quote:
-            atom += char
-            if char == quote:
-                quote = ""
-            index += 1
-            continue
-        if char in "'\"":
-            quote = char
-            atom += char
-            index += 1
-            continue
-        pair = condition[index : index + 2]
-        if pair in ("&&", "||"):
-            flush()
-            tokens.append(pair)
-            index += 2
-            continue
-        if char == "!" and pair != "!=":
-            flush()
-            tokens.append("!")
-            index += 1
-            continue
-        if char == "(" and _IDENTIFIER_TAIL.search(atom.strip()):
-            # A function call such as `always()` or `contains(a, 'b')` is one
-            # atom, not a parenthesized subexpression.
-            group, index = _consume_group(condition, index)
-            atom += group
-            continue
-        if char == "(":
-            flush()
-            tokens.append("(")
-            index += 1
-            continue
-        if char == ")":
-            flush()
-            tokens.append(")")
-            index += 1
-            continue
-        atom += char
-        index += 1
-
-    if quote:
-        raise ParseError(f"unterminated string in {condition!r}")
-    flush()
-    return tokens
-
-
-def _consume_group(condition: str, start: int) -> tuple[str, int]:
-    depth = 0
-    quote = ""
-    for index in range(start, len(condition)):
-        char = condition[index]
-        if quote:
-            if char == quote:
-                quote = ""
-            continue
-        if char in "'\"":
-            quote = char
-        elif char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-            if depth == 0:
-                return condition[start : index + 1], index + 1
-    raise ParseError(f"unbalanced parentheses in {condition!r}")
-
-
-def parse(condition: str) -> Node:
+def _python_syntax(condition: str) -> str:
+    """Translate GitHub's Boolean operators without changing string literals."""
     text = normalize(condition)
     if text.startswith("${{") and text.endswith("}}"):
-        text = text[3:-2]
-    tokens = tokenize(text)
-    if not tokens:
-        raise ParseError("empty condition")
-    node, rest = _parse_or(tokens)
-    if rest:
-        raise ParseError(f"trailing tokens {rest!r} in {condition!r}")
-    return node
+        text = text[3:-2].strip()
+
+    translated: list[str] = []
+    index = 0
+    quoted = False
+    while index < len(text):
+        char = text[index]
+        if char == "'":
+            translated.append(char)
+            if quoted and text[index : index + 2] == "''":
+                translated.append("'")
+                index += 2
+                continue
+            quoted = not quoted
+            index += 1
+            continue
+        if not quoted:
+            pair = text[index : index + 2]
+            if pair == "&&":
+                translated.append(" and ")
+                index += 2
+                continue
+            if pair == "||":
+                translated.append(" or ")
+                index += 2
+                continue
+            if char == "!" and pair != "!=":
+                translated.append(" not ")
+                index += 1
+                continue
+        translated.append(char)
+        index += 1
+
+    if quoted:
+        raise ParseError(f"unterminated string in {condition!r}")
+    return "".join(translated).strip()
 
 
-def _parse_or(tokens: list[str]) -> tuple[Node, list[str]]:
-    node, tokens = _parse_and(tokens)
-    operands = [node]
-    while tokens and tokens[0] == "||":
-        node, tokens = _parse_and(tokens[1:])
-        operands.append(node)
-    return (operands[0] if len(operands) == 1 else Or(tuple(operands)), tokens)
+def parse(condition: str) -> ast.expr:
+    try:
+        return ast.parse(_python_syntax(condition), mode="eval").body
+    except (SyntaxError, ValueError) as error:
+        raise ParseError(str(error)) from error
 
 
-def _parse_and(tokens: list[str]) -> tuple[Node, list[str]]:
-    node, tokens = _parse_unary(tokens)
-    operands = [node]
-    while tokens and tokens[0] == "&&":
-        node, tokens = _parse_unary(tokens[1:])
-        operands.append(node)
-    return (operands[0] if len(operands) == 1 else And(tuple(operands)), tokens)
+def _same(left: ast.AST, right: ast.AST) -> bool:
+    return ast.dump(left, include_attributes=False) == ast.dump(
+        right, include_attributes=False
+    )
 
 
-def _parse_unary(tokens: list[str]) -> tuple[Node, list[str]]:
-    if not tokens:
-        raise ParseError("expression ends after an operator")
-    head, rest = tokens[0], tokens[1:]
-    if head == "!":
-        node, rest = _parse_unary(rest)
-        return Not(node), rest
-    if head == "(":
-        node, rest = _parse_or(rest)
-        if not rest or rest[0] != ")":
-            raise ParseError("missing closing parenthesis")
-        return node, rest[1:]
-    if head in ("&&", "||", ")"):
-        raise ParseError(f"unexpected token {head!r}")
-    return Atom(head), rest
-
-
-def _outcomes(node: Node, guard: str) -> tuple[bool, bool]:
-    """Return (can be true, can be false) while the guard evaluates false."""
-    if isinstance(node, Atom):
-        return (not _is_guard(node.text, guard), True)
-    if isinstance(node, Not):
+def _outcomes(node: ast.expr, guard: ast.expr) -> tuple[bool, bool]:
+    """Return (can be true, can be false) while the guard is false."""
+    if _same(node, guard):
+        return False, True
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
         can_true, can_false = _outcomes(node.operand, guard)
-        return (can_false, can_true)
-    children = [_outcomes(operand, guard) for operand in node.operands]
-    if isinstance(node, And):
-        return (all(t for t, _ in children), any(f for _, f in children))
-    return (any(t for t, _ in children), all(f for _, f in children))
-
-
-def _is_guard(atom: str, guard: str) -> bool:
-    if atom == guard:
-        return True
-    left, operator, right = guard.partition("==")
-    return bool(operator) and atom == f"{right.strip()} == {left.strip()}"
+        return can_false, can_true
+    if isinstance(node, ast.BoolOp):
+        children = [_outcomes(value, guard) for value in node.values]
+        if isinstance(node.op, ast.And):
+            return all(can_true for can_true, _ in children), any(
+                can_false for _, can_false in children
+            )
+        return any(can_true for can_true, _ in children), all(
+            can_false for _, can_false in children
+        )
+    # Every unrelated expression is free to be true or false. This can reject
+    # an unusual but safe condition, but it cannot approve an unsafe one.
+    return True, True
 
 
 def requires(condition: str, guard: str) -> bool:
-    """True when `condition` can only hold while `guard` holds.
-
-    An unparsable condition is reported as not requiring the guard.
-    """
+    """Return whether a condition requires the exact, canonical guard AST."""
     try:
-        node = parse(condition)
+        expression = parse(condition)
+        guard_expression = parse(guard)
     except ParseError:
         return False
-    can_be_true, _ = _outcomes(node, normalize(guard))
+    can_be_true, _ = _outcomes(expression, guard_expression)
     return not can_be_true
+
+
+def overrides_implicit_success(condition: str) -> bool:
+    """Return whether a condition names a GitHub status-check function."""
+    if not normalize(condition):
+        return False
+    try:
+        expression = parse(condition)
+    except ParseError:
+        return True
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id.lower() in STATUS_CHECKS
+        for node in ast.walk(expression)
+    )

--- a/tools/workflow_guards.py
+++ b/tools/workflow_guards.py
@@ -17,7 +17,7 @@ def normalize(text: str) -> str:
 
 
 def _python_syntax(condition: str) -> str:
-    """Translate GitHub's Boolean operators without changing string literals."""
+    """Translate Boolean operators while preserving GitHub's precedence."""
     text = normalize(condition)
     if text.startswith("${{") and text.endswith("}}"):
         text = text[3:-2].strip()
@@ -47,7 +47,10 @@ def _python_syntax(condition: str) -> str:
                 index += 2
                 continue
             if char == "!" and pair != "!=":
-                translated.append(" not ")
+                # Python's `not` binds less tightly than comparisons, unlike
+                # GitHub's `!`. Unary `~` has the required precedence and acts
+                # only as an AST marker; these expressions are never evaluated.
+                translated.append(" ~ ")
                 index += 1
                 continue
         translated.append(char)
@@ -75,7 +78,7 @@ def _outcomes(node: ast.expr, guard: ast.expr) -> tuple[bool, bool]:
     """Return (can be true, can be false) while the guard is false."""
     if _same(node, guard):
         return False, True
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Invert):
         can_true, can_false = _outcomes(node.operand, guard)
         return can_false, can_true
     if isinstance(node, ast.BoolOp):

--- a/tools/workflow_guards.py
+++ b/tools/workflow_guards.py
@@ -1,0 +1,210 @@
+"""Decide whether a GitHub Actions condition truly requires a guard.
+
+Substring matching cannot answer that question: `!(github.repository == 'x')`
+and `github.repository == 'x' || github.event_name == 'push'` both contain the
+guard text while still running elsewhere. This module parses the condition and
+asks whether it can evaluate true while the guard is false. Every other term is
+treated as free, so the answer is conservative: an expression is accepted only
+when the guard is a mandatory conjunct on every path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_IDENTIFIER_TAIL = re.compile(r"[A-Za-z0-9_.\]']$")
+
+
+class ParseError(ValueError):
+    """The condition is not an expression this module can reason about."""
+
+
+@dataclass(frozen=True)
+class Atom:
+    text: str
+
+
+@dataclass(frozen=True)
+class Not:
+    operand: Node
+
+
+@dataclass(frozen=True)
+class And:
+    operands: tuple[Node, ...]
+
+
+@dataclass(frozen=True)
+class Or:
+    operands: tuple[Node, ...]
+
+
+Node = Atom | Not | And | Or
+
+
+def normalize(text: str) -> str:
+    """Collapse whitespace so folded YAML scalars compare by content."""
+    return " ".join(text.split())
+
+
+def tokenize(condition: str) -> list[str]:
+    tokens: list[str] = []
+    atom = ""
+    index = 0
+    quote = ""
+
+    def flush() -> None:
+        nonlocal atom
+        if atom.strip():
+            tokens.append(normalize(atom))
+        atom = ""
+
+    while index < len(condition):
+        char = condition[index]
+        if quote:
+            atom += char
+            if char == quote:
+                quote = ""
+            index += 1
+            continue
+        if char in "'\"":
+            quote = char
+            atom += char
+            index += 1
+            continue
+        pair = condition[index : index + 2]
+        if pair in ("&&", "||"):
+            flush()
+            tokens.append(pair)
+            index += 2
+            continue
+        if char == "!" and pair != "!=":
+            flush()
+            tokens.append("!")
+            index += 1
+            continue
+        if char == "(" and _IDENTIFIER_TAIL.search(atom.strip()):
+            # A function call such as `always()` or `contains(a, 'b')` is one
+            # atom, not a parenthesized subexpression.
+            group, index = _consume_group(condition, index)
+            atom += group
+            continue
+        if char == "(":
+            flush()
+            tokens.append("(")
+            index += 1
+            continue
+        if char == ")":
+            flush()
+            tokens.append(")")
+            index += 1
+            continue
+        atom += char
+        index += 1
+
+    if quote:
+        raise ParseError(f"unterminated string in {condition!r}")
+    flush()
+    return tokens
+
+
+def _consume_group(condition: str, start: int) -> tuple[str, int]:
+    depth = 0
+    quote = ""
+    for index in range(start, len(condition)):
+        char = condition[index]
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in "'\"":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return condition[start : index + 1], index + 1
+    raise ParseError(f"unbalanced parentheses in {condition!r}")
+
+
+def parse(condition: str) -> Node:
+    text = normalize(condition)
+    if text.startswith("${{") and text.endswith("}}"):
+        text = text[3:-2]
+    tokens = tokenize(text)
+    if not tokens:
+        raise ParseError("empty condition")
+    node, rest = _parse_or(tokens)
+    if rest:
+        raise ParseError(f"trailing tokens {rest!r} in {condition!r}")
+    return node
+
+
+def _parse_or(tokens: list[str]) -> tuple[Node, list[str]]:
+    node, tokens = _parse_and(tokens)
+    operands = [node]
+    while tokens and tokens[0] == "||":
+        node, tokens = _parse_and(tokens[1:])
+        operands.append(node)
+    return (operands[0] if len(operands) == 1 else Or(tuple(operands)), tokens)
+
+
+def _parse_and(tokens: list[str]) -> tuple[Node, list[str]]:
+    node, tokens = _parse_unary(tokens)
+    operands = [node]
+    while tokens and tokens[0] == "&&":
+        node, tokens = _parse_unary(tokens[1:])
+        operands.append(node)
+    return (operands[0] if len(operands) == 1 else And(tuple(operands)), tokens)
+
+
+def _parse_unary(tokens: list[str]) -> tuple[Node, list[str]]:
+    if not tokens:
+        raise ParseError("expression ends after an operator")
+    head, rest = tokens[0], tokens[1:]
+    if head == "!":
+        node, rest = _parse_unary(rest)
+        return Not(node), rest
+    if head == "(":
+        node, rest = _parse_or(rest)
+        if not rest or rest[0] != ")":
+            raise ParseError("missing closing parenthesis")
+        return node, rest[1:]
+    if head in ("&&", "||", ")"):
+        raise ParseError(f"unexpected token {head!r}")
+    return Atom(head), rest
+
+
+def _outcomes(node: Node, guard: str) -> tuple[bool, bool]:
+    """Return (can be true, can be false) while the guard evaluates false."""
+    if isinstance(node, Atom):
+        return (not _is_guard(node.text, guard), True)
+    if isinstance(node, Not):
+        can_true, can_false = _outcomes(node.operand, guard)
+        return (can_false, can_true)
+    children = [_outcomes(operand, guard) for operand in node.operands]
+    if isinstance(node, And):
+        return (all(t for t, _ in children), any(f for _, f in children))
+    return (any(t for t, _ in children), all(f for _, f in children))
+
+
+def _is_guard(atom: str, guard: str) -> bool:
+    if atom == guard:
+        return True
+    left, operator, right = guard.partition("==")
+    return bool(operator) and atom == f"{right.strip()} == {left.strip()}"
+
+
+def requires(condition: str, guard: str) -> bool:
+    """True when `condition` can only hold while `guard` holds.
+
+    An unparsable condition is reported as not requiring the guard.
+    """
+    try:
+        node = parse(condition)
+    except ParseError:
+        return False
+    can_be_true, _ = _outcomes(node, normalize(guard))
+    return not can_be_true


### PR DESCRIPTION
Forks inherit Ghosthub's scheduled and release workflows but do not have the
canonical repository's signing, notarization, or publishing authority.
Sensitive jobs now skip outside `kenn-io/ghosthub` instead of creating
recurring failed runs.

- Require the canonical repository for Nightly, Release, and sandbox image
  maintenance jobs, including downstream signing and publishing paths.
- Keep pull-request, branch, and sandbox image validation available to forks.
- Audit every scheduled, secret-consuming, and write-enabled job across both
  `.yml` and `.yaml` workflow files.
- Exercise the policy against mutations of the real workflow graph, including
  optional or negated guards, status-check dependency bypasses, inherited
  secret contexts, and permission changes.
