### PR TITLE
Rust Port: Add durable terminal settings

### DIFF
--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -1116,13 +1116,13 @@ another session or detaching restores navigation immediately and invalidates
 the background task without gaining authority to destroy any session it may
 have created.
 
-Slice 1 reads font family, font size, and theme through:
+Settings values flow through:
 
 ~~~text
 config → workspace projection → UI-facing state → GPUI
 ~~~
 
-The Settings shell exposes durable Appearance and Hosts panes. Appearance
+The Settings shell exposes durable Appearance, Terminal, and Hosts panes. Appearance
 offers the same built-in terminal color families as Swift plus a Custom
 fallback, enumerates installed fixed-pitch fonts, offers standard terminal font
 sizes, and renders a substantial live preview. Valid appearance changes apply
@@ -1133,7 +1133,10 @@ Each persisted change atomically publishes the projection to the running GPUI
 workspace. Terminal palettes never recolor Ghosthub's application chrome;
 interface appearance remains a separate settings concern. Existing terminal
 clients keep the palette they negotiated until reopened; new clients use the
-current defaults. Hosts owns only
+current defaults. Terminal persists the cursor shape, whether shell integration
+may replace that shape, and whether keyboard input hides the pointer until it
+moves again. Cursor changes apply to existing surfaces immediately, including
+dynamic DECSCUSR application requests when shell control is enabled. Hosts owns only
 `[[ssh-host]]` records. The shell's stable navigation, page header, list, and
 detail regions are the permanent container for the remaining Swift settings
 domains.
@@ -1143,7 +1146,7 @@ The parity inventory is:
 | --- | --- |
 | Hosts | Native add, edit, remove, explicit connect, and SSH prompt UI |
 | Appearance | Built-in themes, Custom colors, installed-font and size pickers, live preview, and atomic persistence |
-| Terminal | Startup configuration only; pane not yet implemented |
+| Terminal | Cursor shape, shell-controlled cursor permission, mouse hiding while typing, and atomic persistence |
 | Keyboard | Runtime shortcuts exist; pane not yet implemented |
 | Worktrees | Project/worktree workflows exist; preferences pane not yet implemented |
 | Agents | Not yet implemented |
@@ -1178,6 +1181,9 @@ font-family = "Cascadia Mono"
 font-size = 14
 background = "#0c0f14"
 foreground = "#d8dee9"
+cursor-style = "block"
+shell-integration-cursor = false
+mouse-hide-while-typing = true
 clipboard-write = true
 
 [[ssh-host]]
@@ -1196,7 +1202,8 @@ optional. Ghosthub resolves tmux, Herdr, and Zellij through the remote login
 environment by default; an explicit tmux path remains available for unusual
 installations. SSH endpoint identity is user, hostname, and port; duplicates
 are rejected. `clipboard-write` governs remote OSC 52 writes; remote OSC 52
-reads remain denied regardless of configuration.
+reads remain denied regardless of configuration. `cursor-style` accepts
+`block`, `bar`, or `underline`.
 
 Windows manual acceptance requires WSL2 and tmux. Ghosthub can create the first
 session itself; setup remains documented as deterministic commands for tests

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -328,6 +328,9 @@ struct TerminalFile {
     font_size: Option<u16>,
     background: Option<String>,
     foreground: Option<String>,
+    cursor_style: Option<CursorStyle>,
+    shell_integration_cursor: Option<bool>,
+    mouse_hide_while_typing: Option<bool>,
     clipboard_write: Option<bool>,
 }
 
@@ -430,6 +433,15 @@ impl TryFrom<ConfigFile> for ApplicationConfig {
                 font_size,
                 background,
                 foreground,
+                cursor_style: terminal
+                    .cursor_style
+                    .unwrap_or(defaults.terminal.cursor_style),
+                allow_shell_integration_cursor: terminal
+                    .shell_integration_cursor
+                    .unwrap_or(defaults.terminal.allow_shell_integration_cursor),
+                hide_mouse_while_typing: terminal
+                    .mouse_hide_while_typing
+                    .unwrap_or(defaults.terminal.hide_mouse_while_typing),
                 allow_remote_clipboard_write: terminal
                     .clipboard_write
                     .unwrap_or(defaults.terminal.allow_remote_clipboard_write),
@@ -455,6 +467,9 @@ impl From<&ApplicationConfig> for ConfigFile {
                     .then(|| format!("#{:06x}", config.terminal.background)),
                 foreground: (config.terminal.theme == TerminalTheme::Custom)
                     .then(|| format!("#{:06x}", config.terminal.foreground)),
+                cursor_style: Some(config.terminal.cursor_style),
+                shell_integration_cursor: Some(config.terminal.allow_shell_integration_cursor),
+                mouse_hide_while_typing: Some(config.terminal.hide_mouse_while_typing),
                 clipboard_write: Some(config.terminal.allow_remote_clipboard_write),
             },
             ssh_hosts: config
@@ -574,6 +589,27 @@ pub enum TerminalTheme {
     Custom,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CursorStyle {
+    Block,
+    Bar,
+    Underline,
+}
+
+impl CursorStyle {
+    pub const ALL: [Self; 3] = [Self::Block, Self::Bar, Self::Underline];
+
+    #[must_use]
+    pub const fn title(self) -> &'static str {
+        match self {
+            Self::Block => "Block",
+            Self::Bar => "Line",
+            Self::Underline => "Underline",
+        }
+    }
+}
+
 impl TerminalTheme {
     pub const ALL: [Self; 7] = [
         Self::Pro,
@@ -647,6 +683,9 @@ pub struct TerminalAppearance {
     font_size: u16,
     background: u32,
     foreground: u32,
+    cursor_style: CursorStyle,
+    allow_shell_integration_cursor: bool,
+    hide_mouse_while_typing: bool,
     allow_remote_clipboard_write: bool,
 }
 
@@ -677,6 +716,9 @@ impl TerminalAppearance {
             font_size,
             background: parse_rgb("terminal.background", background)?,
             foreground: parse_rgb("terminal.foreground", foreground)?,
+            cursor_style: CursorStyle::Block,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
             allow_remote_clipboard_write,
         })
     }
@@ -714,6 +756,9 @@ impl TerminalAppearance {
             font_size,
             background,
             foreground,
+            cursor_style: CursorStyle::Block,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
             allow_remote_clipboard_write,
         })
     }
@@ -744,6 +789,21 @@ impl TerminalAppearance {
     }
 
     #[must_use]
+    pub const fn cursor_style(&self) -> CursorStyle {
+        self.cursor_style
+    }
+
+    #[must_use]
+    pub const fn allow_shell_integration_cursor(&self) -> bool {
+        self.allow_shell_integration_cursor
+    }
+
+    #[must_use]
+    pub const fn hide_mouse_while_typing(&self) -> bool {
+        self.hide_mouse_while_typing
+    }
+
+    #[must_use]
     pub const fn allow_remote_clipboard_write(&self) -> bool {
         self.allow_remote_clipboard_write
     }
@@ -751,6 +811,19 @@ impl TerminalAppearance {
     #[must_use]
     pub fn with_remote_clipboard_write(mut self, allowed: bool) -> Self {
         self.allow_remote_clipboard_write = allowed;
+        self
+    }
+
+    #[must_use]
+    pub fn with_terminal_preferences(
+        mut self,
+        cursor_style: CursorStyle,
+        allow_shell_integration_cursor: bool,
+        hide_mouse_while_typing: bool,
+    ) -> Self {
+        self.cursor_style = cursor_style;
+        self.allow_shell_integration_cursor = allow_shell_integration_cursor;
+        self.hide_mouse_while_typing = hide_mouse_while_typing;
         self
     }
 }
@@ -763,6 +836,9 @@ impl Default for TerminalAppearance {
             font_size: 14,
             background: 0x21_27_34,
             foreground: 0xe6_e6_e6,
+            cursor_style: CursorStyle::Block,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
             allow_remote_clipboard_write: true,
         }
     }

--- a/rust/config/tests/appearance.rs
+++ b/rust/config/tests/appearance.rs
@@ -1,4 +1,4 @@
-use config::{TerminalAppearance, TerminalTheme};
+use config::{CursorStyle, TerminalAppearance, TerminalTheme};
 
 #[test]
 fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
@@ -9,6 +9,9 @@ fn default_terminal_appearance_is_projectable_without_ui_dependencies() {
     assert_eq!(appearance.theme(), TerminalTheme::ClearDark);
     assert_eq!(appearance.background(), 0x21_27_34);
     assert_eq!(appearance.foreground(), 0xe6_e6_e6);
+    assert_eq!(appearance.cursor_style(), CursorStyle::Block);
+    assert!(!appearance.allow_shell_integration_cursor());
+    assert!(appearance.hide_mouse_while_typing());
 }
 
 #[test]

--- a/rust/config/tests/application.rs
+++ b/rust/config/tests/application.rs
@@ -4,7 +4,9 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance, TerminalTheme};
+use config::{
+    ApplicationConfig, CursorStyle, Roots, SshHostSettings, TerminalAppearance, TerminalTheme,
+};
 
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -23,6 +25,9 @@ fn missing_application_config_uses_documented_defaults() {
     assert_eq!(loaded.terminal().theme(), TerminalTheme::ClearDark);
     assert_eq!(loaded.terminal().background(), 0x21_27_34);
     assert_eq!(loaded.terminal().foreground(), 0xe6_e6_e6);
+    assert_eq!(loaded.terminal().cursor_style(), CursorStyle::Block);
+    assert!(!loaded.terminal().allow_shell_integration_cursor());
+    assert!(loaded.terminal().hide_mouse_while_typing());
     assert!(loaded.terminal().allow_remote_clipboard_write());
 }
 
@@ -40,6 +45,9 @@ fn application_config_projects_all_read_only_settings() {
             font-size = 16
             background = "#102030"
             foreground = "#f0e0d0"
+            cursor-style = "underline"
+            shell-integration-cursor = true
+            mouse-hide-while-typing = false
             clipboard-write = false
         "##,
     )
@@ -52,6 +60,9 @@ fn application_config_projects_all_read_only_settings() {
     assert_eq!(parsed.terminal().font_size(), 16);
     assert_eq!(parsed.terminal().background(), 0x10_20_30);
     assert_eq!(parsed.terminal().foreground(), 0xf0_e0_d0);
+    assert_eq!(parsed.terminal().cursor_style(), CursorStyle::Underline);
+    assert!(parsed.terminal().allow_shell_integration_cursor());
+    assert!(!parsed.terminal().hide_mouse_while_typing());
     assert!(!parsed.terminal().allow_remote_clipboard_write());
 }
 
