### PR TITLE
Load trusted GUI action from pinned workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Run trusted serialized GUI terminal smoke tests
         if: ${{ matrix.lane == 'self-hosted' }}
-        uses: ./.github/actions/run-gui-terminal-tests
+        uses: $/.github/actions/run-gui-terminal-tests
         with:
           filter: ${{ env.GHOSTHUB_WINDOW_SERVER_TEST_FILTER }}
 


### PR DESCRIPTION
- Trusted macOS CI now loads its GUI launcher from the same reviewed `main` commit as the reusable workflow.
- Pull-request code remains the test input, but it can no longer replace the launcher through the checked-out workspace.
- Hosted and fork behavior are unchanged. Trusted execution remains disabled until this fix merges, then live acceptance can begin.
