### PR TITLE
Run trusted macOS GUI tests reliably

### DIFF
--- a/.github/actions/run-gui-terminal-tests/ActivationPolicy.swift
+++ b/.github/actions/run-gui-terminal-tests/ActivationPolicy.swift
@@ -1,0 +1,8 @@
+import AppKit
+
+func ensureRegularActivationPolicy(
+    currentPolicy: NSApplication.ActivationPolicy,
+    transition: () -> Bool
+) -> Bool {
+    currentPolicy == .regular || transition()
+}

--- a/.github/actions/run-gui-terminal-tests/LaunchApp.swift
+++ b/.github/actions/run-gui-terminal-tests/LaunchApp.swift
@@ -57,7 +57,10 @@ private func executeGUITests() throws -> Int32 {
     }
 
     let application = NSApplication.shared
-    guard application.setActivationPolicy(.regular) else {
+    guard ensureRegularActivationPolicy(
+        currentPolicy: application.activationPolicy(),
+        transition: { application.setActivationPolicy(.regular) }
+    ) else {
         try fail("Could not activate the GUI test application")
     }
     application.finishLaunching()

--- a/.github/actions/run-gui-terminal-tests/run.sh
+++ b/.github/actions/run-gui-terminal-tests/run.sh
@@ -257,7 +257,10 @@ plutil -insert NSPrincipalClass -string NSApplication "$launcher_info"
   -L "$xctest_libraries" \
   -Xlinker -rpath -Xlinker "$xctest_frameworks" \
   -Xlinker -rpath -Xlinker "$xctest_libraries" \
-  -emit-library "$action_root/LaunchApp.swift" -o "$launcher_library"
+  -emit-library \
+  "$action_root/ActivationPolicy.swift" \
+  "$action_root/LaunchApp.swift" \
+  -o "$launcher_library"
 chmod 700 "$launcher_library"
 /usr/bin/xcrun swiftc -O -framework AppKit \
   "$action_root/LaunchBootstrap.swift" -o "$launcher_bootstrap"

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,6 +113,11 @@ for cost. Both lanes select a supported Xcode installation and the exact Zig
 toolchain required by the pinned Ghostty source, then run their complete
 available build and test gates.
 
+The self-hosted GUI tests use a repository-relative action from the same
+reviewed `main` commit as the reusable workflow. The pull-request checkout
+supplies the application and tests, but it cannot replace the trusted GUI
+launcher. Fork pull requests never enter this path.
+
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig
 executable and selected XCFramework target, then places a repository-local

--- a/tools/tests/test_gui_test_launcher.py
+++ b/tools/tests/test_gui_test_launcher.py
@@ -13,10 +13,58 @@ LAUNCH_BOOTSTRAP = (
     Path(__file__).resolve().parents[2]
     / ".github/actions/run-gui-terminal-tests/LaunchBootstrap.swift"
 )
+ACTIVATION_POLICY = (
+    Path(__file__).resolve().parents[2]
+    / ".github/actions/run-gui-terminal-tests/ActivationPolicy.swift"
+)
 LAUNCH_CONTROLLER = (
     Path(__file__).resolve().parents[2]
     / ".github/actions/run-gui-terminal-tests/LaunchController.swift"
 )
+
+
+def test_already_regular_activation_policy_is_accepted(tmp_path: Path) -> None:
+    probe_source = tmp_path / "ActivationPolicyProbe.swift"
+    probe = tmp_path / "activation-policy-probe"
+    probe_source.write_text(
+        """
+        import AppKit
+        import Darwin
+
+        @main
+        enum ActivationPolicyProbe {
+            static func main() {
+                var transitionAttempted = false
+                let ready = ensureRegularActivationPolicy(
+                    currentPolicy: .regular
+                ) {
+                    transitionAttempted = true
+                    return false
+                }
+                guard ready, !transitionAttempted else {
+                    exit(1)
+                }
+            }
+        }
+        """
+    )
+    compilation = subprocess.run(
+        [
+            "/usr/bin/xcrun",
+            "swiftc",
+            "-O",
+            "-framework",
+            "AppKit",
+            str(ACTIVATION_POLICY),
+            str(probe_source),
+            "-o",
+            str(probe),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert compilation.returncode == 0, compilation.stderr
+    subprocess.run([str(probe)], check=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Runs the trusted macOS GUI tests when LaunchServices has already made the launcher a regular foreground application.
- Loads the trusted GUI launcher from the reviewed `main` workflow commit; pull-request code supplies only the application and tests.
- Keeps fork pull requests hosted-only and leaves hosted macOS required during live acceptance.
