### PR TITLE
Load XCTest runtime paths in trusted GUI tests

### DIFF
--- a/.github/actions/run-gui-terminal-tests/LauncherEnvironment.swift
+++ b/.github/actions/run-gui-terminal-tests/LauncherEnvironment.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+private let requiredLauncherEnvironmentNames = [
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "CFFIXED_USER_HOME",
+    "DEVELOPER_DIR",
+    "GHOSTHUB_CI_STATE_ROOT",
+    "LIBGHOSTTY_XCFRAMEWORK_TARGET",
+    "LIBGHOSTTY_ZIG",
+    "RUNNER_TEMP",
+    "SHELL",
+    "TMUX_TMPDIR",
+    "GHOSTHUB_TEST_TMUX_RUN_ID",
+    "GHOSTTY_RESOURCES_DIR",
+]
+
+private let optionalLauncherEnvironmentNames = [
+    "RUNNER_ENVIRONMENT",
+    "CI",
+    "GITHUB_ACTIONS",
+]
+
+struct LauncherEnvironmentError: Error, CustomStringConvertible {
+    let name: String
+
+    var description: String {
+        "GUI launcher environment is missing \(name)."
+    }
+}
+
+func makeLauncherEnvironment(
+    controllerEnvironment: [String: String],
+    workspacePath: String
+) throws -> [String: String] {
+    var environment: [String: String] = [:]
+    for name in requiredLauncherEnvironmentNames {
+        guard let value = controllerEnvironment[name], !value.isEmpty else {
+            throw LauncherEnvironmentError(name: name)
+        }
+        environment[name] = value
+    }
+    for name in optionalLauncherEnvironmentNames {
+        environment[name] = controllerEnvironment[name] ?? ""
+    }
+
+    let developerDirectory = URL(
+        fileURLWithPath: environment["DEVELOPER_DIR"]!,
+        isDirectory: true
+    )
+    let platformDeveloperDirectory = developerDirectory
+        .appendingPathComponent("Platforms/MacOSX.platform/Developer", isDirectory: true)
+    environment["DYLD_LIBRARY_PATH"] = platformDeveloperDirectory
+        .appendingPathComponent("usr/lib", isDirectory: true)
+        .path
+    environment["DYLD_FRAMEWORK_PATH"] = [
+        platformDeveloperDirectory
+            .appendingPathComponent("Library/Frameworks", isDirectory: true)
+            .path,
+        platformDeveloperDirectory
+            .appendingPathComponent("Library/PrivateFrameworks", isDirectory: true)
+            .path,
+    ].joined(separator: ":")
+    environment["PWD"] = workspacePath
+    environment["GITHUB_WORKSPACE"] = workspacePath
+    return environment
+}

--- a/.github/actions/run-gui-terminal-tests/main.swift
+++ b/.github/actions/run-gui-terminal-tests/main.swift
@@ -2,26 +2,8 @@ import AppKit
 import Darwin
 import Foundation
 
-private let requiredLauncherEnvironmentNames = [
-    "PATH",
-    "HOME",
-    "TMPDIR",
-    "CFFIXED_USER_HOME",
-    "DEVELOPER_DIR",
-    "GHOSTHUB_CI_STATE_ROOT",
-    "LIBGHOSTTY_XCFRAMEWORK_TARGET",
-    "LIBGHOSTTY_ZIG",
-    "RUNNER_TEMP",
-    "SHELL",
-    "TMUX_TMPDIR",
-    "GHOSTHUB_TEST_TMUX_RUN_ID",
-    "GHOSTTY_RESOURCES_DIR",
-]
-private let optionalLauncherEnvironmentNames = [
-    "RUNNER_ENVIRONMENT",
-    "CI",
-    "GITHUB_ACTIONS",
-]
+// Swift requires top-level executable code to live in main.swift when the
+// controller is compiled with supporting source files.
 
 let launcherAbsentStatus: Int32 = 3
 let gracefulStopInterval: TimeInterval = 2
