### PR TITLE
Explain trusted action acceptance order

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -116,7 +116,10 @@ available build and test gates.
 The self-hosted GUI tests use a repository-relative action from the same
 reviewed `main` commit as the reusable workflow. The pull-request checkout
 supplies the application and tests, but it cannot replace the trusted GUI
-launcher. Fork pull requests never enter this path.
+launcher. A pull request that changes this action therefore cannot exercise
+its own launcher change. Merge it through hosted validation, then use a
+follow-up same-repository pull request to exercise the reviewed action from
+`main`. Fork pull requests never enter this path.
 
 Some newer Xcode SDK stubs do not advertise the plain `arm64-macos` target.
 Local bootstrap checks every architecture required by the running Zig


### PR DESCRIPTION
Trusted GUI launcher changes now have an explicit rollout sequence: merge
through hosted validation, then exercise the reviewed `main` action from a
follow-up same-repository pull request.

This keeps pull-request code from replacing the trusted launcher. Fork pull
requests remain excluded, and no workflow or runner behavior changes.
