### PR TITLE
Load trusted GUI action from an immutable commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Run trusted serialized GUI terminal smoke tests
         if: ${{ matrix.lane == 'self-hosted' }}
-        uses: kenn-io/ghosthub/.github/actions/run-gui-terminal-tests@594282df4c23b1e4ac1b053ed5cf509f9130bcb4
+        uses: kenn-io/ghosthub/.github/actions/run-gui-terminal-tests@c346e648437b3de0195769fe9d50204aa6974929
         with:
           filter: ${{ env.GHOSTHUB_WINDOW_SERVER_TEST_FILTER }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Run trusted serialized GUI terminal smoke tests
         if: ${{ matrix.lane == 'self-hosted' }}
-        uses: $/.github/actions/run-gui-terminal-tests
+        uses: kenn-io/ghosthub/.github/actions/run-gui-terminal-tests@594282df4c23b1e4ac1b053ed5cf509f9130bcb4
         with:
           filter: ${{ env.GHOSTHUB_WINDOW_SERVER_TEST_FILTER }}
 


### PR DESCRIPTION
- Let the trusted macOS lane load its GUI test action instead of failing job setup on an invalid local path.
- Pin the action to its latest reviewed implementation, including foreground activation and XCTest runtime setup, so pull-request code cannot replace the launcher.
- Keep hosted macOS and fork pull requests unchanged.