@@ -154,23 +136,20 @@ guard suppliedArguments.count == launcherArgumentCount else {
 let applicationArguments = suppliedArguments
 let completionFileURL = URL(fileURLWithPath: applicationArguments[6])
 let controllerEnvironment = ProcessInfo.processInfo.environment
-var launcherEnvironment: [String: String] = [:]
-for name in requiredLauncherEnvironmentNames {
-    guard let value = controllerEnvironment[name], !value.isEmpty else {
-        fputs("GUI launcher environment is missing \(name).\n", stderr)
-        exit(2)
-    }
-    launcherEnvironment[name] = value
-}
-for name in optionalLauncherEnvironmentNames {
-    launcherEnvironment[name] = controllerEnvironment[name] ?? ""
-}
 let workspacePath = URL(
     fileURLWithPath: applicationArguments[5],
     isDirectory: true
 ).standardizedFileURL.path
-launcherEnvironment["PWD"] = workspacePath
-launcherEnvironment["GITHUB_WORKSPACE"] = workspacePath
+var launcherEnvironment: [String: String]
+do {
+    launcherEnvironment = try makeLauncherEnvironment(
+        controllerEnvironment: controllerEnvironment,
+        workspacePath: workspacePath
+    )
+} catch {
+    fputs("\(error)\n", stderr)
+    exit(2)
+}
 launcherEnvironment["GHOSTHUB_TEST_STOP_GRACE"] = String(
     Int(gracefulStopInterval)
 )

--- a/.github/actions/run-gui-terminal-tests/run.sh
+++ b/.github/actions/run-gui-terminal-tests/run.sh
@@ -268,7 +268,9 @@ chmod 700 "$launcher_bootstrap"
 codesign --force --sign - "$launcher_app"
 
 /usr/bin/xcrun swiftc -O -framework AppKit \
-  "$action_root/LaunchController.swift" -o "$launch_controller"
+  "$action_root/LauncherEnvironment.swift" \
+  "$action_root/main.swift" \
+  -o "$launch_controller"
 chmod 700 "$launch_controller"
 
 : > "$launcher_output"

--- a/tools/tests/test_gui_test_launcher.py
+++ b/tools/tests/test_gui_test_launcher.py
@@ -17,10 +17,82 @@ ACTIVATION_POLICY = (
     Path(__file__).resolve().parents[2]
     / ".github/actions/run-gui-terminal-tests/ActivationPolicy.swift"
 )
-LAUNCH_CONTROLLER = (
+LAUNCH_CONTROLLER_MAIN = (
     Path(__file__).resolve().parents[2]
-    / ".github/actions/run-gui-terminal-tests/LaunchController.swift"
+    / ".github/actions/run-gui-terminal-tests/main.swift"
 )
+LAUNCHER_ENVIRONMENT = (
+    Path(__file__).resolve().parents[2]
+    / ".github/actions/run-gui-terminal-tests/LauncherEnvironment.swift"
+)
+
+
+def test_launcher_environment_supplies_xctest_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    probe_source = tmp_path / "LauncherEnvironmentProbe.swift"
+    probe = tmp_path / "launcher-environment-probe"
+    probe_source.write_text(
+        """
+        import Foundation
+
+        @main
+        enum LauncherEnvironmentProbe {
+            static func main() throws {
+                let developerDirectory = "/Applications/Xcode.app/Contents/Developer"
+                let input = [
+                    "PATH": "/usr/bin:/bin",
+                    "HOME": "/tmp/home",
+                    "TMPDIR": "/tmp/",
+                    "CFFIXED_USER_HOME": "/tmp/home",
+                    "DEVELOPER_DIR": developerDirectory,
+                    "GHOSTHUB_CI_STATE_ROOT": "/tmp/state",
+                    "LIBGHOSTTY_XCFRAMEWORK_TARGET": "arm64-apple-macosx",
+                    "LIBGHOSTTY_ZIG": "/tmp/zig",
+                    "RUNNER_TEMP": "/tmp/runner",
+                    "SHELL": "/bin/zsh",
+                    "TMUX_TMPDIR": "/tmp/tmux",
+                    "GHOSTHUB_TEST_TMUX_RUN_ID": "run-id",
+                    "GHOSTTY_RESOURCES_DIR": "/tmp/resources",
+                    "DYLD_LIBRARY_PATH": "/untrusted/library",
+                    "DYLD_FRAMEWORK_PATH": "/untrusted/framework",
+                ]
+                let environment = try makeLauncherEnvironment(
+                    controllerEnvironment: input,
+                    workspacePath: "/tmp/workspace"
+                )
+                let expectedLibraryPath = developerDirectory
+                    + "/Platforms/MacOSX.platform/Developer/usr/lib"
+                let expectedFrameworkPath = [
+                    developerDirectory
+                        + "/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+                    developerDirectory
+                        + "/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks",
+                ].joined(separator: ":")
+                guard environment["DYLD_LIBRARY_PATH"] == expectedLibraryPath,
+                      environment["DYLD_FRAMEWORK_PATH"] == expectedFrameworkPath
+                else {
+                    throw NSError(domain: "LauncherEnvironmentProbe", code: 1)
+                }
+            }
+        }
+        """
+    )
+    compilation = subprocess.run(
+        [
+            "/usr/bin/xcrun",
+            "swiftc",
+            "-O",
+            str(LAUNCHER_ENVIRONMENT),
+            str(probe_source),
+            "-o",
+            str(probe),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert compilation.returncode == 0, compilation.stderr
+    subprocess.run([str(probe)], check=True)
 
 
 def test_already_regular_activation_policy_is_accepted(tmp_path: Path) -> None:
@@ -132,7 +204,8 @@ def test_launcher_anchors_its_process_group_until_cleanup(
             "-O",
             "-framework",
             "AppKit",
-            str(LAUNCH_CONTROLLER),
+            str(LAUNCHER_ENVIRONMENT),
+            str(LAUNCH_CONTROLLER_MAIN),
             "-o",
             str(controller),
         ],


### PR DESCRIPTION
- Let trusted self-hosted GUI tests load the package XCTest bundle when LaunchServices starts them outside SwiftPM.
- Derive XCTest library and framework paths from the selected Xcode developer directory while keeping the existing environment allowlist.
- Keep arbitrary inherited loader settings out of the detached app, and cover the resulting startup environment with a focused executable test.