@@ -259,7 +270,8 @@ fn terminal_appearance_round_trips_without_changing_other_settings() {
     let mut config = ApplicationConfig::from_toml("[wsl]\ndistro = \"Ubuntu\"\n")
         .expect("valid starting configuration");
     let appearance = TerminalAppearance::new("Berkeley Mono", 15, "#111820", "#e4e8ef", false)
-        .expect("valid appearance");
+        .expect("valid appearance")
+        .with_terminal_preferences(CursorStyle::Bar, true, false);
 
     config
         .replace_terminal_appearance(&roots, appearance)
@@ -272,6 +284,9 @@ fn terminal_appearance_round_trips_without_changing_other_settings() {
     assert_eq!(loaded.terminal().background(), 0x11_18_20);
     assert_eq!(loaded.terminal().foreground(), 0xe4_e8_ef);
     assert!(!loaded.terminal().allow_remote_clipboard_write());
+    assert_eq!(loaded.terminal().cursor_style(), CursorStyle::Bar);
+    assert!(loaded.terminal().allow_shell_integration_cursor());
+    assert!(!loaded.terminal().hide_mouse_while_typing());
     fs::remove_dir_all(root).expect("remove temporary config root");
 }
 

--- a/rust/surface/src/lib.rs
+++ b/rust/surface/src/lib.rs
@@ -141,10 +141,19 @@ pub enum Damage {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CursorShape {
+    Block,
+    Bar,
+    Underline,
+    Hidden,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Cursor {
     pub row: usize,
     pub column: usize,
     pub visible: bool,
+    pub shape: CursorShape,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/rust/terminal/src/lib.rs
+++ b/rust/terminal/src/lib.rs
@@ -10,8 +10,8 @@ use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::term::{ClipboardType, Config, Osc52, Term, TermDamage, TermMode};
 use alacritty_terminal::vte::ansi::{
-    Color, CursorShape as VteCursorShape, Handler, ModifyOtherKeys as VteModifyOtherKeys,
-    NamedColor, NamedPrivateMode, PrivateMode, Processor,
+    Color, CursorShape as VteCursorShape, CursorStyle as VteCursorStyle, Handler,
+    ModifyOtherKeys as VteModifyOtherKeys, NamedColor, NamedPrivateMode, PrivateMode, Processor,
 };
 use input::{KittyKeyboard, ModifyOtherKeys, MouseTracking, TerminalModes};
 use surface::{
@@ -185,6 +185,7 @@ pub struct TerminalEngine {
     pixel_size: PixelSize,
     clipboard_policy: ClipboardPolicy,
     default_colors: DefaultColors,
+    config: Config,
 }
 
 impl TerminalEngine {
@@ -233,14 +234,34 @@ impl TerminalEngine {
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
     ) -> Self {
+        Self::with_geometry_and_defaults(
+            size,
+            resize_sequence,
+            pixel_size,
+            clipboard_policy,
+            default_colors,
+            CursorShape::Block,
+        )
+    }
+
+    #[must_use]
+    pub fn with_geometry_and_defaults(
+        size: GridSize,
+        resize_sequence: u64,
+        pixel_size: PixelSize,
+        clipboard_policy: ClipboardPolicy,
+        default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
+    ) -> Self {
         let events = EventCollector::default();
         let config = Config {
             scrolling_history: 0,
+            default_cursor_style: vte_cursor_style(default_cursor_shape),
             kitty_keyboard: true,
             osc52: Osc52::CopyPaste,
             ..Config::default()
         };
-        let term = Term::new(config, &DimensionsValue(size), events.clone());
+        let term = Term::new(config.clone(), &DimensionsValue(size), events.clone());
         let surface = Arc::new(SurfaceStore::new(SurfaceFrame::blank(0, size)));
         let mut engine = Self {
             parser: Processor::new(),
@@ -256,10 +277,18 @@ impl TerminalEngine {
             pixel_size,
             clipboard_policy,
             default_colors,
+            config,
         };
         engine.publish_full();
         engine.term.reset_damage();
         engine
+    }
+
+    pub fn set_default_cursor_shape(&mut self, shape: CursorShape) {
+        self.config.default_cursor_style = vte_cursor_style(shape);
+        self.term.set_options(self.config.clone());
+        self.publish_full();
+        self.term.reset_damage();
     }
 
     #[must_use]
@@ -500,6 +529,18 @@ impl TerminalEngine {
             }
         }
         output
+    }
+}
+
+const fn vte_cursor_style(shape: CursorShape) -> VteCursorStyle {
+    VteCursorStyle {
+        shape: match shape {
+            CursorShape::Block => VteCursorShape::Block,
+            CursorShape::Bar => VteCursorShape::Beam,
+            CursorShape::Underline => VteCursorShape::Underline,
+            CursorShape::Hidden => VteCursorShape::Hidden,
+        },
+        blinking: false,
     }
 }
 

--- a/rust/terminal/src/lib.rs
+++ b/rust/terminal/src/lib.rs
@@ -10,13 +10,13 @@ use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::color::Colors;
 use alacritty_terminal::term::{ClipboardType, Config, Osc52, Term, TermDamage, TermMode};
 use alacritty_terminal::vte::ansi::{
-    Color, Handler, ModifyOtherKeys as VteModifyOtherKeys, NamedColor, NamedPrivateMode,
-    PrivateMode, Processor,
+    Color, CursorShape as VteCursorShape, Handler, ModifyOtherKeys as VteModifyOtherKeys,
+    NamedColor, NamedPrivateMode, PrivateMode, Processor,
 };
 use input::{KittyKeyboard, ModifyOtherKeys, MouseTracking, TerminalModes};
 use surface::{
-    Cell as SurfaceCell, CellStyle, Cursor, Damage, GridSize, PixelSize, Rgb, SurfaceFrame,
-    SurfaceStore,
+    Cell as SurfaceCell, CellStyle, Cursor, CursorShape, Damage, GridSize, PixelSize, Rgb,
+    SurfaceFrame, SurfaceStore,
 };
 
 mod windows_job;
@@ -443,7 +443,14 @@ impl TerminalEngine {
         let cursor = Cursor {
             row: usize::try_from(renderable.cursor.point.line.0).unwrap_or(0),
             column: renderable.cursor.point.column.0,
-            visible: renderable.mode.contains(TermMode::SHOW_CURSOR),
+            visible: renderable.mode.contains(TermMode::SHOW_CURSOR)
+                && renderable.cursor.shape != VteCursorShape::Hidden,
+            shape: match renderable.cursor.shape {
+                VteCursorShape::Block | VteCursorShape::HollowBlock => CursorShape::Block,
+                VteCursorShape::Beam => CursorShape::Bar,
+                VteCursorShape::Underline => CursorShape::Underline,
+                VteCursorShape::Hidden => CursorShape::Hidden,
+            },
         };
         let resize_sequence = self.resize_sequence;
         let pixel_size = self.pixel_size;

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -13,7 +13,7 @@ use session::{
     AdmissionPlan, AttachPlan, CreateOnce, HerdrAttachPlan, HerdrLaunchOnce, RepairOrOpenPlan,
     ZellijAttachPlan, ZellijLaunchOnce,
 };
-use surface::{GridSize, PixelSize, SurfaceStore};
+use surface::{CursorShape, GridSize, PixelSize, SurfaceStore};
 
 use crate::windows_job::RelayJob;
 use crate::{ClipboardPolicy, ClipboardReadRequest, ClipboardWrite, DefaultColors, TerminalEngine};
@@ -99,6 +99,7 @@ enum Command {
     Input(Vec<u8>),
     Key(KeyInput),
     Mouse(MouseInput),
+    DefaultCursorShape(CursorShape),
 }
 
 struct QueuedCommand {
@@ -257,6 +258,7 @@ impl TerminalWorker {
             PixelSize::default(),
             ClipboardPolicy::default(),
             DefaultColors::default(),
+            CursorShape::Block,
         )
     }
 
@@ -273,6 +275,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         Self::launch(
             plan.program(),
@@ -282,6 +285,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -298,6 +302,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         Self::launch(
             plan.program(),
@@ -307,6 +312,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -324,6 +330,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         let (program, args, _target_name) = plan.into_parts();
         Self::launch(
@@ -334,6 +341,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -350,6 +358,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         Self::launch(
             plan.program(),
@@ -359,6 +368,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -375,6 +385,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         Self::launch(
             plan.program(),
@@ -384,6 +395,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -401,6 +413,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         let (program, args, _target_name) = plan.into_parts();
         Self::launch(
@@ -411,6 +424,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -429,6 +443,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         let (program, args, _target_name) = plan.into_parts();
         Self::launch(
@@ -439,6 +454,7 @@ impl TerminalWorker {
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         )
     }
 
@@ -457,6 +473,7 @@ impl TerminalWorker {
             PixelSize::default(),
             ClipboardPolicy::default(),
             DefaultColors::default(),
+            CursorShape::Block,
         )
     }
 
@@ -473,6 +490,7 @@ impl TerminalWorker {
         pixel_size: PixelSize,
         clipboard_policy: ClipboardPolicy,
         default_colors: DefaultColors,
+        default_cursor_shape: CursorShape,
     ) -> Result<Self, WorkerError> {
         let pty_size = pty_size(size, pixel_size)?;
         let job = RelayJob::new().map_err(|error| WorkerError::new("create relay job", error))?;
@@ -505,12 +523,13 @@ impl TerminalWorker {
             return Err(WorkerError::new("contain terminal client", error));
         }
 
-        let engine = TerminalEngine::with_geometry_and_colors(
+        let engine = TerminalEngine::with_geometry_and_defaults(
             size,
             resize_sequence,
             pixel_size,
             clipboard_policy,
             default_colors,
+            default_cursor_shape,
         );
         let surface = engine.surface_handle();
         let (commands, command_receiver) = bounded(COMMAND_CAPACITY);
@@ -700,6 +719,21 @@ impl TerminalWorker {
             &self.ingress,
             Command::Input(bytes),
             "send terminal input",
+        )
+    }
+
+    /// Update the cursor shape used before and after application overrides.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error after the terminal worker has stopped or while its
+    /// bounded command queue is applying backpressure.
+    pub fn set_default_cursor_shape(&self, shape: CursorShape) -> Result<(), WorkerError> {
+        try_send_ordered(
+            &self.commands,
+            &self.ingress,
+            Command::DefaultCursorShape(shape),
+            "update terminal cursor shape",
         )
     }
 
@@ -1225,6 +1259,10 @@ fn process_ready_command(
             encoded.is_empty()
                 || queue_write(pending_writes, WriteSource::Ui, shutdown, events, encoded)
         }
+        Command::DefaultCursorShape(shape) => {
+            engine.set_default_cursor_shape(shape);
+            true
+        }
     }
 }
 
@@ -1474,7 +1512,9 @@ const fn command_bytes(command: &Command) -> usize {
     match command {
         Command::Input(bytes) => bytes.len(),
         Command::Key(KeyInput::Text { text, .. } | KeyInput::Paste(text)) => text.len(),
-        Command::Key(KeyInput::Named { .. }) | Command::Mouse(_) => 0,
+        Command::Key(KeyInput::Named { .. })
+        | Command::Mouse(_)
+        | Command::DefaultCursorShape(_) => 0,
     }
 }
 

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -99,7 +99,6 @@ enum Command {
     Input(Vec<u8>),
     Key(KeyInput),
     Mouse(MouseInput),
-    DefaultCursorShape(CursorShape),
 }
 
 struct QueuedCommand {
@@ -131,6 +130,7 @@ struct ResizeCommand {
 struct IngressState {
     resize: Option<ResizeCommand>,
     mouse_motion: Option<MouseInput>,
+    default_cursor_shape: Option<CursorShape>,
     queued_bytes: usize,
 }
 
@@ -724,17 +724,12 @@ impl TerminalWorker {
 
     /// Update the cursor shape used before and after application overrides.
     ///
-    /// # Errors
-    ///
-    /// Returns an error after the terminal worker has stopped or while its
-    /// bounded command queue is applying backpressure.
-    pub fn set_default_cursor_shape(&self, shape: CursorShape) -> Result<(), WorkerError> {
-        try_send_ordered(
-            &self.commands,
-            &self.ingress,
-            Command::DefaultCursorShape(shape),
-            "update terminal cursor shape",
-        )
+    pub fn set_default_cursor_shape(&self, shape: CursorShape) {
+        self.ingress
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .default_cursor_shape = Some(shape);
+        let _stopped = wake_coalesced(&self.coalesced_wake, "update terminal cursor shape");
     }
 
     /// Resize the VT grid and PTY in one ordered worker operation.
@@ -1259,10 +1254,6 @@ fn process_ready_command(
             encoded.is_empty()
                 || queue_write(pending_writes, WriteSource::Ui, shutdown, events, encoded)
         }
-        Command::DefaultCursorShape(shape) => {
-            engine.set_default_cursor_shape(shape);
-            true
-        }
     }
 }
 
@@ -1306,10 +1297,14 @@ fn process_coalesced(
 ) -> bool {
     let CoalescedWork {
         resize,
+        default_cursor_shape,
         input,
         wake_again,
     } = take_coalesced_work(commands, ingress, accept_mouse_motion);
 
+    if let Some(shape) = default_cursor_shape {
+        engine.set_default_cursor_shape(shape);
+    }
     if let Some(resize) = resize
         && !process_resize(resize, engine, master, shutdown, events)
     {
@@ -1357,6 +1352,7 @@ enum CoalescedInput {
 
 struct CoalescedWork {
     resize: Option<ResizeCommand>,
+    default_cursor_shape: Option<CursorShape>,
     input: CoalescedInput,
     wake_again: bool,
 }
@@ -1372,6 +1368,7 @@ fn take_coalesced_work(
     let mut state = ingress
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let default_cursor_shape = state.default_cursor_shape.take();
     let (resize, input, wake_again) = if accept_mouse_motion {
         match commands.try_recv() {
             Ok(mut command) => {
@@ -1402,6 +1399,7 @@ fn take_coalesced_work(
     };
     CoalescedWork {
         resize,
+        default_cursor_shape,
         input,
         wake_again,
     }
@@ -1512,9 +1510,7 @@ const fn command_bytes(command: &Command) -> usize {
     match command {
         Command::Input(bytes) => bytes.len(),
         Command::Key(KeyInput::Text { text, .. } | KeyInput::Paste(text)) => text.len(),
-        Command::Key(KeyInput::Named { .. })
-        | Command::Mouse(_)
-        | Command::DefaultCursorShape(_) => 0,
+        Command::Key(KeyInput::Named { .. }) | Command::Mouse(_) => 0,
     }
 }
 
@@ -2076,6 +2072,7 @@ mod tests {
                 row: 2,
                 modifiers: Modifiers::default(),
             }),
+            default_cursor_shape: None,
             queued_bytes: 0,
         });
 
@@ -2096,6 +2093,37 @@ mod tests {
             expected
         );
         assert!(matches!(ready.input, CoalescedInput::Motion(_)));
+    }
+
+    #[test]
+    fn cursor_defaults_coalesce_while_ordered_input_is_blocked() {
+        let (sender, receiver) = bounded(1);
+        sender
+            .send(QueuedCommand {
+                command: Command::Input(b"older input".to_vec()),
+                bytes: 11,
+                preceding_resize: None,
+            })
+            .expect("fill ordered queue");
+        let ingress = Mutex::new(IngressState {
+            default_cursor_shape: Some(CursorShape::Underline),
+            queued_bytes: 11,
+            ..IngressState::default()
+        });
+
+        let work = take_coalesced_work(&receiver, &ingress, false);
+
+        assert_eq!(work.default_cursor_shape, Some(CursorShape::Underline));
+        assert!(matches!(work.input, CoalescedInput::None));
+        assert_eq!(receiver.len(), 1, "ordered input remains queued");
+        assert!(
+            ingress
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .default_cursor_shape
+                .is_none(),
+            "the latest cursor default is consumed independently"
+        );
     }
 
     #[test]
@@ -2209,6 +2237,7 @@ mod tests {
                 row: 23,
                 modifiers: Modifiers::default(),
             }),
+            default_cursor_shape: None,
             queued_bytes: 0,
         });
 

--- a/rust/terminal/tests/engine.rs
+++ b/rust/terminal/tests/engine.rs
@@ -1,6 +1,6 @@
 use input::{ModifyOtherKeys, MouseTracking};
 use surface::{CellStyle, CursorShape, Damage, GridSize, PixelSize, Rgb};
-use terminal::{ClipboardPolicy, ClipboardTarget, TerminalEngine};
+use terminal::{ClipboardPolicy, ClipboardTarget, DefaultColors, TerminalEngine};
 
 #[test]
 fn processes_bytes_into_an_owned_surface() {
@@ -46,6 +46,45 @@ fn publishes_application_requested_cursor_shapes() {
     assert_eq!(
         engine.surface().load().cursor().map(|cursor| cursor.shape),
         Some(CursorShape::Underline)
+    );
+}
+
+#[test]
+fn configured_cursor_shape_is_the_initial_and_resettable_engine_default() {
+    let size = GridSize::new(4, 2).expect("valid grid");
+    let mut engine = TerminalEngine::with_geometry_and_defaults(
+        size,
+        0,
+        PixelSize::default(),
+        ClipboardPolicy::default(),
+        DefaultColors::default(),
+        CursorShape::Bar,
+    );
+
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Bar)
+    );
+
+    let _output = engine.process(b"\x1b[4 q");
+    engine.set_default_cursor_shape(CursorShape::Block);
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Underline),
+        "changing the default must not discard an active application override"
+    );
+
+    let _output = engine.process(b"\x1b[0 q");
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Block)
+    );
+
+    engine.set_default_cursor_shape(CursorShape::Bar);
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Bar),
+        "an open terminal without an override must receive the new default"
     );
 }
 

--- a/rust/terminal/tests/engine.rs
+++ b/rust/terminal/tests/engine.rs
@@ -1,5 +1,5 @@
 use input::{ModifyOtherKeys, MouseTracking};
-use surface::{CellStyle, Damage, GridSize, PixelSize, Rgb};
+use surface::{CellStyle, CursorShape, Damage, GridSize, PixelSize, Rgb};
 use terminal::{ClipboardPolicy, ClipboardTarget, TerminalEngine};
 
 #[test]
@@ -29,6 +29,24 @@ fn exposes_modes_that_control_input_encoding() {
     assert!(modes.bracketed_paste);
     assert_eq!(modes.mouse_tracking, MouseTracking::Drag);
     assert!(modes.sgr_mouse);
+}
+
+#[test]
+fn publishes_application_requested_cursor_shapes() {
+    let size = GridSize::new(4, 2).expect("valid grid");
+    let mut engine = TerminalEngine::new(size);
+
+    let _output = engine.process(b"\x1b[6 q");
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Bar)
+    );
+
+    let _output = engine.process(b"\x1b[4 q");
+    assert_eq!(
+        engine.surface().load().cursor().map(|cursor| cursor.shape),
+        Some(CursorShape::Underline)
+    );
 }
 
 #[test]

--- a/rust/terminal/tests/worker.rs
+++ b/rust/terminal/tests/worker.rs
@@ -54,9 +54,7 @@ mod windows {
         let worker = TerminalWorker::attach(&plan, GridSize::new(40, 4).expect("valid grid"))
             .expect("attach ConPTY client");
 
-        worker
-            .set_default_cursor_shape(CursorShape::Underline)
-            .expect("queue cursor default");
+        worker.set_default_cursor_shape(CursorShape::Underline);
 
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {

--- a/rust/terminal/tests/worker.rs
+++ b/rust/terminal/tests/worker.rs
@@ -6,7 +6,7 @@ mod windows {
 
     use input::{KeyInput, Modifiers};
     use session::{AttachPlan, SessionIdentity};
-    use surface::{GridSize, PixelSize};
+    use surface::{CursorShape, GridSize, PixelSize};
     use terminal::{TerminalEvent, TerminalWorker};
 
     #[test]
@@ -36,6 +36,38 @@ mod windows {
                 "child output did not reach surface"
             );
             drop(surface);
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn cursor_default_updates_reach_an_open_terminal_engine() {
+        let plan = AttachPlan::attach_only(
+            "cmd.exe",
+            ["/d", "/c", "ping -n 4 127.0.0.1 >nul"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+            "worker-cursor-test",
+            SessionIdentity::new(1, "$1", 1),
+        );
+        let worker = TerminalWorker::attach(&plan, GridSize::new(40, 4).expect("valid grid"))
+            .expect("attach ConPTY client");
+
+        worker
+            .set_default_cursor_shape(CursorShape::Underline)
+            .expect("queue cursor default");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let shape = worker.surface().load().cursor().map(|cursor| cursor.shape);
+            if shape == Some(CursorShape::Underline) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "cursor default did not reach the terminal engine"
+            );
             thread::sleep(Duration::from_millis(10));
         }
     }

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -16,12 +16,13 @@ use gpui::{
     WindowDecorations, WindowOptions, actions, div, font, prelude::*, px, rgb, rgba, size,
 };
 use model::PortStatus;
-use surface::{CellStyle, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
+use surface::{CellStyle, CursorShape, Damage, GridSize, Rgb, SurfaceFrame, SurfaceStore};
 use workspace::{
-    AppearanceSettingsDraft, ConfiguredSshHost, HerdrSessionState, HostConnectionState, HostItem,
-    KeyEvent as InputKeyEvent, KeyInput, KwtProjectAction, Modifiers as InputModifiers,
-    MouseAction, MouseButton, MouseInput, NamedKey, SessionName, SessionSelection, SshHostDraft,
-    SshPromptRequest, TerminalTheme, Workspace, WorkspaceContent, WorkspaceEvent,
+    AppearanceSettingsDraft, ConfiguredSshHost, CursorStyle, HerdrSessionState,
+    HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput, KwtProjectAction,
+    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionName,
+    SessionSelection, SshHostDraft, SshPromptRequest, TerminalSettingsDraft, TerminalTheme,
+    Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -99,6 +100,7 @@ pub struct PaintRun {
     foreground: u32,
     background: u32,
     style: CellStyle,
+    cursor: Option<CursorShape>,
 }
 
 impl PaintRun {
@@ -126,16 +128,32 @@ impl PaintRun {
     pub const fn bold(&self) -> bool {
         self.style.contains(CellStyle::BOLD)
     }
+
+    #[must_use]
+    pub const fn cursor_shape(&self) -> Option<CursorShape> {
+        self.cursor
+    }
 }
 
 #[must_use]
 pub fn surface_paint_rows(frame: &SurfaceFrame) -> Vec<Vec<PaintRun>> {
+    surface_paint_rows_with_cursor(frame, None)
+}
+
+fn surface_paint_rows_with_cursor(
+    frame: &SurfaceFrame,
+    cursor_override: Option<CursorShape>,
+) -> Vec<Vec<PaintRun>> {
     (0..frame.size().rows())
-        .map(|row| surface_paint_row(frame, row))
+        .map(|row| surface_paint_row(frame, row, cursor_override))
         .collect()
 }
 
-fn surface_paint_row(frame: &SurfaceFrame, row_index: usize) -> Vec<PaintRun> {
+fn surface_paint_row(
+    frame: &SurfaceFrame,
+    row_index: usize,
+    cursor_override: Option<CursorShape>,
+) -> Vec<PaintRun> {
     let cursor = frame.cursor().filter(|cursor| cursor.visible);
     let row = frame.row(row_index);
     let mut runs: Vec<PaintRun> = Vec::new();
@@ -143,8 +161,11 @@ fn surface_paint_row(frame: &SurfaceFrame, row_index: usize) -> Vec<PaintRun> {
         if cell.text().is_empty() && column > 0 && row[column - 1].style.contains(CellStyle::WIDE) {
             continue;
         }
+        let cell_cursor = cursor
+            .filter(|cursor| cursor.row == row_index && cursor.column == column)
+            .map(|cursor| cursor_override.unwrap_or(cursor.shape));
         let inverted = cell.style.contains(CellStyle::INVERSE)
-            ^ cursor.is_some_and(|cursor| cursor.row == row_index && cursor.column == column);
+            ^ matches!(cell_cursor, Some(CursorShape::Block));
         let (mut foreground, background) = if inverted {
             (cell.background, cell.foreground)
         } else {
@@ -170,11 +191,14 @@ fn surface_paint_row(frame: &SurfaceFrame, row_index: usize) -> Vec<PaintRun> {
             foreground: rgb_value(foreground),
             background: rgb_value(background),
             style: cell.style,
+            cursor: cell_cursor
+                .filter(|shape| !matches!(shape, CursorShape::Block | CursorShape::Hidden)),
         };
         if let Some(previous) = runs.last_mut()
             && previous.foreground == run.foreground
             && previous.background == run.background
             && previous.style == run.style
+            && previous.cursor == run.cursor
         {
             previous.text.push_str(&run.text);
             previous.columns += run.columns;
@@ -190,6 +214,7 @@ pub struct SurfacePaintCache {
     generation: u64,
     size: Option<GridSize>,
     cursor: Option<surface::Cursor>,
+    cursor_override: Option<CursorShape>,
     rows: Vec<Arc<Vec<PaintRun>>>,
 }
 
@@ -198,7 +223,11 @@ impl SurfacePaintCache {
         *self = Self::default();
     }
 
-    pub fn update(&mut self, frame: &SurfaceFrame) -> &[Arc<Vec<PaintRun>>] {
+    pub fn update(
+        &mut self,
+        frame: &SurfaceFrame,
+        cursor_override: Option<CursorShape>,
+    ) -> &[Arc<Vec<PaintRun>>] {
         let scrolled = frame
             .damage()
             .iter()
@@ -206,9 +235,10 @@ impl SurfacePaintCache {
         let full = self.size != Some(frame.size())
             || self.rows.len() != frame.size().rows()
             || frame.requires_full_repaint(self.generation)
-            || frame.damage().contains(&Damage::Full);
+            || frame.damage().contains(&Damage::Full)
+            || self.cursor_override != cursor_override;
         if full {
-            self.rows = surface_paint_rows(frame)
+            self.rows = surface_paint_rows_with_cursor(frame, cursor_override)
                 .into_iter()
                 .map(Arc::new)
                 .collect();
@@ -221,7 +251,13 @@ impl SurfacePaintCache {
                         if let Some(exposed) =
                             apply_cached_scroll(&mut self.rows, top, bottom, delta)
                         {
-                            repaint_rows(&mut self.rows, frame, exposed.start, exposed.end);
+                            repaint_rows(
+                                &mut self.rows,
+                                frame,
+                                exposed.start,
+                                exposed.end,
+                                cursor_override,
+                            );
                         }
                         if let Some(cursor) = self.cursor
                             && cursor.row >= top
@@ -235,32 +271,51 @@ impl SurfacePaintCache {
                         }
                     }
                     Damage::Rows { start, end } => {
-                        repaint_rows(&mut self.rows, frame, start, end);
+                        repaint_rows(&mut self.rows, frame, start, end, cursor_override);
                     }
                 }
             }
             for row in scrolled_cursor_rows {
-                repaint_rows(&mut self.rows, frame, row, row + 1);
+                repaint_rows(&mut self.rows, frame, row, row + 1, cursor_override);
             }
             if scrolled || self.cursor != frame.cursor() {
                 if let Some(cursor) = self.cursor {
-                    repaint_rows(&mut self.rows, frame, cursor.row, cursor.row + 1);
+                    repaint_rows(
+                        &mut self.rows,
+                        frame,
+                        cursor.row,
+                        cursor.row + 1,
+                        cursor_override,
+                    );
                 }
                 if let Some(cursor) = frame.cursor() {
-                    repaint_rows(&mut self.rows, frame, cursor.row, cursor.row + 1);
+                    repaint_rows(
+                        &mut self.rows,
+                        frame,
+                        cursor.row,
+                        cursor.row + 1,
+                        cursor_override,
+                    );
                 }
             }
         }
         self.generation = frame.generation();
         self.size = Some(frame.size());
         self.cursor = frame.cursor();
+        self.cursor_override = cursor_override;
         &self.rows
     }
 }
 
-fn repaint_rows(rows: &mut [Arc<Vec<PaintRun>>], frame: &SurfaceFrame, start: usize, end: usize) {
+fn repaint_rows(
+    rows: &mut [Arc<Vec<PaintRun>>],
+    frame: &SurfaceFrame,
+    start: usize,
+    end: usize,
+    cursor_override: Option<CursorShape>,
+) {
     for row in start..end.min(rows.len()) {
-        rows[row] = Arc::new(surface_paint_row(frame, row));
+        rows[row] = Arc::new(surface_paint_row(frame, row, cursor_override));
     }
 }
 
@@ -314,6 +369,7 @@ pub struct RootView {
     wheel_remainder: f32,
     keyboard: TerminalKeyboard,
     pointer: TerminalPointer,
+    terminal_pointer_visibility: TerminalPointerVisibility,
     sidebar_visible: bool,
     collapsed_session_groups: HashSet<SessionGroupKey>,
     new_session: Option<NewSessionDraft>,
@@ -323,6 +379,13 @@ pub struct RootView {
     pending_worktree_navigation: Option<u64>,
     session_action_menu: Option<SessionActionMenu>,
     restore_focus: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum TerminalPointerVisibility {
+    #[default]
+    Visible,
+    Hidden,
 }
 
 #[derive(Default)]
@@ -439,15 +502,17 @@ impl SshField {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SettingsPane {
     Appearance,
+    Terminal,
     Hosts,
 }
 
 impl SettingsPane {
-    const ALL: [Self; 2] = [Self::Appearance, Self::Hosts];
+    const ALL: [Self; 3] = [Self::Appearance, Self::Terminal, Self::Hosts];
 
     const fn title(self) -> &'static str {
         match self {
             Self::Appearance => "Appearance",
+            Self::Terminal => "Terminal",
             Self::Hosts => "Hosts",
         }
     }
@@ -455,7 +520,57 @@ impl SettingsPane {
     const fn subtitle(self) -> &'static str {
         match self {
             Self::Appearance => "Choose a terminal theme and installed monospace font.",
+            Self::Terminal => "Control cursor behavior and pointer visibility while typing.",
             Self::Hosts => "Connect the machines and tmux sessions in your SSH network.",
+        }
+    }
+
+    const fn adjacent(self, reverse: bool) -> Option<Self> {
+        match (self, reverse) {
+            (Self::Appearance, false) | (Self::Hosts, true) => Some(Self::Terminal),
+            (Self::Terminal, false) => Some(Self::Hosts),
+            (Self::Hosts, false) | (Self::Appearance, true) => None,
+            (Self::Terminal, true) => Some(Self::Appearance),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TerminalField {
+    CursorStyle,
+    ShellIntegrationCursor,
+    HideMouseWhileTyping,
+}
+
+impl TerminalField {
+    const fn adjacent(self, reverse: bool) -> Self {
+        match (self, reverse) {
+            (Self::CursorStyle, false) | (Self::HideMouseWhileTyping, true) => {
+                Self::ShellIntegrationCursor
+            }
+            (Self::ShellIntegrationCursor, false) | (Self::CursorStyle, true) => {
+                Self::HideMouseWhileTyping
+            }
+            (Self::ShellIntegrationCursor, true) | (Self::HideMouseWhileTyping, false) => {
+                Self::CursorStyle
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TerminalEditor {
+    draft: TerminalSettingsDraft,
+    field: TerminalField,
+    error: Option<String>,
+}
+
+impl TerminalEditor {
+    const fn new(draft: TerminalSettingsDraft) -> Self {
+        Self {
+            draft,
+            field: TerminalField::CursorStyle,
+            error: None,
         }
     }
 }
@@ -559,6 +674,7 @@ struct SettingsDialog {
     pane: SettingsPane,
     sidebar_focus: Option<SettingsPane>,
     appearance_editor: AppearanceEditor,
+    terminal_editor: TerminalEditor,
     selected_host_id: Option<String>,
     host_editor: Option<SshHostEditor>,
     pending_remove: Option<ConfiguredSshHost>,
@@ -569,6 +685,7 @@ impl SettingsDialog {
     fn new(
         hosts: &[ConfiguredSshHost],
         appearance: AppearanceSettingsDraft,
+        terminal: TerminalSettingsDraft,
         font_families: Vec<String>,
     ) -> Self {
         let selected = hosts.first();
@@ -576,6 +693,7 @@ impl SettingsDialog {
             pane: SettingsPane::Appearance,
             sidebar_focus: Some(SettingsPane::Appearance),
             appearance_editor: AppearanceEditor::new(appearance, font_families),
+            terminal_editor: TerminalEditor::new(terminal),
             selected_host_id: selected.map(|host| host.id().to_owned()),
             host_editor: selected.map(|host| SshHostEditor::new(Some(host))),
             pending_remove: None,
@@ -597,6 +715,14 @@ fn focus_settings_detail(dialog: &mut SettingsDialog, reverse: bool) -> bool {
             };
             true
         }
+        SettingsPane::Terminal => {
+            dialog.terminal_editor.field = if reverse {
+                TerminalField::HideMouseWhileTyping
+            } else {
+                TerminalField::CursorStyle
+            };
+            true
+        }
         SettingsPane::Hosts => {
             let Some(editor) = &mut dialog.host_editor else {
                 return false;
@@ -613,24 +739,16 @@ fn focus_settings_detail(dialog: &mut SettingsDialog, reverse: bool) -> bool {
 
 fn advance_settings_focus(dialog: &mut SettingsDialog, reverse: bool) {
     if let Some(pane) = dialog.sidebar_focus {
-        match (pane, reverse) {
-            (SettingsPane::Appearance, false) => {
-                dialog.sidebar_focus = Some(SettingsPane::Hosts);
-            }
-            (SettingsPane::Hosts, true) => {
-                dialog.sidebar_focus = Some(SettingsPane::Appearance);
-            }
-            (SettingsPane::Hosts, false) | (SettingsPane::Appearance, true) => {
-                if focus_settings_detail(dialog, reverse) {
-                    dialog.sidebar_focus = None;
-                } else {
-                    dialog.sidebar_focus = Some(if reverse {
-                        SettingsPane::Hosts
-                    } else {
-                        SettingsPane::Appearance
-                    });
-                }
-            }
+        if let Some(next) = pane.adjacent(reverse) {
+            dialog.sidebar_focus = Some(next);
+        } else if focus_settings_detail(dialog, reverse) {
+            dialog.sidebar_focus = None;
+        } else {
+            dialog.sidebar_focus = Some(if reverse {
+                SettingsPane::Hosts
+            } else {
+                SettingsPane::Appearance
+            });
         }
         return;
     }
@@ -661,6 +779,23 @@ fn advance_settings_focus(dialog: &mut SettingsDialog, reverse: bool) {
             }
             dialog.appearance_editor.open_picker = None;
             dialog.appearance_editor.error = None;
+        }
+        SettingsPane::Terminal => {
+            let at_edge = if reverse {
+                dialog.terminal_editor.field == TerminalField::CursorStyle
+            } else {
+                dialog.terminal_editor.field == TerminalField::HideMouseWhileTyping
+            };
+            if at_edge {
+                dialog.sidebar_focus = Some(if reverse {
+                    SettingsPane::Hosts
+                } else {
+                    SettingsPane::Appearance
+                });
+            } else {
+                dialog.terminal_editor.field = dialog.terminal_editor.field.adjacent(reverse);
+            }
+            dialog.terminal_editor.error = None;
         }
         SettingsPane::Hosts => {
             let Some(editor) = &mut dialog.host_editor else {
@@ -1591,6 +1726,7 @@ impl RootView {
             wheel_remainder: 0.0,
             keyboard: TerminalKeyboard::default(),
             pointer: TerminalPointer::default(),
+            terminal_pointer_visibility: TerminalPointerVisibility::Visible,
             sidebar_visible: true,
             collapsed_session_groups: HashSet::new(),
             new_session: None,
@@ -1734,8 +1870,14 @@ impl RootView {
     fn open_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let hosts = self.workspace.configured_ssh_hosts();
         let appearance = self.workspace.configured_appearance();
+        let terminal = self.workspace.configured_terminal_settings();
         let font_families = terminal_font_families(cx, &appearance.font_family);
-        self.settings_dialog = Some(SettingsDialog::new(&hosts, appearance, font_families));
+        self.settings_dialog = Some(SettingsDialog::new(
+            &hosts,
+            appearance,
+            terminal,
+            font_families,
+        ));
         self.session_action_menu = None;
         window.focus(&self.settings_focus);
         cx.notify();
@@ -1956,6 +2098,70 @@ impl RootView {
         cx.stop_propagation();
     }
 
+    fn persist_terminal_settings(&mut self, draft: TerminalSettingsDraft, cx: &mut Context<Self>) {
+        match self.workspace.save_terminal_settings(&draft) {
+            Ok(()) => {
+                if let Some(dialog) = &mut self.settings_dialog {
+                    dialog.terminal_editor.error = None;
+                }
+            }
+            Err(error) => {
+                if let Some(dialog) = &mut self.settings_dialog {
+                    dialog.terminal_editor.error = Some(error.to_string());
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    fn edit_terminal_field(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        if event.is_held {
+            return;
+        }
+        let key = event.keystroke.key.to_ascii_lowercase();
+        let Some(editor) = self
+            .settings_dialog
+            .as_mut()
+            .map(|dialog| &mut dialog.terminal_editor)
+        else {
+            return;
+        };
+        let activate = matches!(key.as_str(), "enter" | "space");
+        let arrows = matches!(key.as_str(), "up" | "down" | "left" | "right");
+        let changed = match editor.field {
+            TerminalField::CursorStyle if activate || arrows => {
+                let current = CursorStyle::ALL
+                    .iter()
+                    .position(|style| *style == editor.draft.cursor_style)
+                    .unwrap_or_default();
+                let reverse = matches!(key.as_str(), "up" | "left");
+                let offset = if reverse {
+                    CursorStyle::ALL.len() - 1
+                } else {
+                    1
+                };
+                editor.draft.cursor_style =
+                    CursorStyle::ALL[(current + offset) % CursorStyle::ALL.len()];
+                true
+            }
+            TerminalField::ShellIntegrationCursor if activate => {
+                editor.draft.allow_shell_integration_cursor =
+                    !editor.draft.allow_shell_integration_cursor;
+                true
+            }
+            TerminalField::HideMouseWhileTyping if activate => {
+                editor.draft.hide_mouse_while_typing = !editor.draft.hide_mouse_while_typing;
+                true
+            }
+            _ => false,
+        };
+        if changed {
+            let draft = editor.draft;
+            self.persist_terminal_settings(draft, cx);
+            cx.stop_propagation();
+        }
+    }
+
     fn remove_ssh_host(&mut self, cx: &mut Context<Self>) {
         let Some(host) = self
             .settings_dialog
@@ -2055,6 +2261,15 @@ impl RootView {
             cx.stop_propagation();
             return;
         }
+        if pane == SettingsPane::Terminal
+            && matches!(
+                key.as_str(),
+                "enter" | "space" | "up" | "down" | "left" | "right"
+            )
+        {
+            self.edit_terminal_field(event, cx);
+            return;
+        }
         if key == "enter" && !event.is_held {
             if pane == SettingsPane::Appearance {
                 cx.stop_propagation();
@@ -2091,6 +2306,15 @@ impl RootView {
             self.edit_appearance_field(event, window, cx);
             return;
         }
+        if pane == SettingsPane::Terminal {
+            cx.stop_propagation();
+            return;
+        }
+        self.edit_ssh_field(event, cx);
+    }
+
+    fn edit_ssh_field(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        let key = event.keystroke.key.to_ascii_lowercase();
         let Some(editor) = self
             .settings_dialog
             .as_mut()
@@ -3368,12 +3592,13 @@ impl RootView {
             && let Some((canonical, input)) =
                 retained_key_event(&self.keyboard, keystroke, InputKeyEvent::Repeat)
         {
-            self.send_key_event(
+            let accepted = self.send_key_event(
                 presentation_id,
                 input,
                 &canonical.identity,
                 InputKeyEvent::Repeat,
             );
+            self.hide_pointer_after_typing(accepted, cx);
             cx.stop_propagation();
             return;
         }
@@ -3390,7 +3615,8 @@ impl RootView {
             if !event.is_held
                 && let Some(text) = cx.read_from_clipboard().and_then(|item| item.text())
             {
-                self.send_key(presentation_id, KeyInput::paste(text));
+                let accepted = self.send_key(presentation_id, KeyInput::paste(text));
+                self.hide_pointer_after_typing(accepted, cx);
             }
             cx.stop_propagation();
             return;
@@ -3407,7 +3633,8 @@ impl RootView {
                 .input_for(&canonical.identity, event, canonical.modifiers)
         });
         if let Some(input) = input {
-            self.send_key_event(presentation_id, input, &canonical.identity, event);
+            let accepted = self.send_key_event(presentation_id, input, &canonical.identity, event);
+            self.hide_pointer_after_typing(accepted, cx);
             cx.stop_propagation();
         }
     }
@@ -3502,6 +3729,10 @@ impl RootView {
         if !self.presentation_accepts_input(presentation_id) {
             return;
         }
+        if self.terminal_pointer_visibility == TerminalPointerVisibility::Hidden {
+            self.terminal_pointer_visibility = TerminalPointerVisibility::Visible;
+            cx.notify();
+        }
         let button = event.pressed_button.and_then(terminal_mouse_button);
         let cell = self.terminal_cell_at(event.position.x.into(), event.position.y.into());
         if let Some(cell) = self.pointer.observe(cell) {
@@ -3591,8 +3822,8 @@ impl RootView {
         self.enqueue_input(presentation_id, PendingUiInput::Mouse(input))
     }
 
-    fn send_key(&mut self, presentation_id: u64, input: KeyInput) {
-        self.enqueue_input(presentation_id, PendingUiInput::Key(input));
+    fn send_key(&mut self, presentation_id: u64, input: KeyInput) -> bool {
+        self.enqueue_input(presentation_id, PendingUiInput::Key(input))
     }
 
     fn send_key_event(
@@ -3601,12 +3832,12 @@ impl RootView {
         input: KeyInput,
         key: &TerminalKeyIdentity,
         event: InputKeyEvent,
-    ) {
+    ) -> bool {
         if !self.presentation_accepts_input(presentation_id) {
-            return;
+            return false;
         }
         if !self.keyboard.accepts(key, event) {
-            return;
+            return false;
         }
         let reserved_key_releases = match event {
             InputKeyEvent::Press => self.keyboard.reservations_after_press(key),
@@ -3619,6 +3850,22 @@ impl RootView {
             reserved_key_releases,
         ) {
             self.keyboard.finish_accepted(key, pressed_input, event);
+            return true;
+        }
+        false
+    }
+
+    fn hide_pointer_after_typing(&mut self, accepted: bool, cx: &mut Context<Self>) {
+        if accepted
+            && self
+                .workspace
+                .snapshot()
+                .appearance()
+                .hide_mouse_while_typing()
+            && self.terminal_pointer_visibility == TerminalPointerVisibility::Visible
+        {
+            self.terminal_pointer_visibility = TerminalPointerVisibility::Hidden;
+            cx.notify();
         }
     }
 
@@ -3865,10 +4112,17 @@ impl RootView {
         if self.observed_surface_identity != Some(identity) {
             self.paint_cache.clear();
         }
-        let rows = self.paint_cache.update(&frame).to_vec();
+        let appearance = snapshot.appearance();
+        let cursor_override = (!appearance.allow_shell_integration_cursor()).then(|| {
+            match appearance.cursor_style() {
+                CursorStyle::Block => CursorShape::Block,
+                CursorStyle::Bar => CursorShape::Bar,
+                CursorStyle::Underline => CursorShape::Underline,
+            }
+        });
+        let rows = self.paint_cache.update(&frame, cursor_override).to_vec();
         self.observed_surface_identity = Some(identity);
         self.observed_surface_generation = frame.generation();
-        let appearance = snapshot.appearance();
         let terminal = self.terminal_surface_element(presentation_id, appearance, rows, cx);
 
         div()
@@ -3900,6 +4154,10 @@ impl RootView {
             .text_size(px(f32::from(appearance.font_size())))
             .line_height(px(self.terminal_metrics.line_height))
             .font_weight(FontWeight::NORMAL)
+            .when(
+                self.terminal_pointer_visibility == TerminalPointerVisibility::Hidden,
+                |element| element.cursor(gpui::CursorStyle::None),
+            )
             .on_key_down(cx.listener(move |this, event, window, cx| {
                 this.on_key_down(presentation_id, event, window, cx);
             }))
@@ -5334,6 +5592,250 @@ impl RootView {
             .into_any_element()
     }
 
+    fn terminal_cursor_option(
+        style: CursorStyle,
+        draft: TerminalSettingsDraft,
+        keyboard_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let selected = draft.cursor_style == style;
+        let cursor = match style {
+            CursorStyle::Block => div().w(px(12.0)).h(px(20.0)).bg(rgb(0x8d_c8ff)),
+            CursorStyle::Bar => div().w(px(2.0)).h(px(20.0)).bg(rgb(0x8d_c8ff)),
+            CursorStyle::Underline => div().w(px(12.0)).h(px(2.0)).bg(rgb(0x8d_c8ff)),
+        };
+        div()
+            .id(("terminal-cursor-style", style as usize))
+            .w(px(170.0))
+            .h(px(82.0))
+            .px_3()
+            .flex()
+            .items_center()
+            .gap_3()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(if keyboard_focused || selected {
+                0x4a_8f_cf
+            } else {
+                0x34_3a46
+            }))
+            .bg(rgb(if selected { 0x20_2b3a } else { 0x11_141a }))
+            .cursor_pointer()
+            .child(
+                div()
+                    .w(px(34.0))
+                    .h(px(36.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded_sm()
+                    .bg(rgb(0x08_0a0f))
+                    .child(cursor),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(style.title())
+                    .when(selected, |element| {
+                        element.child(
+                            div()
+                                .text_xs()
+                                .text_color(rgb(0x79_b8_f3))
+                                .child("Selected"),
+                        )
+                    }),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                if let Some(dialog) = &mut this.settings_dialog {
+                    dialog.sidebar_focus = None;
+                    dialog.terminal_editor.field = TerminalField::CursorStyle;
+                    dialog.terminal_editor.draft.cursor_style = style;
+                }
+                window.focus(&this.settings_focus);
+                if let Some(draft) = this
+                    .settings_dialog
+                    .as_ref()
+                    .map(|dialog| dialog.terminal_editor.draft)
+                {
+                    this.persist_terminal_settings(draft, cx);
+                }
+            }))
+            .into_any_element()
+    }
+
+    fn terminal_toggle_row(
+        &self,
+        id: &'static str,
+        title: &'static str,
+        description: &'static str,
+        field: TerminalField,
+        enabled: bool,
+        cx: &mut Context<Self>,
+    ) -> gpui::AnyElement {
+        let keyboard_focused = self.settings_dialog.as_ref().is_some_and(|dialog| {
+            dialog.sidebar_focus.is_none() && dialog.terminal_editor.field == field
+        });
+        div()
+            .id(id)
+            .min_h(px(66.0))
+            .px_3()
+            .py_2()
+            .flex()
+            .items_center()
+            .justify_between()
+            .gap_4()
+            .rounded_md()
+            .border_1()
+            .border_color(rgb(if keyboard_focused {
+                0x4a_8f_cf
+            } else {
+                0x34_3a46
+            }))
+            .bg(rgb(0x11_141a))
+            .cursor_pointer()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(div().text_sm().child(title))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(rgb(0x8f_96_a3))
+                            .child(description),
+                    ),
+            )
+            .child(
+                div()
+                    .w(px(38.0))
+                    .h(px(22.0))
+                    .p(px(3.0))
+                    .flex()
+                    .justify_end()
+                    .when(!enabled, gpui::Styled::justify_start)
+                    .rounded_full()
+                    .bg(rgb(if enabled { 0x2b_72aa } else { 0x3a_404c }))
+                    .child(div().size(px(16.0)).rounded_full().bg(rgb(0xf1_f4f8))),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                if let Some(dialog) = &mut this.settings_dialog {
+                    dialog.sidebar_focus = None;
+                    dialog.terminal_editor.field = field;
+                    match field {
+                        TerminalField::ShellIntegrationCursor => {
+                            dialog.terminal_editor.draft.allow_shell_integration_cursor =
+                                !dialog.terminal_editor.draft.allow_shell_integration_cursor;
+                        }
+                        TerminalField::HideMouseWhileTyping => {
+                            dialog.terminal_editor.draft.hide_mouse_while_typing =
+                                !dialog.terminal_editor.draft.hide_mouse_while_typing;
+                        }
+                        TerminalField::CursorStyle => {}
+                    }
+                }
+                window.focus(&this.settings_focus);
+                if let Some(draft) = this
+                    .settings_dialog
+                    .as_ref()
+                    .map(|dialog| dialog.terminal_editor.draft)
+                {
+                    this.persist_terminal_settings(draft, cx);
+                }
+            }))
+            .into_any_element()
+    }
+
+    fn settings_terminal_editor(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
+        let Some(editor) = self
+            .settings_dialog
+            .as_ref()
+            .map(|dialog| &dialog.terminal_editor)
+        else {
+            return div().into_any_element();
+        };
+        let cursor_keyboard_focused = self.settings_dialog.as_ref().is_some_and(|dialog| {
+            dialog.sidebar_focus.is_none()
+                && dialog.terminal_editor.field == TerminalField::CursorStyle
+        });
+        let mut cursor_options = div().flex().flex_wrap().gap_2();
+        for style in CursorStyle::ALL {
+            cursor_options = cursor_options.child(Self::terminal_cursor_option(
+                style,
+                editor.draft,
+                cursor_keyboard_focused,
+                cx,
+            ));
+        }
+        let mut form = div()
+            .w_full()
+            .max_w(px(900.0))
+            .flex()
+            .flex_col()
+            .gap_6()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_3()
+                    .child(
+                        div()
+                            .text_base()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child("Cursor"),
+                    )
+                    .child(cursor_options)
+                    .child(self.terminal_toggle_row(
+                        "terminal-shell-cursor",
+                        "Allow shell integration to control cursor shape",
+                        "Honor cursor-shape requests from shells and terminal applications.",
+                        TerminalField::ShellIntegrationCursor,
+                        editor.draft.allow_shell_integration_cursor,
+                        cx,
+                    )),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_3()
+                    .child(
+                        div()
+                            .text_base()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child("Interaction"),
+                    )
+                    .child(self.terminal_toggle_row(
+                        "terminal-hide-mouse",
+                        "Hide mouse while typing",
+                        "Reveal the pointer again as soon as it moves over the terminal.",
+                        TerminalField::HideMouseWhileTyping,
+                        editor.draft.hide_mouse_while_typing,
+                        cx,
+                    )),
+            );
+        if let Some(error) = &editor.error {
+            form = form.child(
+                div()
+                    .text_xs()
+                    .text_color(rgb(0xd0_7070))
+                    .child(error.clone()),
+            );
+        }
+        div()
+            .id("settings-terminal-editor")
+            .flex_1()
+            .min_w_0()
+            .h_full()
+            .overflow_y_scroll()
+            .px_6()
+            .py_5()
+            .child(form)
+            .into_any_element()
+    }
+
     fn settings_sidebar(&self, cx: &mut Context<Self>) -> gpui::AnyElement {
         let active = self
             .settings_dialog
@@ -5739,6 +6241,7 @@ impl RootView {
         let pane = dialog.pane;
         let detail = match pane {
             SettingsPane::Appearance => self.settings_appearance_editor(cx),
+            SettingsPane::Terminal => self.settings_terminal_editor(cx),
             SettingsPane::Hosts => div()
                 .flex_1()
                 .min_h_0()
@@ -8505,6 +9008,11 @@ fn paint_run_element(run: PaintRun, cell_width: f32) -> gpui::AnyElement {
     if run.style.contains(CellStyle::STRIKE) {
         element = element.line_through();
     }
+    element = match run.cursor {
+        Some(CursorShape::Bar) => element.border_l_2().border_color(rgb(run.foreground)),
+        Some(CursorShape::Underline) => element.border_b_2().border_color(rgb(run.foreground)),
+        Some(CursorShape::Block | CursorShape::Hidden) | None => element,
+    };
     element.into_any_element()
 }
 
@@ -8947,25 +9455,25 @@ mod tests {
         HostHeaderAction, INPUT_BUFFER_FULL_DIAGNOSTIC, INPUT_BUFFERED_DIAGNOSTIC, InputRefusal,
         LayoutKey, NewSessionDraft, NewSessionKind, NewWorktreeMode, PendingUiInput, ProjectDialog,
         QueuedUiInput, SessionGroup, SessionGroupKey, SessionRowAction, SettingsDialog,
-        SettingsPane, SshField, SshHostEditor, TERMINAL_NOTICE_DURATION, TerminalKeyIdentity,
-        TerminalKeyboard, TerminalPointer, TerminalResize, TransientNotice, UI_INPUT_BYTE_CAPACITY,
-        UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority, WorktreeHostAccess, WorktreeOpenContext,
-        WorktreeOpenMode, WorktreeOpenTarget, WorktreePresentation, WorktreeRemoveTarget,
-        WorktreeSessionPresence, WorktreeSocket, activate_settings_sidebar_pane,
-        active_session_selection, adjacent_appearance_field, advance_settings_focus,
-        appearance_draft_is_persistable, appearance_preview_color, application_navigation_width,
-        apply_new_worktree_failure, apply_worktree_removal_failure, available_herdr_row_actions,
-        can_create_worktree, can_kill_worktree, canonical_terminal_key_with,
-        chrome_palette_for_terminal_theme, clear_terminal_input_state, clears_after_input_delivery,
-        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
-        has_ambiguous_worktree_source, herdr_row_actions, herdr_session_menu_actions,
-        host_header_action, host_landing_text, input_queue_has_capacity,
-        is_toggle_sidebar_shortcut, kill_confirmation_description, kill_confirmation_title,
-        kwt_operation_failure_owns_dialog, named_key, new_session_validation, normalize_cell_width,
-        owns_created_worktree_navigation, pull_request_import_selector,
-        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
-        session_backend_id, session_creation_available, session_group_visibility,
-        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        SettingsPane, SshField, SshHostEditor, TERMINAL_NOTICE_DURATION, TerminalField,
+        TerminalKeyIdentity, TerminalKeyboard, TerminalPointer, TerminalResize, TransientNotice,
+        UI_INPUT_BYTE_CAPACITY, UI_INPUT_CAPACITY, WheelBatch, WorktreeAuthority,
+        WorktreeHostAccess, WorktreeOpenContext, WorktreeOpenMode, WorktreeOpenTarget,
+        WorktreePresentation, WorktreeRemoveTarget, WorktreeSessionPresence, WorktreeSocket,
+        activate_settings_sidebar_pane, active_session_selection, adjacent_appearance_field,
+        advance_settings_focus, appearance_draft_is_persistable, appearance_preview_color,
+        application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
+        available_herdr_row_actions, can_create_worktree, can_kill_worktree,
+        canonical_terminal_key_with, chrome_palette_for_terminal_theme, clear_terminal_input_state,
+        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
+        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
+        herdr_session_menu_actions, host_header_action, host_landing_text,
+        input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
+        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
+        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
+        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
+        session_action_menu_position, session_backend_id, session_creation_available,
+        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_font_changed, terminal_key_input,
         terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
         tmux_row_actions, toggle_session_group_state, transitioned_presentation,
@@ -8977,10 +9485,11 @@ mod tests {
     use std::time::{Duration, Instant};
     use surface::{GridSize, SurfaceFrame, SurfaceStore};
     use workspace::{
-        AppearanceSettingsDraft, HerdrSessionItem, HerdrSessionState, HostConnectionState,
-        HostDiagnostic, HostItem, KeyEvent, KeyInput, KwtBranchItem, KwtPullRequestItem, Modifiers,
-        MouseAction, MouseButton, MouseInput, NamedKey, ProjectItem, SessionItem, SessionSelection,
-        SshHostDraft, TerminalTheme, WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
+        AppearanceSettingsDraft, CursorStyle, HerdrSessionItem, HerdrSessionState,
+        HostConnectionState, HostDiagnostic, HostItem, KeyEvent, KeyInput, KwtBranchItem,
+        KwtPullRequestItem, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey, ProjectItem,
+        SessionItem, SessionSelection, SshHostDraft, TerminalSettingsDraft, TerminalTheme,
+        WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
     };
 
     #[test]
@@ -9036,11 +9545,25 @@ mod tests {
             background: "#0c0f14".to_owned(),
             foreground: "#d8dee9".to_owned(),
         };
-        let dialog = SettingsDialog::new(&[], appearance.clone(), vec!["Cascadia Mono".to_owned()]);
+        let terminal = TerminalSettingsDraft {
+            cursor_style: CursorStyle::Block,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
+        };
+        let dialog = SettingsDialog::new(
+            &[],
+            appearance.clone(),
+            terminal,
+            vec!["Cascadia Mono".to_owned()],
+        );
 
         assert_eq!(
             SettingsPane::ALL,
-            [SettingsPane::Appearance, SettingsPane::Hosts]
+            [
+                SettingsPane::Appearance,
+                SettingsPane::Terminal,
+                SettingsPane::Hosts,
+            ]
         );
         assert_eq!(dialog.pane, SettingsPane::Appearance);
         assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
@@ -9059,22 +9582,24 @@ mod tests {
             background: "#212734".to_owned(),
             foreground: "#e6e6e6".to_owned(),
         };
-        let mut dialog = SettingsDialog::new(&[], appearance, vec!["Cascadia Mono".to_owned()]);
+        let terminal = TerminalSettingsDraft {
+            cursor_style: CursorStyle::Bar,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
+        };
+        let mut dialog =
+            SettingsDialog::new(&[], appearance, terminal, vec!["Cascadia Mono".to_owned()]);
+
+        advance_settings_focus(&mut dialog, false);
+        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Terminal));
+        assert!(activate_settings_sidebar_pane(&mut dialog));
+        assert_eq!(dialog.pane, SettingsPane::Terminal);
 
         advance_settings_focus(&mut dialog, false);
         assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Hosts));
-        assert!(activate_settings_sidebar_pane(&mut dialog));
-        assert_eq!(dialog.pane, SettingsPane::Hosts);
-
-        advance_settings_focus(&mut dialog, false);
-        assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
-        assert!(activate_settings_sidebar_pane(&mut dialog));
-        assert_eq!(dialog.pane, SettingsPane::Appearance);
-
-        advance_settings_focus(&mut dialog, false);
         advance_settings_focus(&mut dialog, false);
         assert_eq!(dialog.sidebar_focus, None);
-        assert_eq!(dialog.appearance_editor.field, AppearanceField::Theme);
+        assert_eq!(dialog.terminal_editor.field, TerminalField::CursorStyle);
 
         advance_settings_focus(&mut dialog, false);
         advance_settings_focus(&mut dialog, false);
@@ -9083,7 +9608,10 @@ mod tests {
 
         advance_settings_focus(&mut dialog, true);
         assert_eq!(dialog.sidebar_focus, None);
-        assert_eq!(dialog.appearance_editor.field, AppearanceField::FontSize);
+        assert_eq!(
+            dialog.terminal_editor.field,
+            TerminalField::HideMouseWhileTyping
+        );
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -3869,11 +3869,7 @@ impl RootView {
 
     fn hide_pointer_after_typing(&mut self, accepted: bool, cx: &mut Context<Self>) {
         if accepted
-            && self
-                .workspace
-                .snapshot()
-                .appearance()
-                .hide_mouse_while_typing()
+            && self.workspace.hide_mouse_while_typing()
             && self.terminal_pointer_visibility == TerminalPointerVisibility::Visible
         {
             self.terminal_pointer_visibility = TerminalPointerVisibility::Hidden;

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -830,6 +830,14 @@ fn activate_settings_sidebar_pane(dialog: &mut SettingsDialog) -> bool {
     true
 }
 
+const fn focused_settings_detail(dialog: &SettingsDialog) -> Option<SettingsPane> {
+    if dialog.sidebar_focus.is_none() {
+        Some(dialog.pane)
+    } else {
+        None
+    }
+}
+
 #[derive(Clone)]
 struct SshPromptDialog {
     request: SshPromptRequest,
@@ -2233,6 +2241,10 @@ impl RootView {
             .settings_dialog
             .as_ref()
             .map_or(SettingsPane::Appearance, |dialog| dialog.pane);
+        let detail_pane = self
+            .settings_dialog
+            .as_ref()
+            .and_then(focused_settings_detail);
         if key == "escape" && !event.is_held {
             if self
                 .settings_dialog
@@ -2261,7 +2273,7 @@ impl RootView {
             cx.stop_propagation();
             return;
         }
-        if pane == SettingsPane::Terminal
+        if detail_pane == Some(SettingsPane::Terminal)
             && matches!(
                 key.as_str(),
                 "enter" | "space" | "up" | "down" | "left" | "right"
@@ -9466,8 +9478,8 @@ mod tests {
         available_herdr_row_actions, can_create_worktree, can_kill_worktree,
         canonical_terminal_key_with, chrome_palette_for_terminal_theme, clear_terminal_input_state,
         clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, has_ambiguous_worktree_source, herdr_row_actions,
-        herdr_session_menu_actions, host_header_action, host_landing_text,
+        coalesce_last_wheel, focused_settings_detail, has_ambiguous_worktree_source,
+        herdr_row_actions, herdr_session_menu_actions, host_header_action, host_landing_text,
         input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
         kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
         new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
@@ -9594,12 +9606,17 @@ mod tests {
         assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Terminal));
         assert!(activate_settings_sidebar_pane(&mut dialog));
         assert_eq!(dialog.pane, SettingsPane::Terminal);
+        assert_eq!(focused_settings_detail(&dialog), None);
 
         advance_settings_focus(&mut dialog, false);
         assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Hosts));
         advance_settings_focus(&mut dialog, false);
         assert_eq!(dialog.sidebar_focus, None);
         assert_eq!(dialog.terminal_editor.field, TerminalField::CursorStyle);
+        assert_eq!(
+            focused_settings_detail(&dialog),
+            Some(SettingsPane::Terminal)
+        );
 
         advance_settings_focus(&mut dialog, false);
         advance_settings_focus(&mut dialog, false);

--- a/rust/ui/tests/root_view.rs
+++ b/rust/ui/tests/root_view.rs
@@ -57,7 +57,7 @@ fn paint_cache_applies_scroll_damage_and_repaints_exposed_rows() {
     }
     let store = SurfaceStore::new(initial);
     let mut cache = SurfacePaintCache::default();
-    let _initial = cache.update(&store.load());
+    let _initial = cache.update(&store.load(), None);
 
     assert!(store.update(
         2,
@@ -73,7 +73,7 @@ fn paint_cache_applies_scroll_damage_and_repaints_exposed_rows() {
         |frame| *frame.cell_mut(2) = Cell::plain("d"),
     ));
 
-    let rows = cache.update(&store.load());
+    let rows = cache.update(&store.load(), None);
     let text: Vec<_> = rows.iter().map(|row| row[0].text()).collect();
     assert_eq!(text, ["b", "c", "d"]);
 }
@@ -87,7 +87,7 @@ fn paint_cache_repaints_blank_rows_exposed_by_scroll_only_damage() {
     }
     let store = SurfaceStore::new(initial);
     let mut cache = SurfacePaintCache::default();
-    let _initial = cache.update(&store.load());
+    let _initial = cache.update(&store.load(), None);
 
     assert!(store.update(
         2,
@@ -100,7 +100,7 @@ fn paint_cache_repaints_blank_rows_exposed_by_scroll_only_damage() {
         |_| {},
     ));
 
-    let rows = cache.update(&store.load());
+    let rows = cache.update(&store.load(), None);
     let text = rows.iter().map(|row| row[0].text()).collect::<Vec<_>>();
     assert_eq!(text, ["b", "c", " "]);
 }
@@ -114,7 +114,7 @@ fn paint_cache_does_not_replay_scroll_after_consuming_an_intermediate_frame() {
     }
     let store = SurfaceStore::new(initial);
     let mut cache = SurfacePaintCache::default();
-    let _initial = cache.update(&store.load());
+    let _initial = cache.update(&store.load(), None);
 
     assert!(store.update(
         2,
@@ -126,7 +126,7 @@ fn paint_cache_does_not_replay_scroll_after_consuming_an_intermediate_frame() {
         }],
         |_| {},
     ));
-    let _intermediate = cache.update(&store.load());
+    let _intermediate = cache.update(&store.load(), None);
     assert!(store.update(
         3,
         size,
@@ -140,7 +140,7 @@ fn paint_cache_does_not_replay_scroll_after_consuming_an_intermediate_frame() {
         },
     ));
 
-    let rows = cache.update(&store.load());
+    let rows = cache.update(&store.load(), None);
     let text = rows.iter().map(|row| row[0].text()).collect::<Vec<_>>();
     assert_eq!(text, ["Z", "c", "d"]);
 }
@@ -156,10 +156,11 @@ fn paint_cache_does_not_scroll_cursor_highlighting_with_cells() {
         row: 1,
         column: 0,
         visible: true,
+        shape: surface::CursorShape::Block,
     }));
     let store = SurfaceStore::new(initial);
     let mut cache = SurfacePaintCache::default();
-    let _initial = cache.update(&store.load());
+    let _initial = cache.update(&store.load(), None);
 
     assert!(store.update(
         2,
@@ -178,11 +179,12 @@ fn paint_cache_does_not_scroll_cursor_highlighting_with_cells() {
                 row: 1,
                 column: 0,
                 visible: true,
+                shape: surface::CursorShape::Block,
             }));
         },
     ));
 
-    let rows = cache.update(&store.load());
+    let rows = cache.update(&store.load(), None);
     assert_eq!(rows[0][0].foreground(), 0xd8_de_e9);
     assert_eq!(rows[1][0].foreground(), 0x0c_0f_14);
 }
@@ -231,6 +233,7 @@ fn terminal_paint_rows_preserve_cell_style_and_cursor() {
         row: 0,
         column: 1,
         visible: true,
+        shape: surface::CursorShape::Block,
     }));
 
     let rows = surface_paint_rows(&frame);
@@ -243,6 +246,30 @@ fn terminal_paint_rows_preserve_cell_style_and_cursor() {
     assert_eq!(rows[0][1].text(), "b");
     assert_eq!(rows[0][1].foreground(), 0x04_05_06);
     assert_eq!(rows[0][1].background(), 0x01_02_03);
+}
+
+#[test]
+fn terminal_paint_rows_preserve_dynamic_cursor_shape_and_allow_an_override() {
+    let size = GridSize::new(1, 1).expect("valid grid");
+    let mut frame = SurfaceFrame::blank(1, size);
+    *frame.cell_mut(0) = Cell::plain("a");
+    frame.cell_mut(0).foreground = Rgb::new(1, 2, 3);
+    frame.cell_mut(0).background = Rgb::new(4, 5, 6);
+    frame.set_cursor(Some(Cursor {
+        row: 0,
+        column: 0,
+        visible: true,
+        shape: surface::CursorShape::Bar,
+    }));
+
+    let rows = surface_paint_rows(&frame);
+    assert_eq!(rows[0][0].cursor_shape(), Some(surface::CursorShape::Bar));
+    assert_eq!(rows[0][0].foreground(), 0x01_02_03);
+
+    let mut cache = SurfacePaintCache::default();
+    let rows = cache.update(&frame, Some(surface::CursorShape::Block));
+    assert_eq!(rows[0][0].cursor_shape(), None);
+    assert_eq!(rows[0][0].foreground(), 0x04_05_06);
 }
 
 #[test]

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -24,7 +24,7 @@ pub use session::{
     HerdrLifecycleAction, HerdrSessionName, HerdrSessionNameError, HerdrSessionState, SessionName,
     SessionNameError, ZellijSessionName, ZellijSessionNameError,
 };
-use surface::{GridSize, PixelSize, Rgb, SurfaceStore};
+use surface::{CursorShape, GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
     ClipboardPolicy, ClipboardReadRequest as TerminalClipboardRead, ClipboardTarget, DefaultColors,
     TerminalEvent, TerminalStartup, TerminalWorker,
@@ -4442,6 +4442,7 @@ impl Workspace {
                 .map_err(|error| WorkspaceError::new(error.to_string()))?;
             appearance
         };
+        update_default_cursor_shapes(&self.inner, cursor_shape(draft.cursor_style));
         let _snapshot_write = begin_snapshot_write(&self.inner);
         *self
             .inner
@@ -12793,6 +12794,7 @@ fn prepare_remote_tmux_attachment(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -12943,6 +12945,7 @@ fn prepare_remote_herdr_attachment(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -13120,6 +13123,7 @@ fn prepare_remote_zellij_attachment(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -13458,6 +13462,7 @@ fn create_remote_herdr_fresh(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok(worker)
@@ -13575,6 +13580,7 @@ fn create_remote_zellij_fresh(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok(worker)
@@ -13970,6 +13976,7 @@ fn create_herdr_fresh(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| WorkspaceError::new(error.to_string()))?;
             Ok((worker, geometry))
@@ -14076,6 +14083,7 @@ fn create_zellij_fresh(
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| WorkspaceError::new(error.to_string()))?;
 
@@ -14339,6 +14347,7 @@ fn create_fresh(
         launch_geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| WorkspaceError::new(error.to_string()))?;
     let client_identity = request
@@ -15764,6 +15773,7 @@ fn launch_fresh_tmux(
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
     Ok((
@@ -15973,6 +15983,7 @@ fn launch_fresh_protected_worktree_once(
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| {
         WorktreeLaunchError::Attach(AttachFreshError::Host(WorkspaceError::new(
@@ -16113,6 +16124,7 @@ fn launch_fresh_worktree_once(
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| {
         WorktreeLaunchError::Attach(AttachFreshError::Host(WorkspaceError::new(
@@ -16338,6 +16350,7 @@ fn launch_fresh_herdr(
                 geometry.pixels,
                 ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
                 current_default_colors(inner),
+                current_default_cursor_shape(inner),
             )
             .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
             Ok((worker, geometry))
@@ -16370,6 +16383,7 @@ fn launch_fresh_zellij(
         geometry.pixels,
         ClipboardPolicy::remote(inner.allow_remote_clipboard_write),
         current_default_colors(inner),
+        current_default_cursor_shape(inner),
     )
     .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
     Ok((worker, fresh.clone(), session.name().to_owned(), geometry))
@@ -16418,6 +16432,49 @@ fn current_default_colors(inner: &Inner) -> DefaultColors {
         .read()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     default_colors(&appearance)
+}
+
+fn current_default_cursor_shape(inner: &Inner) -> CursorShape {
+    let appearance = inner
+        .appearance
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    cursor_shape(appearance.cursor_style())
+}
+
+fn update_default_cursor_shapes(inner: &Inner, shape: CursorShape) {
+    if let Some(worker) = inner
+        .worker
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .active()
+    {
+        let _ignored = worker.set_default_cursor_shape(shape);
+    }
+    {
+        let retained = inner
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for presentation in &retained.entries {
+            let _ignored = presentation.worker.set_default_cursor_shape(shape);
+        }
+    }
+    let remote = inner
+        .remote_retained
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for presentation in &remote.entries {
+        let _ignored = presentation.worker.set_default_cursor_shape(shape);
+    }
+}
+
+const fn cursor_shape(style: CursorStyle) -> CursorShape {
+    match style {
+        CursorStyle::Block => CursorShape::Block,
+        CursorStyle::Bar => CursorShape::Bar,
+        CursorStyle::Underline => CursorShape::Underline,
+    }
 }
 
 fn rgb(color: u32) -> Rgb {

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -4404,6 +4404,15 @@ impl Workspace {
             )
     }
 
+    #[must_use]
+    pub fn hide_mouse_while_typing(&self) -> bool {
+        self.inner
+            .appearance
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .hide_mouse_while_typing()
+    }
+
     /// Persist terminal appearance settings and publish them to the running
     /// workspace. Existing clients keep their negotiated terminal palette;
     /// the UI and newly opened clients use the saved values immediately.

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-pub use config::TerminalTheme;
 use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance};
+pub use config::{CursorStyle, TerminalTheme};
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HerdrInventory, HostError,
     HostSnapshot, KwtInventory, KwtPullRequestImportRequest, KwtSshExecutable, LiveSessionTarget,
@@ -72,6 +72,9 @@ pub struct Appearance {
     font_size: u16,
     background: u32,
     foreground: u32,
+    cursor_style: CursorStyle,
+    allow_shell_integration_cursor: bool,
+    hide_mouse_while_typing: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -81,6 +84,33 @@ pub struct AppearanceSettingsDraft {
     pub font_size: String,
     pub background: String,
     pub foreground: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TerminalSettingsDraft {
+    pub cursor_style: CursorStyle,
+    pub allow_shell_integration_cursor: bool,
+    pub hide_mouse_while_typing: bool,
+}
+
+impl From<&TerminalAppearance> for TerminalSettingsDraft {
+    fn from(value: &TerminalAppearance) -> Self {
+        Self {
+            cursor_style: value.cursor_style(),
+            allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
+            hide_mouse_while_typing: value.hide_mouse_while_typing(),
+        }
+    }
+}
+
+impl From<&Appearance> for TerminalSettingsDraft {
+    fn from(value: &Appearance) -> Self {
+        Self {
+            cursor_style: value.cursor_style(),
+            allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
+            hide_mouse_while_typing: value.hide_mouse_while_typing(),
+        }
+    }
 }
 
 impl From<&TerminalAppearance> for AppearanceSettingsDraft {
@@ -132,6 +162,21 @@ impl Appearance {
     pub const fn foreground(&self) -> u32 {
         self.foreground
     }
+
+    #[must_use]
+    pub const fn cursor_style(&self) -> CursorStyle {
+        self.cursor_style
+    }
+
+    #[must_use]
+    pub const fn allow_shell_integration_cursor(&self) -> bool {
+        self.allow_shell_integration_cursor
+    }
+
+    #[must_use]
+    pub const fn hide_mouse_while_typing(&self) -> bool {
+        self.hide_mouse_while_typing
+    }
 }
 
 impl From<TerminalAppearance> for Appearance {
@@ -142,6 +187,9 @@ impl From<TerminalAppearance> for Appearance {
             font_size: value.font_size(),
             background: value.background(),
             foreground: value.foreground(),
+            cursor_style: value.cursor_style(),
+            allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
+            hide_mouse_while_typing: value.hide_mouse_while_typing(),
         }
     }
 }
@@ -4286,6 +4334,26 @@ impl Workspace {
             )
     }
 
+    #[must_use]
+    pub fn configured_terminal_settings(&self) -> TerminalSettingsDraft {
+        self.inner
+            .settings
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map_or_else(
+                || {
+                    let appearance = self
+                        .inner
+                        .appearance
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    TerminalSettingsDraft::from(&*appearance)
+                },
+                |settings| TerminalSettingsDraft::from(settings.config.terminal()),
+            )
+    }
+
     /// Persist terminal appearance settings and publish them to the running
     /// workspace. Existing clients keep their negotiated terminal palette;
     /// the UI and newly opened clients use the saved values immediately.
@@ -4317,7 +4385,56 @@ impl Workspace {
                 draft.foreground.trim(),
                 settings.config.terminal().allow_remote_clipboard_write(),
             )
-            .map_err(|error| WorkspaceError::new(error.to_string()))?;
+            .map_err(|error| WorkspaceError::new(error.to_string()))?
+            .with_terminal_preferences(
+                settings.config.terminal().cursor_style(),
+                settings.config.terminal().allow_shell_integration_cursor(),
+                settings.config.terminal().hide_mouse_while_typing(),
+            );
+            let roots = settings.roots.clone();
+            settings
+                .config
+                .replace_terminal_appearance(&roots, appearance.clone())
+                .map_err(|error| WorkspaceError::new(error.to_string()))?;
+            appearance
+        };
+        let _snapshot_write = begin_snapshot_write(&self.inner);
+        *self
+            .inner
+            .appearance
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = appearance.into();
+        self.inner.revision.fetch_add(1, Ordering::Release);
+        Ok(())
+    }
+
+    /// Persist terminal interaction settings and publish them to the running workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when settings storage is unavailable or cannot be written.
+    pub fn save_terminal_settings(
+        &self,
+        draft: &TerminalSettingsDraft,
+    ) -> Result<(), WorkspaceError> {
+        let appearance = {
+            let mut settings = self
+                .inner
+                .settings
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let settings = settings
+                .as_mut()
+                .ok_or_else(|| WorkspaceError::new("Terminal settings storage is unavailable"))?;
+            let appearance = settings
+                .config
+                .terminal()
+                .clone()
+                .with_terminal_preferences(
+                    draft.cursor_style,
+                    draft.allow_shell_integration_cursor,
+                    draft.hide_mouse_while_typing,
+                );
             let roots = settings.roots.clone();
             settings
                 .config
@@ -18441,6 +18558,9 @@ mod tests {
             font_size: 14,
             background: 0x12_34_56,
             foreground: 0x65_43_21,
+            cursor_style: CursorStyle::Block,
+            allow_shell_integration_cursor: false,
+            hide_mouse_while_typing: true,
         };
 
         let colors = default_colors(&appearance);
@@ -18482,6 +18602,9 @@ mod tests {
                 font_size: 14,
                 background,
                 foreground,
+                cursor_style: CursorStyle::Block,
+                allow_shell_integration_cursor: false,
+                hide_mouse_while_typing: true,
             };
             let colors = default_colors(&appearance);
             let mut engine = TerminalEngine::with_default_colors(

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{RecvTimeoutError, SyncSender, sync_channel};
 use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::thread;
@@ -27,7 +27,7 @@ pub use session::{
 use surface::{CursorShape, GridSize, PixelSize, Rgb, SurfaceStore};
 use terminal::{
     ClipboardPolicy, ClipboardReadRequest as TerminalClipboardRead, ClipboardTarget, DefaultColors,
-    TerminalEvent, TerminalStartup, TerminalWorker,
+    TerminalEvent, TerminalStartup, TerminalWorker, WorkerError,
 };
 
 const REDUCED_COLOR_NOTICE: &str =
@@ -3285,12 +3285,42 @@ struct TerminalGeometry {
     sequence: u64,
 }
 
+struct CursorDefault(AtomicU8);
+
+impl CursorDefault {
+    const fn new(style: CursorStyle) -> Self {
+        Self(AtomicU8::new(cursor_style_code(style)))
+    }
+
+    fn load(&self) -> CursorShape {
+        match self.0.load(Ordering::Acquire) {
+            0 => CursorShape::Block,
+            1 => CursorShape::Bar,
+            2 => CursorShape::Underline,
+            _ => unreachable!("cursor default contains an invalid shape"),
+        }
+    }
+
+    fn store(&self, style: CursorStyle) {
+        self.0.store(cursor_style_code(style), Ordering::Release);
+    }
+}
+
+const fn cursor_style_code(style: CursorStyle) -> u8 {
+    match style {
+        CursorStyle::Block => 0,
+        CursorStyle::Bar => 1,
+        CursorStyle::Underline => 2,
+    }
+}
+
 fn publish_worker_at_latest_geometry<T, E>(
     geometry: &Mutex<TerminalGeometry>,
     workers: &Mutex<WorkerState<T>>,
     worker: T,
     initial_geometry: TerminalGeometry,
     resize: impl FnOnce(&T, TerminalGeometry) -> Result<(), E>,
+    reconcile: impl FnOnce(&T),
 ) -> Result<u64, E> {
     let geometry = geometry
         .lock()
@@ -3302,7 +3332,20 @@ fn publish_worker_at_latest_geometry<T, E>(
     if latest_geometry != initial_geometry {
         resize(&worker, latest_geometry)?;
     }
-    Ok(workers.publish(worker))
+    let generation = workers.publish(worker);
+    reconcile(
+        workers
+            .active()
+            .expect("worker was published before reconciliation"),
+    );
+    Ok(generation)
+}
+
+fn resize_terminal_worker(
+    worker: &TerminalWorker,
+    geometry: TerminalGeometry,
+) -> Result<(), WorkerError> {
+    worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
 }
 
 struct ConptyAdmissionAttacher {
@@ -3327,6 +3370,7 @@ impl AdmissionAttacher for ConptyAdmissionAttacher {
 
 struct Inner {
     appearance: RwLock<Appearance>,
+    cursor_default: CursorDefault,
     host_scoped_inventory: bool,
     wsl_config: Option<WslConfig>,
     wsl_executable: Mutex<Option<WslExecutable>>,
@@ -3980,9 +4024,11 @@ impl Workspace {
             } => *presentation_id,
             _ => 0,
         };
+        let cursor_default = CursorDefault::new(snapshot.appearance.cursor_style());
         Self {
             inner: Arc::new(Inner {
                 appearance: RwLock::new(snapshot.appearance),
+                cursor_default,
                 host_scoped_inventory: false,
                 wsl_config: None,
                 wsl_executable: Mutex::new(None),
@@ -4129,6 +4175,7 @@ impl Workspace {
         refresh_runtime: Arc<dyn RefreshRuntime>,
     ) -> Self {
         let allow_remote_clipboard_write = appearance.allow_remote_clipboard_write();
+        let cursor_default = CursorDefault::new(appearance.cursor_style());
         let hosts = wsl
             .as_ref()
             .map(WslHostSpec::host_item)
@@ -4140,6 +4187,7 @@ impl Workspace {
         Self {
             inner: Arc::new(Inner {
                 appearance: RwLock::new(appearance.into()),
+                cursor_default,
                 host_scoped_inventory: true,
                 wsl_config,
                 wsl_executable: Mutex::new(wsl_executable),
@@ -4202,9 +4250,11 @@ impl Workspace {
     #[must_use]
     pub fn start_wsl(config: WslConfig, appearance: TerminalAppearance) -> Self {
         let allow_remote_clipboard_write = appearance.allow_remote_clipboard_write();
+        let cursor_default = CursorDefault::new(appearance.cursor_style());
         let workspace = Self {
             inner: Arc::new(Inner {
                 appearance: RwLock::new(appearance.into()),
+                cursor_default,
                 host_scoped_inventory: false,
                 wsl_config: Some(config.clone()),
                 wsl_executable: Mutex::new(None),
@@ -4442,13 +4492,14 @@ impl Workspace {
                 .map_err(|error| WorkspaceError::new(error.to_string()))?;
             appearance
         };
-        update_default_cursor_shapes(&self.inner, cursor_shape(draft.cursor_style));
+        self.inner.cursor_default.store(draft.cursor_style);
         let _snapshot_write = begin_snapshot_write(&self.inner);
         *self
             .inner
             .appearance
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = appearance.into();
+        update_default_cursor_shapes(&self.inner, self.inner.cursor_default.load());
         self.inner.revision.fetch_add(1, Ordering::Release);
         Ok(())
     }
@@ -6000,6 +6051,7 @@ impl Workspace {
         let presentation_id = presentation.presentation_id;
         presentation.worker.set_clipboard_writes_enabled(true);
         let (_, previous_worker) = workers.replace(presentation.worker);
+        reconcile_active_worker_cursor(&self.inner, &workers);
         let previous_remote = remote_active.take();
         clear_pending_paste(&self.inner);
         set_terminal_notice(&self.inner, term);
@@ -6023,11 +6075,10 @@ impl Workspace {
         {
             worker.set_clipboard_writes_enabled(false);
             let _cancelled = worker.cancel_paste();
-            self.inner
-                .remote_retained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .insert(RemoteRetainedPresentation { active, worker });
+            insert_remote_retained_presentation(
+                &self.inner,
+                RemoteRetainedPresentation { active, worker },
+            );
         }
         drop(snapshot_write);
         Ok(true)
@@ -6849,17 +6900,16 @@ impl Workspace {
         drop(worker);
         clear_pending_paste(&self.inner);
         clear_terminal_notice(&self.inner);
-        self.inner
-            .retained_presentations
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(RetainedPresentation {
+        insert_retained_presentation(
+            &self.inner,
+            RetainedPresentation {
                 key: key.clone(),
                 selection: selection.clone(),
                 attachment: active_attachment,
                 worker: active_worker,
                 presentation_id,
-            });
+            },
+        );
         self.restore_inventory_state();
         drop(attachment);
         Ok(Some(key))
@@ -8623,6 +8673,7 @@ fn activate_retained_presentation(
     worker.set_clipboard_writes_enabled(false);
     let surface = worker.surface_handle();
     let worker_generation = workers.publish(worker);
+    reconcile_active_worker_cursor(inner, &workers);
     drop(workers);
 
     clear_pending_paste(inner);
@@ -8667,11 +8718,36 @@ fn reinsert_retained_presentation(
     inner: &Inner,
     presentation: RetainedPresentation<TerminalWorker>,
 ) {
-    inner
+    insert_retained_presentation(inner, presentation);
+}
+
+fn insert_retained_presentation(inner: &Inner, presentation: RetainedPresentation<TerminalWorker>) {
+    let mut retained = inner
         .retained_presentations
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(presentation);
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    presentation
+        .worker
+        .set_default_cursor_shape(current_default_cursor_shape(inner));
+    retained.insert(presentation);
+}
+
+fn insert_remote_retained_presentation(inner: &Inner, presentation: RemoteRetainedPresentation) {
+    let mut retained = inner
+        .remote_retained
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    presentation
+        .worker
+        .set_default_cursor_shape(current_default_cursor_shape(inner));
+    retained.insert(presentation);
+}
+
+fn reconcile_active_worker_cursor(inner: &Inner, workers: &WorkerState<TerminalWorker>) {
+    workers
+        .active()
+        .expect("worker was published before cursor reconciliation")
+        .set_default_cursor_shape(current_default_cursor_shape(inner));
 }
 
 const fn event_source_may_have_more(processed: usize, budget: usize, exited: bool) -> bool {
@@ -14266,9 +14342,8 @@ fn publish_created_presentation(
         &inner.worker,
         worker,
         initial_geometry,
-        |worker, geometry| {
-            worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
-        },
+        resize_terminal_worker,
+        |worker| worker.set_default_cursor_shape(current_default_cursor_shape(inner)),
     ) {
         attachment.clear_if_current(generation);
         finish_pending_creation(inner, &pending);
@@ -14497,9 +14572,8 @@ fn run_attach(inner: &Inner, request: &AttachRequest, term: AttachTerm, generati
                 &inner.worker,
                 worker,
                 initial_geometry,
-                |worker, geometry| {
-                    worker.resize_with_metadata(geometry.grid, geometry.sequence, geometry.pixels)
-                },
+                resize_terminal_worker,
+                |worker| worker.set_default_cursor_shape(current_default_cursor_shape(inner)),
             ) {
                 let current_request = attachment
                     .active()
@@ -14661,6 +14735,7 @@ fn publish_remote_worker(
         None
     };
     let (worker_generation, previous_worker) = workers.replace(worker);
+    reconcile_active_worker_cursor(inner, &workers);
     let previous_remote = remote_active.replace(RemoteActive {
         key,
         selection: selection.clone(),
@@ -14694,29 +14769,27 @@ fn publish_remote_worker(
         (Some(worker), Some(active), _) if active.retainable => {
             worker.set_clipboard_writes_enabled(false);
             let _cancelled = worker.cancel_paste();
-            inner
-                .remote_retained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .insert(RemoteRetainedPresentation { active, worker });
+            insert_remote_retained_presentation(
+                inner,
+                RemoteRetainedPresentation { active, worker },
+            );
         }
         (Some(worker), None, Some(attachment)) => {
             worker.set_clipboard_writes_enabled(false);
             let _cancelled = worker.cancel_paste();
             let selection = attachment.request.selection();
             let key = attachment.request.presentation_key();
-            inner
-                .retained_presentations
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .insert(RetainedPresentation {
+            insert_retained_presentation(
+                inner,
+                RetainedPresentation {
                     key,
                     selection,
                     attachment,
                     worker,
                     presentation_id: previous_presentation_id
                         .expect("active local presentation identity was checked"),
-                });
+                },
+            );
         }
         _ => {}
     }
@@ -14820,6 +14893,7 @@ fn run_attach_over_remote(
         return;
     }
     let (_, previous_worker) = workers.replace(worker);
+    reconcile_active_worker_cursor(inner, &workers);
     let previous_remote = remote_active.take();
     set_terminal_notice(inner, attached_term);
     let presentation_id = next_presentation_id(inner);
@@ -14843,11 +14917,7 @@ fn run_attach_over_remote(
     {
         worker.set_clipboard_writes_enabled(false);
         let _cancelled = worker.cancel_paste();
-        inner
-            .remote_retained
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(RemoteRetainedPresentation { active, worker });
+        insert_remote_retained_presentation(inner, RemoteRetainedPresentation { active, worker });
     }
     drop(snapshot_write);
 }
@@ -14890,11 +14960,14 @@ fn run_retained_retry(inner: &Inner, retry: &RetainedRetry) {
                 return;
             }
             worker.set_clipboard_writes_enabled(false);
-            let published = inner
+            let mut retained = inner
                 .retained_presentations
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .finish_restart(&retry.key, worker, &retry.request.name, &resolved_request);
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            worker.set_default_cursor_shape(current_default_cursor_shape(inner));
+            let published =
+                retained.finish_restart(&retry.key, worker, &retry.request.name, &resolved_request);
+            drop(retained);
             if published {
                 publish_attach_inventory(inner, &resolved_request, snapshot);
                 inner.revision.fetch_add(1, Ordering::Release);
@@ -15449,11 +15522,7 @@ fn publish_restored_retained_presentation(
     presentation: RetainedPresentation<TerminalWorker>,
 ) {
     let _snapshot_write = begin_snapshot_write(inner);
-    inner
-        .retained_presentations
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(presentation);
+    insert_retained_presentation(inner, presentation);
     inner.revision.fetch_add(1, Ordering::Release);
 }
 
@@ -16435,11 +16504,7 @@ fn current_default_colors(inner: &Inner) -> DefaultColors {
 }
 
 fn current_default_cursor_shape(inner: &Inner) -> CursorShape {
-    let appearance = inner
-        .appearance
-        .read()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    cursor_shape(appearance.cursor_style())
+    inner.cursor_default.load()
 }
 
 fn update_default_cursor_shapes(inner: &Inner, shape: CursorShape) {
@@ -16449,7 +16514,7 @@ fn update_default_cursor_shapes(inner: &Inner, shape: CursorShape) {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .active()
     {
-        let _ignored = worker.set_default_cursor_shape(shape);
+        worker.set_default_cursor_shape(shape);
     }
     {
         let retained = inner
@@ -16457,7 +16522,7 @@ fn update_default_cursor_shapes(inner: &Inner, shape: CursorShape) {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         for presentation in &retained.entries {
-            let _ignored = presentation.worker.set_default_cursor_shape(shape);
+            presentation.worker.set_default_cursor_shape(shape);
         }
     }
     let remote = inner
@@ -16465,15 +16530,7 @@ fn update_default_cursor_shapes(inner: &Inner, shape: CursorShape) {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     for presentation in &remote.entries {
-        let _ignored = presentation.worker.set_default_cursor_shape(shape);
-    }
-}
-
-const fn cursor_shape(style: CursorStyle) -> CursorShape {
-    match style {
-        CursorStyle::Block => CursorShape::Block,
-        CursorStyle::Bar => CursorShape::Bar,
-        CursorStyle::Underline => CursorShape::Underline,
+        presentation.worker.set_default_cursor_shape(shape);
     }
 }
 
@@ -20291,6 +20348,7 @@ mod tests {
                 *applied.lock().expect("applied geometry lock") = Some(geometry);
                 Ok::<(), ()>(())
             },
+            |_| {},
         )
         .expect("publish worker");
 
@@ -20331,6 +20389,7 @@ mod tests {
                     release_receiver.recv().expect("resume publication");
                     Ok::<(), ()>(())
                 },
+                |_| {},
             )
             .expect("publish worker")
         });
@@ -20343,6 +20402,54 @@ mod tests {
 
         assert!(geometry_was_locked, "geometry lock was released too early");
         assert!(worker_was_locked, "worker lock was released too early");
+    }
+
+    #[test]
+    fn worker_publication_reconciles_settings_changed_during_launch() {
+        let initial = default_terminal_geometry();
+        let latest = TerminalGeometry {
+            sequence: initial.sequence + 1,
+            ..initial
+        };
+        let geometry = Arc::new(Mutex::new(latest));
+        let workers = Arc::new(Mutex::new(WorkerState::new()));
+        let cursor_default = Arc::new(AtomicU8::new(0));
+        let published_cursor = Arc::new(AtomicU8::new(0));
+        let (launching_sender, launching_receiver) = std::sync::mpsc::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let publishing_geometry = Arc::clone(&geometry);
+        let publishing_workers = Arc::clone(&workers);
+        let publishing_default = Arc::clone(&cursor_default);
+        let publishing_cursor = Arc::clone(&published_cursor);
+        let publisher = thread::spawn(move || {
+            publish_worker_at_latest_geometry(
+                &publishing_geometry,
+                &publishing_workers,
+                publishing_cursor,
+                initial,
+                |_, _| {
+                    launching_sender.send(()).expect("signal launch in flight");
+                    release_receiver.recv().expect("finish launch");
+                    Ok::<(), ()>(())
+                },
+                |worker| {
+                    worker.store(
+                        publishing_default.load(Ordering::Acquire),
+                        Ordering::Release,
+                    );
+                },
+            )
+            .expect("publish worker")
+        });
+
+        launching_receiver
+            .recv()
+            .expect("launch reached publication");
+        cursor_default.store(2, Ordering::Release);
+        release_sender.send(()).expect("release publication");
+        let _generation = publisher.join().expect("publisher thread");
+
+        assert_eq!(published_cursor.load(Ordering::Acquire), 2);
     }
 
     #[test]

--- a/rust/workspace/tests/view_state.rs
+++ b/rust/workspace/tests/view_state.rs
@@ -190,3 +190,48 @@ fn saved_appearance_is_persisted_and_published_without_rebuilding_hosts() {
     );
     fs::remove_dir_all(root).expect("remove temporary config root");
 }
+
+#[test]
+fn saved_terminal_settings_are_persisted_and_published_without_rebuilding_hosts() {
+    let root = std::env::temp_dir().join(format!(
+        "ghosthub-workspace-terminal-settings-{}-{}",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    let value = root.to_string_lossy().into_owned();
+    let roots = Roots {
+        ghosthub_home: value.clone(),
+        config: value.clone(),
+        state: value.clone(),
+        helpers: value,
+    };
+    let workspace = Workspace::application_with_remote_hosts(
+        TerminalAppearance::default(),
+        None,
+        Vec::new(),
+        ApplicationConfig::default(),
+        roots.clone(),
+        None,
+        None,
+    );
+    let draft = workspace::TerminalSettingsDraft {
+        cursor_style: workspace::CursorStyle::Underline,
+        allow_shell_integration_cursor: true,
+        hide_mouse_while_typing: false,
+    };
+
+    workspace
+        .save_terminal_settings(&draft)
+        .expect("save terminal settings");
+
+    let snapshot = workspace.snapshot();
+    assert_eq!(snapshot.appearance().cursor_style(), draft.cursor_style);
+    assert!(snapshot.appearance().allow_shell_integration_cursor());
+    assert!(!snapshot.appearance().hide_mouse_while_typing());
+    assert!(snapshot.hosts().is_empty());
+    let loaded = ApplicationConfig::load(&roots).expect("reload application config");
+    assert_eq!(loaded.terminal().cursor_style(), draft.cursor_style);
+    assert!(loaded.terminal().allow_shell_integration_cursor());
+    assert!(!loaded.terminal().hide_mouse_while_typing());
+    fs::remove_dir_all(root).expect("remove temporary config root");
+}

--- a/rust/workspace/tests/view_state.rs
+++ b/rust/workspace/tests/view_state.rs
@@ -219,11 +219,13 @@ fn saved_terminal_settings_are_persisted_and_published_without_rebuilding_hosts(
         allow_shell_integration_cursor: true,
         hide_mouse_while_typing: false,
     };
+    assert!(workspace.hide_mouse_while_typing());
 
     workspace
         .save_terminal_settings(&draft)
         .expect("save terminal settings");
 
+    assert!(!workspace.hide_mouse_while_typing());
     let snapshot = workspace.snapshot();
     assert_eq!(snapshot.appearance().cursor_style(), draft.cursor_style);
     assert!(snapshot.appearance().allow_shell_integration_cursor());


### PR DESCRIPTION
- Adds a durable Terminal pane to the Rust Settings shell for cursor style, shell-controlled cursor shape, and hiding the pointer while typing.
- Applies valid changes immediately and persists them atomically, so existing terminal surfaces reflect the selected behavior without a restart.
- Honors application DECSCUSR cursor requests only when shell cursor control is enabled; otherwise Ghosthub consistently renders the chosen block, line, or underline cursor.
- Restores the hidden pointer as soon as it moves over the terminal and keeps keyboard input, resizing, and mouse reporting on their existing paths.
- Includes the Terminal pane in Tab navigation and supports Enter or Space activation for keyboard-only users.
- Leaves selection-copy, session previews, and quit confirmation out until their Rust runtime behavior exists, avoiding settings that would be cosmetic or misleading.
- Passes the full Rust workspace test suite, formatting, workspace checks, Clippy with warnings denied, and dependency-policy checks.