### PR TITLE
Stabilize tmux recovery test startup

### DIFF
--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -218,6 +218,10 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         model.openBorrowedTmuxSession(remoteSelection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor(timeout: .seconds(5)) {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
 
         // A transient surface failure, then a successful reconnect.
         surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected


### PR DESCRIPTION
- Fixes the hosted macOS CI flake reported by [run 32592651444](https://github.com/kenn-io/ghosthub/actions/runs/32592651444). The tmux recovery test could inject its first surface exit before the initial attachment had published its connected state, making the reconnect wait depend on MainActor scheduling.
- Waits for the observable connected state before injecting the transient surface failure. The test now starts from the established-attachment state its recovery assertions require, while production behavior remains unchanged.
- The focused test passed 50 arm64 attempts, the full Swift lane passed 1,754 tests in 179 suites, and the arm64 build plus essential workflow smoke passed.
