### PR TITLE
Add transparent background support

### DIFF
--- a/Sources/App/BorrowedHerdrSessionView.swift
+++ b/Sources/App/BorrowedHerdrSessionView.swift
@@ -17,6 +17,7 @@ struct BorrowedHerdrSessionView: View {
     var onReconnectNow: () -> Void
     var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     init(
         handle: BorrowedHerdrSessionHandle,
@@ -55,49 +56,63 @@ struct BorrowedHerdrSessionView: View {
                 defersTerminalResize: defersTerminalResize,
                 onCloseRequest: onCloseRequest
             )
-        } else if recoveryState != nil {
-            ContentUnavailableView {
-                Label(recoveryTitle, systemImage: "network.slash")
-            } description: {
-                VStack(spacing: 10) {
-                    if showsReconnectProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                    Text(recoveryMessage)
-                        .multilineTextAlignment(.center)
-                }
-            } actions: {
-                if primaryRecoveryActionTitle != nil {
-                    Button("Reconnect Now", action: onReconnectNow)
-                }
-                if showsReviewConnection {
-                    Button("Review Connection", action: onReviewConnection)
-                }
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
-                }
-            }
-        } else if let disconnectionReason {
-            ContentUnavailableView {
-                Label(
-                    disconnectionTitle,
-                    systemImage: attachmentClosure == .detached
-                        ? "rectangle.portrait.and.arrow.right"
-                        : "network.slash"
-                )
-            } description: {
-                Text(disconnectionReason)
-            } actions: {
-                Button(recoveryActionTitle, action: onRetryRequest)
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
-                }
-            }
         } else {
-            ProgressView("Opening \(handle.name)…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            sessionFallback
         }
+    }
+
+    /// Recovery, disconnection, and opening states share one chrome-tinted
+    /// backdrop: the cover behind them goes clear under a transparent
+    /// config, so without this they would float over the bare desktop. When
+    /// opaque the tint is the canonical surface color over an identical
+    /// opaque cover, so rendering is unchanged.
+    private var sessionFallback: some View {
+        ZStack {
+            if recoveryState != nil {
+                ContentUnavailableView {
+                    Label(recoveryTitle, systemImage: "network.slash")
+                } description: {
+                    VStack(spacing: 10) {
+                        if showsReconnectProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(recoveryMessage)
+                            .multilineTextAlignment(.center)
+                    }
+                } actions: {
+                    if primaryRecoveryActionTitle != nil {
+                        Button("Reconnect Now", action: onReconnectNow)
+                    }
+                    if showsReviewConnection {
+                        Button("Review Connection", action: onReviewConnection)
+                    }
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else if let disconnectionReason {
+                ContentUnavailableView {
+                    Label(
+                        disconnectionTitle,
+                        systemImage: attachmentClosure == .detached
+                            ? "rectangle.portrait.and.arrow.right"
+                            : "network.slash"
+                    )
+                } description: {
+                    Text(disconnectionReason)
+                } actions: {
+                    Button(recoveryActionTitle, action: onRetryRequest)
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else {
+                ProgressView("Opening \(handle.name)…")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WorkspaceSurfaceColor.chrome(backgroundAppearance))
     }
 
     var recoveryTitle: String {

--- a/Sources/App/BorrowedHerdrSessionView.swift
+++ b/Sources/App/BorrowedHerdrSessionView.swift
@@ -1,5 +1,6 @@
 import GhosthubTerminal
 import GhosthubTransport
+import GhosthubUI
 import SwiftUI
 
 struct BorrowedHerdrSessionView: View {
@@ -160,6 +161,7 @@ private struct NativeHerdrTerminalView: View {
     var defersTerminalResize: Bool
     var onCloseRequest: () -> Void
     @State private var observerID = UUID()
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     var body: some View {
         TerminalSurfaceSwiftUIView(
@@ -167,7 +169,7 @@ private struct NativeHerdrTerminalView: View {
             defersSurfaceResize: defersTerminalResize
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+        .background(TerminalSurfaceBackdrop.color(for: backgroundAppearance))
         .overlay(alignment: .top) {
             if let message = surfaceView.paneSplitErrorMessage {
                 NativePaneSplitErrorOverlay(message: message)

--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -24,6 +24,7 @@ struct BorrowedTmuxSessionView: View {
     var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
     @State private var isRetryConfirmationPresented = false
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     init(
         handle: BorrowedTmuxSessionHandle,
@@ -73,7 +74,43 @@ struct BorrowedTmuxSessionView: View {
                     defersTerminalResize: defersTerminalResize,
                     onCloseRequest: onCloseRequest
                 )
-            } else if recoveryState != nil {
+            } else {
+                sessionFallback
+            }
+        }
+        .confirmationDialog(
+            "Run the launch command again?",
+            isPresented: $isRetryConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Run Command Again", role: .destructive) {
+                onConfirmedRetryRequest()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "The command may have started before the connection "
+                        + "dropped. Running it again could repeat its side "
+                        + "effects."
+                )
+                if let retryConfirmationCommand {
+                    Text(retryConfirmationCommand)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    /// Recovery, disconnection, and opening states share one chrome-tinted
+    /// backdrop: the cover behind them goes clear under a transparent
+    /// config, so without this they would float over the bare desktop. When
+    /// opaque the tint is the canonical surface color over an identical
+    /// opaque cover, so rendering is unchanged.
+    private var sessionFallback: some View {
+        ZStack {
+            if recoveryState != nil {
                 ContentUnavailableView {
                     Label(recoveryTitle, systemImage: "network.slash")
                 } description: {
@@ -122,32 +159,10 @@ struct BorrowedTmuxSessionView: View {
                 }
             } else {
                 ProgressView("Opening \(displayTitle ?? handle.name)…")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .confirmationDialog(
-            "Run the launch command again?",
-            isPresented: $isRetryConfirmationPresented,
-            titleVisibility: .visible
-        ) {
-            Button("Run Command Again", role: .destructive) {
-                onConfirmedRetryRequest()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(
-                    "The command may have started before the connection "
-                        + "dropped. Running it again could repeat its side "
-                        + "effects."
-                )
-                if let retryConfirmationCommand {
-                    Text(retryConfirmationCommand)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                }
-            }
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WorkspaceSurfaceColor.chrome(backgroundAppearance))
     }
 
     var recoveryTitle: String {

--- a/Sources/App/BorrowedTmuxSessionView.swift
+++ b/Sources/App/BorrowedTmuxSessionView.swift
@@ -1,6 +1,7 @@
 import GhosthubTransport
 import GhosthubTerminal
 import GhosthubTmux
+import GhosthubUI
 import SwiftUI
 
 struct BorrowedTmuxSessionView: View {
@@ -227,6 +228,7 @@ private struct NativeTmuxTerminalView: View {
     var defersTerminalResize: Bool
     var onCloseRequest: () -> Void
     @State private var observerID = UUID()
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     var body: some View {
         TerminalSurfaceSwiftUIView(
@@ -234,7 +236,7 @@ private struct NativeTmuxTerminalView: View {
             defersSurfaceResize: defersTerminalResize
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+        .background(TerminalSurfaceBackdrop.color(for: backgroundAppearance))
         .overlay(alignment: .top) {
             if let message = surfaceView.paneSplitErrorMessage {
                 NativePaneSplitErrorOverlay(message: message)

--- a/Sources/App/BorrowedZellijSessionView.swift
+++ b/Sources/App/BorrowedZellijSessionView.swift
@@ -1,5 +1,6 @@
 import GhosthubTerminal
 import GhosthubTransport
+import GhosthubUI
 import SwiftUI
 
 struct BorrowedZellijSessionView: View {
@@ -155,6 +156,7 @@ private struct NativeZellijTerminalView: View {
     var defersTerminalResize: Bool
     var onCloseRequest: () -> Void
     @State private var observerID = UUID()
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     var body: some View {
         TerminalSurfaceSwiftUIView(
@@ -162,7 +164,7 @@ private struct NativeZellijTerminalView: View {
             defersSurfaceResize: defersTerminalResize
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+        .background(TerminalSurfaceBackdrop.color(for: backgroundAppearance))
         .onAppear {
             surfaceView.registerPaneCloseRequestObserver(
                 id: observerID,

--- a/Sources/App/BorrowedZellijSessionView.swift
+++ b/Sources/App/BorrowedZellijSessionView.swift
@@ -17,6 +17,7 @@ struct BorrowedZellijSessionView: View {
     var onReconnectNow: () -> Void
     var onReviewConnection: () -> Void
     var onHostSettingsRequest: () -> Void
+    @Environment(\.terminalBackgroundAppearance) private var backgroundAppearance
 
     init(
         handle: BorrowedZellijSessionHandle,
@@ -55,53 +56,67 @@ struct BorrowedZellijSessionView: View {
                 defersTerminalResize: defersTerminalResize,
                 onCloseRequest: onCloseRequest
             )
-        } else if recoveryState != nil {
-            ContentUnavailableView {
-                Label(recoveryTitle, systemImage: "network.slash")
-            } description: {
-                VStack(spacing: 10) {
-                    if showsReconnectProgress {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                    Text(recoveryMessage)
-                        .multilineTextAlignment(.center)
-                }
-            } actions: {
-                if primaryRecoveryActionTitle != nil {
-                    Button("Reconnect Now", action: onReconnectNow)
-                }
-                if showsReviewConnection {
-                    Button("Review Connection", action: onReviewConnection)
-                }
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
-                }
-            }
-        } else if let disconnectionReason {
-            ContentUnavailableView {
-                Label(
-                    attachmentClosure == .detached
-                        ? "Attachment closed" : "Unable to attach",
-                    systemImage: attachmentClosure == .detached
-                        ? "rectangle.portrait.and.arrow.right"
-                        : "network.slash"
-                )
-            } description: {
-                Text(disconnectionReason)
-            } actions: {
-                Button(
-                    attachmentClosure == .detached ? "Reconnect" : "Retry",
-                    action: onRetryRequest
-                )
-                if showsHostSettingsAction {
-                    Button("Host Settings", action: onHostSettingsRequest)
-                }
-            }
         } else {
-            ProgressView("Opening \(handle.name)…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            sessionFallback
         }
+    }
+
+    /// Recovery, disconnection, and opening states share one chrome-tinted
+    /// backdrop: the cover behind them goes clear under a transparent
+    /// config, so without this they would float over the bare desktop. When
+    /// opaque the tint is the canonical surface color over an identical
+    /// opaque cover, so rendering is unchanged.
+    private var sessionFallback: some View {
+        ZStack {
+            if recoveryState != nil {
+                ContentUnavailableView {
+                    Label(recoveryTitle, systemImage: "network.slash")
+                } description: {
+                    VStack(spacing: 10) {
+                        if showsReconnectProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(recoveryMessage)
+                            .multilineTextAlignment(.center)
+                    }
+                } actions: {
+                    if primaryRecoveryActionTitle != nil {
+                        Button("Reconnect Now", action: onReconnectNow)
+                    }
+                    if showsReviewConnection {
+                        Button("Review Connection", action: onReviewConnection)
+                    }
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else if let disconnectionReason {
+                ContentUnavailableView {
+                    Label(
+                        attachmentClosure == .detached
+                            ? "Attachment closed" : "Unable to attach",
+                        systemImage: attachmentClosure == .detached
+                            ? "rectangle.portrait.and.arrow.right"
+                            : "network.slash"
+                    )
+                } description: {
+                    Text(disconnectionReason)
+                } actions: {
+                    Button(
+                        attachmentClosure == .detached ? "Reconnect" : "Retry",
+                        action: onRetryRequest
+                    )
+                    if showsHostSettingsAction {
+                        Button("Host Settings", action: onHostSettingsRequest)
+                    }
+                }
+            } else {
+                ProgressView("Opening \(handle.name)…")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WorkspaceSurfaceColor.chrome(backgroundAppearance))
     }
 
     var recoveryTitle: String {

--- a/Sources/App/TerminalSurfaceBackdrop.swift
+++ b/Sources/App/TerminalSurfaceBackdrop.swift
@@ -1,0 +1,15 @@
+import GhosthubTerminalSupport
+import SwiftUI
+
+enum TerminalSurfaceBackdrop {
+    /// Fills the cell-grid letterbox gap around a terminal surface. Clear
+    /// when transparent: the surface draws its own alpha background, and any
+    /// paint behind it would defeat the configured opacity.
+    static func color(
+        for appearance: TerminalBackgroundAppearance
+    ) -> Color {
+        appearance.isTransparent
+            ? .clear
+            : Color(nsColor: .textBackgroundColor)
+    }
+}

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1327,6 +1327,16 @@ struct WorkspaceWindow: View {
             WorkspaceWindowChrome.apply(to: window)
         }
         .onReceive(NotificationCenter.default.publisher(
+            for: NSWindow.didEnterFullScreenNotification
+        )) { notification in
+            reapplyChromeForFullscreenTransition(notification)
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: NSWindow.didExitFullScreenNotification
+        )) { notification in
+            reapplyChromeForFullscreenTransition(notification)
+        }
+        .onReceive(NotificationCenter.default.publisher(
             for: .ghosthubRenameWorkspaceWindow
         )) { notification in
             guard let requestedWindow = notification.object as? NSWindow,
@@ -1563,6 +1573,17 @@ struct WorkspaceWindow: View {
             automaticTitle: automaticWindowTitle
         )
     }
+
+    #if canImport(AppKit)
+    private func reapplyChromeForFullscreenTransition(
+        _ notification: Notification
+    ) {
+        guard let window = notification.object as? NSWindow,
+              window === sceneModel.workspaceWindow
+        else { return }
+        WorkspaceWindowChrome.apply(to: window)
+    }
+    #endif
 }
 
 private struct WorkspaceWindowTitleRenameRequest: Identifiable {

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -45,7 +45,14 @@ extension FocusedValues {
 #if canImport(AppKit)
 @MainActor
 enum WorkspaceWindowChrome {
-    static func apply(to window: NSWindow) {
+    static func apply(
+        to window: NSWindow,
+        appearance: TerminalBackgroundAppearance =
+            LibghosttyRuntime.shared.backgroundAppearance,
+        applyBlur: (NSWindow) -> Void = {
+            LibghosttyRuntime.shared.applyWindowBackgroundBlur(to: $0)
+        }
+    ) {
         // Keep workspace controls in the standard titlebar. Native window tabs
         // add their own AppKit-managed row when a tab group is present.
         window.toolbar = nil
@@ -55,17 +62,38 @@ enum WorkspaceWindowChrome {
         // view hierarchy. A terminal window must remain free to shrink to the
         // compact dimensions AppKit's standard titlebar permits.
         window.contentMinSize = .zero
-        window.backgroundColor = WorkspaceSurfaceColor.nsColor
+
+        // Native fullscreen has nothing behind the window; transparency
+        // there renders as gray. Match Ghostty.app and stay opaque.
+        let transparent = appearance.isTransparent
+            && !window.styleMask.contains(.fullScreen)
+
+        if transparent {
+            window.isOpaque = false
+            // Near-clear rather than .clear matches Terminal.app rendering;
+            // same trick Ghostty.app uses.
+            window.backgroundColor = .white.withAlphaComponent(0.001)
+            if appearance.appliesWindowBlur {
+                applyBlur(window)
+            }
+        } else {
+            window.isOpaque = true
+            window.backgroundColor = WorkspaceSurfaceColor.nsColor
+        }
+
         guard let closeButton = window.standardWindowButton(.closeButton),
               let titlebar = closeButton.superview
         else { return }
         titlebar.wantsLayer = true
-        titlebar.effectiveAppearance.performAsCurrentDrawingAppearance {
-            titlebar.layer?.backgroundColor =
-                WorkspaceSurfaceColor.nsColor.cgColor
+        if transparent {
+            titlebar.layer?.backgroundColor = NSColor.clear.cgColor
+        } else {
+            titlebar.effectiveAppearance.performAsCurrentDrawingAppearance {
+                titlebar.layer?.backgroundColor =
+                    WorkspaceSurfaceColor.nsColor.cgColor
+            }
         }
     }
-
 }
 
 /// Invisible NSView that reports its hosting window's key
@@ -1284,6 +1312,20 @@ struct WorkspaceWindow: View {
                 }
             )
         )
+        .onReceive(terminalRuntime.$backgroundAppearance) { appearance in
+            guard let window = sceneModel.workspaceWindow else { return }
+            WorkspaceWindowChrome.apply(to: window, appearance: appearance)
+        }
+        .onChange(of: sceneModel.isFocusedWindow) { _, focused in
+            // Blur has no effect on invisible windows; re-apply when this
+            // window gains focus so restored/deminiaturized windows pick
+            // it up.
+            guard focused,
+                  terminalRuntime.backgroundAppearance.isTransparent,
+                  let window = sceneModel.workspaceWindow
+            else { return }
+            WorkspaceWindowChrome.apply(to: window)
+        }
         .onReceive(NotificationCenter.default.publisher(
             for: .ghosthubRenameWorkspaceWindow
         )) { notification in

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1244,7 +1244,16 @@ struct WorkspaceWindow: View {
             \.availableSiblingShortcuts,
             sceneModel.availableSiblingShortcuts
         )
-        .background(WorkspaceSurfaceColor.color.ignoresSafeArea())
+        .environment(
+            \.terminalBackgroundAppearance,
+            terminalRuntime.backgroundAppearance
+        )
+        .background(
+            (terminalRuntime.backgroundAppearance.isTransparent
+                ? Color.clear
+                : WorkspaceSurfaceColor.color)
+                .ignoresSafeArea()
+        )
         .overlay(alignment: .top) {
             if let notice = visibleConfigReloadNotice {
                 ConfigReloadNoticeView(

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -1249,9 +1249,8 @@ struct WorkspaceWindow: View {
             terminalRuntime.backgroundAppearance
         )
         .background(
-            (terminalRuntime.backgroundAppearance.isTransparent
-                ? Color.clear
-                : WorkspaceSurfaceColor.color)
+            WorkspaceSurfaceColor
+                .behindTerminal(terminalRuntime.backgroundAppearance)
                 .ignoresSafeArea()
         )
         .overlay(alignment: .top) {

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -162,6 +162,7 @@ public final class LibghosttyRuntime: ObservableObject,
         PassthroughSubject<LibghosttyConfigReloadNotice?, Never>()
     private let pipeline: LibghosttyConfigPipeline
     private let configMonitorFactory: ConfigMonitorFactory
+    private let increasedContrastProvider: () -> Bool
     private nonisolated let resolvedColorGenerations =
         ResolvedColorGenerationTracker()
     private var resolvedColorEntries: [UInt: ResolvedColorEntry] = [:]
@@ -253,10 +254,14 @@ public final class LibghosttyRuntime: ObservableObject,
     init(
         pipeline: LibghosttyConfigPipeline,
         runtimeState: LibghosttyRuntimeState? = nil,
-        configMonitorFactory: @escaping ConfigMonitorFactory
+        configMonitorFactory: @escaping ConfigMonitorFactory,
+        increasedContrastProvider: @escaping () -> Bool = {
+            NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+        }
     ) {
         self.pipeline = pipeline
         self.configMonitorFactory = configMonitorFactory
+        self.increasedContrastProvider = increasedContrastProvider
         self.runtimeState = runtimeState ?? LibghosttyRuntimeState()
         bootstrapStatus = .ready()
         phase = .loadingConfig
@@ -605,8 +610,7 @@ public final class LibghosttyRuntime: ObservableObject,
         guard let configHandle else { return }
         let appearance = Self.readBackgroundAppearance(
             from: configHandle,
-            increasedContrast: NSWorkspace.shared
-                .accessibilityDisplayShouldIncreaseContrast
+            increasedContrast: increasedContrastProvider()
         )
         if appearance != backgroundAppearance {
             backgroundAppearance = appearance

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -151,6 +151,8 @@ public final class LibghosttyRuntime: ObservableObject,
         LibghosttyConfigReloadNotice?
     @Published public private(set) var resolvedTerminalColorsBySurface:
         [UInt: TerminalResolvedColors]
+    @Published public private(set) var backgroundAppearance:
+        TerminalBackgroundAppearance = .opaque
 
     public let runtimeState: LibghosttyRuntimeState
     public let renderTracker = SurfaceRenderTracker()
@@ -171,6 +173,8 @@ public final class LibghosttyRuntime: ObservableObject,
     private var monitorFailureMessage: String?
     private var monitorFailureNoticeID: UUID?
     private nonisolated(unsafe) var notificationObservers: [NSObjectProtocol] = []
+    private nonisolated(unsafe) var workspaceNotificationObservers:
+        [NSObjectProtocol] = []
     private static var didInitializeLibrary = false
 
     public var configPaths: LibghosttyConfigPaths {
@@ -185,6 +189,17 @@ public final class LibghosttyRuntime: ObservableObject,
     public var needsConfirmQuit: Bool {
         guard let appHandle else { return false }
         return ghostty_app_needs_confirm_quit(appHandle)
+    }
+
+    /// Applies the configured background blur to a window via libghostty.
+    /// Safe to call repeatedly; radius 0 clears any existing blur. No effect
+    /// unless the window is visible, so callers re-apply on focus changes.
+    public func applyWindowBackgroundBlur(to window: NSWindow) {
+        guard let appHandle else { return }
+        ghostty_set_window_background_blur(
+            appHandle,
+            Unmanaged.passUnretained(window).toOpaque()
+        )
     }
 
     /// Colors shared by every live surface in the current configuration.
@@ -255,6 +270,10 @@ public final class LibghosttyRuntime: ObservableObject,
     deinit {
         for observer in notificationObservers {
             NotificationCenter.default.removeObserver(observer)
+        }
+
+        for observer in workspaceNotificationObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
         }
 
         if let appHandle {
@@ -579,6 +598,19 @@ public final class LibghosttyRuntime: ObservableObject,
             ghostty_config_free(existing)
         }
         configHandle = config
+        refreshBackgroundAppearance()
+    }
+
+    private func refreshBackgroundAppearance() {
+        guard let configHandle else { return }
+        let appearance = Self.readBackgroundAppearance(
+            from: configHandle,
+            increasedContrast: NSWorkspace.shared
+                .accessibilityDisplayShouldIncreaseContrast
+        )
+        if appearance != backgroundAppearance {
+            backgroundAppearance = appearance
+        }
     }
 
     private func readDiagnostics(from config: ghostty_config_t) -> [String] {
@@ -623,6 +655,20 @@ public final class LibghosttyRuntime: ObservableObject,
             ) { [weak self] _ in
                 guard let appHandle = self?.appHandle else { return }
                 ghostty_app_set_focus(appHandle, false)
+            }
+        )
+        // Accessibility display notifications post on NSWorkspace's own
+        // notification center, not NotificationCenter.default.
+        workspaceNotificationObservers.append(
+            NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace
+                    .accessibilityDisplayOptionsDidChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.refreshBackgroundAppearance()
+                }
             }
         )
     }
@@ -731,7 +777,7 @@ public final class LibghosttyRuntime: ObservableObject,
         configReloadNoticeSubject.send(notice)
     }
 
-    private static func ensureLibraryInitialized() -> Bool {
+    static func ensureLibraryInitialized() -> Bool {
         if didInitializeLibrary {
             return true
         }
@@ -1305,6 +1351,35 @@ public final class LibghosttyRuntime: ObservableObject,
               let surface = target.target.surface
         else { return nil }
         return UInt(bitPattern: surface)
+    }
+
+    nonisolated static func readBackgroundAppearance(
+        from config: ghostty_config_t,
+        increasedContrast: Bool
+    ) -> TerminalBackgroundAppearance {
+        var opacity = 1.0
+        let opacityKey = "background-opacity"
+        _ = ghostty_config_get(
+            config,
+            &opacity,
+            opacityKey,
+            UInt(opacityKey.lengthOfBytes(using: .utf8))
+        )
+
+        var blur: Int16 = 0
+        let blurKey = "background-blur"
+        _ = ghostty_config_get(
+            config,
+            &blur,
+            blurKey,
+            UInt(blurKey.lengthOfBytes(using: .utf8))
+        )
+
+        return TerminalBackgroundAppearance(
+            opacity: opacity,
+            blurCValue: blur,
+            increasedContrast: increasedContrast
+        )
     }
 
     private nonisolated static func resolvedTerminalColors(

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -1357,6 +1357,8 @@ public final class LibghosttyRuntime: ObservableObject,
         from config: ghostty_config_t,
         increasedContrast: Bool
     ) -> TerminalBackgroundAppearance {
+        // An absent or mismatched key leaves the out-parameter untouched,
+        // so the pre-seeded values are the fallback defaults.
         var opacity = 1.0
         let opacityKey = "background-opacity"
         _ = ghostty_config_get(

--- a/Sources/Terminal/TerminalSurfaceSnapshotter.swift
+++ b/Sources/Terminal/TerminalSurfaceSnapshotter.swift
@@ -276,7 +276,13 @@ public final class TerminalSurfaceSnapshotter {
         return (bytes + alignment - 1) / alignment * alignment
     }
 
-    private nonisolated static func makeThumbnail(
+    /// Thumbnails flatten over this fill; a translucent layer color under
+    /// background-opacity < 1 must not let the sidebar show through previews.
+    nonisolated static func opaqueFill(from color: CGColor?) -> CGColor {
+        color?.copy(alpha: 1) ?? NSColor.black.cgColor
+    }
+
+    nonisolated static func makeThumbnail(
         _ sourceImage: CGImage,
         outputSize: (width: Int, height: Int),
         backgroundColor: CGColor
@@ -296,7 +302,7 @@ public final class TerminalSurfaceSnapshotter {
             ).union(.byteOrder32Little).rawValue
         ) else { return nil }
         let outputSize = CGSize(width: outputWidth, height: outputHeight)
-        context.setFillColor(backgroundColor)
+        context.setFillColor(opaqueFill(from: backgroundColor))
         context.fill(CGRect(origin: .zero, size: outputSize))
         context.interpolationQuality = .high
         let sourceSize = CGSize(

--- a/Sources/TerminalSupport/TerminalBackgroundAppearance.swift
+++ b/Sources/TerminalSupport/TerminalBackgroundAppearance.swift
@@ -1,0 +1,56 @@
+public enum TerminalBackgroundBlur: Equatable, Sendable {
+    case disabled
+    case radius(Int)
+    /// macOS 26 glass styles (config c-values -1/-2). The window still goes
+    /// transparent, but the libghostty radius-blur call is skipped, matching
+    /// Ghostty.app.
+    case systemGlass
+}
+
+/// Window/chrome transparency derived from the loaded libghostty config.
+/// libghostty remains authoritative for parsing; this type only interprets
+/// the values `ghostty_config_get` returns.
+public struct TerminalBackgroundAppearance: Equatable, Sendable {
+    public let opacity: Double
+    public let blur: TerminalBackgroundBlur
+
+    public static let opaque = Self(
+        opacity: 1.0, blurCValue: 0, increasedContrast: false
+    )
+
+    public init(
+        opacity: Double,
+        blurCValue: Int16,
+        increasedContrast: Bool
+    ) {
+        if increasedContrast {
+            self.opacity = 1.0
+            blur = .disabled
+            return
+        }
+        self.opacity = min(max(opacity, 0.0), 1.0)
+        switch blurCValue {
+        case ..<0:
+            blur = .systemGlass
+        case 0:
+            blur = .disabled
+        default:
+            blur = .radius(Int(blurCValue))
+        }
+    }
+
+    public var isTransparent: Bool { opacity < 1.0 }
+
+    /// Whether the applier should hand this window to libghostty's
+    /// background-blur call. True for `.disabled` too: calling with radius 0
+    /// clears blur left over from a previous transparent configuration.
+    public var appliesWindowBlur: Bool {
+        guard isTransparent else { return false }
+        switch blur {
+        case .disabled, .radius:
+            return true
+        case .systemGlass:
+            return false
+        }
+    }
+}

--- a/Sources/TerminalSupport/TerminalBackgroundAppearance.swift
+++ b/Sources/TerminalSupport/TerminalBackgroundAppearance.swift
@@ -3,7 +3,11 @@ public enum TerminalBackgroundBlur: Equatable, Sendable {
     case radius(Int)
     /// macOS 26 glass styles (config c-values -1/-2). The window still goes
     /// transparent, but the libghostty radius-blur call is skipped, matching
-    /// Ghostty.app.
+    /// Ghostty.app: the embedded blur function would pass the negative glass
+    /// value straight to CGSSetWindowBackgroundBlurRadius. Like Ghostty.app,
+    /// a radius installed by an earlier config survives a live reload into a
+    /// glass style; Ghosthub does not render glass and cannot clear the
+    /// radius without calling private CGS API directly.
     case systemGlass
 }
 

--- a/Sources/UI/PaneColors.swift
+++ b/Sources/UI/PaneColors.swift
@@ -93,6 +93,18 @@ public enum WorkspaceSurfaceColor {
 
     public static let color: Color = .init(nsColor: nsColor)
 
+    /// Canonical surface color at a given alpha, for translucent chrome when
+    /// the terminal background is transparent. Alpha 1 returns the canonical
+    /// opaque color.
+    public static func nsColor(opacity: Double) -> NSColor {
+        guard opacity < 1.0 else { return nsColor }
+        return nsColor.withAlphaComponent(opacity)
+    }
+
+    public static func color(opacity: Double) -> Color {
+        Color(nsColor: nsColor(opacity: opacity))
+    }
+
     public static func hexString(
         for appearance: NSAppearance
     ) -> String {

--- a/Sources/UI/PaneColors.swift
+++ b/Sources/UI/PaneColors.swift
@@ -1,4 +1,5 @@
 import AppKit
+import GhosthubTerminalSupport
 import SwiftUI
 
 // MARK: - Appearance-aware surface colors
@@ -97,12 +98,31 @@ public enum WorkspaceSurfaceColor {
     /// the terminal background is transparent. Alpha 1 returns the canonical
     /// opaque color.
     public static func nsColor(opacity: Double) -> NSColor {
-        guard opacity < 1.0 else { return nsColor }
-        return nsColor.withAlphaComponent(opacity)
+        let clamped = min(max(opacity, 0.0), 1.0)
+        guard clamped < 1.0 else { return nsColor }
+        return nsColor.withAlphaComponent(clamped)
     }
 
     public static func color(opacity: Double) -> Color {
         Color(nsColor: nsColor(opacity: opacity))
+    }
+
+    /// Clear when the terminal background is transparent — the surface
+    /// behind draws its own alpha, and any paint here would stack and
+    /// darken it. Canonical surface color otherwise.
+    public static func behindTerminal(
+        _ appearance: TerminalBackgroundAppearance
+    ) -> Color {
+        appearance.isTransparent ? .clear : color
+    }
+
+    /// Chrome surfaces (sidebar, panels): tinted at the configured opacity
+    /// when transparent so the window shows one consistent translucency;
+    /// canonical opaque color otherwise.
+    public static func chrome(
+        _ appearance: TerminalBackgroundAppearance
+    ) -> Color {
+        color(opacity: appearance.isTransparent ? appearance.opacity : 1.0)
     }
 
     public static func hexString(

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -25,6 +25,8 @@ public struct RootView: View {
     @State private var isSidebarTransitioning = false
     @State private var sidebarTransitionID = UUID()
     @Environment(\.controlActiveState) private var controlActiveState
+    @Environment(\.terminalBackgroundAppearance)
+    private var backgroundAppearance
     @State private var lastKnownWindowWidth: CGFloat = 0
     @State private var sidePanelAutoCollapsed = false
     @State private var sidePanelUserOverride = false
@@ -531,7 +533,11 @@ public struct RootView: View {
 
     private var workspaceContent: some View {
         workspaceColumns
-            .background(WorkspaceSurfaceColor.color)
+            .background(
+                backgroundAppearance.isTransparent
+                    ? Color.clear
+                    : WorkspaceSurfaceColor.color
+            )
     }
 
     private var workspaceColumns: some View {
@@ -754,7 +760,13 @@ public struct RootView: View {
             }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(WorkspaceSurfaceColor.color)
+        .background(
+            WorkspaceSurfaceColor.color(
+                opacity: backgroundAppearance.isTransparent
+                    ? backgroundAppearance.opacity
+                    : 1.0
+            )
+        )
     }
 
     private func reviewSSHHostKey(
@@ -1699,8 +1711,17 @@ public struct RootView: View {
             if let parkingView = content.tmuxSessionPreviewParkingBuilder?() {
                 parkingView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .opacity(
+                        backgroundAppearance.isTransparent ? 0.001 : 1.0
+                    )
             }
-            WorkspaceSurfaceColor.color
+            // Parked preview surfaces must keep rendering (snapshots need
+            // them drawn) but stay hidden: an opaque cover would block the
+            // desktop when the window is transparent, a clear one would
+            // expose them, so near-zero opacity hides them instead.
+            (backgroundAppearance.isTransparent
+                ? Color.clear
+                : WorkspaceSurfaceColor.color)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             terminalWorkspaceContent
         }

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -1814,79 +1814,91 @@ public struct RootView: View {
                       )
                   ) {
             view
-        } else if display.suppressesAutomaticWorktreeSessionOpen,
-                  !display.isWorkspaceRestorationPending,
-                  selectedWorktreeTmuxSession != nil {
-            ContentUnavailableView {
-                Label("Session detached", systemImage: "terminal")
-            } description: {
-                Text("Select this workspace to attach its tmux session.")
-            }
-        } else if let pendingSession = selectedWorktreeTmuxSession {
-            ProgressView("Opening \(displayName(for: pendingSession))…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if selection.selectedWorktreeID != nil
-            || selection.selectedDirectoryWorkspaceID != nil {
-            ContentUnavailableView {
-                Label("No tmux session", systemImage: "terminal")
-            } description: {
-                Text(
-                    "This kwt workspace does not currently report a tmux session."
-                )
-            } actions: {
-                if let refresh = handlers.refreshWorkspaceInventory {
-                    Button("Refresh", action: refresh)
-                }
-            }
-        } else if display.isWorkspaceInventoryLoading {
-            ProgressView("Loading workspaces…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let error = display.workspaceInventoryError {
-            ContentUnavailableView {
-                Label(
-                    "Unable to refresh workspaces",
-                    systemImage: "exclamationmark.triangle"
-                )
-            } description: {
-                Text(error)
-            } actions: {
-                if let refresh = handlers.refreshWorkspaceInventory {
-                    Button("Retry", action: refresh)
-                }
-            }
-        } else if snapshot.projects.isEmpty,
-                  snapshot.hosts.allSatisfy({
-                      $0.tmuxSessions.isEmpty
-                          && $0.herdrSessions.isEmpty
-                          && $0.zellijSessions.isEmpty
-                  }) {
-            VStack(spacing: 14) {
-                Text("Welcome to Ghosthub")
-                    .font(.system(size: 24, weight: .semibold))
-                Text(
-                    "Your kwt workspaces and multiplexer sessions will appear in the sidebar."
-                )
-                .font(.system(size: 14))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                Text(
-                    "Register projects with kwt, or add an SSH host in Settings. Ghosthub attaches without taking over multiplexer tabs, panes, layouts, or history."
-                )
-                .font(.system(size: 13))
-                .foregroundStyle(.tertiary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 460)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ContentUnavailableView(
-                "No Active Session",
-                systemImage: "terminal",
-                description: Text(
-                    "Select a multiplexer session or kwt workspace from the sidebar."
-                )
-            )
+            emptyWorkspaceState
         }
+    }
+
+    /// Non-terminal states share one chrome-tinted backdrop: the cover
+    /// behind them stays clear for the terminal branches, so without this
+    /// they would float over the bare desktop when transparent. When
+    /// opaque the tint is the canonical surface color over an identical
+    /// opaque cover, so rendering is unchanged.
+    private var emptyWorkspaceState: some View {
+        ZStack {
+            if display.suppressesAutomaticWorktreeSessionOpen,
+               !display.isWorkspaceRestorationPending,
+               selectedWorktreeTmuxSession != nil {
+                ContentUnavailableView {
+                    Label("Session detached", systemImage: "terminal")
+                } description: {
+                    Text("Select this workspace to attach its tmux session.")
+                }
+            } else if let pendingSession = selectedWorktreeTmuxSession {
+                ProgressView("Opening \(displayName(for: pendingSession))…")
+            } else if selection.selectedWorktreeID != nil
+                || selection.selectedDirectoryWorkspaceID != nil {
+                ContentUnavailableView {
+                    Label("No tmux session", systemImage: "terminal")
+                } description: {
+                    Text(
+                        "This kwt workspace does not currently report a tmux session."
+                    )
+                } actions: {
+                    if let refresh = handlers.refreshWorkspaceInventory {
+                        Button("Refresh", action: refresh)
+                    }
+                }
+            } else if display.isWorkspaceInventoryLoading {
+                ProgressView("Loading workspaces…")
+            } else if let error = display.workspaceInventoryError {
+                ContentUnavailableView {
+                    Label(
+                        "Unable to refresh workspaces",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                } description: {
+                    Text(error)
+                } actions: {
+                    if let refresh = handlers.refreshWorkspaceInventory {
+                        Button("Retry", action: refresh)
+                    }
+                }
+            } else if snapshot.projects.isEmpty,
+                      snapshot.hosts.allSatisfy({
+                          $0.tmuxSessions.isEmpty
+                              && $0.herdrSessions.isEmpty
+                              && $0.zellijSessions.isEmpty
+                      }) {
+                VStack(spacing: 14) {
+                    Text("Welcome to Ghosthub")
+                        .font(.system(size: 24, weight: .semibold))
+                    Text(
+                        "Your kwt workspaces and multiplexer sessions will appear in the sidebar."
+                    )
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    Text(
+                        "Register projects with kwt, or add an SSH host in Settings. Ghosthub attaches without taking over multiplexer tabs, panes, layouts, or history."
+                    )
+                    .font(.system(size: 13))
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 460)
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Active Session",
+                    systemImage: "terminal",
+                    description: Text(
+                        "Select a multiplexer session or kwt workspace from the sidebar."
+                    )
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WorkspaceSurfaceColor.chrome(backgroundAppearance))
     }
 
     private var worktreeVisibility: WorktreeVisibility {

--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -534,9 +534,7 @@ public struct RootView: View {
     private var workspaceContent: some View {
         workspaceColumns
             .background(
-                backgroundAppearance.isTransparent
-                    ? Color.clear
-                    : WorkspaceSurfaceColor.color
+                WorkspaceSurfaceColor.behindTerminal(backgroundAppearance)
             )
     }
 
@@ -760,13 +758,7 @@ public struct RootView: View {
             }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            WorkspaceSurfaceColor.color(
-                opacity: backgroundAppearance.isTransparent
-                    ? backgroundAppearance.opacity
-                    : 1.0
-            )
-        )
+        .background(WorkspaceSurfaceColor.chrome(backgroundAppearance))
     }
 
     private func reviewSSHHostKey(
@@ -1709,19 +1701,23 @@ public struct RootView: View {
     private var terminalWorkspaceWithPreviewParking: some View {
         ZStack {
             if let parkingView = content.tmuxSessionPreviewParkingBuilder?() {
+                // Parked preview surfaces must keep rendering (snapshots
+                // need them drawn) but stay hidden: with a transparent
+                // window the cover below goes clear, so near-zero opacity
+                // hides them instead. Terminal occlusion pausing is
+                // window-scoped (TerminalSurfaceView reads only
+                // window.occlusionState/isVisible/isKeyWindow), so 0 would
+                // not pause the surfaces, but SwiftUI may skip compositing
+                // views at exactly zero opacity; 0.001 avoids that and
+                // matches the near-clear window background convention in
+                // WorkspaceWindowChrome.apply.
                 parkingView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .opacity(
                         backgroundAppearance.isTransparent ? 0.001 : 1.0
                     )
             }
-            // Parked preview surfaces must keep rendering (snapshots need
-            // them drawn) but stay hidden: an opaque cover would block the
-            // desktop when the window is transparent, a clear one would
-            // expose them, so near-zero opacity hides them instead.
-            (backgroundAppearance.isTransparent
-                ? Color.clear
-                : WorkspaceSurfaceColor.color)
+            WorkspaceSurfaceColor.behindTerminal(backgroundAppearance)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             terminalWorkspaceContent
         }

--- a/Sources/UI/TerminalBackgroundAppearanceEnvironment.swift
+++ b/Sources/UI/TerminalBackgroundAppearanceEnvironment.swift
@@ -2,8 +2,8 @@ import GhosthubTerminalSupport
 import SwiftUI
 
 public extension EnvironmentValues {
-    // Live background appearance derived from the libghostty config.
-    // Defaults to opaque so nothing flashes transparent before the
-    // terminal runtime loads its configuration.
+    /// Live background appearance derived from the libghostty config.
+    /// Defaults to opaque so nothing flashes transparent before the
+    /// terminal runtime loads its configuration.
     @Entry var terminalBackgroundAppearance: TerminalBackgroundAppearance = .opaque
 }

--- a/Sources/UI/TerminalBackgroundAppearanceEnvironment.swift
+++ b/Sources/UI/TerminalBackgroundAppearanceEnvironment.swift
@@ -1,0 +1,9 @@
+import GhosthubTerminalSupport
+import SwiftUI
+
+public extension EnvironmentValues {
+    // Live background appearance derived from the libghostty config.
+    // Defaults to opaque so nothing flashes transparent before the
+    // terminal runtime loads its configuration.
+    @Entry var terminalBackgroundAppearance: TerminalBackgroundAppearance = .opaque
+}

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -151,6 +151,8 @@ struct WorkspaceSidebarView: View {
     @Environment(\.accessibilityDifferentiateWithoutColor)
     private var differentiateWithoutColor
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.terminalBackgroundAppearance)
+    private var backgroundAppearance
     let snapshot: WorkspaceSnapshot
     let sectionCache: WorkspaceSidebarSectionCache?
     let snapshotRevision: UInt64
@@ -461,7 +463,11 @@ struct WorkspaceSidebarView: View {
         .padding(.vertical, 1)
         .background {
             ZStack {
-                WorkspaceSurfaceColor.color
+                WorkspaceSurfaceColor.color(
+                    opacity: backgroundAppearance.isTransparent
+                        ? backgroundAppearance.opacity
+                        : 1.0
+                )
                 Color.primary.opacity(
                     colorSchemeContrast == .increased ? 0.08 : 0.035
                 )

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -466,9 +466,7 @@ struct WorkspaceSidebarView: View {
                 // The sidebar column already paints the tinted surface when
                 // transparent; repainting it here would compound the alpha
                 // and make the header block more opaque than the rest.
-                backgroundAppearance.isTransparent
-                    ? Color.clear
-                    : WorkspaceSurfaceColor.color
+                WorkspaceSurfaceColor.behindTerminal(backgroundAppearance)
                 Color.primary.opacity(
                     colorSchemeContrast == .increased ? 0.08 : 0.035
                 )

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -463,11 +463,12 @@ struct WorkspaceSidebarView: View {
         .padding(.vertical, 1)
         .background {
             ZStack {
-                WorkspaceSurfaceColor.color(
-                    opacity: backgroundAppearance.isTransparent
-                        ? backgroundAppearance.opacity
-                        : 1.0
-                )
+                // The sidebar column already paints the tinted surface when
+                // transparent; repainting it here would compound the alpha
+                // and make the header block more opaque than the rest.
+                backgroundAppearance.isTransparent
+                    ? Color.clear
+                    : WorkspaceSurfaceColor.color
                 Color.primary.opacity(
                     colorSchemeContrast == .increased ? 0.08 : 0.035
                 )

--- a/Tests/App/TerminalSurfaceBackdropTests.swift
+++ b/Tests/App/TerminalSurfaceBackdropTests.swift
@@ -1,0 +1,25 @@
+import AppKit
+import GhosthubTerminalSupport
+import SwiftUI
+import Testing
+@testable import GhosthubApp
+
+@Suite("TerminalSurfaceBackdrop")
+@MainActor
+struct TerminalSurfaceBackdropTests {
+    @Test("clear under a transparent appearance")
+    func transparentBackdrop() {
+        let appearance = TerminalBackgroundAppearance(
+            opacity: 0.8, blurCValue: 0, increasedContrast: false
+        )
+        #expect(TerminalSurfaceBackdrop.color(for: appearance) == .clear)
+    }
+
+    @Test("system text background when opaque")
+    func opaqueBackdrop() {
+        #expect(
+            TerminalSurfaceBackdrop.color(for: .opaque)
+                == Color(nsColor: .textBackgroundColor)
+        )
+    }
+}

--- a/Tests/App/WorkspaceWindowChromeTests.swift
+++ b/Tests/App/WorkspaceWindowChromeTests.swift
@@ -57,6 +57,37 @@ struct WorkspaceWindowChromeTests {
         #expect(blurCalls == 1)
     }
 
+    /// AppKit rejects inserting .fullScreen into styleMask outside a real
+    /// fullscreen transition, which needs a window server. Overriding the
+    /// getter exercises the same guard headlessly.
+    private final class FullscreenStyledWindow: NSWindow {
+        override var styleMask: NSWindow.StyleMask {
+            get { super.styleMask.union(.fullScreen) }
+            set { super.styleMask = newValue }
+        }
+    }
+
+    @Test("fullscreen windows stay opaque under transparent appearance")
+    func fullscreenStaysOpaque() {
+        let window = FullscreenStyledWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: true
+        )
+        var blurCalls = 0
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 20, increasedContrast: false
+            ),
+            applyBlur: { _ in blurCalls += 1 }
+        )
+        #expect(window.isOpaque)
+        #expect(resolvedAlpha(of: window) == 1)
+        #expect(blurCalls == 0)
+    }
+
     @Test("glass blur styles skip the blur call but stay transparent")
     func glassSkipsBlur() {
         let window = makeWindow()

--- a/Tests/App/WorkspaceWindowChromeTests.swift
+++ b/Tests/App/WorkspaceWindowChromeTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+import GhosthubTerminalSupport
+import Testing
+@testable import GhosthubApp
+
+@Suite("WorkspaceWindowChrome appearance")
+@MainActor
+struct WorkspaceWindowChromeTests {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: true
+        )
+    }
+
+    private func resolvedAlpha(of window: NSWindow) -> CGFloat? {
+        window.backgroundColor.usingColorSpace(.sRGB)?.alphaComponent
+    }
+
+    @Test("transparent appearance unsets window opacity")
+    func transparentWindow() {
+        let window = makeWindow()
+        var blurredWindows: [NSWindow] = []
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 20, increasedContrast: false
+            ),
+            applyBlur: { blurredWindows.append($0) }
+        )
+        #expect(!window.isOpaque)
+        #expect((resolvedAlpha(of: window) ?? 1) < 0.01)
+        #expect(window.hasShadow)
+        #expect(blurredWindows.count == 1)
+    }
+
+    @Test("opaque appearance restores current chrome")
+    func opaqueWindow() {
+        let window = makeWindow()
+        var blurCalls = 0
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 20, increasedContrast: false
+            ),
+            applyBlur: { _ in blurCalls += 1 }
+        )
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: .opaque,
+            applyBlur: { _ in blurCalls += 1 }
+        )
+        #expect(window.isOpaque)
+        #expect(resolvedAlpha(of: window) == 1)
+        #expect(blurCalls == 1)
+    }
+
+    @Test("glass blur styles skip the blur call but stay transparent")
+    func glassSkipsBlur() {
+        let window = makeWindow()
+        var blurCalls = 0
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: -1, increasedContrast: false
+            ),
+            applyBlur: { _ in blurCalls += 1 }
+        )
+        #expect(!window.isOpaque)
+        #expect(blurCalls == 0)
+    }
+}

--- a/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
+++ b/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import GhosttyKit
 import Testing
@@ -89,6 +88,8 @@ struct LibghosttyBackgroundAppearanceTests {
 
         // A no-op change handler keeps filesystem events from triggering
         // reloads mid-test; the explicit reloadConfig below is synchronous.
+        // Contrast is pinned off so the 0.8 -> 1.0 transition is always
+        // observable regardless of this machine's accessibility settings.
         let runtime = LibghosttyRuntime(
             pipeline: pipeline,
             configMonitorFactory: { request in
@@ -97,18 +98,13 @@ struct LibghosttyBackgroundAppearanceTests {
                     errorHandler: request.errorHandler,
                     changeHandler: {}
                 )
-            }
+            },
+            increasedContrastProvider: { false }
         )
         try #require(runtime.phase == .ready)
 
-        if NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast {
-            // Increased contrast forces opaque, so transparency cannot be
-            // observed on this machine; the derivation path still runs.
-            #expect(runtime.backgroundAppearance == .opaque)
-        } else {
-            #expect(runtime.backgroundAppearance.opacity == 0.8)
-            #expect(runtime.backgroundAppearance.isTransparent)
-        }
+        #expect(runtime.backgroundAppearance.opacity == 0.8)
+        #expect(runtime.backgroundAppearance.isTransparent)
 
         try "background-opacity = 1.0\n".write(
             to: pipeline.paths.globalConfigFile,

--- a/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
+++ b/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import GhosttyKit
+import Testing
+@testable import GhosthubTerminal
+@testable import GhosthubTerminalSupport
+
+@MainActor
+@Suite("Libghostty background appearance")
+struct LibghosttyBackgroundAppearanceTests {
+    private func loadConfig(_ contents: String) throws -> ghostty_config_t {
+        try #require(LibghosttyRuntime.ensureLibraryInitialized())
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true
+        )
+        let file = dir.appendingPathComponent("ghostty.conf")
+        try contents.write(to: file, atomically: true, encoding: .utf8)
+        let config = try #require(ghostty_config_new())
+        file.path.withCString { pointer in
+            ghostty_config_load_file(config, pointer, file.path.utf8.count)
+        }
+        ghostty_config_finalize(config)
+        return config
+    }
+
+    @Test("reads opacity and blur from config")
+    func readsTransparentConfig() throws {
+        let config = try loadConfig(
+            """
+            background-opacity = 0.8
+            background-blur = true
+            """
+        )
+        defer { ghostty_config_free(config) }
+        let appearance = LibghosttyRuntime.readBackgroundAppearance(
+            from: config, increasedContrast: false
+        )
+        #expect(appearance.opacity == 0.8)
+        #expect(appearance.blur == .radius(20))
+        #expect(appearance.isTransparent)
+    }
+
+    @Test("defaults to opaque when keys are absent")
+    func defaultsOpaque() throws {
+        let config = try loadConfig("font-size = 13\n")
+        defer { ghostty_config_free(config) }
+        let appearance = LibghosttyRuntime.readBackgroundAppearance(
+            from: config, increasedContrast: false
+        )
+        #expect(appearance == .opaque)
+    }
+
+    @Test("numeric blur radius is preserved")
+    func numericBlur() throws {
+        let config = try loadConfig(
+            """
+            background-opacity = 0.9
+            background-blur = 32
+            """
+        )
+        defer { ghostty_config_free(config) }
+        let appearance = LibghosttyRuntime.readBackgroundAppearance(
+            from: config, increasedContrast: false
+        )
+        #expect(appearance.blur == .radius(32))
+    }
+
+    @Test("increased contrast forces opaque")
+    func increasedContrastForcesOpaque() throws {
+        let config = try loadConfig(
+            """
+            background-opacity = 0.8
+            background-blur = true
+            """
+        )
+        defer { ghostty_config_free(config) }
+        let appearance = LibghosttyRuntime.readBackgroundAppearance(
+            from: config, increasedContrast: true
+        )
+        #expect(appearance == .opaque)
+    }
+}

--- a/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
+++ b/Tests/Terminal/LibghosttyBackgroundAppearanceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import GhosttyKit
 import Testing
@@ -14,6 +15,9 @@ struct LibghosttyBackgroundAppearanceTests {
         try FileManager.default.createDirectory(
             at: dir, withIntermediateDirectories: true
         )
+        // Config loading is eager, so the directory can go as soon as the
+        // finalized handle is returned.
+        defer { try? FileManager.default.removeItem(at: dir) }
         let file = dir.appendingPathComponent("ghostty.conf")
         try contents.write(to: file, atomically: true, encoding: .utf8)
         let config = try #require(ghostty_config_new())
@@ -64,6 +68,56 @@ struct LibghosttyBackgroundAppearanceTests {
             from: config, increasedContrast: false
         )
         #expect(appearance.blur == .radius(32))
+    }
+
+    @Test("publishes appearance at startup and on reload")
+    func publishesAppearanceAcrossReloads() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pipeline = LibghosttyConfigPipeline(
+            paths: LibghosttyConfigPaths(configDirectory: dir)
+        )
+        try "background-opacity = 0.8\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // A no-op change handler keeps filesystem events from triggering
+        // reloads mid-test; the explicit reloadConfig below is synchronous.
+        let runtime = LibghosttyRuntime(
+            pipeline: pipeline,
+            configMonitorFactory: { request in
+                LibghosttyConfigFileMonitor(
+                    fileURLs: request.files,
+                    errorHandler: request.errorHandler,
+                    changeHandler: {}
+                )
+            }
+        )
+        try #require(runtime.phase == .ready)
+
+        if NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast {
+            // Increased contrast forces opaque, so transparency cannot be
+            // observed on this machine; the derivation path still runs.
+            #expect(runtime.backgroundAppearance == .opaque)
+        } else {
+            #expect(runtime.backgroundAppearance.opacity == 0.8)
+            #expect(runtime.backgroundAppearance.isTransparent)
+        }
+
+        try "background-opacity = 1.0\n".write(
+            to: pipeline.paths.globalConfigFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        runtime.reloadConfig(force: true)
+
+        #expect(runtime.backgroundAppearance == .opaque)
     }
 
     @Test("increased contrast forces opaque")

--- a/Tests/Terminal/TerminalSurfaceSnapshotFlatteningTests.swift
+++ b/Tests/Terminal/TerminalSurfaceSnapshotFlatteningTests.swift
@@ -3,10 +3,10 @@ import CoreGraphics
 import Testing
 @testable import GhosthubTerminal
 
-// The composite path moved onto the GPU (CoreImage over IOSurfaces) with the
-// always-live preview rework, so flattening coverage lives at the `opaqueFill`
-// seam the composite consumes; the live-surface smoke tests exercise the full
-// render.
+/// The composite path moved onto the GPU (CoreImage over IOSurfaces) with the
+/// always-live preview rework, so flattening coverage lives at the `opaqueFill`
+/// seam the composite consumes; the live-surface smoke tests exercise the full
+/// render.
 @Suite("Terminal surface snapshot flattening")
 struct TerminalSurfaceSnapshotFlatteningTests {
     @Test("translucent layer color becomes an opaque fill with the same components")

--- a/Tests/Terminal/TerminalSurfaceSnapshotFlatteningTests.swift
+++ b/Tests/Terminal/TerminalSurfaceSnapshotFlatteningTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import CoreGraphics
+import Testing
+@testable import GhosthubTerminal
+
+@Suite("Terminal surface snapshot flattening")
+struct TerminalSurfaceSnapshotFlatteningTests {
+    @Test("translucent layer color becomes an opaque fill with the same components")
+    func translucentColorBecomesOpaque() throws {
+        let translucent = try #require(CGColor(
+            colorSpace: CGColorSpaceCreateDeviceRGB(),
+            components: [0.2, 0.4, 0.6, 0.3]
+        ))
+        let fill = TerminalSurfaceSnapshotter.opaqueFill(from: translucent)
+        #expect(fill.alpha == 1)
+        let components = try #require(fill.components)
+        #expect(components[0] == 0.2)
+        #expect(components[1] == 0.4)
+        #expect(components[2] == 0.6)
+    }
+
+    @Test("missing layer color falls back to opaque black")
+    func missingColorFallsBackToOpaqueBlack() throws {
+        let fill = TerminalSurfaceSnapshotter.opaqueFill(from: nil)
+        #expect(fill.alpha == 1)
+        let converted = try #require(
+            fill.converted(
+                to: CGColorSpaceCreateDeviceRGB(),
+                intent: .defaultIntent,
+                options: nil
+            )
+        )
+        let components = try #require(converted.components)
+        #expect(components[0] == 0)
+        #expect(components[1] == 0)
+        #expect(components[2] == 0)
+    }
+
+    @Test("thumbnail from a translucent surface over a translucent fill is fully opaque")
+    func thumbnailPixelsAreOpaque() throws {
+        let source = try #require(makeTranslucentImage(width: 8, height: 8))
+        let thumbnail = try #require(TerminalSurfaceSnapshotter.makeThumbnail(
+            source,
+            outputSize: (width: 16, height: 12),
+            backgroundColor: CGColor(red: 0, green: 0, blue: 1, alpha: 0.4)
+        ))
+        let pixels = try #require(thumbnail.dataProvider?.data as Data?)
+        let bytesPerRow = thumbnail.bytesPerRow
+        for row in 0 ..< thumbnail.height {
+            for column in 0 ..< thumbnail.width {
+                let alpha = pixels[row * bytesPerRow + column * 4 + 3]
+                #expect(alpha == 255, "pixel (\(column), \(row)) is translucent")
+            }
+        }
+    }
+
+    private func makeTranslucentImage(width: Int, height: Int) -> CGImage? {
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(
+                rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue
+            ).union(.byteOrder32Little).rawValue
+        ) else { return nil }
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 0.5))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
+    }
+}

--- a/Tests/TerminalSupport/TerminalBackgroundAppearanceTests.swift
+++ b/Tests/TerminalSupport/TerminalBackgroundAppearanceTests.swift
@@ -66,7 +66,7 @@ struct TerminalBackgroundAppearanceTests {
         #expect(appearance.blur == .disabled)
     }
 
-    @Test("window blur call is skipped only for glass styles")
+    @Test("window blur call is skipped for glass styles and opaque windows")
     func blurCall() {
         #expect(
             TerminalBackgroundAppearance(

--- a/Tests/TerminalSupport/TerminalBackgroundAppearanceTests.swift
+++ b/Tests/TerminalSupport/TerminalBackgroundAppearanceTests.swift
@@ -1,0 +1,95 @@
+import Testing
+@testable import GhosthubTerminalSupport
+
+@Suite("TerminalBackgroundAppearance")
+struct TerminalBackgroundAppearanceTests {
+    @Test("opaque by default")
+    func opaqueDefault() {
+        let appearance = TerminalBackgroundAppearance.opaque
+        #expect(appearance.opacity == 1.0)
+        #expect(appearance.blur == .disabled)
+        #expect(!appearance.isTransparent)
+    }
+
+    @Test(
+        "derives transparency from opacity",
+        arguments: [
+            (0.8, true),
+            (1.0, false),
+            (0.999, true),
+        ]
+    )
+    func transparency(opacity: Double, transparent: Bool) {
+        let appearance = TerminalBackgroundAppearance(
+            opacity: opacity, blurCValue: 0, increasedContrast: false
+        )
+        #expect(appearance.isTransparent == transparent)
+    }
+
+    @Test("clamps out-of-range opacity")
+    func clamping() {
+        #expect(
+            TerminalBackgroundAppearance(
+                opacity: -0.5, blurCValue: 0, increasedContrast: false
+            ).opacity == 0.0
+        )
+        #expect(
+            TerminalBackgroundAppearance(
+                opacity: 1.5, blurCValue: 0, increasedContrast: false
+            ).opacity == 1.0
+        )
+    }
+
+    @Test(
+        "maps blur c-values",
+        arguments: [
+            (Int16(0), TerminalBackgroundBlur.disabled),
+            (Int16(20), TerminalBackgroundBlur.radius(20)),
+            (Int16(-1), TerminalBackgroundBlur.systemGlass),
+            (Int16(-2), TerminalBackgroundBlur.systemGlass),
+        ]
+    )
+    func blurMapping(cValue: Int16, expected: TerminalBackgroundBlur) {
+        let appearance = TerminalBackgroundAppearance(
+            opacity: 0.8, blurCValue: cValue, increasedContrast: false
+        )
+        #expect(appearance.blur == expected)
+    }
+
+    @Test("increased contrast forces opaque")
+    func highContrast() {
+        let appearance = TerminalBackgroundAppearance(
+            opacity: 0.5, blurCValue: 20, increasedContrast: true
+        )
+        #expect(!appearance.isTransparent)
+        #expect(appearance.opacity == 1.0)
+        #expect(appearance.blur == .disabled)
+    }
+
+    @Test("window blur call is skipped only for glass styles")
+    func blurCall() {
+        #expect(
+            TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 20, increasedContrast: false
+            ).appliesWindowBlur
+        )
+        // Radius 0 still calls through so a live-reload that disables
+        // blur clears the window's existing blur radius.
+        #expect(
+            TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 0, increasedContrast: false
+            ).appliesWindowBlur
+        )
+        #expect(
+            !TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: -1, increasedContrast: false
+            ).appliesWindowBlur
+        )
+        // Opaque windows never apply blur.
+        #expect(
+            !TerminalBackgroundAppearance(
+                opacity: 1.0, blurCValue: 20, increasedContrast: false
+            ).appliesWindowBlur
+        )
+    }
+}

--- a/Tests/UI/WorkspaceSurfaceColorTests.swift
+++ b/Tests/UI/WorkspaceSurfaceColorTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Testing
+@testable import GhosthubUI
+
+@Suite("WorkspaceSurfaceColor opacity")
+struct WorkspaceSurfaceColorTests {
+    @Test("tinted variant carries the requested alpha")
+    func tintAlpha() {
+        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+            let tinted = WorkspaceSurfaceColor.nsColor(opacity: 0.8)
+            let resolved = tinted.usingColorSpace(.sRGB)
+            #expect(resolved != nil)
+            #expect(abs((resolved?.alphaComponent ?? 0) - 0.8) < 0.001)
+        }
+    }
+
+    @Test("opacity 1 matches the canonical color")
+    func fullOpacityMatchesCanonical() {
+        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+            let full = WorkspaceSurfaceColor.nsColor(opacity: 1.0)
+                .usingColorSpace(.sRGB)
+            let canonical = WorkspaceSurfaceColor.nsColor
+                .usingColorSpace(.sRGB)
+            #expect(full?.redComponent == canonical?.redComponent)
+            #expect(full?.alphaComponent == 1.0)
+        }
+    }
+}

--- a/Tests/UI/WorkspaceSurfaceColorTests.swift
+++ b/Tests/UI/WorkspaceSurfaceColorTests.swift
@@ -4,14 +4,34 @@ import Testing
 
 @Suite("WorkspaceSurfaceColor opacity")
 struct WorkspaceSurfaceColorTests {
-    @Test("tinted variant carries the requested alpha")
-    func tintAlpha() {
-        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+    @Test(
+        "tinted variant carries the requested alpha",
+        arguments: [NSAppearance.Name.darkAqua, .aqua]
+    )
+    func tintAlpha(appearanceName: NSAppearance.Name) {
+        NSAppearance(named: appearanceName)!.performAsCurrentDrawingAppearance {
             let tinted = WorkspaceSurfaceColor.nsColor(opacity: 0.8)
             let resolved = tinted.usingColorSpace(.sRGB)
             #expect(resolved != nil)
             #expect(abs((resolved?.alphaComponent ?? 0) - 0.8) < 0.001)
         }
+    }
+
+    @Test("dynamic base color survives the alpha wrap")
+    func dynamicResolutionSurvivesAlphaWrap() {
+        var dark: NSColor?
+        var light: NSColor?
+        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+            dark = WorkspaceSurfaceColor.nsColor(opacity: 0.8)
+                .usingColorSpace(.sRGB)
+        }
+        NSAppearance(named: .aqua)!.performAsCurrentDrawingAppearance {
+            light = WorkspaceSurfaceColor.nsColor(opacity: 0.8)
+                .usingColorSpace(.sRGB)
+        }
+        #expect(dark != nil)
+        #expect(light != nil)
+        #expect(dark?.redComponent != light?.redComponent)
     }
 
     @Test("opacity 1 matches the canonical color")
@@ -22,7 +42,21 @@ struct WorkspaceSurfaceColorTests {
             let canonical = WorkspaceSurfaceColor.nsColor
                 .usingColorSpace(.sRGB)
             #expect(full?.redComponent == canonical?.redComponent)
+            #expect(full?.greenComponent == canonical?.greenComponent)
+            #expect(full?.blueComponent == canonical?.blueComponent)
             #expect(full?.alphaComponent == 1.0)
+        }
+    }
+
+    @Test("out-of-range opacity clamps to 0...1")
+    func opacityClamps() {
+        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+            let over = WorkspaceSurfaceColor.nsColor(opacity: 1.5)
+                .usingColorSpace(.sRGB)
+            let under = WorkspaceSurfaceColor.nsColor(opacity: -0.5)
+                .usingColorSpace(.sRGB)
+            #expect(over?.alphaComponent == 1.0)
+            #expect(under?.alphaComponent == 0.0)
         }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -762,8 +762,10 @@ non-opaque with a near-clear background, blur is applied through
 `ghostty_set_window_background_blur`, chrome surfaces tint the canonical
 workspace surface color at the configured opacity, and layers directly
 behind the terminal render clear. Accessibility increased-contrast forces
-opaque. Native fullscreen windows stay opaque. `ghostty.conf` is the sole
-source of truth; there is no separate Ghosthub setting.
+opaque. Native fullscreen windows stay opaque. There is no separate Ghosthub
+setting; effective values come from the loaded configuration graph rooted at
+`ghostty.conf`, where the project's `terminal.conf` and recursive
+`config-file` includes can override the root.
 
 ## Session Attachment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -752,6 +752,19 @@ recursive include graph with debouncing. Invalid candidates never replace the
 last valid configuration. Automatic successes are silent, automatic failures
 remain visible, and explicit reloads publish a user-visible result.
 
+### Background transparency
+
+`LibghosttyRuntime` derives a `TerminalBackgroundAppearance` (opacity, blur)
+from `background-opacity` and `background-blur` in the loaded libghostty
+config at startup and on every config reload; libghostty remains
+authoritative for parsing. When opacity is below 1, workspace windows become
+non-opaque with a near-clear background, blur is applied through
+`ghostty_set_window_background_blur`, chrome surfaces tint the canonical
+workspace surface color at the configured opacity, and layers directly
+behind the terminal render clear. Accessibility increased-contrast forces
+opaque. Native fullscreen windows stay opaque. `ghostty.conf` is the sole
+source of truth; there is no separate Ghosthub setting.
+
 ## Session Attachment
 
 Each scene owns one active interactive presentation slot shared by tmux, Herdr,

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -35,6 +35,22 @@ theme = Catppuccin Macchiato
 Conditional light and dark themes, and paths to your own theme files, work the
 same way.
 
+## Background transparency
+
+Ghosthub reads `background-opacity` and `background-blur` from `ghostty.conf`
+at startup and on every reload:
+
+```text
+background-opacity = 0.85
+background-blur = 20
+```
+
+When opacity is below 1, workspace windows and their chrome become
+translucent at the configured opacity, and blur is applied behind the window.
+Increased contrast (**System Settings → Accessibility → Display**) forces an
+opaque window, and native fullscreen always stays opaque. There is no
+separate Ghosthub setting; `ghostty.conf` is the sole source of truth.
+
 ## Shell startup
 
 For local shells, Ghosthub preserves libghostty's normal macOS login-shell and

--- a/website/docs/content/terminal-configuration.md
+++ b/website/docs/content/terminal-configuration.md
@@ -49,7 +49,9 @@ When opacity is below 1, workspace windows and their chrome become
 translucent at the configured opacity, and blur is applied behind the window.
 Increased contrast (**System Settings → Accessibility → Display**) forces an
 opaque window, and native fullscreen always stays opaque. There is no
-separate Ghosthub setting; `ghostty.conf` is the sole source of truth.
+separate Ghosthub setting; effective values come from your loaded
+configuration graph rooted at `ghostty.conf`, so a project `terminal.conf` or
+a `config-file` include can override the root.
 
 ## Shell startup
 


### PR DESCRIPTION
I'm happy to sign the CLA if this is something you would be interested in.

- Ghosthub windows now honor `background-opacity` and `background-blur` from the terminal config. When opacity is below 1, the window, titlebar, sidebar, and empty states become translucent at one consistent level, and the layers behind the terminal render clear so the desktop shows through — matching how Ghostty.app treats the same settings.
- The appearance derives from the loaded libghostty config graph at startup and on every reload, so edits to `ghostty.conf` apply live without a restart. libghostty remains authoritative for parsing; there is no separate Ghosthub setting.
- Blur is applied through `ghostty_set_window_background_blur`, the same entry point Ghostty.app uses. macOS 26 glass-style values skip the radius call, matching upstream behavior.
- Accessibility increased contrast forces opaque. Native fullscreen stays opaque, with chrome re-applied on fullscreen enter and exit.
- tmux, Herdr, and Zellij session views previously painted an opaque fill behind the terminal surface; that fill now clears under transparency so the surface's own alpha is visible.
- Sidebar preview thumbnails flatten over an opaque background so cards stay legible regardless of terminal transparency.
- Existing users keep today's look unless they lower `background-opacity`; the default config's `0.95` now has a subtle visible effect, and `1` restores a fully opaque window.
- Docs: an architecture note on the appearance derivation and a website Guide section for the two config keys. No screenshot refresh: the Guide addition documents config keys rather than UI operation, and the existing screenshot set's visuals are not materially altered at default opacity.

https://claude.ai/code/session_01LraXVn3ZPiWmALufmeiDHW
