### PR TITLE
Allow forced removal of dirty worktrees

### DIFF
--- a/Sources/App/KwtWorktreeClient.swift
+++ b/Sources/App/KwtWorktreeClient.swift
@@ -13,10 +13,13 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
     case removalIdentityUnavailable
     case removalTargetChanged
     case removalHostChanged
+    case removalChangesChanged
     case removalPreflightUnavailable(host: String, message: String)
     case sessionStartedAfterConfirmation(session: String)
     case commandFailed(host: String, status: Int32)
     case removalFailed(host: String, status: Int32)
+    case changeStatusFailed(host: String, status: Int32)
+    case malformedChangeStatus(host: String)
     case createdWorktreeMissing(branch: String)
     case malformedBranches(host: String)
 
@@ -43,6 +46,9 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
         case .removalHostChanged:
             "The host destination changed after confirmation. Review the host"
                 + " settings and try again."
+        case .removalChangesChanged:
+            "The worktree gained uncommitted changes after confirmation."
+                + " Review the updated removal warning and try again."
         case let .removalPreflightUnavailable(host, message):
             "kwt could not verify the worktree on \(host): \(message)"
         case let .sessionStartedAfterConfirmation(session):
@@ -52,6 +58,11 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
             "kwt could not create the worktree on \(host) (status \(status))."
         case let .removalFailed(host, status):
             "kwt could not remove the worktree on \(host) (status \(status))."
+        case let .changeStatusFailed(host, status):
+            "kwt could not check the worktree for uncommitted changes on"
+                + " \(host) (status \(status))."
+        case let .malformedChangeStatus(host):
+            "kwt returned an invalid worktree change status on \(host)."
         case let .createdWorktreeMissing(branch):
             "kwt completed, but \(branch) was not present in the refreshed inventory."
         case let .malformedBranches(host):
@@ -60,8 +71,9 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
     }
 }
 
-/// Executes only kwt's supported worktree-creation surface. Ghosthub does not
-/// choose a worktree path or launch its own workspace/session implementation.
+/// Executes only kwt's supported worktree lifecycle surfaces. Ghosthub does
+/// not choose a worktree path or launch its own workspace/session
+/// implementation.
 struct KwtWorktreeClient: Sendable {
     private static let jsonMarker = "GHOSTHUB_KWT_JSON\n"
     typealias LocalRunner = @Sendable (
@@ -234,6 +246,7 @@ struct KwtWorktreeClient: Sendable {
         worktreePath: String,
         generation: String,
         projectPath: String,
+        force: Bool = false,
         on host: CommandHost
     ) async throws {
         let binaryPrelude: String
@@ -260,6 +273,7 @@ struct KwtWorktreeClient: Sendable {
             worktreePath: worktreePath,
             generation: generation,
             projectPath: projectPath,
+            force: force,
             platform: platform,
             binaryPrelude: binaryPrelude,
             windowsKwtRelativePath: windowsKwtRelativePath
@@ -279,6 +293,87 @@ struct KwtWorktreeClient: Sendable {
             throw KwtWorktreeError.removalFailed(
                 host: host.displayName,
                 status: result.status
+            )
+        }
+    }
+
+    func changes(
+        worktreePath: String,
+        projectPath: String,
+        on host: CommandHost
+    ) async throws -> WorktreeChangeSummary {
+        let binaryPrelude: String
+        let windowsKwtRelativePath: String?
+        let platform: SSHHostInfo.Platform
+        switch host {
+        case .local:
+            binaryPrelude = KwtBinaryLocator.commandPrelude(
+                exactPath: localBinaryPath
+            )
+            windowsKwtRelativePath = nil
+            platform = .posix
+        case let .ssh(info):
+            binaryPrelude = KwtBinaryLocator.remoteCommandPrelude(
+                revision: remoteBinaryRevision
+            )
+            windowsKwtRelativePath =
+                KwtBinaryLocator.windowsRemoteManagedRelativePath(
+                    revision: remoteBinaryRevision
+                )
+            platform = info.platform
+        }
+        let command = Self.changesCommand(
+            projectPath: projectPath,
+            platform: platform,
+            binaryPrelude: binaryPrelude,
+            windowsKwtRelativePath: windowsKwtRelativePath
+        )
+        let localRunner = localRunner
+        let remoteRunner = remoteRunner
+        let shell = loginShellProvider()
+        let result = await Task.detached(priority: .userInitiated) {
+            switch host {
+            case .local:
+                localRunner(shell, command)
+            case let .ssh(info):
+                remoteRunner(info, command)
+            }
+        }.value
+        guard result.status == 0 else {
+            throw KwtWorktreeError.changeStatusFailed(
+                host: host.displayName,
+                status: result.status
+            )
+        }
+        let normalizedOutput = result.stdout.replacingOccurrences(
+            of: "\r\n",
+            with: "\n"
+        )
+        guard let markerRange = normalizedOutput.range(
+            of: Self.jsonMarker,
+            options: .backwards
+        ) else {
+            throw KwtWorktreeError.malformedChangeStatus(
+                host: host.displayName
+            )
+        }
+        let json = normalizedOutput[markerRange.upperBound...]
+        do {
+            let records = try JSONDecoder().decode(
+                [KwtWorktreeChangeRecord].self,
+                from: Data(json.utf8)
+            )
+            guard let record = records.first(where: {
+                $0.path == worktreePath
+            }) else {
+                return .clean
+            }
+            return record.gitStatus.summary
+        } catch let error as KwtWorktreeError {
+            throw error
+        } catch {
+            throw KwtWorktreeError.malformedChangeStatus(
+                host: host.displayName
             )
         }
     }
@@ -344,27 +439,84 @@ struct KwtWorktreeClient: Sendable {
         worktreePath: String,
         generation: String,
         projectPath: String,
+        force: Bool,
         platform: SSHHostInfo.Platform,
         binaryPrelude: String,
         windowsKwtRelativePath: String?
     ) -> String {
         if platform == .windows {
+            var arguments = ["remove"]
+            if force {
+                arguments.append("--force")
+            }
+            arguments += [
+                "--if-generation",
+                generation,
+                worktreePath,
+            ]
             return KwtPowerShellCommand.run(
-                arguments: [
-                    "remove",
-                    "--if-generation",
-                    generation,
-                    worktreePath,
-                ],
+                arguments: arguments,
                 workingDirectory: projectPath,
                 managedRelativePath: windowsKwtRelativePath
             )
         }
         return binaryPrelude
             + "cd -- \(shellQuotedCommandArgument(projectPath)) || exit $?; "
-            + "exec \"$ghosthub_kwt_path\" remove --if-generation "
+            + "exec \"$ghosthub_kwt_path\" remove"
+            + (force ? " --force" : "")
+            + " --if-generation "
             + shellQuotedCommandArgument(generation)
             + " "
             + shellQuotedCommandArgument(worktreePath)
+    }
+
+    private static func changesCommand(
+        projectPath: String,
+        platform: SSHHostInfo.Platform,
+        binaryPrelude: String,
+        windowsKwtRelativePath: String?
+    ) -> String {
+        if platform == .windows {
+            return KwtPowerShellCommand.run(
+                arguments: ["status", "--json", "--no-fetch"],
+                workingDirectory: projectPath,
+                marker: "GHOSTHUB_KWT_JSON",
+                managedRelativePath: windowsKwtRelativePath
+            )
+        }
+        return binaryPrelude
+            + "cd -- \(shellQuotedCommandArgument(projectPath)) || exit $?; "
+            + "printf 'GHOSTHUB_KWT_JSON\\n'; "
+            + "exec \"$ghosthub_kwt_path\" status --json --no-fetch"
+    }
+}
+
+private struct KwtWorktreeChangeRecord: Decodable {
+    let path: String
+    let gitStatus: KwtGitStatusRecord
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case gitStatus = "git_status"
+    }
+}
+
+private struct KwtGitStatusRecord: Decodable {
+    let modified: Int
+    let added: Int
+    let deleted: Int
+    let untracked: Int
+    let staged: Int
+    let conflicts: Int
+
+    var summary: WorktreeChangeSummary {
+        WorktreeChangeSummary(
+            modified: modified,
+            added: added,
+            deleted: deleted,
+            untracked: untracked,
+            staged: staged,
+            conflicts: conflicts
+        )
     }
 }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -55,6 +55,9 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias KwtWorktreeRemover = @Sendable (
         String, String, String, CommandHost
     ) async throws -> Void
+    typealias KwtWorktreeChangeReader = @Sendable (
+        String, String, CommandHost
+    ) async throws -> WorktreeChangeSummary
     typealias KwtBranchLister = @Sendable (
         String, CommandHost
     ) async throws -> [WorktreeBranchCandidate]
@@ -748,6 +751,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private let kwtRemoteProvisioner: KwtRemoteProvisioner
     private let kwtWorktreeCreator: KwtWorktreeCreator
     private let kwtWorktreeRemover: KwtWorktreeRemover
+    private let kwtForceWorktreeRemover: KwtWorktreeRemover
+    private let kwtWorktreeChangeReader: KwtWorktreeChangeReader
     private let kwtBranchLister: KwtBranchLister
     private let kwtPullRequestLister: KwtPullRequestLister
     private let kwtPullRequestImporter: KwtPullRequestImporter
@@ -967,6 +972,24 @@ final class WorkspaceSceneModel: ObservableObject {
             try await KwtWorktreeClient().remove(
                 worktreePath: worktreePath,
                 generation: generation,
+                projectPath: projectPath,
+                on: host
+            )
+        },
+        kwtForceWorktreeRemover: @escaping KwtWorktreeRemover = {
+            worktreePath, generation, projectPath, host in
+            try await KwtWorktreeClient().remove(
+                worktreePath: worktreePath,
+                generation: generation,
+                projectPath: projectPath,
+                force: true,
+                on: host
+            )
+        },
+        kwtWorktreeChangeReader: @escaping KwtWorktreeChangeReader = {
+            worktreePath, projectPath, host in
+            try await KwtWorktreeClient().changes(
+                worktreePath: worktreePath,
                 projectPath: projectPath,
                 on: host
             )
@@ -1215,6 +1238,8 @@ final class WorkspaceSceneModel: ObservableObject {
         self.kwtRemoteProvisioner = kwtRemoteProvisioner
         self.kwtWorktreeCreator = kwtWorktreeCreator
         self.kwtWorktreeRemover = kwtWorktreeRemover
+        self.kwtForceWorktreeRemover = kwtForceWorktreeRemover
+        self.kwtWorktreeChangeReader = kwtWorktreeChangeReader
         self.kwtBranchLister = kwtBranchLister
         self.kwtPullRequestLister = kwtPullRequestLister
         self.kwtPullRequestImporter = kwtPullRequestImporter
@@ -2460,6 +2485,11 @@ final class WorkspaceSceneModel: ObservableObject {
         ) else {
             throw KwtWorktreeError.removalIdentityUnavailable
         }
+        let changes = try await kwtWorktreeChangeReader(
+            worktree.path,
+            project.rootPath,
+            host
+        )
 
         let sessionKillRequest: TmuxSessionKillRequest?
         if let session = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -2498,7 +2528,8 @@ final class WorkspaceSceneModel: ObservableObject {
             worktree: worktree,
             project: project,
             confirmedHost: hostSummary,
-            sessionKillRequest: sessionKillRequest
+            sessionKillRequest: sessionKillRequest,
+            changes: changes
         )
     }
 
@@ -2592,6 +2623,20 @@ final class WorkspaceSceneModel: ObservableObject {
         guard let generation = worktree.generation else {
             throw KwtWorktreeError.removalTargetChanged
         }
+        if !checkoutAlreadyAbsent {
+            let currentChanges = try await kwtWorktreeChangeReader(
+                worktree.path,
+                project.rootPath,
+                confirmedHost
+            )
+            guard removalHostEndpointMatches(request) else {
+                throw KwtWorktreeError.removalHostChanged
+            }
+            if currentChanges.hasUncommittedChanges,
+               !request.forceRemoval {
+                throw KwtWorktreeError.removalChangesChanged
+            }
+        }
         let removalTombstone =
             WorktreeMutationCoordinator.RemovalTombstone(
                 path: worktree.path,
@@ -2636,7 +2681,10 @@ final class WorkspaceSceneModel: ObservableObject {
             }
             if !checkoutAlreadyAbsent {
                 do {
-                    try await kwtWorktreeRemover(
+                    let remover = request.forceRemoval
+                        ? kwtForceWorktreeRemover
+                        : kwtWorktreeRemover
+                    try await remover(
                         worktree.path,
                         generation,
                         project.rootPath,
@@ -2757,6 +2805,8 @@ final class WorkspaceSceneModel: ObservableObject {
              TmuxSessionKillError.sessionNotRunning:
             return .refreshSessionIdentity
         case KwtWorktreeError.removalTargetChanged:
+            return .reconfirmChangedTarget
+        case KwtWorktreeError.removalChangesChanged:
             return .reconfirmChangedTarget
         case KwtWorktreeError.sessionStartedAfterConfirmation:
             return .reconfirmStartedSession
@@ -3073,6 +3123,7 @@ final class WorkspaceSceneModel: ObservableObject {
             matches: updatedRequest.worktree,
             project: updatedRequest.project
         ) || updatedRequest.sessionKillRequest != request.sessionKillRequest
+            || updatedRequest.changes != request.changes
     }
 
     private func removalHostEndpointMatches(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2587,6 +2587,8 @@ final class WorkspaceSceneModel: ObservableObject {
             Set<WorkspaceTmuxSessionSelection>?
         var requiresWorkspaceReestablishment = false
         var terminatedSession = false
+        var killedSessionReestablishmentTarget:
+            WorkspaceTmuxSessionSelection?
         invalidateKwtInventoryRefresh()
         defer {
             ownsWorktreeMutation = false
@@ -2598,6 +2600,14 @@ final class WorkspaceSceneModel: ObservableObject {
                 requiresWorkspaceReestablishment:
                 requiresWorkspaceReestablishment
             )
+            if let killedSessionReestablishmentTarget {
+                _ = presentTmuxSession(
+                    killedSessionReestablishmentTarget,
+                    launchMode: .attach,
+                    intent: .userInitiated,
+                    activatesPresentation: false
+                )
+            }
         }
 
         let preflight: KwtHostInventory
@@ -2708,6 +2718,9 @@ final class WorkspaceSceneModel: ObservableObject {
                     if outcome.targetChanged {
                         throw KwtWorktreeError.removalTargetChanged
                     }
+                    let killedRestorationTarget = terminatedSession
+                        ? outcome.restorationTargets?.first
+                        : nil
                     if !request.forceRemoval,
                        let worktreeError = removalError as? KwtWorktreeError,
                        case .removalFailed = worktreeError,
@@ -2717,7 +2730,10 @@ final class WorkspaceSceneModel: ObservableObject {
                            confirmedHost
                        ),
                        removalHostEndpointMatches(request),
+                       !terminatedSession || killedRestorationTarget != nil,
                        changes.hasUncommittedChanges {
+                        killedSessionReestablishmentTarget =
+                            killedRestorationTarget
                         throw KwtWorktreeError.removalChangesChanged
                     }
                     throw removalError

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2708,6 +2708,18 @@ final class WorkspaceSceneModel: ObservableObject {
                     if outcome.targetChanged {
                         throw KwtWorktreeError.removalTargetChanged
                     }
+                    if !request.forceRemoval,
+                       let worktreeError = removalError as? KwtWorktreeError,
+                       case .removalFailed = worktreeError,
+                       let changes = try? await kwtWorktreeChangeReader(
+                           worktree.path,
+                           project.rootPath,
+                           confirmedHost
+                       ),
+                       removalHostEndpointMatches(request),
+                       changes.hasUncommittedChanges {
+                        throw KwtWorktreeError.removalChangesChanged
+                    }
                     throw removalError
                 }
             }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -1421,19 +1421,12 @@ public struct RootView: View {
                 dismissButton: .default(Text("OK"))
             )
         case let .worktreeRemovalConfirmation(request):
-            let sessionMessage = request.sessionKillRequest == nil
-                ? ""
-                : " Its live tmux session will be terminated first,"
-                + " including every window, pane, and process."
             return Alert(
                 title: Text("Remove “\(request.worktree.name)”?"),
-                message: Text(
-                    "This removes the worktree at "
-                        + "\(request.worktree.path)."
-                        + sessionMessage
-                        + " The Git branch will be kept."
-                ),
-                primaryButton: .destructive(Text("Remove Worktree")) {
+                message: Text(request.worktreeRemovalMessage),
+                primaryButton: .destructive(
+                    Text(request.worktreeRemovalActionTitle)
+                ) {
                     WorkspacePresentationLifecycle
                         .beginWorktreeRemovalResolution(
                             pendingWorktreeRemoval: &pendingWorktreeRemoval

--- a/Sources/UI/RootViewConfiguration.swift
+++ b/Sources/UI/RootViewConfiguration.swift
@@ -202,17 +202,44 @@ public struct WorktreeRemovalRequest: Equatable, Sendable {
     public let project: ProjectSummary
     public let confirmedHost: HostSummary
     public let sessionKillRequest: TmuxSessionKillRequest?
+    public let changes: WorktreeChangeSummary
+
+    public var forceRemoval: Bool {
+        changes.hasUncommittedChanges
+    }
 
     public init(
         worktree: WorktreeSummary,
         project: ProjectSummary,
         confirmedHost: HostSummary,
-        sessionKillRequest: TmuxSessionKillRequest? = nil
+        sessionKillRequest: TmuxSessionKillRequest? = nil,
+        changes: WorktreeChangeSummary = .clean
     ) {
         self.worktree = worktree
         self.project = project
         self.confirmedHost = confirmedHost
         self.sessionKillRequest = sessionKillRequest
+        self.changes = changes
+    }
+
+    var worktreeRemovalActionTitle: String {
+        forceRemoval ? "Force Remove Worktree" : "Remove Worktree"
+    }
+
+    var worktreeRemovalMessage: String {
+        let sessionMessage = sessionKillRequest == nil
+            ? ""
+            : " Its live tmux session will be terminated first,"
+            + " including every window, pane, and process."
+        let changesMessage = forceRemoval
+            ? " This worktree has uncommitted changes. Force removal"
+            + " permanently discards every staged, unstaged, and untracked"
+            + " change in it."
+            : ""
+        return "This removes the worktree at \(worktree.path)."
+            + sessionMessage
+            + changesMessage
+            + " The Git branch will be kept."
     }
 }
 

--- a/Sources/Workspace/ProjectWorktreeModels.swift
+++ b/Sources/Workspace/ProjectWorktreeModels.swift
@@ -424,6 +424,42 @@ public struct WorktreeSummary: Identifiable, Equatable, Sendable {
 
 }
 
+public struct WorktreeChangeSummary: Equatable, Sendable {
+    public static let clean = WorktreeChangeSummary()
+
+    public let modified: Int
+    public let added: Int
+    public let deleted: Int
+    public let untracked: Int
+    public let staged: Int
+    public let conflicts: Int
+
+    public init(
+        modified: Int = 0,
+        added: Int = 0,
+        deleted: Int = 0,
+        untracked: Int = 0,
+        staged: Int = 0,
+        conflicts: Int = 0
+    ) {
+        self.modified = modified
+        self.added = added
+        self.deleted = deleted
+        self.untracked = untracked
+        self.staged = staged
+        self.conflicts = conflicts
+    }
+
+    public var hasUncommittedChanges: Bool {
+        modified > 0
+            || added > 0
+            || deleted > 0
+            || untracked > 0
+            || staged > 0
+            || conflicts > 0
+    }
+}
+
 public struct WorktreeVisibility: Equatable, Sendable {
     public static let `default` = WorktreeVisibility()
 

--- a/Tests/App/KwtWorktreeClientTests.swift
+++ b/Tests/App/KwtWorktreeClientTests.swift
@@ -278,6 +278,104 @@ struct KwtWorktreeClientTests {
         #expect(recorder.command?.contains("--force") == false)
     }
 
+    @Test("worktree changes are read from kwt status JSON")
+    func worktreeChanges() async throws {
+        let recorder = CommandRecorder()
+        let client = KwtWorktreeClient(
+            localRunner: { shell, command in
+                recorder.record(shell: shell, command: command)
+                return (
+                    0,
+                    """
+                    shell startup noise
+                    GHOSTHUB_KWT_JSON
+                    [
+                      {
+                        "path": "/worktrees/ghost hub/feature",
+                        "branch": "feature/remove",
+                        "status": "modified",
+                        "git_status": {
+                          "modified": 2,
+                          "added": 1,
+                          "deleted": 3,
+                          "untracked": 4,
+                          "staged": 5,
+                          "ahead": 6,
+                          "behind": 7,
+                          "conflicts": 8
+                        }
+                      }
+                    ]
+                    """
+                )
+            },
+            localBinaryPath: "/Applications/Ghost Hub.app/Contents/Helpers/kwt",
+            loginShellProvider: { "/bin/zsh" }
+        )
+
+        let changes = try await client.changes(
+            worktreePath: "/worktrees/ghost hub/feature",
+            projectPath: "/code/ghost hub",
+            on: .local
+        )
+
+        #expect(changes == WorktreeChangeSummary(
+            modified: 2,
+            added: 1,
+            deleted: 3,
+            untracked: 4,
+            staged: 5,
+            conflicts: 8
+        ))
+        #expect(
+            recorder.command?.contains(
+                "exec \"$ghosthub_kwt_path\" status --json --no-fetch"
+            ) == true
+        )
+    }
+
+    @Test("force removal passes explicit force authority to kwt")
+    func forceRemoval() async throws {
+        let recorder = CommandRecorder()
+        let client = KwtWorktreeClient(
+            localRunner: { shell, command in
+                recorder.record(shell: shell, command: command)
+                return (0, "")
+            },
+            localBinaryPath: "/Applications/Ghost Hub.app/Contents/Helpers/kwt",
+            loginShellProvider: { "/bin/zsh" }
+        )
+
+        try await client.remove(
+            worktreePath: "/worktrees/ghost hub/feature",
+            generation: "0123456789abcdef0123456789abcdef",
+            projectPath: "/code/ghost hub",
+            force: true,
+            on: .local
+        )
+
+        #expect(recorder.command?.contains(
+            "remove --force --if-generation "
+                + "'0123456789abcdef0123456789abcdef' "
+                + "'/worktrees/ghost hub/feature'"
+        ) == true)
+    }
+
+    @Test("an absent worktree has no changes left to discard")
+    func absentWorktreeChanges() async throws {
+        let client = KwtWorktreeClient(
+            localRunner: { _, _ in (0, "GHOSTHUB_KWT_JSON\n[]") }
+        )
+
+        let changes = try await client.changes(
+            worktreePath: "/worktrees/removed",
+            projectPath: "/code/project",
+            on: .local
+        )
+
+        #expect(changes == .clean)
+    }
+
     @Test("Windows removal uses the managed kwt helper")
     func windowsRemoteRemoval() async throws {
         let recorder = CommandRecorder()

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -353,6 +353,12 @@ func makeModel(
             on: host
         )
     },
+    kwtForceWorktreeRemover:
+    @escaping WorkspaceSceneModel.KwtWorktreeRemover = { _, _, _, _ in },
+    kwtWorktreeChangeReader:
+    @escaping WorkspaceSceneModel.KwtWorktreeChangeReader = { _, _, _ in
+        .clean
+    },
     worktreeMutationCoordinator: WorktreeMutationCoordinator =
         WorktreeMutationCoordinator(),
     herdrLifecycleCoordinator: HerdrSessionLifecycleCoordinator =
@@ -509,6 +515,8 @@ func makeModel(
         kwtRemoteProvisioner: kwtRemoteProvisioner,
         kwtWorktreeCreator: kwtWorktreeCreator,
         kwtWorktreeRemover: kwtWorktreeRemover,
+        kwtForceWorktreeRemover: kwtForceWorktreeRemover,
+        kwtWorktreeChangeReader: kwtWorktreeChangeReader,
         worktreeMutationCoordinator: worktreeMutationCoordinator,
         herdrLifecycleCoordinator: herdrLifecycleCoordinator,
         zellijSessionKillCoordinator: zellijSessionKillCoordinator,

--- a/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
@@ -1135,6 +1135,76 @@ extension WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test("a dirty rejection after session termination requires force confirmation")
+    func dirtyRejectionAfterSessionTerminationRequiresForce() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let surfaces = RecordingNativeSessionSurfaceStore()
+        let reads = LockedValue(0)
+        let kills = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            nativeTmuxSurfaceStore: surfaces,
+            nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            localKwtPathProvider: { "/test/kwt" },
+            kwtInventoryLoader: { _ in fixture.beforeRemoval },
+            kwtWorktreeRemover: { _, _, _, _ in
+                throw KwtWorktreeError.removalFailed(
+                    host: "Local",
+                    status: 1
+                )
+            },
+            kwtWorktreeChangeReader: { _, _, _ in
+                reads.withLock { $0 += 1 }
+                return reads.load() < 3
+                    ? .clean
+                    : WorktreeChangeSummary(untracked: 1)
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                TmuxSessionIdentity(
+                    serverPID: "31415",
+                    sessionID: "$8",
+                    createdAt: "1721552400"
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
+        )
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor {
+            !surfaces.requestedConfigurations.isEmpty
+        }
+        let initialRequestCount = surfaces.requestedConfigurations.count
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Dirty removal should require force confirmation")
+            await model.shutdown()
+            return
+        }
+        await waitUntilMainActor {
+            surfaces.requestedConfigurations.count > initialRequestCount
+        }
+
+        #expect(updatedRequest.forceRemoval)
+        #expect(kills.load() == 1)
+        let restoredCommand = try #require(
+            surfaces.requestedConfigurations.last?.command
+        )
+        #expect(restoredCommand.contains("kwt"))
+        #expect(restoredCommand.contains("open"))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("failed removal preserves pending workspace establishment")
     func failedRemovalPreservesPendingEstablishment() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
@@ -1135,9 +1135,14 @@ extension WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
-    @Test("a dirty rejection after session termination requires force confirmation")
-    func dirtyRejectionAfterSessionTerminationRequiresForce() async throws {
-        let fixture = try removalFixture()
+    @Test(
+        "a dirty rejection after session termination restores the killed session",
+        arguments: [true, false]
+    )
+    func dirtyRejectionAfterSessionTerminationRestoresSession(
+        wasOpened: Bool
+    ) async throws {
+        let fixture = try removalFixture(runningSession: true)
         let environment = fixture.environment
         let removable = fixture.removable
         let surfaces = RecordingNativeSessionSurfaceStore()
@@ -1177,9 +1182,11 @@ extension WorkspaceWorktreeRemovalTests {
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
         )
-        model.openBorrowedTmuxSession(selection)
-        await waitUntilMainActor {
-            !surfaces.requestedConfigurations.isEmpty
+        if wasOpened {
+            model.openBorrowedTmuxSession(selection)
+            await waitUntilMainActor {
+                !surfaces.requestedConfigurations.isEmpty
+            }
         }
         let initialRequestCount = surfaces.requestedConfigurations.count
 
@@ -1196,6 +1203,10 @@ extension WorkspaceWorktreeRemovalTests {
 
         #expect(updatedRequest.forceRemoval)
         #expect(kills.load() == 1)
+        #expect(
+            model.activeBorrowedTmuxSelection
+                == (wasOpened ? selection : nil)
+        )
         let restoredCommand = try #require(
             surfaces.requestedConfigurations.last?.command
         )

--- a/Tests/App/WorkspaceWorktreeRemovalTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTests.swift
@@ -11,6 +11,63 @@ import Testing
 @Suite("Workspace worktree removal", .serialized)
 struct WorkspaceWorktreeRemovalTests {
     @MainActor
+    @Test("changes found after confirmation require explicit force removal")
+    func changesFoundAfterConfirmationRequireForce() async throws {
+        let fixture = try removalFixture()
+        let environment = fixture.environment
+        let reads = LockedValue(0)
+        let loads = LockedValue(0)
+        let normalRemovals = LockedValue(0)
+        let forcedRemovals = LockedValue(0)
+        let afterRemoval = inventory(environment)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: fixture.snapshot,
+            kwtInventoryLoader: { _ in
+                loads.withLock { $0 += 1 }
+                return loads.load() < 3
+                    ? fixture.beforeRemoval
+                    : afterRemoval
+            },
+            kwtWorktreeRemover: { _, _, _, _ in
+                normalRemovals.withLock { $0 += 1 }
+            },
+            kwtForceWorktreeRemover: { _, _, _, _ in
+                forcedRemovals.withLock { $0 += 1 }
+            },
+            kwtWorktreeChangeReader: { _, _, _ in
+                reads.withLock { $0 += 1 }
+                return reads.load() == 1
+                    ? .clean
+                    : WorktreeChangeSummary(untracked: 1)
+            }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(
+            fixture.removable.id
+        )
+        #expect(request.forceRemoval == false)
+
+        let result = try await model.resolveWorktreeRemoval(request)
+        guard case let .confirmationRequired(updatedRequest) = result else {
+            Issue.record("Removal should require force confirmation")
+            await model.shutdown()
+            return
+        }
+
+        #expect(updatedRequest.forceRemoval)
+        #expect(updatedRequest.changes.untracked == 1)
+        #expect(normalRemovals.load() == 0)
+        #expect(forcedRemovals.load() == 0)
+
+        #expect(try await model.resolveWorktreeRemoval(updatedRequest) == .removed)
+        #expect(normalRemovals.load() == 0)
+        #expect(forcedRemovals.load() == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test(
         "removal reconciles worktree and session state in other scenes",
         arguments: [false, true]

--- a/Tests/UI/WorkspaceAlertTests.swift
+++ b/Tests/UI/WorkspaceAlertTests.swift
@@ -1,7 +1,25 @@
+import GhosthubTestSupport
+import GhosthubWorkspace
 import Testing
 @testable import GhosthubUI
 
 struct WorkspaceAlertTests {
+    @Test("dirty worktree removal names discarded changes and force action")
+    func dirtyWorktreeRemovalPresentation() {
+        let host = HostSummary.fixture()
+        let project = ProjectSummary.fixture(hostID: host.id)
+        let request = WorktreeRemovalRequest(
+            worktree: .fixture(hostID: host.id, projectID: project.id),
+            project: project,
+            confirmedHost: host,
+            changes: WorktreeChangeSummary(modified: 1, untracked: 2)
+        )
+
+        #expect(request.worktreeRemovalActionTitle == "Force Remove Worktree")
+        #expect(request.worktreeRemovalMessage.contains("uncommitted changes"))
+        #expect(request.worktreeRemovalMessage.contains("permanently discards"))
+    }
+
     @Test("workspace actions share one alert identity domain")
     func workspaceActionsShareAlertIdentityDomain() {
         let session = WorkspaceAlert.sessionKillFailure(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,9 @@ that appeared after an ordinary confirmation require a new force
 confirmation. It then terminates only that freshly confirmed tmux identity and
 delegates an absence-guarded removal to pinned KWT. KWT revalidates the
 project, generation, and socket under its lifecycle lock and refuses removal
-if the workspace session reappears before deleting the checkout.
+if the workspace session reappears before deleting the checkout. If ordinary
+removal discovers still newer uncommitted changes after Ghosthub terminates the
+session, Ghosthub restores the session and requires force confirmation.
 
 Ghosthub still has one UI application process and no Ghosthub-owned daemon.
 For the Windows MVP, tmux inside WSL2 is the long-lived session owner. Closing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,11 +264,14 @@ explicit `TMUX_TMPDIR`, KWT commands receive that same value as tmux discovery
 and attachment; cached rows never correlate sessions across those server roots.
 Removing a generation-backed worktree on either server type is separately
 confirmed. Ghosthub captures the exact socket and live session identity, when
-present, and terminates only that freshly confirmed tmux identity after
-approval. It then delegates an absence-guarded removal to pinned KWT. KWT
-revalidates the project, generation, and socket under its lifecycle lock and
-refuses removal if the workspace session reappears before deleting the
-checkout.
+present, and reads KWT's machine-readable no-fetch Git status for the exact
+path. Uncommitted changes turn the action into an explicit force confirmation.
+Ghosthub reads the status again before terminating the session, so changes
+that appeared after an ordinary confirmation require a new force
+confirmation. It then terminates only that freshly confirmed tmux identity and
+delegates an absence-guarded removal to pinned KWT. KWT revalidates the
+project, generation, and socket under its lifecycle lock and refuses removal
+if the workspace session reappears before deleting the checkout.
 
 Ghosthub still has one UI application process and no Ghosthub-owned daemon.
 For the Windows MVP, tmux inside WSL2 is the long-lived session owner. Closing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,7 +262,7 @@ shows that the client exists. A genuinely separate same-named default-socket
 session remains visible as unbound inventory. When WSL config selects an
 explicit `TMUX_TMPDIR`, KWT commands receive that same value as tmux discovery
 and attachment; cached rows never correlate sessions across those server roots.
-Removing a generation-backed worktree on either server type is separately
+In the macOS app, removing a generation-backed worktree is separately
 confirmed. Ghosthub captures the exact socket and live session identity, when
 present, and reads KWT's machine-readable no-fetch Git status for the exact
 path. Uncommitted changes turn the action into an explicit force confirmation.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -717,8 +717,10 @@ session. If a clean worktree became dirty, Ghosthub presents the force warning
 instead of attempting ordinary removal. KWT revalidates the identity facts
 under the project lifecycle lock, terminates only the confirmed session when
 necessary, and removes the checkout in the same guarded operation. A replaced
-session or changed socket fails closed and requires new confirmation. Closing
-or detaching a presentation never grants this removal authority.
+session or changed socket fails closed and requires new confirmation. If KWT
+finds still newer changes after Ghosthub terminates the session, Ghosthub
+restores the session before presenting the force confirmation. Closing or
+detaching a presentation never grants this removal authority.
 
 On experimental Windows hosts, an explicit Install Bundled kwt action probes
 the process architecture, uploads the matching pinned AMD64 or ARM64 helper,

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -706,9 +706,10 @@ repositories, worktrees, and tmux sessions remain untouched. Reads and
 mutations stay off the UI thread, and the last usable project tree remains
 visible while either is in flight.
 
-Removing a generation-backed worktree is a distinct destructive action. The
-confirmation is bound to its exact project, generation, tmux socket, and a
-fresh live session identity or freshly confirmed absence. Pinned KWT
+In the macOS app, removing a generation-backed worktree is a distinct
+destructive action. The confirmation is bound to its exact project,
+generation, tmux socket, and a fresh live session identity or freshly
+confirmed absence. Pinned KWT
 also reports the worktree's staged, unstaged, and untracked change counts
 before Ghosthub presents the confirmation. A worktree with uncommitted changes
 names that data-loss risk and requires an explicit **Force Remove Worktree**

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -709,11 +709,16 @@ visible while either is in flight.
 Removing a generation-backed worktree is a distinct destructive action. The
 confirmation is bound to its exact project, generation, tmux socket, and a
 fresh live session identity or freshly confirmed absence. Pinned KWT
-revalidates those facts under the project lifecycle lock, terminates only the
-confirmed session when necessary, and removes the checkout in the same guarded
-operation. A replaced session or changed socket fails closed and requires new
-confirmation. Closing or detaching a presentation never grants this removal
-authority.
+also reports the worktree's staged, unstaged, and untracked change counts
+before Ghosthub presents the confirmation. A worktree with uncommitted changes
+names that data-loss risk and requires an explicit **Force Remove Worktree**
+action. Ghosthub checks for new changes again before it terminates a confirmed
+session. If a clean worktree became dirty, Ghosthub presents the force warning
+instead of attempting ordinary removal. KWT revalidates the identity facts
+under the project lifecycle lock, terminates only the confirmed session when
+necessary, and removes the checkout in the same guarded operation. A replaced
+session or changed socket fails closed and requires new confirmation. Closing
+or detaching a presentation never grants this removal authority.
 
 On experimental Windows hosts, an explicit Install Bundled kwt action probes
 the process architecture, uploads the matching pinned AMD64 or ARM64 helper,


### PR DESCRIPTION
On macOS, removing a worktree with unstaged changes currently ends in a generic `kwt could not remove the worktree` error. Ghosthub does not explain that local work is blocking removal or offer a way to continue, so the user has to leave the app to deal with it.

This change replaces that dead end with an explicit choice:

- Ghosthub warns that the worktree has uncommitted changes and that removing it will permanently discard them.
- The destructive action becomes **Force Remove Worktree**, making the data-loss decision clear.
- If new changes appear after the user confirms an ordinary removal, Ghosthub stops and asks again instead of discarding them.
- The Git branch is kept.

Clean worktrees continue to use the existing **Remove Worktree** confirmation.

Fixes #179
