### PR TITLE
Rust Port: Open KWT workspaces on the correct tmux server

### DIFF
--- a/Sources/App/HerdrSessionProbeBroker.swift
+++ b/Sources/App/HerdrSessionProbeBroker.swift
@@ -71,6 +71,12 @@ final class HerdrSessionProbeBroker {
         await .exact(name: name, discovery: sessions(on: host))
     }
 
+    func sessionConsumerCount(on host: CommandHost) -> Int {
+        guard let entry = entries[host] else { return 0 }
+        return entry.consumers.count
+            + entry.consumersWaitingForCancellation.count
+    }
+
     func invalidateSessions(on host: CommandHost) {
         guard var entry = entries[host] else { return }
         let result = cancellation(on: host)

--- a/Sources/App/KwtSSHLeaseClient.swift
+++ b/Sources/App/KwtSSHLeaseClient.swift
@@ -228,6 +228,7 @@ final class KwtSSHLease: KwtSSHLeaseHolding, @unchecked Sendable {
                 while process.isRunning, clock.now < deadline {
                     try await Task.sleep(for: .milliseconds(10))
                 }
+                try Task.checkCancellation()
             } onCancel: { [self] in
                 terminateForCleanup()
             }

--- a/Sources/App/KwtWorktreeClient.swift
+++ b/Sources/App/KwtWorktreeClient.swift
@@ -38,7 +38,7 @@ enum KwtWorktreeError: Error, Equatable, LocalizedError {
         case .removalInProgress:
             "Another worktree change is already in progress."
         case .removalIdentityUnavailable:
-            "The worktree has no stable creation identity. Refresh the"
+            "The worktree has no stable removal identity. Refresh the"
                 + " workspace and try again."
         case .removalTargetChanged:
             "The worktree or its tmux session changed after confirmation."

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -87,6 +87,9 @@ private struct NativeTmuxAttachment {
     var windowsKwtRelativePath: String?
     var socketName: String?
     var protectedWorkspacePath: String?
+    var kwtWorktreeIdentity: KwtWorktreeOpenIdentity?
+    var kwtProtectedWorktreeIdentity: KwtProtectedWorktreeOpenIdentity?
+    var kwtExpectedSessionName: String?
     var launchMode: TmuxAttachmentLaunchMode
     var initialCommand: String?
     var workingDirectory: String?
@@ -94,11 +97,13 @@ private struct NativeTmuxAttachment {
     var sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
     var sshConnection: KwtSSHConnection?
     var sessionIdentity: TmuxSessionIdentity?
+    var expectedAttachIdentity: TmuxSessionIdentity?
     var paneSplitClientToken: String
     var clientTTYDirectory: String?
     var ignoresClientSize: Bool
     var previewGridSize: TmuxGridSize?
     var supportsClientSizing: Bool
+    var supportsClientIdentity: Bool
     var supportsPaneSplitting: Bool
     var remoteExitStatusURL: URL?
 
@@ -314,7 +319,12 @@ final class NativeTmuxSessionCoordinator {
         initialCommand: String? = nil,
         workingDirectory: String? = nil,
         openWorkspace: Bool = false,
+        kwtWorktreeIdentity: KwtWorktreeOpenIdentity? = nil,
+        kwtProtectedWorktreeIdentity:
+        KwtProtectedWorktreeOpenIdentity? = nil,
+        kwtExpectedSessionName: String? = nil,
         sessionIdentity: TmuxSessionIdentity? = nil,
+        expectedAttachIdentity: TmuxSessionIdentity? = nil,
         expectedRouteIdentity: String? = nil,
         ignoresClientSize: Bool = false,
         previewGridSize: TmuxGridSize? = nil
@@ -363,17 +373,18 @@ final class NativeTmuxSessionCoordinator {
                 let sshConnection: KwtSSHConnection?
                 let sshConnectionSnapshot: SSHConnectionArgumentsSnapshot
                 if case let .ssh(info) = host {
-                    sshConnection = try await remoteConnectionProvider(
+                    let connection = try await remoteConnectionProvider(
                         hostID,
                         info
                     )
                     if let expectedRouteIdentity,
-                       sshConnection?.routeIdentity != expectedRouteIdentity {
-                        try? await sshConnection?.release()
+                       connection.routeIdentity != expectedRouteIdentity {
+                        try? await connection.release()
                         throw KwtSSHLeaseError.routeChanged
                     }
+                    sshConnection = connection
                     sshConnectionSnapshot = SSHConnectionArgumentsSnapshot(
-                        arguments: sshConnection?.arguments ?? []
+                        connection
                     )
                 } else {
                     sshConnection = nil
@@ -412,7 +423,12 @@ final class NativeTmuxSessionCoordinator {
                     initialCommand: launchMode == .create ? initialCommand : nil,
                     workingDirectory: workingDirectory,
                     openWorkspace: openWorkspace,
+                    kwtWorktreeIdentity: kwtWorktreeIdentity,
+                    kwtProtectedWorktreeIdentity:
+                    kwtProtectedWorktreeIdentity,
+                    kwtExpectedSessionName: kwtExpectedSessionName,
                     sessionIdentity: sessionIdentity,
+                    expectedAttachIdentity: expectedAttachIdentity,
                     ignoresClientSize: ignoresClientSize,
                     previewGridSize: previewGridSize,
                     sshConnectionSnapshot: sshConnectionSnapshot,
@@ -436,7 +452,11 @@ final class NativeTmuxSessionCoordinator {
         initialCommand: String?,
         workingDirectory: String?,
         openWorkspace: Bool,
+        kwtWorktreeIdentity: KwtWorktreeOpenIdentity?,
+        kwtProtectedWorktreeIdentity: KwtProtectedWorktreeOpenIdentity?,
+        kwtExpectedSessionName: String?,
         sessionIdentity: TmuxSessionIdentity?,
+        expectedAttachIdentity: TmuxSessionIdentity?,
         ignoresClientSize: Bool,
         previewGridSize: TmuxGridSize?,
         sshConnectionSnapshot: SSHConnectionArgumentsSnapshot,
@@ -509,6 +529,10 @@ final class NativeTmuxSessionCoordinator {
                     : nil,
                 socketName: socketName,
                 protectedWorkspacePath: protectedWorkspacePath,
+                kwtWorktreeIdentity: kwtWorktreeIdentity,
+                kwtProtectedWorktreeIdentity:
+                kwtProtectedWorktreeIdentity,
+                kwtExpectedSessionName: kwtExpectedSessionName,
                 launchMode: launchMode,
                 initialCommand: launchMode == .create ? initialCommand : nil,
                 workingDirectory: workingDirectory,
@@ -516,6 +540,7 @@ final class NativeTmuxSessionCoordinator {
                 sshConnectionSnapshot: sshConnectionSnapshot,
                 sshConnection: sshConnection,
                 sessionIdentity: sessionIdentity,
+                expectedAttachIdentity: expectedAttachIdentity,
                 paneSplitClientToken: attachmentID.uuidString.lowercased(),
                 clientTTYDirectory: host.isRemote ? nil : StateHome.resolved()
                     .appendingPathComponent(
@@ -524,6 +549,8 @@ final class NativeTmuxSessionCoordinator {
                 ignoresClientSize: effectiveIgnoresClientSize,
                 previewGridSize: effectivePreviewGridSize,
                 supportsClientSizing: supportsClientSizing,
+                supportsClientIdentity: TmuxPaneSplitter
+                    .supportsClientIdentity(host: host),
                 supportsPaneSplitting: TmuxPaneSplitter
                     .supportsPaneSplitting(
                         version: resolved.version,
@@ -665,7 +692,13 @@ final class NativeTmuxSessionCoordinator {
     func attachmentRouteIdentity(
         _ handle: BorrowedTmuxSessionHandle
     ) -> String? {
-        attachments[handle.id]?.sshConnection?.routeIdentity
+        attachments[handle.id]?.sshConnectionSnapshot.routeIdentity
+    }
+
+    func attachmentConnectionSnapshot(
+        _ handle: BorrowedTmuxSessionHandle
+    ) -> SSHConnectionArgumentsSnapshot? {
+        attachments[handle.id]?.sshConnectionSnapshot
     }
 
     func hasDeferredPresentationStyle(
@@ -996,7 +1029,12 @@ final class NativeTmuxSessionCoordinator {
             workspacePath: attachment.openWorkspace
                 ? attachment.workingDirectory
                 : nil,
+            kwtWorktreeIdentity: attachment.kwtWorktreeIdentity,
+            kwtProtectedWorktreeIdentity:
+            attachment.kwtProtectedWorktreeIdentity,
+            kwtExpectedSessionName: attachment.kwtExpectedSessionName,
             protectedWorkspacePath: attachment.protectedWorkspacePath,
+            expectedAttachIdentity: attachment.expectedAttachIdentity,
             presentationStyle: presentationStyle,
             launchMode: attachment.launchMode,
             initialCommand: attachment.initialCommand,
@@ -1318,7 +1356,7 @@ final class NativeTmuxSessionCoordinator {
               paneSplitClients[handle.id] == nil,
               paneSplitClientBindings[handle.id] == nil
         else { return }
-        guard attachments[handle.id]?.supportsPaneSplitting == true else {
+        guard attachments[handle.id]?.supportsClientIdentity == true else {
             if previewIdentityRetryHandles.remove(handle.id) != nil {
                 unavailablePreviewIdentityHandles.insert(handle.id)
                 onAttachedSessionIdentityUnavailable?(handle)
@@ -1783,7 +1821,7 @@ final class NativeTmuxSessionCoordinator {
         _ handle: BorrowedTmuxSessionHandle
     ) async -> TmuxSessionIdentity? {
         guard let attachment = attachments[handle.id],
-              attachment.supportsPaneSplitting,
+              attachment.supportsClientIdentity,
               launchedAttachmentIDs[handle.id] == attachment.id,
               paneSplitClients[handle.id] != nil
         else { return nil }

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -622,6 +622,13 @@ final class NativeTmuxSessionCoordinator {
         removeHandle(handle, for: key, keyAlreadyRemoved: true)
     }
 
+    func detach(_ handle: BorrowedTmuxSessionHandle) {
+        let key = sessionKey(handle)
+        guard handlesByKey[key] == handle else { return }
+        handlesByKey.removeValue(forKey: key)
+        removeHandle(handle, for: key, keyAlreadyRemoved: true)
+    }
+
     @discardableResult
     func detachAll(hostID: UUID) -> [BorrowedTmuxSessionHandle] {
         let entries = handlesByKey.filter { $0.key.hostID == hostID }

--- a/Sources/App/TmuxPaneSplitter.swift
+++ b/Sources/App/TmuxPaneSplitter.swift
@@ -57,6 +57,10 @@ struct TmuxPaneSplitter: Sendable {
         self.runner = runner ?? Self.run
     }
 
+    static func supportsClientIdentity(host: CommandHost) -> Bool {
+        platform(for: host) == .posix
+    }
+
     static func supportsPaneSplitting(
         version: String,
         host: CommandHost

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -142,6 +142,9 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias TmuxSessionIdentityReading = @Sendable (
         WorkspaceTmuxSessionSelection, CommandHost
     ) async throws -> TmuxSessionIdentity
+    typealias TmuxRoutedSessionIdentityReading = @Sendable (
+        WorkspaceTmuxSessionSelection, CommandHost, [String]
+    ) async throws -> TmuxSessionIdentity
     typealias TmuxSessionIdentityReviewReading = @Sendable (
         WorkspaceTmuxSessionSelection, TmuxSessionIdentity?, CommandHost
     ) async throws -> ReviewedTmuxSessionIdentity
@@ -525,7 +528,8 @@ final class WorkspaceSceneModel: ObservableObject {
             hostID = selection.hostID
             name = selection.name
             socketName = selection.socketName
-            tmuxAttachMode = selection.tmuxAttachMode
+            tmuxAttachMode = selection.tmuxAttachMode == .direct
+                ? nil : selection.tmuxAttachMode
         }
 
         var previewKey: TmuxPreviewKey {
@@ -667,9 +671,9 @@ final class WorkspaceSceneModel: ObservableObject {
     private var pendingRestoration: WorkspaceWindowState?
     private var pendingRestorationLaunchIntent:
         WorkspaceWindowLaunchIntent?
-    private var protectedRestorationProbeTask: Task<Void, Never>?
-    private var protectedRestorationProbeID: UUID?
-    private var protectedRestorationRefreshPending = false
+    private var exactTmuxRestorationProbeTask: Task<Void, Never>?
+    private var exactTmuxRestorationProbeID: UUID?
+    private var exactTmuxRestorationRefreshPending = false
     private var herdrRestorationValidationTask: Task<Void, Never>?
     private var herdrRestorationValidationID: UUID?
     private var zellijRestorationValidationTask: Task<Void, Never>?
@@ -910,6 +914,8 @@ final class WorkspaceSceneModel: ObservableObject {
     private let presentationSSHEnvironment: [String: String]
     private let tmuxSessionKiller: ReviewedTmuxSessionKilling
     private let tmuxSessionIdentityReader: TmuxSessionIdentityReading
+    private let tmuxRoutedSessionIdentityReader:
+        TmuxRoutedSessionIdentityReading
     private let tmuxSessionIdentityReviewer:
         TmuxSessionIdentityReviewReading
     private let tmuxSessionStyler: TmuxSessionStyling
@@ -1347,6 +1353,15 @@ final class WorkspaceSceneModel: ObservableObject {
                 on: host
             )
         },
+        tmuxRoutedSessionIdentityReader:
+        @escaping TmuxRoutedSessionIdentityReading = {
+            selection, host, arguments in
+            try await TmuxSessionKiller().sessionIdentity(
+                selection,
+                on: host,
+                sshConnectionArguments: arguments
+            )
+        },
         tmuxSessionIdentityReviewer:
         @escaping TmuxSessionIdentityReviewReading = {
             selection, knownIdentity, host in
@@ -1531,6 +1546,8 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         self.tmuxSessionKiller = tmuxSessionKiller
         self.tmuxSessionIdentityReader = tmuxSessionIdentityReader
+        self.tmuxRoutedSessionIdentityReader =
+            tmuxRoutedSessionIdentityReader
         self.tmuxSessionIdentityReviewer = tmuxSessionIdentityReviewer
         self.tmuxSessionStyler = tmuxSessionStyler
         self.tmuxPresentationStyleProvider =
@@ -2000,10 +2017,10 @@ final class WorkspaceSceneModel: ObservableObject {
         pendingRestorationLaunchIntent = nil
         isWorkspaceRestorationPending = false
         suppressesAutomaticWorktreeSessionOpen = false
-        protectedRestorationProbeTask?.cancel()
-        protectedRestorationProbeTask = nil
-        protectedRestorationProbeID = nil
-        protectedRestorationRefreshPending = false
+        exactTmuxRestorationProbeTask?.cancel()
+        exactTmuxRestorationProbeTask = nil
+        exactTmuxRestorationProbeID = nil
+        exactTmuxRestorationRefreshPending = false
         herdrRestorationValidationTask?.cancel()
         herdrRestorationValidationTask = nil
         herdrRestorationValidationID = nil
@@ -2088,8 +2105,8 @@ final class WorkspaceSceneModel: ObservableObject {
 
     private func attemptPendingRestoration() {
         guard let pendingRestoration else { return }
-        if protectedRestorationProbeTask != nil {
-            protectedRestorationRefreshPending = true
+        if exactTmuxRestorationProbeTask != nil {
+            exactTmuxRestorationRefreshPending = true
             return
         }
         guard herdrRestorationValidationTask == nil,
@@ -2140,8 +2157,8 @@ final class WorkspaceSceneModel: ObservableObject {
             self.pendingRestoration = nil
             pendingRestorationLaunchIntent = nil
             isWorkspaceRestorationPending = false
-        case let .needsProtectedProbe(resolvedSelection, tmuxSelection):
-            beginProtectedRestorationProbe(
+        case let .needsExactTmuxProbe(resolvedSelection, tmuxSelection):
+            beginExactTmuxRestorationProbe(
                 selection: resolvedSelection,
                 tmuxSelection: tmuxSelection,
                 expectedState: pendingRestoration
@@ -2417,42 +2434,44 @@ final class WorkspaceSceneModel: ObservableObject {
         scheduleZellijSessionDiscovery()
     }
 
-    private func beginProtectedRestorationProbe(
+    private func beginExactTmuxRestorationProbe(
         selection resolvedSelection: WorkspaceSelection,
         tmuxSelection: WorkspaceTmuxSessionSelection,
         expectedState: WorkspaceWindowState
     ) {
-        guard protectedRestorationProbeTask == nil,
+        guard exactTmuxRestorationProbeTask == nil,
               let hostSummary = snapshot.host(id: tmuxSelection.hostID),
               let host = CommandHostResolver.resolve(hostSummary)
         else { return }
         let probeID = UUID()
-        protectedRestorationProbeID = probeID
-        protectedRestorationProbeTask = Task { [weak self] in
+        exactTmuxRestorationProbeID = probeID
+        exactTmuxRestorationProbeTask = Task { [weak self] in
             defer {
-                if self?.protectedRestorationProbeID == probeID {
-                    self?.protectedRestorationProbeTask = nil
-                    self?.protectedRestorationProbeID = nil
+                if self?.exactTmuxRestorationProbeID == probeID {
+                    self?.exactTmuxRestorationProbeTask = nil
+                    self?.exactTmuxRestorationProbeID = nil
                 }
             }
+            let expectedAttachIdentity: TmuxSessionIdentity
             do {
-                _ = try await self?.tmuxSessionIdentityReader(
+                guard let identity = try await self?.tmuxSessionIdentityReader(
                     tmuxSelection,
                     host
-                )
+                ) else { return }
+                expectedAttachIdentity = identity
             } catch {
-                self?.retryProtectedRestorationAfterProbeCleanupIfNeeded(
+                self?.retryExactTmuxRestorationAfterProbeCleanupIfNeeded(
                     probeID
                 )
                 return
             }
             guard !Task.isCancelled,
                   let self,
-                  protectedRestorationProbeID == probeID else {
+                  exactTmuxRestorationProbeID == probeID else {
                 return
             }
             guard pendingRestoration == expectedState,
-                  case let .needsProtectedProbe(
+                  case let .needsExactTmuxProbe(
                       currentSelection,
                       currentTmuxSelection
                   ) = WorkspaceWindowRestorationResolver.resolve(
@@ -2466,21 +2485,22 @@ final class WorkspaceSceneModel: ObservableObject {
                       currentHostSummary
                   )
             else {
-                retryProtectedRestorationAfterProbeCleanupIfNeeded(probeID)
+                retryExactTmuxRestorationAfterProbeCleanupIfNeeded(probeID)
                 return
             }
             guard currentSelection == resolvedSelection,
                   currentTmuxSelection == tmuxSelection,
                   currentHost == host else {
-                retryProtectedRestorationAfterProbeCleanupIfNeeded(probeID)
+                retryExactTmuxRestorationAfterProbeCleanupIfNeeded(probeID)
                 return
             }
-            protectedRestorationRefreshPending = false
+            exactTmuxRestorationRefreshPending = false
             applyRestoredSelection(resolvedSelection)
             _ = presentTmuxSession(
                 tmuxSelection,
                 launchMode: .attach,
-                intent: .restoreOnly
+                intent: .restoreOnly,
+                expectedAttachIdentity: expectedAttachIdentity
             )
             pendingRestoration = nil
             isWorkspaceRestorationPending = false
@@ -2488,12 +2508,12 @@ final class WorkspaceSceneModel: ObservableObject {
         }
     }
 
-    private func retryProtectedRestorationAfterProbeCleanupIfNeeded(
+    private func retryExactTmuxRestorationAfterProbeCleanupIfNeeded(
         _ probeID: UUID
     ) {
-        guard protectedRestorationProbeID == probeID,
-              protectedRestorationRefreshPending else { return }
-        protectedRestorationRefreshPending = false
+        guard exactTmuxRestorationProbeID == probeID,
+              exactTmuxRestorationRefreshPending else { return }
+        exactTmuxRestorationRefreshPending = false
         Task { @MainActor [weak self] in
             await Task.yield()
             self?.attemptPendingRestoration()
@@ -2749,6 +2769,11 @@ final class WorkspaceSceneModel: ObservableObject {
         ) else {
             throw KwtWorktreeError.removalIdentityUnavailable
         }
+        guard worktree.tmuxAttachMode != .protected
+            || worktree.tmuxSocketName != nil
+        else {
+            throw KwtWorktreeError.removalIdentityUnavailable
+        }
         let changes: WorktreeChangeSummary
         do {
             try await ensureRemoteKwtForOperation(hostID: project.hostID)
@@ -2773,6 +2798,7 @@ final class WorkspaceSceneModel: ObservableObject {
             for: worktree
         ) {
             if !refreshSessionIdentity,
+               session.socketName == nil,
                WorkspaceSidebarModel.canRequestKill(
                    session,
                    in: snapshot,
@@ -5671,6 +5697,9 @@ final class WorkspaceSceneModel: ObservableObject {
                       $0.name == context.selection.name
                   })
             else { continue }
+            guard !Self.requiresKwtEndpointConfirmation(context) else {
+                continue
+            }
             context.phase = .attachOnly
             presentation.reconnectContext = context
             presentation.establishmentConfirmationTask?.cancel()
@@ -7678,7 +7707,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 activeBorrowedTmuxRetryRequiresConfirmation,
                 retryCommand: activeBorrowedTmuxRetryCommand,
                 surface: { [weak self] in
-                    self?.protectedTmuxSurface(handle: handle)
+                    self?.publishedTmuxSurface(handle: handle)
                 },
                 onCloseRequest: { [weak self] in
                     guard let self else { return }
@@ -7737,6 +7766,51 @@ final class WorkspaceSceneModel: ObservableObject {
         if pendingCreation?.initialCommand != nil,
            pendingCreation?.commandReplayAuthorized != true {
             presentTmuxSession(selection, launchMode: .attachOnly)
+            return
+        }
+        let requiresNamedKwtFallbackIdentity =
+            selection.tmuxAttachMode == .direct
+                && selection.socketName != nil
+                && selection.workspacePath != nil
+                && (selection.worktreeID != nil
+                    || selection.directoryWorkspaceID != nil)
+                && kwtAvailabilityByHost[selection.hostID] == false
+                && retainedTmuxPresentations[
+                    TmuxPresentationKey(selection)
+                ] == nil
+        if requiresNamedKwtFallbackIdentity {
+            guard let hostSummary = snapshot.host(id: selection.hostID),
+                  let host = CommandHostResolver.resolve(hostSummary)
+            else { return }
+            let navigationRevision = userNavigationRevision
+            Task { [weak self] in
+                guard let self else { return }
+                let review: ReviewedTmuxSessionIdentity
+                do {
+                    review = try await tmuxSessionIdentityReviewer(
+                        selection,
+                        nil,
+                        host
+                    )
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled,
+                      userNavigationRevision == navigationRevision,
+                      kwtAvailabilityByHost[selection.hostID] == false,
+                      currentKwtSelectionMatches(selection),
+                      let currentHostSummary = snapshot.host(
+                          id: selection.hostID
+                      ),
+                      CommandHostResolver.resolve(currentHostSummary) == host
+                else { return }
+                presentTmuxSession(
+                    selection,
+                    launchMode: .attach,
+                    expectedAttachIdentity: review.identity,
+                    expectedRouteIdentity: review.routeIdentity
+                )
+            }
             return
         }
         presentTmuxSession(
@@ -7924,6 +7998,7 @@ final class WorkspaceSceneModel: ObservableObject {
             $0.hostID == hostID
                 && !$0.isStale
                 && $0.tmuxSocketName == nil
+                && $0.tmuxAttachMode == .direct
                 && $0.tmuxSessionName == name
         }),
             let selection = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -7932,7 +8007,10 @@ final class WorkspaceSceneModel: ObservableObject {
             return selection
         }
         if let workspace = snapshot.directoryWorkspaces.first(where: {
-            $0.hostID == hostID && $0.tmuxSessionName == name
+            $0.hostID == hostID
+                && $0.tmuxSocketName == nil
+                && $0.tmuxAttachMode == .direct
+                && $0.tmuxSessionName == name
         }) {
             return WorkspaceSidebarModel.tmuxSessionSelection(for: workspace)
         }
@@ -9471,6 +9549,97 @@ final class WorkspaceSceneModel: ObservableObject {
         case restoreOnly
     }
 
+    private func kwtWorktreeOpenIdentity(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> KwtWorktreeOpenIdentity? {
+        guard selection.tmuxAttachMode == .direct,
+              let worktreeID = selection.worktreeID,
+              let generation = WorktreeGeneration.canonical(
+                  selection.worktreeGeneration
+              ),
+              let worktree = snapshot.worktree(id: worktreeID),
+              !worktree.isStale,
+              worktree.hostID == selection.hostID,
+              WorktreeGeneration.canonical(worktree.generation)
+              .map({ $0 == generation }) ?? true,
+              let project = snapshot.project(id: worktree.projectID),
+              !project.isStale,
+              project.hostID == selection.hostID
+        else { return nil }
+        return KwtWorktreeOpenIdentity(
+            repository: project.scopedKey,
+            registrationFingerprint: project.registrationFingerprint,
+            generation: generation,
+            sessionName: selection.name,
+            tmuxAttachMode: selection.tmuxAttachMode?.rawValue ?? ""
+        )
+    }
+
+    private func kwtProtectedWorktreeOpenIdentity(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> KwtProtectedWorktreeOpenIdentity? {
+        guard selection.tmuxAttachMode == .protected,
+              let worktreeID = selection.worktreeID,
+              let path = selection.workspacePath,
+              let generation = WorktreeGeneration.canonical(
+                  selection.worktreeGeneration
+              ),
+              let socketName = selection.socketName,
+              let worktree = snapshot.worktree(id: worktreeID),
+              !worktree.isStale,
+              worktree.hostID == selection.hostID,
+              worktree.path == path,
+              WorktreeGeneration.canonical(worktree.generation) == generation,
+              worktree.tmuxSessionName == selection.name,
+              worktree.tmuxSocketName == socketName,
+              worktree.tmuxAttachMode == .protected,
+              let project = snapshot.project(id: worktree.projectID),
+              !project.isStale,
+              project.hostID == selection.hostID
+        else { return nil }
+        return KwtProtectedWorktreeOpenIdentity(
+            path: path,
+            projectPath: project.rootPath,
+            repository: project.scopedKey,
+            registrationFingerprint: project.registrationFingerprint,
+            generation: generation,
+            sessionName: selection.name,
+            socketName: socketName,
+            tmuxAttachMode: selection.tmuxAttachMode?.rawValue ?? ""
+        )
+    }
+
+    private func currentKwtSelectionMatches(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        if let worktreeID = selection.worktreeID,
+           let worktree = snapshot.worktree(id: worktreeID) {
+            return WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+                == selection
+        }
+        if let directoryID = selection.directoryWorkspaceID,
+           let directory = snapshot.directoryWorkspace(id: directoryID) {
+            return WorkspaceSidebarModel.tmuxSessionSelection(for: directory)
+                == selection
+        }
+        return false
+    }
+
+    private func kwtDirectoryExpectedSessionName(
+        for selection: WorkspaceTmuxSessionSelection
+    ) -> String? {
+        guard selection.tmuxAttachMode == .direct,
+              let directoryID = selection.directoryWorkspaceID,
+              let directory = snapshot.directoryWorkspace(id: directoryID),
+              directory.hostID == selection.hostID,
+              directory.path == selection.workspacePath,
+              directory.tmuxSessionName == selection.name,
+              directory.tmuxSocketName == selection.socketName,
+              directory.tmuxAttachMode == .direct
+        else { return nil }
+        return selection.name
+    }
+
     @discardableResult
     private func presentTmuxSession(
         _ selection: WorkspaceTmuxSessionSelection,
@@ -9481,7 +9650,9 @@ final class WorkspaceSceneModel: ObservableObject {
         activatesPresentation: Bool = true,
         startsHidden: Bool = false,
         ignoresClientSize: Bool = false,
-        previewGridSize: TmuxGridSize? = nil
+        previewGridSize: TmuxGridSize? = nil,
+        expectedAttachIdentity: TmuxSessionIdentity? = nil,
+        expectedRouteIdentity: String? = nil
     ) -> BorrowedTmuxSessionHandle? {
         if activatesPresentation {
             cancelPendingTmuxPreviewActivations()
@@ -9500,6 +9671,9 @@ final class WorkspaceSceneModel: ObservableObject {
            WorktreeGeneration.isCanonical(generation) {
             selection.worktreeGeneration = generation
         }
+        guard selection.tmuxAttachMode != .protected
+            || selection.socketName != nil
+        else { return nil }
         guard !worktreeRemovalIsPending(for: selection) else { return nil }
         let effectiveLaunchMode: TmuxAttachmentLaunchMode =
             (selection.tmuxAttachMode == .protected
@@ -9617,17 +9791,40 @@ final class WorkspaceSceneModel: ObservableObject {
         // establishes a workspace, so attach directly with ignore-size.
         let attachmentLaunchMode: TmuxAttachmentLaunchMode =
             startsHidden ? .attachOnly : effectiveLaunchMode
-        let knownSessions = tmuxSessionsByHost[selection.hostID]
-            ?? host.tmuxSessions
-        let sessionIsDiscovered = selection.socketName == nil
-            && knownSessions.contains { $0.name == selection.name }
         let managedKwtUnavailable =
             kwtAvailabilityByHost[selection.hostID] == false
-        let openWorkspace = intent == .userInitiated
+        let mayOpenWorkspace = intent == .userInitiated
             && attachmentLaunchMode == .attach
             && selection.tmuxAttachMode == .direct
             && selection.workspacePath != nil
-            && (!sessionIsDiscovered || !managedKwtUnavailable)
+            && !managedKwtUnavailable
+        let requiresKwtWorktreeIdentity = mayOpenWorkspace
+            && selection.worktreeID != nil
+            && selection.worktreeGeneration != nil
+        let kwtWorktreeIdentity = requiresKwtWorktreeIdentity
+            ? kwtWorktreeOpenIdentity(for: selection) : nil
+        guard !requiresKwtWorktreeIdentity || kwtWorktreeIdentity != nil
+        else { return nil }
+        let requiresKwtDirectoryIdentity = mayOpenWorkspace
+            && selection.directoryWorkspaceID != nil
+        let kwtExpectedSessionName = requiresKwtDirectoryIdentity
+            ? kwtDirectoryExpectedSessionName(for: selection) : nil
+        guard !requiresKwtDirectoryIdentity
+            || kwtExpectedSessionName != nil
+        else { return nil }
+        let openWorkspace = mayOpenWorkspace
+            && (selection.worktreeID == nil || kwtWorktreeIdentity != nil)
+            && (selection.directoryWorkspaceID == nil
+                || kwtExpectedSessionName != nil)
+        let requiresProtectedWorktreeIdentity =
+            attachmentLaunchMode == .attach
+                && selection.tmuxAttachMode == .protected
+                && selection.workspacePath != nil
+        let kwtProtectedWorktreeIdentity = requiresProtectedWorktreeIdentity
+            ? kwtProtectedWorktreeOpenIdentity(for: selection) : nil
+        guard !requiresProtectedWorktreeIdentity
+            || kwtProtectedWorktreeIdentity != nil
+        else { return nil }
         let protectedSessionNeedsEstablishment = intent == .userInitiated
             && attachmentLaunchMode == .attach
             && selection.tmuxAttachMode == .protected
@@ -9648,7 +9845,12 @@ final class WorkspaceSceneModel: ObservableObject {
                 : nil,
             workingDirectory: selection.workspacePath,
             openWorkspace: openWorkspace,
-            sessionIdentity: discoveredIdentity,
+            kwtWorktreeIdentity: kwtWorktreeIdentity,
+            kwtProtectedWorktreeIdentity: kwtProtectedWorktreeIdentity,
+            kwtExpectedSessionName: kwtExpectedSessionName,
+            sessionIdentity: expectedAttachIdentity ?? discoveredIdentity,
+            expectedAttachIdentity: expectedAttachIdentity,
+            expectedRouteIdentity: expectedRouteIdentity,
             ignoresClientSize: startsHidden || ignoresClientSize,
             previewGridSize: startsHidden
                 ? self.previewGridSize(for: selection) : previewGridSize
@@ -9691,7 +9893,8 @@ final class WorkspaceSceneModel: ObservableObject {
         presentation.sizingIntent = startsHidden ? .hidden : .interactive
         presentation.launchesThroughKwtWorkspace =
             openWorkspace || protectedSessionNeedsEstablishment
-        presentation.reconnectExpectedIdentity = discoveredIdentity
+        presentation.reconnectExpectedIdentity =
+            expectedAttachIdentity ?? discoveredIdentity
         objectWillChange.send()
         retainedTmuxPresentations[key] = presentation
         retainedTmuxPresentationKeysByHandle[handle.id] = key
@@ -9913,7 +10116,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     guard let self, let presentation,
                           retainedTmuxPresentations[key] === presentation
                     else { return nil }
-                    return protectedTmuxSurface(handle: presentation.handle)
+                    return publishedTmuxSurface(handle: presentation.handle)
                 },
                 handleID: { [weak presentation] in
                     presentation?.handle.id
@@ -10252,6 +10455,17 @@ final class WorkspaceSceneModel: ObservableObject {
             return nil
         }
         return nativeTmuxSessionCoordinator.surface(handle: handle)
+    }
+
+    private func publishedTmuxSurface(
+        handle: BorrowedTmuxSessionHandle
+    ) -> TerminalSurfaceView? {
+        guard let presentation = retainedTmuxPresentation(for: handle),
+              presentation.reconnectContext.map(
+                  Self.requiresKwtEndpointConfirmation
+              ) != true
+        else { return nil }
+        return protectedTmuxSurface(handle: handle)
     }
 
     private func acquireProtectedTmuxAttachmentScopeIfNeeded(
@@ -10796,10 +11010,7 @@ final class WorkspaceSceneModel: ObservableObject {
         _ lhs: WorkspaceTmuxSessionSelection,
         _ rhs: WorkspaceTmuxSessionSelection
     ) -> Bool {
-        lhs.hostID == rhs.hostID
-            && lhs.name == rhs.name
-            && lhs.socketName == rhs.socketName
-            && lhs.tmuxAttachMode == rhs.tmuxAttachMode
+        TmuxPresentationKey(lhs) == TmuxPresentationKey(rhs)
     }
 
     private func transferPendingCreation(
@@ -10972,6 +11183,7 @@ final class WorkspaceSceneModel: ObservableObject {
         )
         guard discoveredIdentity != nil
             || isConnectedActiveTmuxSession(selection)
+            || hasAuthoritativeNamedTmuxEndpoint(selection)
         else {
             throw TmuxSessionKillError.sessionNotRunning(
                 host: currentHost.displayName,
@@ -10992,6 +11204,36 @@ final class WorkspaceSceneModel: ObservableObject {
             sessionCreatedAt: review.identity.createdAt,
             routeIdentity: review.routeIdentity
         )
+    }
+
+    private func hasAuthoritativeNamedTmuxEndpoint(
+        _ selection: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        guard selection.tmuxAttachMode == .direct,
+              selection.socketName != nil
+        else { return false }
+        if let worktreeID = selection.worktreeID,
+           let worktree = snapshot.worktree(id: worktreeID) {
+            return !worktree.isStale
+                && worktree.hostID == selection.hostID
+                && worktree.tmuxSessionName == selection.name
+                && worktree.tmuxSocketName == selection.socketName
+                && worktree.tmuxAttachMode == selection.tmuxAttachMode
+                && worktree.path == selection.workspacePath
+                && worktree.generation == selection.worktreeGeneration
+        }
+        if let directoryWorkspaceID = selection.directoryWorkspaceID,
+           let workspace = snapshot.directoryWorkspace(
+               id: directoryWorkspaceID
+           ) {
+            return workspace.hostID == selection.hostID
+                && workspace.path == selection.workspacePath
+                && workspace.tmuxSessionName == selection.name
+                && workspace.tmuxSocketName == selection.socketName
+                && workspace.tmuxAttachMode == selection.tmuxAttachMode
+                && workspace.sessionLive
+        }
+        return false
     }
 
     func killTmuxSession(
@@ -11126,7 +11368,8 @@ final class WorkspaceSceneModel: ObservableObject {
         _ selection: WorkspaceTmuxSessionSelection,
         hostSummary: HostSummary
     ) -> TmuxSessionIdentity? {
-        guard selection.socketName == nil,
+        guard selection.tmuxAttachMode != .protected,
+              selection.socketName == nil,
               let summary = hostSummary.tmuxSessions.first(where: {
                   $0.name == selection.name
               })
@@ -11175,6 +11418,25 @@ final class WorkspaceSceneModel: ObservableObject {
         state: ConnectionState
     ) {
         let previousState = borrowedTmuxConnectionStates[handle.id]
+        if state == .connected,
+           let presentation = retainedTmuxPresentation(for: handle),
+           let context = presentation.reconnectContext,
+           context.handleID == handle.id,
+           Self.requiresKwtEndpointConfirmation(context) {
+            // `kwt open` resolves its endpoint at execution time. Keep the
+            // surface provisional until the endpoint captured by the row is
+            // present, so an inventory race cannot publish a client attached
+            // to a different session or socket.
+            borrowedTmuxConnectionStates[handle.id] = .connecting
+            presentation.reconnectContext?.routeIdentity =
+                nativeTmuxSessionCoordinator.attachmentRouteIdentity(handle)
+            presentation.reconnectContext?.surfaceExitCode = nil
+            presentation.reconnectContext?.surfaceLaunchFailed = false
+            startEstablishmentConfirmationIfNeeded(
+                presentation: presentation
+            )
+            return
+        }
         switch state {
         case .disconnected:
             releaseProtectedTmuxAttachmentScope(handleID: handle.id)
@@ -12494,6 +12756,9 @@ final class WorkspaceSceneModel: ObservableObject {
         for presentation: RetainedTmuxPresentation,
         context: TmuxReconnectContext
     ) async -> TmuxSessionProbeOutcome {
+        guard context.selection.tmuxAttachMode != .protected
+            || context.selection.socketName != nil
+        else { return .failure(.sessionContextUnavailable) }
         if context.selection.socketName == nil {
             let observationSequence = beginTmuxDiscoveryObservation(
                 hostID: context.selection.hostID
@@ -12735,17 +13000,57 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             return
         }
-        let knownSessions = tmuxSessionsByHost[selection.hostID]
-            ?? host.tmuxSessions
-        let sessionIsDiscovered = selection.socketName == nil
-            && knownSessions.contains { $0.name == selection.name }
         let managedKwtUnavailable =
             kwtAvailabilityByHost[selection.hostID] == false
-        let openWorkspace = intent == .userInitiated
+        let mayOpenWorkspace = intent == .userInitiated
             && launchMode == .attach
             && selection.tmuxAttachMode == .direct
             && selection.workspacePath != nil
-            && (!sessionIsDiscovered || !managedKwtUnavailable)
+            && !managedKwtUnavailable
+        let requiresKwtWorktreeIdentity = mayOpenWorkspace
+            && selection.worktreeID != nil
+            && selection.worktreeGeneration != nil
+        let kwtWorktreeIdentity = requiresKwtWorktreeIdentity
+            ? kwtWorktreeOpenIdentity(for: selection) : nil
+        guard !requiresKwtWorktreeIdentity || kwtWorktreeIdentity != nil
+        else {
+            stopTmuxReconnectWithUnableToAttach(
+                presentation,
+                "The worktree changed before it was opened."
+            )
+            return
+        }
+        let requiresKwtDirectoryIdentity = mayOpenWorkspace
+            && selection.directoryWorkspaceID != nil
+        let kwtExpectedSessionName = requiresKwtDirectoryIdentity
+            ? kwtDirectoryExpectedSessionName(for: selection) : nil
+        guard !requiresKwtDirectoryIdentity
+            || kwtExpectedSessionName != nil
+        else {
+            stopTmuxReconnectWithUnableToAttach(
+                presentation,
+                "The directory workspace changed before it was opened."
+            )
+            return
+        }
+        let openWorkspace = mayOpenWorkspace
+            && (selection.worktreeID == nil || kwtWorktreeIdentity != nil)
+            && (selection.directoryWorkspaceID == nil
+                || kwtExpectedSessionName != nil)
+        let requiresProtectedWorktreeIdentity = launchMode == .attach
+            && selection.tmuxAttachMode == .protected
+            && selection.workspacePath != nil
+        let kwtProtectedWorktreeIdentity = requiresProtectedWorktreeIdentity
+            ? kwtProtectedWorktreeOpenIdentity(for: selection) : nil
+        guard !requiresProtectedWorktreeIdentity
+            || kwtProtectedWorktreeIdentity != nil
+        else {
+            stopTmuxReconnectWithUnableToAttach(
+                presentation,
+                "The protected worktree changed before it was opened."
+            )
+            return
+        }
         let protectedSessionNeedsEstablishment = intent == .userInitiated
             && launchMode == .attach
             && selection.tmuxAttachMode == .protected
@@ -12782,7 +13087,11 @@ final class WorkspaceSceneModel: ObservableObject {
             initialCommand: launchMode == .create ? initialCommand : nil,
             workingDirectory: selection.workspacePath,
             openWorkspace: openWorkspace,
+            kwtWorktreeIdentity: kwtWorktreeIdentity,
+            kwtProtectedWorktreeIdentity: kwtProtectedWorktreeIdentity,
+            kwtExpectedSessionName: kwtExpectedSessionName,
             sessionIdentity: presentation.reconnectExpectedIdentity,
+            expectedAttachIdentity: presentation.reconnectExpectedIdentity,
             expectedRouteIdentity: routeIdentity,
             ignoresClientSize: startsNonSizing,
             previewGridSize: startsNonSizing ? previewGridSize : nil
@@ -12927,6 +13236,12 @@ final class WorkspaceSceneModel: ObservableObject {
         let initialDelays = [.zero] + createdSessionDiscoveryDelays
         let keepsProbingUntilConfirmed =
             context.selection.tmuxAttachMode == .protected
+        let requiresEndpointConfirmation = Self
+            .requiresKwtEndpointConfirmation(context)
+        let requiresClientEndpointConfirmation = Self
+            .requiresKwtClientEndpointConfirmation(context)
+        let expectedConnectionState: ConnectionState =
+            requiresEndpointConfirmation ? .connecting : .connected
         let settledDelay = createdSessionDiscoveryDelays.last(where: {
             $0 > .zero
         }) ?? .seconds(4)
@@ -12946,27 +13261,117 @@ final class WorkspaceSceneModel: ObservableObject {
                 guard let self, let presentation,
                       !Task.isCancelled,
                       presentation.reconnectContext == context,
-                      borrowedTmuxConnectionStates[handle.id] == .connected
+                      borrowedTmuxConnectionStates[handle.id]
+                      == expectedConnectionState
                 else { return }
-                let outcome = await tmuxProbeOutcome(
-                    for: presentation,
-                    context: context
-                )
+                let outcome = if requiresClientEndpointConfirmation {
+                    await kwtEndpointConfirmationOutcome(
+                        for: presentation,
+                        context: context
+                    )
+                } else {
+                    await tmuxProbeOutcome(
+                        for: presentation,
+                        context: context
+                    )
+                }
                 guard !Task.isCancelled,
                       presentation.reconnectContext == context,
-                      borrowedTmuxConnectionStates[handle.id] == .connected
+                      borrowedTmuxConnectionStates[handle.id]
+                      == expectedConnectionState
                 else { return }
                 if outcome == .present {
                     presentation.reconnectContext?.phase = .attachOnly
                     presentation.establishmentConfirmationTask = nil
                     releaseProtectedTmuxAttachmentScope(handleID: handle.id)
+                    if requiresEndpointConfirmation {
+                        nativeTmuxStateChanged(
+                            handle: handle,
+                            state: .connected
+                        )
+                    }
                     return
                 }
             }
-            guard let presentation,
+            guard let self, let presentation,
                   presentation.reconnectContext == context
             else { return }
             presentation.establishmentConfirmationTask = nil
+            if requiresEndpointConfirmation {
+                // The surface may be attached to the endpoint KWT resolved
+                // after the row was selected. Removing it detaches that client
+                // rather than retaining or exposing an unverified terminal.
+                invalidateBorrowedTmuxSession(presentation.selection)
+            }
+        }
+    }
+
+    private static func requiresKwtEndpointConfirmation(
+        _ context: TmuxReconnectContext
+    ) -> Bool {
+        context.phase == .establishingWorkspace
+            && context.usesKwtWorkspaceCommand
+            && context.selection.tmuxAttachMode == .direct
+    }
+
+    private static func requiresKwtClientEndpointConfirmation(
+        _ context: TmuxReconnectContext
+    ) -> Bool {
+        requiresKwtEndpointConfirmation(context)
+            && context.selection.socketName != nil
+    }
+
+    private func kwtEndpointConfirmationOutcome(
+        for presentation: RetainedTmuxPresentation,
+        context: TmuxReconnectContext
+    ) async -> TmuxSessionProbeOutcome {
+        guard let connection = nativeTmuxSessionCoordinator
+            .attachmentConnectionSnapshot(presentation.handle),
+            connection.routeIdentity == context.routeIdentity
+        else { return .absent }
+        if case let .ssh(info) = context.host,
+           info.platform == .windows {
+            do {
+                // The Windows launch validates `kwt open --start-session`
+                // output before attaching psmux to this exact endpoint. Probe
+                // that endpoint on the same route because psmux cannot report
+                // the launched client's identity.
+                _ = try await tmuxRoutedSessionIdentityReader(
+                    context.selection,
+                    context.host,
+                    connection.arguments
+                )
+                return .present
+            } catch TmuxSessionKillError.sessionNotRunning {
+                return .absent
+            } catch {
+                return .failure(.sessionContextUnavailable)
+            }
+        }
+        let attachedIdentity: TmuxSessionIdentity
+        switch nativeTmuxSessionCoordinator
+            .attachedSessionIdentityResolution(presentation.handle) {
+        case .pending:
+            nativeTmuxSessionCoordinator.requestAttachedSessionIdentity(
+                presentation.handle
+            )
+            return .failure(.sessionContextUnavailable)
+        case let .resolved(identity):
+            attachedIdentity = identity
+        case .unavailable:
+            return .failure(.sessionContextUnavailable)
+        }
+        do {
+            let capturedIdentity = try await tmuxRoutedSessionIdentityReader(
+                context.selection,
+                context.host,
+                connection.arguments
+            )
+            return capturedIdentity == attachedIdentity ? .present : .absent
+        } catch TmuxSessionKillError.sessionNotRunning {
+            return .absent
+        } catch {
+            return .failure(.sessionContextUnavailable)
         }
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -541,12 +541,12 @@ final class WorkspaceSceneModel: ObservableObject {
         }
 
         var sessionID: String {
-            [
-                hostID.uuidString,
-                tmuxAttachMode?.rawValue ?? "unbound",
-                socketName ?? "default",
-                name,
-            ].joined(separator: ":")
+            WorkspaceTmuxSessionSelection.canonicalEndpointID(
+                hostID: hostID,
+                name: name,
+                socketName: socketName,
+                tmuxAttachMode: tmuxAttachMode
+            )
         }
     }
     private enum RetainedTmuxSizingIntent {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -9554,14 +9554,18 @@ final class WorkspaceSceneModel: ObservableObject {
     ) -> KwtWorktreeOpenIdentity? {
         guard selection.tmuxAttachMode == .direct,
               let worktreeID = selection.worktreeID,
+              let path = selection.workspacePath,
               let generation = WorktreeGeneration.canonical(
                   selection.worktreeGeneration
               ),
               let worktree = snapshot.worktree(id: worktreeID),
               !worktree.isStale,
               worktree.hostID == selection.hostID,
-              WorktreeGeneration.canonical(worktree.generation)
-              .map({ $0 == generation }) ?? true,
+              worktree.path == path,
+              WorktreeGeneration.canonical(worktree.generation) == generation,
+              worktree.tmuxSessionName == selection.name,
+              worktree.tmuxSocketName == selection.socketName,
+              worktree.tmuxAttachMode == selection.tmuxAttachMode,
               let project = snapshot.project(id: worktree.projectID),
               !project.isStale,
               project.hostID == selection.hostID

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -11162,12 +11162,7 @@ final class WorkspaceSceneModel: ObservableObject {
             activeBorrowedTmuxRecoveryState = nil
             sessionConnectionRecoveryRequest = nil
         }
-        nativeTmuxSessionCoordinator.detach(
-            hostID: presentation.selection.hostID,
-            name: presentation.selection.name,
-            socketName: presentation.selection.socketName,
-            tmuxAttachMode: presentation.selection.tmuxAttachMode
-        )
+        nativeTmuxSessionCoordinator.detach(handle)
     }
 
     func prepareTmuxSessionKill(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -4234,6 +4234,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 )
             } else if let pendingRestoration {
                 if event.allowsRemovalRestoration {
+                    adoptReconciledRestorationTargets(
+                        event.reconciledRestorationTargets,
+                        scope: event.scope
+                    )
                     restorePresentationsAfterFailedRemoval(
                         pendingRestoration,
                         reconciledTargets: event.reconciledRestorationTargets,
@@ -4909,6 +4913,37 @@ final class WorkspaceSceneModel: ObservableObject {
                 activatesPresentation: activatesPresentation,
                 startsHidden: !activatesPresentation
             )
+        }
+    }
+
+    /// The reconciled targets are authoritative for every scene, so a scene
+    /// whose snapshot still carries the pre-removal endpoint adopts them
+    /// before restoring. Otherwise the restoration's kwt identity check
+    /// would compare the reconciled selection against the stale record and
+    /// skip the presentation until the next inventory pass.
+    private func adoptReconciledRestorationTargets(
+        _ targets: Set<WorkspaceTmuxSessionSelection>?,
+        scope: WorktreeMutationCoordinator.Scope
+    ) {
+        guard let targets, !targets.isEmpty else { return }
+        for target in targets {
+            guard let generation = WorktreeGeneration.canonical(
+                target.worktreeGeneration
+            ),
+                let index = snapshot.worktrees.firstIndex(where: {
+                    $0.hostID == scope.hostID
+                        && WorktreeGeneration.canonical($0.generation)
+                        == generation
+                })
+            else { continue }
+            var worktree = snapshot.worktrees[index]
+            worktree.path = target.workspacePath ?? worktree.path
+            worktree.tmuxSessionName = target.name
+            worktree.tmuxSocketName = target.socketName
+            worktree.tmuxAttachMode =
+                target.tmuxAttachMode ?? worktree.tmuxAttachMode
+            guard worktree != snapshot.worktrees[index] else { continue }
+            snapshot.worktrees[index] = worktree
         }
     }
 
@@ -9837,6 +9872,13 @@ final class WorkspaceSceneModel: ObservableObject {
             selection,
             hostSummary: host
         )
+        // A workspace row attaching by name would accept any same-name
+        // session. Without kwt's identity flags, fence the attach on the
+        // discovered identity so it rejects a replacement session.
+        let isWorkspaceBound = selection.worktreeID != nil
+            || selection.directoryWorkspaceID != nil
+        let fencedAttachIdentity = expectedAttachIdentity
+            ?? (isWorkspaceBound && !openWorkspace ? discoveredIdentity : nil)
         let handle = nativeTmuxSessionCoordinator.attach(
             hostID: selection.hostID,
             name: selection.name,
@@ -9853,7 +9895,7 @@ final class WorkspaceSceneModel: ObservableObject {
             kwtProtectedWorktreeIdentity: kwtProtectedWorktreeIdentity,
             kwtExpectedSessionName: kwtExpectedSessionName,
             sessionIdentity: expectedAttachIdentity ?? discoveredIdentity,
-            expectedAttachIdentity: expectedAttachIdentity,
+            expectedAttachIdentity: fencedAttachIdentity,
             expectedRouteIdentity: expectedRouteIdentity,
             ignoresClientSize: startsHidden || ignoresClientSize,
             previewGridSize: startsHidden
@@ -13283,6 +13325,14 @@ final class WorkspaceSceneModel: ObservableObject {
                     presentation.reconnectContext?.phase = .attachOnly
                     presentation.establishmentConfirmationTask = nil
                     releaseProtectedTmuxAttachmentScope(handleID: handle.id)
+                    // Keep the identity kwt's endpoint check verified so a
+                    // later attach-only reconnect stays fenced to it.
+                    if requiresClientEndpointConfirmation,
+                       case let .resolved(identity) =
+                       nativeTmuxSessionCoordinator
+                           .attachedSessionIdentityResolution(handle) {
+                        presentation.reconnectExpectedIdentity = identity
+                    }
                     if requiresEndpointConfirmation {
                         nativeTmuxStateChanged(
                             handle: handle,

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -53,7 +53,66 @@ struct WorkspaceTmuxDescriptor: Codable, Hashable, Sendable {
     var hostKey: String
     var sessionName: String
     var socketName: String?
+    var tmuxAttachMode: TmuxAttachMode?
     var owner: WorkspaceTmuxOwnerDescriptor
+
+    init(
+        hostKey: String,
+        sessionName: String,
+        socketName: String?,
+        tmuxAttachMode: TmuxAttachMode? = nil,
+        owner: WorkspaceTmuxOwnerDescriptor
+    ) {
+        self.hostKey = hostKey
+        self.sessionName = sessionName
+        self.socketName = socketName
+        self.tmuxAttachMode = Self.persistedAttachMode(
+            tmuxAttachMode,
+            owner: owner
+        )
+        self.owner = owner
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case hostKey
+        case sessionName
+        case socketName
+        case tmuxAttachMode
+        case owner
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hostKey = try container.decode(String.self, forKey: .hostKey)
+        sessionName = try container.decode(String.self, forKey: .sessionName)
+        socketName = try container.decodeIfPresent(
+            String.self,
+            forKey: .socketName
+        )
+        owner = try container.decode(
+            WorkspaceTmuxOwnerDescriptor.self,
+            forKey: .owner
+        )
+        tmuxAttachMode = try container.decodeIfPresent(
+            TmuxAttachMode.self,
+            forKey: .tmuxAttachMode
+        )
+    }
+
+    private static func persistedAttachMode(
+        _ mode: TmuxAttachMode?,
+        owner: WorkspaceTmuxOwnerDescriptor
+    ) -> TmuxAttachMode? {
+        if let mode {
+            return mode
+        }
+        return switch owner {
+        case .unbound:
+            nil
+        case .worktree, .directoryWorkspace:
+            .direct
+        }
+    }
 }
 
 struct WorkspaceHerdrDescriptor: Codable, Hashable, Sendable {
@@ -189,6 +248,7 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
                 hostKey: activeHost.configKey,
                 sessionName: active.name,
                 socketName: active.socketName,
+                tmuxAttachMode: active.tmuxAttachMode,
                 owner: owner
             )
         }
@@ -307,6 +367,7 @@ enum ProjectWorktreeWindowPlan {
                     hostKey: host.configKey,
                     sessionName: sessionName,
                     socketName: worktree.tmuxSocketName,
+                    tmuxAttachMode: worktree.tmuxAttachMode,
                     owner: .worktree(generation: generation)
                 )
             )
@@ -381,7 +442,7 @@ enum WorkspaceRestorationResolution: Equatable, Sendable {
         selection: WorkspaceSelection,
         presentation: WorkspaceRestoredPresentation?
     )
-    case needsProtectedProbe(
+    case needsExactTmuxProbe(
         selection: WorkspaceSelection,
         tmux: WorkspaceTmuxSessionSelection
     )
@@ -434,7 +495,8 @@ enum WorkspaceWindowRestorationResolver {
             case .unbound:
                 guard navigation.worktreeGeneration == nil,
                       navigation.directoryWorkspacePath == nil,
-                      tmux.socketName == nil
+                      tmux.socketName == nil,
+                      tmux.tmuxAttachMode == nil
                 else { return .invalid }
             case let .worktree(generation):
                 guard WorktreeGeneration.canonical(generation) != nil,
@@ -565,10 +627,15 @@ enum WorkspaceWindowRestorationResolver {
         if worktreeGeneration != nil, owner == nil {
             return .pending(selection: selection)
         }
-        if let owner,
-           owner.tmuxSessionName != tmux.sessionName
-           || owner.tmuxSocketName != tmux.socketName {
-            return .pending(selection: selection)
+        if let owner {
+            guard owner.tmuxSessionName == tmux.sessionName,
+                  owner.tmuxSocketName == tmux.socketName,
+                  tmux.tmuxAttachMode.map({
+                      owner.tmuxAttachMode == $0
+                  }) ?? true
+            else {
+                return .pending(selection: selection)
+            }
         }
         let directoryOwner: DirectoryWorkspaceSummary?
         if case let .directoryWorkspace(path) = tmux.owner {
@@ -578,7 +645,10 @@ enum WorkspaceWindowRestorationResolver {
                     && $0.path == path
             }
             guard directoryOwner?.tmuxSessionName == tmux.sessionName,
-                  directoryOwner?.tmuxSocketName == tmux.socketName
+                  directoryOwner?.tmuxSocketName == tmux.socketName,
+                  tmux.tmuxAttachMode.map({
+                      directoryOwner?.tmuxAttachMode == $0
+                  }) ?? true
             else {
                 return .pending(selection: selection)
             }
@@ -593,7 +663,8 @@ enum WorkspaceWindowRestorationResolver {
             workspacePath: owner?.path ?? directoryOwner?.path,
             worktreeGeneration: worktreeGeneration,
             socketName: tmux.socketName,
-            tmuxAttachMode: owner?.tmuxAttachMode
+            tmuxAttachMode: tmux.tmuxAttachMode
+                ?? owner?.tmuxAttachMode
                 ?? directoryOwner?.tmuxAttachMode
         )
 
@@ -607,13 +678,14 @@ enum WorkspaceWindowRestorationResolver {
             return .pending(selection: selection)
         }
 
-        if tmuxSelection.tmuxAttachMode == .protected {
-            guard owner != nil
-            else { return .pending(selection: selection) }
-            return .needsProtectedProbe(
+        if tmuxSelection.socketName != nil {
+            return .needsExactTmuxProbe(
                 selection: selection,
                 tmux: tmuxSelection
             )
+        }
+        if tmuxSelection.tmuxAttachMode == .protected {
+            return .pending(selection: selection)
         }
         guard host.tmuxSessions.contains(where: {
             $0.name == tmux.sessionName

--- a/Sources/Tmux/TmuxAttachmentInfo.swift
+++ b/Sources/Tmux/TmuxAttachmentInfo.swift
@@ -17,6 +17,79 @@ public struct TmuxClientSize: Equatable, Sendable {
     }
 }
 
+/// Identity captured from one direct KWT worktree inventory record.
+///
+/// KWT accepts the four stored fields as one guarded-open contract. Its open
+/// command rejects protected workspaces, so accepting only `direct` here also
+/// preserves the selected attachment mode at execution time.
+public struct KwtWorktreeOpenIdentity: Equatable, Sendable {
+    public let repository: String
+    public let registrationFingerprint: String
+    public let generation: String
+    public let sessionName: String
+
+    public init?(
+        repository: String,
+        registrationFingerprint: String,
+        generation: String,
+        sessionName: String,
+        tmuxAttachMode: String
+    ) {
+        guard !repository.isEmpty,
+              !registrationFingerprint.isEmpty,
+              !generation.isEmpty,
+              !sessionName.isEmpty,
+              tmuxAttachMode == "direct"
+        else { return nil }
+        self.repository = repository
+        self.registrationFingerprint = registrationFingerprint
+        self.generation = generation
+        self.sessionName = sessionName
+    }
+}
+
+/// Identity captured from one protected KWT worktree inventory record.
+///
+/// KWT validates every field before attaching, preserving the selected
+/// registration, worktree generation, session, and named tmux endpoint.
+public struct KwtProtectedWorktreeOpenIdentity: Equatable, Sendable {
+    public let path: String
+    public let projectPath: String
+    public let repository: String
+    public let registrationFingerprint: String
+    public let generation: String
+    public let sessionName: String
+    public let socketName: String
+
+    public init?(
+        path: String,
+        projectPath: String,
+        repository: String,
+        registrationFingerprint: String,
+        generation: String,
+        sessionName: String,
+        socketName: String,
+        tmuxAttachMode: String
+    ) {
+        guard !path.isEmpty,
+              !projectPath.isEmpty,
+              !repository.isEmpty,
+              !registrationFingerprint.isEmpty,
+              !generation.isEmpty,
+              !sessionName.isEmpty,
+              !socketName.isEmpty,
+              tmuxAttachMode == "protected"
+        else { return nil }
+        self.path = path
+        self.projectPath = projectPath
+        self.repository = repository
+        self.registrationFingerprint = registrationFingerprint
+        self.generation = generation
+        self.sessionName = sessionName
+        self.socketName = socketName
+    }
+}
+
 /// An ordinary tmux client launched inside a libghostty terminal surface.
 /// Tmux owns rendering, windows, panes, history, input, and process lifetime.
 /// Ghosthub enables tmux's session mouse option before presenting the client so
@@ -26,7 +99,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
     public let host: CommandHost
     public let socketName: String?
     public let workspacePath: String?
+    public let kwtWorktreeIdentity: KwtWorktreeOpenIdentity?
+    public let kwtProtectedWorktreeIdentity:
+        KwtProtectedWorktreeOpenIdentity?
+    public let kwtExpectedSessionName: String?
     public let protectedWorkspacePath: String?
+    public let expectedAttachIdentity: TmuxSessionIdentity?
     public let presentationStyle: TmuxPresentationStyle?
     public var launchMode: TmuxAttachmentLaunchMode
     public let initialCommand: String?
@@ -38,7 +116,12 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         host: CommandHost,
         socketName: String? = nil,
         workspacePath: String? = nil,
+        kwtWorktreeIdentity: KwtWorktreeOpenIdentity? = nil,
+        kwtProtectedWorktreeIdentity:
+        KwtProtectedWorktreeOpenIdentity? = nil,
+        kwtExpectedSessionName: String? = nil,
         protectedWorkspacePath: String? = nil,
+        expectedAttachIdentity: TmuxSessionIdentity? = nil,
         presentationStyle: TmuxPresentationStyle? = nil,
         launchMode: TmuxAttachmentLaunchMode = .attach,
         initialCommand: String? = nil,
@@ -49,7 +132,11 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         self.host = host
         self.socketName = socketName
         self.workspacePath = workspacePath
+        self.kwtWorktreeIdentity = kwtWorktreeIdentity
+        self.kwtProtectedWorktreeIdentity = kwtProtectedWorktreeIdentity
+        self.kwtExpectedSessionName = kwtExpectedSessionName
         self.protectedWorkspacePath = protectedWorkspacePath
+        self.expectedAttachIdentity = expectedAttachIdentity
         self.presentationStyle = presentationStyle
         self.launchMode = launchMode
         self.initialCommand = initialCommand
@@ -199,9 +286,17 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                     )
                     commands.append("export PATH")
                 }
-                let protectedAttach = [
-                    kwtPath, "pr", "attach", protectedWorkspacePath,
-                ].map(shellQuotedCommandArgument).joined(separator: " ")
+                guard let protectedArguments = kwtProtectedAttachArguments(
+                    workspacePath: protectedWorkspacePath
+                ) else {
+                    commands.append(
+                        "printf 'Ghosthub: KWT worktree identity changed\\n' >&2"
+                    )
+                    commands.append("exit 1")
+                    break
+                }
+                let protectedAttach = ([kwtPath] + protectedArguments)
+                    .map(shellQuotedCommandArgument).joined(separator: " ")
                 commands.append(
                     kwtAttachWithSessionSetupCommand(
                         protectedAttach,
@@ -223,9 +318,18 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                         )
                         commands.append("export PATH")
                     }
-                    let openWorkspace = [
-                        kwtPath, "open", workspacePath,
-                    ].map(shellQuotedCommandArgument).joined(separator: " ")
+                    guard let openArguments = kwtOpenArguments(
+                        workspacePath: workspacePath
+                    ) else {
+                        commands.append(
+                            "printf 'Ghosthub: KWT worktree identity changed\\n' >&2"
+                        )
+                        commands.append("exit 1")
+                        break
+                    }
+                    let openWorkspace = ([kwtPath] + openArguments)
+                        .map(shellQuotedCommandArgument)
+                        .joined(separator: " ")
                     // Let kwt create and attach with one tmux client.
                     // A detached `--start-session` phase is unsafe when the
                     // user's tmux server enables destroy-unattached.
@@ -246,13 +350,20 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
                 }
             }
         case .attachOnly:
-            commands.append(mouseSetupCommand(tmuxPath: tmuxPath))
-            commands.append(
-                presentationCommand?.bestEffortCommand(
-                    tmuxPath: tmuxPath
-                ) ?? ":"
-            )
-            commands.append("exec \(attach)")
+            if protectedWorkspacePath != nil, socketName == nil {
+                commands.append(
+                    "printf 'Ghosthub: protected tmux endpoint is unavailable\\n' >&2"
+                )
+                commands.append("exit 1")
+            } else {
+                commands.append(mouseSetupCommand(tmuxPath: tmuxPath))
+                commands.append(
+                    presentationCommand?.bestEffortCommand(
+                        tmuxPath: tmuxPath
+                    ) ?? ":"
+                )
+                commands.append("exec \(attach)")
+            }
         case .create:
             let createAndAttach = localCreateAndAttachCommand(
                 tmuxPath: tmuxPath,
@@ -303,8 +414,20 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         if ignoresClientSize {
             arguments += ["-f", "ignore-size"]
         }
-        arguments += ["-t", "=\(sessionName)"]
-        return arguments
+        guard let expectedAttachIdentity else {
+            arguments += ["-t", "=\(sessionName)"]
+            return arguments
+        }
+        arguments += ["-t", expectedAttachIdentity.sessionID]
+        let attach = arguments
+            .map(shellQuotedCommandArgument)
+            .joined(separator: " ")
+        return [
+            "if-shell", "-F", "-t", expectedAttachIdentity.sessionID,
+            expectedAttachIdentity.formatCondition,
+            attach,
+            "display-message -p 'Ghosthub: tmux session identity changed'",
+        ]
     }
 
     private var initialSizeCommand: String? {
@@ -377,17 +500,30 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             )
         }
         let attach: String
-        if let protectedWorkspacePath,
-           launchMode != .attachOnly {
+        if protectedWorkspacePath != nil,
+           socketName == nil,
+           launchMode == .attachOnly {
+            attach =
+                "printf 'Ghosthub: protected tmux endpoint is unavailable\\n' >&2; "
+                    + "exit 1"
+        } else if let protectedWorkspacePath, launchMode != .attachOnly {
             let protectedAttach: String
-            if let remoteKwtCommandPrelude {
+            if let remoteKwtCommandPrelude,
+               let protectedArguments = kwtProtectedAttachArguments(
+                   workspacePath: protectedWorkspacePath
+               ) {
                 let kwtAttach = remoteKwtCommandPrelude
-                    + "\"$ghosthub_kwt_path\" 'pr' 'attach' "
-                    + shellQuotedCommandArgument(protectedWorkspacePath)
+                    + (["\"$ghosthub_kwt_path\""] + protectedArguments.map(
+                        shellQuotedCommandArgument
+                    )).joined(separator: " ")
                 protectedAttach = kwtAttachWithSessionSetupCommand(
                     kwtAttach,
                     tmuxPath: tmuxPath
                 )
+            } else if remoteKwtCommandPrelude != nil {
+                protectedAttach =
+                    "printf 'Ghosthub: KWT worktree identity changed\\n' >&2; "
+                        + "exit 1"
             } else {
                 protectedAttach =
                     "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
@@ -447,18 +583,26 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
             )
         }
         let remoteOpen: String
-        if let remoteKwtCommandPrelude {
+        if let remoteKwtCommandPrelude,
+           let openArguments = kwtOpenArguments(
+               workspacePath: workspacePath
+           ) {
             let kwtOpen = remoteKwtCommandPrelude
-                + "\"$ghosthub_kwt_path\" 'open' "
-                + shellQuotedCommandArgument(workspacePath)
+                + "\"$ghosthub_kwt_path\" "
+                + openArguments.map(shellQuotedCommandArgument)
+                .joined(separator: " ")
             remoteOpen = kwtAttachWithSessionSetupCommand(
                 kwtOpen,
                 tmuxPath: tmuxPath
             )
-        } else {
+        } else if remoteKwtCommandPrelude == nil {
             remoteOpen =
                 "printf 'Ghosthub: managed kwt is unavailable\\n' >&2; "
                     + "exit 127"
+        } else {
+            remoteOpen =
+                "printf 'Ghosthub: KWT worktree identity changed\\n' >&2; "
+                    + "exit 1"
         }
         let initialBody = recordedClientTTYBody([
             "unset TMUX TMUX_PANE",
@@ -501,7 +645,10 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         \(powerShellKwtResolutionPrelude(
             managedRelativePath: windowsKwtRelativePath
         ))
-        & $ghosthubKwt 'open' \(powerShellEncodedArgument(workspacePath))
+        \(windowsKwtWorkspaceAttachScript(
+            tmuxPath: tmuxPath,
+            workspacePath: workspacePath
+        ))
         exit $LASTEXITCODE
         """
         let initialAttach = shellCommand(
@@ -519,6 +666,84 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         ])
     }
 
+    private func windowsKwtWorkspaceAttachScript(
+        tmuxPath: String,
+        workspacePath: String
+    ) -> String {
+        guard let openArguments = kwtOpenArguments(
+            workspacePath: workspacePath
+        ) else {
+            return "Write-Error 'Ghosthub: KWT worktree identity changed'; exit 1"
+        }
+        let openCommand = "& $ghosthubKwt " + openArguments
+            .map(powerShellEncodedArgument)
+            .joined(separator: " ")
+        let attach = windowsMuxCommand(
+            tmuxPath: tmuxPath,
+            arguments: attachArguments
+        )
+        let expectedSocketName = socketName ?? ""
+        return """
+        $ghosthubEndpointJSON = \(openCommand) '--start-session' '--json'
+        $ghosthubKwtStatus = $LASTEXITCODE
+        if ($ghosthubKwtStatus -ne 0) {
+            exit $ghosthubKwtStatus
+        }
+        try {
+            $ghosthubEndpoint = $ghosthubEndpointJSON | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Write-Error 'Ghosthub: kwt returned an invalid tmux endpoint'
+            exit 1
+        }
+        if ([string]$ghosthubEndpoint.session_name -cne \(powerShellEncodedArgument(sessionName))
+            -or [string]$ghosthubEndpoint.tmux_socket_name -cne \(
+                powerShellEncodedArgument(expectedSocketName)
+            )
+            -or [string]$ghosthubEndpoint.tmux_attach_mode -cne
+                \(powerShellEncodedArgument("direct"))) {
+            Write-Error 'Ghosthub: kwt tmux endpoint changed'
+            exit 1
+        }
+        \(attach)
+        """
+    }
+
+    private func kwtOpenArguments(workspacePath: String) -> [String]? {
+        var arguments = ["open", workspacePath]
+        if let identity = kwtWorktreeIdentity {
+            guard identity.sessionName == sessionName else { return nil }
+            arguments += [
+                "--expected-repository", identity.repository,
+                "--expected-registration", identity.registrationFingerprint,
+                "--expected-generation", identity.generation,
+                "--expected-session", identity.sessionName,
+            ]
+        } else if let kwtExpectedSessionName {
+            guard kwtExpectedSessionName == sessionName else { return nil }
+            arguments += ["--expected-session", kwtExpectedSessionName]
+        }
+        return arguments
+    }
+
+    private func kwtProtectedAttachArguments(
+        workspacePath: String
+    ) -> [String]? {
+        guard let identity = kwtProtectedWorktreeIdentity,
+              identity.path == workspacePath,
+              identity.sessionName == sessionName,
+              identity.socketName == socketName
+        else { return nil }
+        return [
+            "pr", "attach", identity.path,
+            "--project", identity.projectPath,
+            "--expected-repository", identity.repository,
+            "--expected-registration", identity.registrationFingerprint,
+            "--expected-generation", identity.generation,
+            "--expected-session", identity.sessionName,
+            "--expected-socket", identity.socketName,
+        ]
+    }
+
     private func windowsRemoteAttachCommand(
         info: SSHHostInfo,
         tmuxPath: String,
@@ -526,13 +751,25 @@ public struct TmuxAttachmentInfo: Equatable, Sendable {
         sshConnectionArguments: [String]
     ) -> String {
         let attach: String
-        if let protectedWorkspacePath, launchMode != .attachOnly {
-            attach = """
-            \(powerShellKwtResolutionPrelude(
-                managedRelativePath: windowsKwtRelativePath
-            ))
-            & $ghosthubKwt 'pr' 'attach' \(powerShellEncodedArgument(protectedWorkspacePath))
-            """
+        if protectedWorkspacePath != nil,
+           socketName == nil,
+           launchMode == .attachOnly {
+            attach = "Write-Error 'Ghosthub: protected tmux endpoint is unavailable'; exit 1"
+        } else if let protectedWorkspacePath, launchMode != .attachOnly {
+            if let protectedArguments = kwtProtectedAttachArguments(
+                workspacePath: protectedWorkspacePath
+            ) {
+                attach = """
+                \(powerShellKwtResolutionPrelude(
+                    managedRelativePath: windowsKwtRelativePath
+                ))
+                & $ghosthubKwt \(protectedArguments.map(
+                    powerShellEncodedArgument
+                ).joined(separator: " "))
+                """
+            } else {
+                attach = "Write-Error 'Ghosthub: KWT worktree identity changed'; exit 1"
+            }
         } else {
             attach = windowsMuxCommand(
                 tmuxPath: tmuxPath,

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -218,9 +218,24 @@ public struct WorkspaceTmuxSessionSelection:
     }
 
     public var id: String {
+        Self.canonicalEndpointID(
+            hostID: hostID,
+            name: name,
+            socketName: socketName,
+            tmuxAttachMode: tmuxAttachMode
+        )
+    }
+
+    public static func canonicalEndpointID(
+        hostID: UUID,
+        name: String,
+        socketName: String?,
+        tmuxAttachMode: TmuxAttachMode?
+    ) -> String {
         [
             hostID.uuidString,
-            tmuxAttachMode?.rawValue ?? "unbound",
+            tmuxAttachMode == .direct
+                ? "unbound" : tmuxAttachMode?.rawValue ?? "unbound",
             socketName ?? "default",
             name,
         ].joined(separator: ":")

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -444,6 +444,31 @@ public enum WorkspaceSidebarModel {
         guard selection.tmuxAttachMode != .protected else {
             return false
         }
+        if selection.tmuxAttachMode == .direct,
+           selection.socketName != nil {
+            if let worktreeID = selection.worktreeID,
+               let worktree = snapshot.worktree(id: worktreeID) {
+                return !worktree.isStale
+                    && worktree.hostID == selection.hostID
+                    && worktree.tmuxSessionName == selection.name
+                    && worktree.tmuxSocketName == selection.socketName
+                    && worktree.tmuxAttachMode == selection.tmuxAttachMode
+                    && worktree.path == selection.workspacePath
+                    && worktree.generation == selection.worktreeGeneration
+            }
+            if let directoryWorkspaceID = selection.directoryWorkspaceID,
+               let workspace = snapshot.directoryWorkspace(
+                   id: directoryWorkspaceID
+               ) {
+                return workspace.hostID == selection.hostID
+                    && workspace.path == selection.workspacePath
+                    && workspace.tmuxSessionName == selection.name
+                    && workspace.tmuxSocketName == selection.socketName
+                    && workspace.tmuxAttachMode == selection.tmuxAttachMode
+                    && workspace.sessionLive
+            }
+            return false
+        }
         return snapshot.host(id: selection.hostID)?.tmuxSessions.contains {
             $0.name == selection.name && $0.hasStableIdentity
         } == true
@@ -610,16 +635,14 @@ public enum WorkspaceSidebarModel {
 
     private static func directoryWorkspaceRow(
         _ workspace: DirectoryWorkspaceSummary,
-        host: HostSummary
+        host _: HostSummary
     ) -> WorkspaceSidebarRow {
         WorkspaceSidebarRow(
             target: .directoryWorkspace(workspace.id),
             icon: .directoryWorkspace,
             title: workspace.name,
             subtitle: workspace.path,
-            sessionIsRunning: host.tmuxSessions.contains {
-                $0.name == workspace.tmuxSessionName
-            }
+            sessionIsRunning: workspace.sessionLive
         )
     }
 

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -885,6 +885,7 @@ struct WorkspaceSidebarView: View {
         let isSelected = Self.isRowSelected(
             row,
             selection: selection,
+            rowTmuxSession: tmuxSession,
             activeTmuxSession: activeTmuxSession,
             activeHerdrSession: activeHerdrSession,
             activeZellijSession: activeZellijSession
@@ -1291,6 +1292,7 @@ struct WorkspaceSidebarView: View {
     static func isRowSelected(
         _ row: WorkspaceSidebarRow,
         selection: WorkspaceSelection,
+        rowTmuxSession: WorkspaceTmuxSessionSelection? = nil,
         activeTmuxSession: WorkspaceTmuxSessionSelection?,
         activeHerdrSession: WorkspaceHerdrSessionSelection?,
         activeZellijSession: WorkspaceZellijSessionSelection? = nil
@@ -1313,6 +1315,10 @@ struct WorkspaceSidebarView: View {
                 name: name
             )
         }
+        if let rowTmuxSession, let activeTmuxSession,
+           sameTmuxPresentationEndpoint(rowTmuxSession, activeTmuxSession) {
+            return true
+        }
         if case let .worktree(worktreeID) = row.target,
            activeTmuxSession?.worktreeID == worktreeID {
             return true
@@ -1325,6 +1331,18 @@ struct WorkspaceSidebarView: View {
             && activeHerdrSession == nil
             && activeZellijSession == nil
             && selection.navigationTarget == row.target
+    }
+
+    private static func sameTmuxPresentationEndpoint(
+        _ lhs: WorkspaceTmuxSessionSelection,
+        _ rhs: WorkspaceTmuxSessionSelection
+    ) -> Bool {
+        let lhsMode = lhs.tmuxAttachMode == .direct ? nil : lhs.tmuxAttachMode
+        let rhsMode = rhs.tmuxAttachMode == .direct ? nil : rhs.tmuxAttachMode
+        return lhs.hostID == rhs.hostID
+            && lhs.name == rhs.name
+            && lhs.socketName == rhs.socketName
+            && lhsMode == rhsMode
     }
 
     private func sessionActionLabel(

--- a/Tests/App/HerdrSessionProbeBrokerTests.swift
+++ b/Tests/App/HerdrSessionProbeBrokerTests.swift
@@ -106,7 +106,9 @@ struct HerdrSessionProbeBrokerTests {
         async let first = broker.sessions(on: .local)
         async let second = broker.sessions(on: .local)
         await gate.waitUntilBlocked()
-        await Task.yield()
+        await waitUntilMainActor {
+            broker.sessionConsumerCount(on: .local) == 2
+        }
         await gate.open()
 
         #expect(await first == expected)

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -504,9 +504,10 @@ struct NativeTmuxSessionCoordinatorTests {
         #expect(invalidations.load().isEmpty)
     }
 
-    @Test("tmux older than 3.4 does not install pane split shortcuts")
-    func oldTmuxDoesNotInstallSplitHandler() async {
+    @Test("tmux older than 3.4 captures identity without split shortcuts")
+    func oldTmuxCapturesIdentityWithoutSplitHandler() async {
         let store = RecordingNativeSessionSurfaceStore()
+        let identityReads = LockedValue(0)
         let host = CommandHost.ssh(SSHHostInfo(
             user: "operator",
             hostname: "legacy.example.test",
@@ -527,6 +528,12 @@ struct NativeTmuxSessionCoordinatorTests {
             },
             remoteConnectionProvider: { _, _ in
                 testKwtSSHAttachment(arguments: sshArguments)
+            },
+            paneSplitter: TmuxPaneSplitter { _, arguments, command in
+                #expect(arguments == sshArguments)
+                #expect(command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY"))
+                identityReads.withLock { $0 += 1 }
+                return (0, coordinatorSplitClientOutput)
             }
         )
         var isReady = false
@@ -540,15 +547,15 @@ struct NativeTmuxSessionCoordinatorTests {
 
         await waitUntilMainActor { isReady }
         _ = coordinator.surface(handle: handle)
-        coordinator.requestAttachedSessionIdentity(handle)
+        await waitUntilMainActor {
+            coordinator.attachedSessionIdentityResolution(handle)
+                == .resolved(coordinatorSplitIdentity)
+        }
 
         #expect(store.surface.paneSplitShortcutHandler == nil)
         #expect(!store.surface.terminalFindController.isAvailable)
         #expect(!coordinator.supportsPaneSplitting(handle))
-        #expect(
-            coordinator.attachedSessionIdentityResolution(handle)
-                == .unavailable
-        )
+        #expect(identityReads.load() == 1)
     }
 
     @Test("initial client binding retries while the attachment is live")
@@ -814,6 +821,18 @@ struct NativeTmuxSessionCoordinatorTests {
         )
         var isReady = false
         coordinator.onSurfaceReady = { _ in isReady = true }
+        let protectedIdentity = try #require(
+            KwtProtectedWorktreeOpenIdentity(
+                path: "/worktrees/pr-32",
+                projectPath: "/repos/ghosthub",
+                repository: "github.com/kenn-io/ghosthub",
+                registrationFingerprint: "registration-123",
+                generation: "0123456789abcdef0123456789abcdef",
+                sessionName: "pr-32",
+                socketName: "kwt-pr-0123456789abcdef",
+                tmuxAttachMode: "protected"
+            )
+        )
         let handle = coordinator.attach(
             hostID: UUID(),
             name: "pr-32",
@@ -821,6 +840,7 @@ struct NativeTmuxSessionCoordinatorTests {
             socketName: "kwt-pr-0123456789abcdef",
             tmuxAttachMode: .protected,
             workingDirectory: "/worktrees/pr-32",
+            kwtProtectedWorktreeIdentity: protectedIdentity,
             sessionIdentity: coordinatorSplitIdentity
         )
 
@@ -835,6 +855,7 @@ struct NativeTmuxSessionCoordinatorTests {
         ))
         #expect(command.contains("/worktrees/pr-32"))
         #expect(command.contains("kwt-pr-0123456789abcdef"))
+        #expect(command.contains("--expected-generation"))
         #expect(!command.contains("'open'"))
     }
 

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -475,6 +475,15 @@ func makeModel(
     WorkspaceSceneModel.TmuxSessionIdentityReading = { selection, host in
         try await TmuxSessionKiller().sessionIdentity(selection, on: host)
     },
+    tmuxRoutedSessionIdentityReader: @escaping
+    WorkspaceSceneModel.TmuxRoutedSessionIdentityReading = {
+        selection, host, arguments in
+        try await TmuxSessionKiller().sessionIdentity(
+            selection,
+            on: host,
+            sshConnectionArguments: arguments
+        )
+    },
     tmuxSessionIdentityReviewer:
     WorkspaceSceneModel.TmuxSessionIdentityReviewReading? = nil,
     tmuxSessionStyler: @escaping
@@ -621,6 +630,7 @@ func makeModel(
             try await tmuxSessionKiller(selection, identity, host)
         },
         tmuxSessionIdentityReader: tmuxSessionIdentityReader,
+        tmuxRoutedSessionIdentityReader: tmuxRoutedSessionIdentityReader,
         tmuxSessionIdentityReviewer: tmuxSessionIdentityReviewer ?? {
             selection, knownIdentity, host in
             let identity: TmuxSessionIdentity

--- a/Tests/App/WorkspaceRestorationTests.swift
+++ b/Tests/App/WorkspaceRestorationTests.swift
@@ -310,27 +310,35 @@ private final class ControlledProtectedProbe: @unchecked Sendable {
 }
 
 @MainActor
-private struct ProtectedRestorationHarness {
+private struct ExactTmuxRestorationHarness {
     let model: WorkspaceSceneModel
     let probe: ProtectedProbeSpy
+    let surfaceStore: RecordingNativeSessionSurfaceStore
     let savedState: WorkspaceWindowState
 
-    static func make(outcome: ProtectedProbeSpy.Outcome) throws -> Self {
+    static func make(
+        outcome: ProtectedProbeSpy.Outcome,
+        socketName: String = "kwt-pr-0123456789abcdef",
+        attachMode: TmuxAttachMode = .protected
+    ) throws -> Self {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
         snapshot.worktrees[0].tmuxSessionName = "pr-42"
-        snapshot.worktrees[0].tmuxSocketName = "kwt-pr-0123456789abcdef"
-        snapshot.worktrees[0].tmuxAttachMode = .protected
+        snapshot.worktrees[0].tmuxSocketName = socketName
+        snapshot.worktrees[0].tmuxAttachMode = attachMode
         snapshot.worktrees[0].generation = restorationWorktreeGeneration
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(name: "pr-42", managed: false, windows: []),
         ]
         let probe = ProtectedProbeSpy(outcome: outcome)
+        let surfaceStore = RecordingNativeSessionSurfaceStore()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            localKwtPathProvider: { "/usr/bin/kwt" },
             tmuxSessionIdentityReader: probe.read
         )
         let savedState = WorkspaceWindowState(
@@ -343,13 +351,19 @@ private struct ProtectedRestorationHarness {
             tmux: .init(
                 hostKey: environment.host.configKey,
                 sessionName: "pr-42",
-                socketName: "kwt-pr-0123456789abcdef",
+                socketName: socketName,
+                tmuxAttachMode: attachMode,
                 owner: .worktree(
                     generation: restorationWorktreeGeneration
                 )
             )
         )
-        return Self(model: model, probe: probe, savedState: savedState)
+        return Self(
+            model: model,
+            probe: probe,
+            surfaceStore: surfaceStore,
+            savedState: savedState
+        )
     }
 }
 
@@ -1643,9 +1657,76 @@ struct WorkspaceRestorationTests {
         #expect(!command.contains("new-session"))
     }
 
+    @Test("remote exact restoration keeps its identity fence on reconnect")
+    func remoteExactRestorationReconnectKeepsIdentityFence() async throws {
+        let environment = try setupRemoteEnvironment()
+        let identity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$7",
+            createdAt: "1721552400"
+        )
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "pr-42"
+        snapshot.worktrees[0].tmuxSocketName = "kwt"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation = restorationWorktreeGeneration
+        let surfaceStore = RecordingNativeSessionSurfaceStore()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionValidationExactProbe: { _, _ in .success(true) },
+            tmuxSessionIdentityReader: { _, _ in identity },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let state = WorkspaceWindowState(
+            windowID: UUID(),
+            navigation: .init(
+                hostKey: environment.host.configKey,
+                projectKey: environment.project.scopedKey,
+                worktreeGeneration: restorationWorktreeGeneration
+            ),
+            tmux: .init(
+                hostKey: environment.host.configKey,
+                sessionName: "pr-42",
+                socketName: "kwt",
+                tmuxAttachMode: .direct,
+                owner: .worktree(
+                    generation: restorationWorktreeGeneration
+                )
+            )
+        )
+
+        model.beginRestoration(state)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSelection != nil
+        }
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.lastCommand != nil
+        }
+        let initialRequestCount = surfaceStore.requestedConfigurations.count
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestedConfigurations.count > initialRequestCount
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        let command = try #require(surfaceStore.lastCommand)
+        #expect(command.contains("if-shell"))
+        #expect(command.contains("#{pid},123"))
+        #expect(command.contains("#{session_created},1721552400"))
+        #expect(command.contains("Ghosthub: tmux session identity changed"))
+        await model.shutdown()
+    }
+
     @Test("protected restoration probes exact socket before kwt attach")
     func protectedRestorationProbesBeforeAttach() async throws {
-        let harness = try ProtectedRestorationHarness.make(outcome: .present)
+        let harness = try ExactTmuxRestorationHarness.make(outcome: .present)
 
         harness.model.beginRestoration(harness.savedState)
         await waitUntil { harness.probe.selections.count == 1 }
@@ -1663,12 +1744,53 @@ struct WorkspaceRestorationTests {
             harness.model.activeBorrowedTmuxSelection?.socketName
                 == "kwt-pr-0123456789abcdef"
         )
+        await waitUntilMainActor {
+            harness.model.prepareActiveBorrowedTmuxSurface()
+            return harness.surfaceStore.lastCommand != nil
+        }
+        let command = try #require(harness.surfaceStore.lastCommand)
+        #expect(command.contains("--project"))
+        #expect(command.contains("--expected-repository"))
+        #expect(command.contains("--expected-registration"))
+        #expect(command.contains("--expected-generation"))
+        #expect(command.contains("--expected-session"))
+        #expect(command.contains("--expected-socket"))
         #expect(!harness.model.suppressesAutomaticWorktreeSessionOpen)
+        await harness.model.shutdown()
+    }
+
+    @Test("direct named restoration probes its exact endpoint")
+    func directNamedRestorationProbesBeforeAttach() async throws {
+        let harness = try ExactTmuxRestorationHarness.make(
+            outcome: .present,
+            socketName: "kwt",
+            attachMode: .direct
+        )
+
+        harness.model.beginRestoration(harness.savedState)
+        await waitUntil { harness.probe.selections.count == 1 }
+
+        let selection = try #require(harness.probe.selections.first)
+        #expect(selection.socketName == "kwt")
+        #expect(selection.tmuxAttachMode == .direct)
+        await waitUntilMainActor {
+            harness.model.activeBorrowedTmuxSelection != nil
+        }
+        #expect(harness.model.activeBorrowedTmuxSelection == selection)
+        await waitUntilMainActor {
+            harness.model.prepareActiveBorrowedTmuxSurface()
+            return harness.surfaceStore.lastCommand != nil
+        }
+        let command = try #require(harness.surfaceStore.lastCommand)
+        #expect(command.contains("if-shell"))
+        #expect(command.contains("#{pid},123"))
+        #expect(command.contains("#{session_id},$7"))
+        #expect(command.contains("#{session_created},1721552400"))
     }
 
     @Test("absent protected session remains pending without fallback")
     func protectedAbsenceStaysPending() async throws {
-        let harness = try ProtectedRestorationHarness.make(outcome: .absent)
+        let harness = try ExactTmuxRestorationHarness.make(outcome: .absent)
 
         harness.model.beginRestoration(harness.savedState)
         await waitUntil { harness.probe.completionCount >= 1 }
@@ -1683,7 +1805,7 @@ struct WorkspaceRestorationTests {
 
     @Test("failed protected probe retries only after inventory refresh")
     func protectedFailureRetriesOnRefresh() async throws {
-        let harness = try ProtectedRestorationHarness.make(outcome: .failed)
+        let harness = try ExactTmuxRestorationHarness.make(outcome: .failed)
 
         harness.model.beginRestoration(harness.savedState)
         await waitUntil { harness.probe.completionCount >= 1 }
@@ -1947,6 +2069,7 @@ struct WorkspaceRestorationTests {
                 hostKey: environment.host.configKey,
                 sessionName: "pr-42",
                 socketName: "kwt-pr-0123456789abcdef",
+                tmuxAttachMode: .protected,
                 owner: .worktree(
                     generation: restorationWorktreeGeneration
                 )
@@ -1958,7 +2081,7 @@ struct WorkspaceRestorationTests {
         var updatedSnapshot = model.snapshot
         updatedSnapshot.worktrees[0].path = "/tmp/ghosthub-refreshed"
         model.snapshot = updatedSnapshot
-        guard case .needsProtectedProbe = WorkspaceWindowRestorationResolver
+        guard case .needsExactTmuxProbe = WorkspaceWindowRestorationResolver
             .resolve(state, in: model.snapshot) else {
             Issue.record("updated target should still require a probe")
             return
@@ -2012,6 +2135,7 @@ struct WorkspaceRestorationTests {
                 hostKey: environment.host.configKey,
                 sessionName: "pr-42",
                 socketName: "kwt-pr-0123456789abcdef",
+                tmuxAttachMode: .protected,
                 owner: .worktree(
                     generation: restorationWorktreeGeneration
                 )
@@ -2068,6 +2192,7 @@ struct WorkspaceRestorationTests {
                 hostKey: environment.host.configKey,
                 sessionName: "pr-42",
                 socketName: "kwt-pr-0123456789abcdef",
+                tmuxAttachMode: .protected,
                 owner: .worktree(
                     generation: restorationWorktreeGeneration
                 )
@@ -2112,6 +2237,7 @@ struct WorkspaceRestorationTests {
                 hostKey: environment.host.configKey,
                 sessionName: "pr-42",
                 socketName: "kwt-pr-0123456789abcdef",
+                tmuxAttachMode: .protected,
                 owner: .worktree(
                     generation: restorationWorktreeGeneration
                 )

--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -2568,7 +2568,10 @@ struct WorkspaceTmuxDiscoveryTests {
                             repository: environment.project.scopedKey,
                             name: environment.project.name,
                             path: environment.project.rootPath,
-                            lastTouched: nil
+                            lastTouched: nil,
+                            registrationFingerprint:
+                            environment.snapshot.projects[0]
+                                .registrationFingerprint
                         ),
                         worktrees: inventoryRemoved.load() ? [] : [
                             KwtWorktreeRecord(
@@ -2880,7 +2883,10 @@ struct WorkspaceTmuxDiscoveryTests {
                             repository: environment.project.scopedKey,
                             name: environment.project.name,
                             path: environment.project.rootPath,
-                            lastTouched: nil
+                            lastTouched: nil,
+                            registrationFingerprint:
+                            environment.snapshot.projects[0]
+                                .registrationFingerprint
                         ),
                         worktrees: [
                             KwtWorktreeRecord(

--- a/Tests/App/WorkspaceTmuxKillTests.swift
+++ b/Tests/App/WorkspaceTmuxKillTests.swift
@@ -13,6 +13,63 @@ import Testing
 
 extension WorkspaceTmuxDiscoveryTests {
     @MainActor
+    @Test("direct named directory kill uses exact endpoint review")
+    func directNamedDirectoryKillUsesExactEndpointReview() async throws {
+        let environment = try setupStandardEnvironment()
+        let workspace = DirectoryWorkspaceSummary(
+            id: UUID(),
+            hostID: environment.host.id,
+            name: "jibot",
+            path: "/workspaces/jibot",
+            tmuxSessionName: "kwt-workspace-dir-jibot-abc",
+            tmuxSocketName: "kwt",
+            tmuxAttachMode: .direct,
+            sessionLive: true
+        )
+        var snapshot = environment.snapshot
+        snapshot.directoryWorkspaces = [workspace]
+        let reviews = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            tmuxSessionIdentityReviewer: { selection, identity, _ in
+                _ = reviews.increment()
+                #expect(selection.socketName == "kwt")
+                #expect(identity == nil)
+                return ReviewedTmuxSessionIdentity(
+                    identity: TmuxSessionIdentity(
+                        serverPID: "31415",
+                        sessionID: "$8",
+                        createdAt: "1721552400"
+                    ),
+                    routeIdentity: nil
+                )
+            }
+        )
+        let selection = WorkspaceSidebarModel.tmuxSessionSelection(
+            for: workspace
+        )
+
+        let request = try await model.prepareTmuxSessionKill(selection)
+
+        #expect(reviews.count == 1)
+        #expect(request.serverPID == "31415")
+
+        var staleSelection = selection
+        staleSelection.workspacePath = "/workspaces/replacement"
+        await #expect {
+            try await model.prepareTmuxSessionKill(staleSelection)
+        } throws: { error in
+            error as? TmuxSessionKillError == .sessionNotRunning(
+                host: "localhost",
+                session: workspace.tmuxSessionName
+            )
+        }
+        #expect(reviews.count == 1)
+    }
+
+    @MainActor
     @Test("kill carries reviewed identity and route through confirmation")
     func killUsesConfirmedSessionIdentity() async throws {
         let environment = try setupStandardEnvironment()
@@ -90,6 +147,8 @@ extension WorkspaceTmuxDiscoveryTests {
         ])
         var snapshot = environment.snapshot
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
@@ -155,6 +214,8 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         var snapshot = environment.snapshot
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -370,14 +431,21 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("connected attachment supplies protected-session identity")
     func connectedAttachmentSuppliesIdentity() async throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "protected"
+        snapshot.worktrees[0].tmuxAttachMode = .protected
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let identityReads = Counter()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            localKwtPathProvider: { "/usr/bin/kwt" },
             tmuxSessionIdentityReader: { _, _ in
                 _ = identityReads.increment()
                 return TmuxSessionIdentity(
@@ -387,13 +455,10 @@ extension WorkspaceTmuxDiscoveryTests {
                 )
             }
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: "kwt-ghosthub-main",
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            socketName: "protected",
-            tmuxAttachMode: .protected
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
@@ -782,14 +847,21 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("protected kill availability survives a generation change")
     func protectedKillSurvivesGenerationChange() async throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "protected"
+        snapshot.worktrees[0].tmuxAttachMode = .protected
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let identityReads = Counter()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            localKwtPathProvider: { "/usr/bin/kwt" },
             tmuxSessionIdentityReader: { _, _ in
                 _ = identityReads.increment()
                 return TmuxSessionIdentity(
@@ -799,14 +871,10 @@ extension WorkspaceTmuxDiscoveryTests {
                 )
             }
         )
-        var selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: "kwt-ghosthub-main",
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            worktreeGeneration: "0123456789abcdef0123456789abcdef",
-            socketName: "protected",
-            tmuxAttachMode: .protected
+        var selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -2038,6 +2038,62 @@ extension WorkspaceTmuxDiscoveryTests {
         await model.shutdown()
     }
 
+    @MainActor
+    @Test(
+        "stale direct worktree endpoint does not launch kwt open",
+        arguments: ["path", "session", "socket", "attach mode", "generation"]
+    )
+    func staleDirectWorktreeEndpointDoesNotOpen(
+        changedField: String
+    ) async throws {
+        let environment = try setupStandardEnvironment()
+        var selectedSnapshot = environment.snapshot
+        selectedSnapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        selectedSnapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        selectedSnapshot.worktrees[0].tmuxAttachMode = .direct
+        selectedSnapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let stale = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: selectedSnapshot.worktrees[0]
+            )
+        )
+        var currentSnapshot = selectedSnapshot
+        switch changedField {
+        case "path":
+            currentSnapshot.worktrees[0].path = "/worktrees/replacement"
+        case "session":
+            currentSnapshot.worktrees[0].tmuxSessionName =
+                "kwt-ghosthub-replacement"
+        case "socket":
+            currentSnapshot.worktrees[0].tmuxSocketName = "kwt-replacement"
+        case "attach mode":
+            currentSnapshot.worktrees[0].tmuxAttachMode = .protected
+        case "generation":
+            currentSnapshot.worktrees[0].generation = nil
+        default:
+            Issue.record("Unknown changed field: \(changedField)")
+            return
+        }
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: currentSnapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+
+        model.openBorrowedTmuxSession(stale)
+        await Task.yield()
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(surfaceStore.requestCount == 0)
+        await model.shutdown()
+    }
+
 }
 
 extension WorkspaceTmuxDiscoveryTests {

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -906,6 +906,9 @@ extension WorkspaceTmuxDiscoveryTests {
 
         model.openBorrowedTmuxSession(unbound)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor {
+            model.retainedBorrowedTmuxSessionIsConnected(unbound)
+        }
         let handle = try #require(
             model.retainedBorrowedTmuxHandle(for: unbound)
         )
@@ -915,6 +918,8 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(surfaceStore.requestCount == 1)
         #expect(model.activeBorrowedTmuxSelection == worktree)
+        #expect(model.previewableTmuxSessionIDs == [worktree.id])
+        #expect(model.connectedBorrowedTmuxSessionIDs == [worktree.id])
 
         model.closeBorrowedTmuxSession(worktree)
 

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -13,6 +13,32 @@ import Testing
 
 extension WorkspaceTmuxDiscoveryTests {
     @MainActor
+    @Test("unresolved protected worktree stays pending")
+    func unresolvedProtectedWorktreeStaysPending() throws {
+        let environment = try setupStandardEnvironment()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/opt/homebrew/bin/tmux")
+            }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .protected
+        )
+
+        model.openBorrowedTmuxSession(selection)
+
+        #expect(model.retainedBorrowedTmuxHandle(for: selection) == nil)
+        #expect(model.activeBorrowedTmuxSelection == nil)
+    }
+
+    @MainActor
     @Test("created sessions publish into host inventory immediately")
     func createdSessionPublishesImmediately() throws {
         let environment = try setupStandardEnvironment()
@@ -312,14 +338,14 @@ extension WorkspaceTmuxDiscoveryTests {
         }
 
         #expect(model.activeBorrowedTmuxSelection == nil)
-        #expect(commands.load().isEmpty)
+        #expect(commands.load().allSatisfy { !$0.contains("ignore-size") })
         #expect(!surfaceStore.removedKeys.isEmpty)
         await model.shutdown()
     }
 
     @MainActor
-    @Test("hiding a socketless protected session never sizes the default server")
-    func hidingSocketlessProtectedSessionDetachesWithoutSizing() async throws {
+    @Test("a socketless protected session never reaches default-server sizing")
+    func socketlessProtectedSessionDoesNotReachSizing() async throws {
         let environment = try setupStandardEnvironment()
         let hiddenSizingMutations = LockedValue(0)
         let surfaceStore = SceneTmuxSurfaceStoreStub()
@@ -357,20 +383,12 @@ extension WorkspaceTmuxDiscoveryTests {
         )
 
         model.openBorrowedTmuxSession(selection)
-        await launchActiveTmuxSurface(model, store: surfaceStore)
-        await waitUntilMainActor {
-            model.retainedBorrowedTmuxSessionIsConnected(selection)
-        }
-        model.hideBorrowedTmuxSession(selection)
-        await waitUntilMainActor {
-            hiddenSizingMutations.load() > 0
-                || model.retainedBorrowedTmuxHandle(for: selection) == nil
-        }
+        try await Task.sleep(for: .milliseconds(100))
 
         #expect(hiddenSizingMutations.load() == 0)
         #expect(model.activeBorrowedTmuxSelection == nil)
         #expect(model.retainedBorrowedTmuxHandle(for: selection) == nil)
-        #expect(!surfaceStore.removedKeys.isEmpty)
+        #expect(surfaceStore.requestCount == 0)
         await model.shutdown()
     }
 
@@ -423,6 +441,9 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("hiding workspace provisioning preserves kwt establishment")
     func hidingWorkspaceProvisioningPreservesKwtEstablishment() async throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -431,7 +452,7 @@ extension WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: {
                 resolutionStarted.store(true)
@@ -460,6 +481,7 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
             tmuxAttachMode: .direct
         )
 
@@ -491,6 +513,9 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("hiding kwt provisioning survives discovery advancing the phase")
     func hidingKwtProvisioningSurvivesDiscoveryAdvancingPhase() async throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -499,7 +524,7 @@ extension WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: {
                 resolutionStarted.store(true)
@@ -538,6 +563,7 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
             tmuxAttachMode: .direct
         )
 
@@ -575,6 +601,9 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("hidden workspace provisioning detaches without a client identity")
     func hiddenWorkspaceProvisioningDetachesWithoutIdentity() async throws {
         let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -582,7 +611,7 @@ extension WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: {
                 resolutionStarted.store(true)
@@ -600,6 +629,7 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
             tmuxAttachMode: .direct
         )
 
@@ -836,6 +866,55 @@ extension WorkspaceTmuxDiscoveryTests {
         model.openBorrowedTmuxSession(canonical)
         #expect(model.activeBorrowedTmuxSelection == canonical)
         #expect(model.retainedBorrowedTmuxHandle(for: canonical) == handle)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a direct worktree reuses its unbound default-server presentation")
+    func directWorktreeReusesUnboundPresentation() async throws {
+        let environment = try setupStandardEnvironment()
+        let sessionName = "kwt-ghosthub-main"
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.hosts[0].tmuxSessions = [.init(
+            name: sessionName,
+            managed: false,
+            windows: []
+        )]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+        let unbound = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName
+        )
+        let worktree = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
+        )
+
+        model.openBorrowedTmuxSession(unbound)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        let handle = try #require(
+            model.retainedBorrowedTmuxHandle(for: unbound)
+        )
+        model.openBorrowedTmuxSession(worktree)
+
+        #expect(model.retainedBorrowedTmuxHandle(for: worktree) == handle)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.requestCount == 1)
+        #expect(model.activeBorrowedTmuxSelection == worktree)
         await model.shutdown()
     }
 
@@ -1109,6 +1188,84 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("directory workspace open guards the selected KWT session")
+    func directoryWorkspaceOpenGuardsSelectedSession() async throws {
+        let environment = try setupStandardEnvironment()
+        let directory = DirectoryWorkspaceSummary(
+            id: UUID(),
+            hostID: environment.host.id,
+            name: "hub",
+            path: "/srv/hub",
+            tmuxSessionName: "kwt-workspace-dir-hub",
+            sessionLive: false
+        )
+        var snapshot = environment.snapshot
+        snapshot.directoryWorkspaces = [directory]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            localKwtPathProvider: { "/test/kwt" }
+        )
+        let selection = WorkspaceSidebarModel.tmuxSessionSelection(
+            for: directory
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'--expected-session'"))
+        #expect(command.contains("'kwt-workspace-dir-hub'"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("directory session drift does not launch KWT open")
+    func directorySessionDriftDoesNotOpen() async throws {
+        let environment = try setupStandardEnvironment()
+        let directoryID = UUID()
+        var snapshot = environment.snapshot
+        snapshot.directoryWorkspaces = [.init(
+            id: directoryID,
+            hostID: environment.host.id,
+            name: "hub",
+            path: "/srv/hub",
+            tmuxSessionName: "kwt-workspace-dir-renamed-hub",
+            sessionLive: false
+        )]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+        let staleSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-workspace-dir-hub",
+            directoryWorkspaceID: directoryID,
+            workspacePath: "/srv/hub",
+            tmuxAttachMode: .direct
+        )
+
+        model.openBorrowedTmuxSession(staleSelection)
+        await Task.yield()
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(surfaceStore.requestCount == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("explicit close dismisses an unresolved-host presentation")
     func explicitCloseDismissesUnresolvedHostPresentation() throws {
         let environment = try setupStandardEnvironment()
@@ -1275,10 +1432,11 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("explicit reselection attaches a replaced worktree's session")
     func explicitReselectionAttachesReplacedSession() throws {
         let environment = try setupStandardEnvironment()
+        let originalGeneration = "0123456789abcdef0123456789abcdef"
+        let replacementGeneration = "fedcba9876543210fedcba9876543210"
         var snapshot = environment.snapshot
         snapshot.worktrees[0].tmuxSessionName = "editor"
-        snapshot.worktrees[0].generation =
-            "fedcba9876543210fedcba9876543210"
+        snapshot.worktrees[0].generation = originalGeneration
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -1290,15 +1448,18 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "editor",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
-            worktreeGeneration: "0123456789abcdef0123456789abcdef",
+            worktreeGeneration: originalGeneration,
             tmuxAttachMode: .direct
         )
         model.openBorrowedTmuxSession(observed)
         #expect(
             model.activeBorrowedTmuxSelection?.worktreeGeneration
-                == "0123456789abcdef0123456789abcdef"
+                == originalGeneration
         )
 
+        var replacementSnapshot = model.snapshot
+        replacementSnapshot.worktrees[0].generation = replacementGeneration
+        model.snapshot = replacementSnapshot
         var reselection = model.selection
         reselection.select(
             .worktree(environment.worktree.id),
@@ -1308,7 +1469,7 @@ extension WorkspaceTmuxDiscoveryTests {
 
         #expect(
             model.activeBorrowedTmuxSelection?.worktreeGeneration
-                == "fedcba9876543210fedcba9876543210"
+                == replacementGeneration
         )
         #expect(model.activeBorrowedTmuxLaunchMode == .attach)
     }
@@ -1335,11 +1496,15 @@ extension WorkspaceTmuxDiscoveryTests {
         replacementGeneration: String
     ) async throws {
         let environment = try setupStandardEnvironment()
+        let originalGeneration = "0123456789abcdef0123456789abcdef"
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].generation = originalGeneration
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             nativeTmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") }
         )
@@ -1348,7 +1513,7 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
-            worktreeGeneration: "0123456789abcdef0123456789abcdef",
+            worktreeGeneration: originalGeneration,
             tmuxAttachMode: .direct
         )
         let other = WorkspaceTmuxSessionSelection(
@@ -1370,6 +1535,11 @@ extension WorkspaceTmuxDiscoveryTests {
         replacement.name = replacementName
         replacement.socketName = replacementSocket
         replacement.worktreeGeneration = replacementGeneration
+        var replacementSnapshot = model.snapshot
+        replacementSnapshot.worktrees[0].tmuxSessionName = replacementName
+        replacementSnapshot.worktrees[0].tmuxSocketName = replacementSocket
+        replacementSnapshot.worktrees[0].generation = replacementGeneration
+        model.snapshot = replacementSnapshot
         model.openBorrowedTmuxSession(replacement)
         await waitUntilMainActor {
             model.prepareActiveBorrowedTmuxSurface()
@@ -1450,6 +1620,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1492,12 +1664,10 @@ extension WorkspaceTmuxDiscoveryTests {
             configuredHosts.eraseToAnyPublisher(),
             startServices: true
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: sessionName,
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            tmuxAttachMode: .direct
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
 
         await waitUntilMainActor {
@@ -1521,6 +1691,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1557,12 +1729,10 @@ extension WorkspaceTmuxDiscoveryTests {
             configuredHosts.eraseToAnyPublisher(),
             startServices: true
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: sessionName,
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            tmuxAttachMode: .direct
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
 
         await waitUntilMainActor {
@@ -1586,6 +1756,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1604,12 +1776,10 @@ extension WorkspaceTmuxDiscoveryTests {
             },
             kwtRemoteProvisioner: { _ in throw CancellationError() }
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: sessionName,
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            tmuxAttachMode: .direct
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
 
         await #expect(throws: CancellationError.self) {
@@ -1625,23 +1795,30 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("a missing helper during branch listing restores direct attach")
-    func branchStatus127FallsBackToDirectAttach() async throws {
+    @Test("a missing helper uses the captured named tmux endpoint")
+    func missingHelperUsesCapturedNamedEndpoint() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
-        snapshot.hosts[0].tmuxSessions = [
-            TmuxSessionSummary(
-                name: sessionName,
-                managed: true,
-                windows: []
-            ),
-        ]
+        snapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let identity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$7",
+            createdAt: "1721552400"
+        )
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let failure = KwtWorktreeError.commandFailed(
             host: environment.host.name,
             status: 127
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
         let model = try makeModel(
             database: environment.database,
@@ -1651,14 +1828,14 @@ extension WorkspaceTmuxDiscoveryTests {
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },
-            kwtBranchLister: { _, _ in throw failure }
-        )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: sessionName,
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            tmuxAttachMode: .direct
+            kwtBranchLister: { _, _ in throw failure },
+            tmuxSessionIdentityReviewer: { reviewed, _, _ in
+                #expect(reviewed == selection)
+                return ReviewedTmuxSessionIdentity(
+                    identity: identity,
+                    routeIdentity: nil
+                )
+            }
         )
 
         await #expect(throws: failure) {
@@ -1669,7 +1846,62 @@ extension WorkspaceTmuxDiscoveryTests {
 
         let command = try #require(surfaceStore.lastConfiguration?.command)
         #expect(command.contains("'attach-session'"))
+        #expect(command.contains("-L"))
+        #expect(command.contains("kwt-main"))
         #expect(!command.contains("'open'"))
+        #expect(command.contains("if-shell"))
+        #expect(command.contains("#{pid},123"))
+        #expect(command.contains("#{session_id}"))
+        #expect(command.contains("$7"))
+        #expect(command.contains("#{session_created},1721552400"))
+        #expect(command.contains("Ghosthub: tmux session identity changed"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a missing helper fails closed without named endpoint identity")
+    func missingHelperRequiresCapturedNamedEndpointIdentity() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let reviews = Mutex(0)
+        let failure = KwtWorktreeError.commandFailed(
+            host: environment.host.name,
+            status: 127
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            kwtBranchLister: { _, _ in throw failure },
+            tmuxSessionIdentityReviewer: { _, _, _ in
+                reviews.withLock { $0 += 1 }
+                throw TmuxSessionKillError.identityUnavailable(
+                    host: environment.host.name,
+                    session: "kwt-ghosthub-main"
+                )
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
+        )
+
+        await #expect(throws: failure) {
+            try await model.branches(for: environment.project.id)
+        }
+        model.openBorrowedTmuxSession(selection)
+        await waitUntilMainActor { reviews.withLock { $0 } == 1 }
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(surfaceStore.requestCount == 0)
         await model.shutdown()
     }
 
@@ -1731,6 +1963,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1746,12 +1980,10 @@ extension WorkspaceTmuxDiscoveryTests {
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: sessionName,
-            worktreeID: environment.worktree.id,
-            worktreePath: environment.worktree.path,
-            tmuxAttachMode: .direct
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
 
         model.openBorrowedTmuxSession(selection)
@@ -1760,6 +1992,50 @@ extension WorkspaceTmuxDiscoveryTests {
         let command = try #require(surfaceStore.lastConfiguration?.command)
         #expect(command.contains("'open'"))
         #expect(command.contains(environment.worktree.path))
+        #expect(command.contains("'--expected-repository'"))
+        #expect(command.contains(environment.project.scopedKey))
+        #expect(command.contains("'--expected-registration'"))
+        #expect(command.contains("remote-registration"))
+        #expect(command.contains("'--expected-generation'"))
+        #expect(command.contains("0123456789abcdef0123456789abcdef"))
+        #expect(command.contains("'--expected-session'"))
+        #expect(command.contains(sessionName))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("replaced worktree at the same path does not launch kwt open")
+    func replacedWorktreeAtSamePathDoesNotOpen() async throws {
+        let environment = try setupStandardEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].generation =
+            "fedcba9876543210fedcba9876543210"
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPathProvider: {
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+        let stale = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: "kwt-ghosthub-main",
+            worktreeID: environment.worktree.id,
+            workspacePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
+            tmuxAttachMode: .direct
+        )
+
+        model.openBorrowedTmuxSession(stale)
+        await Task.yield()
+
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(surfaceStore.requestCount == 0)
+        await model.shutdown()
     }
 
 }

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -870,8 +870,8 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("a direct worktree reuses its unbound default-server presentation")
-    func directWorktreeReusesUnboundPresentation() async throws {
+    @Test("a direct worktree reuses and closes its unbound presentation")
+    func directWorktreeReusesAndClosesUnboundPresentation() async throws {
         let environment = try setupStandardEnvironment()
         let sessionName = "kwt-ghosthub-main"
         var snapshot = environment.snapshot
@@ -915,6 +915,25 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(model.retainedBorrowedTmuxPresentationCount == 1)
         #expect(surfaceStore.requestCount == 1)
         #expect(model.activeBorrowedTmuxSelection == worktree)
+
+        model.closeBorrowedTmuxSession(worktree)
+
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(surfaceStore.removedKeys.count == 1)
+
+        model.openBorrowedTmuxSession(worktree)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 2
+        }
+        let reopenedHandle = try #require(
+            model.retainedBorrowedTmuxHandle(for: worktree)
+        )
+
+        #expect(reopenedHandle != handle)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        #expect(surfaceStore.requestCount == 2)
+        #expect(surfaceStore.removedKeys.count == 1)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -72,6 +72,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -444,6 +445,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -516,6 +518,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -604,6 +607,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let resolutionStarted = LockedValue(false)
         let releaseResolution = DispatchSemaphore(value: 0)
         defer { releaseResolution.signal() }
@@ -1815,6 +1819,57 @@ extension WorkspaceTmuxDiscoveryTests {
         let command = try #require(surfaceStore.lastConfiguration?.command)
         #expect(command.contains("'open'"))
         #expect(command.contains(environment.worktree.path))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a generationless worktree attaches fenced to its discovered session")
+    func generationlessWorktreeAttachesFencedToDiscoveredSession() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].tmuxSocketName = nil
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation = nil
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: [],
+                serverPID: "123",
+                sessionID: "$7",
+                createdAt: "1721552400"
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            }
+        )
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
+        )
+        #expect(selection.worktreeGeneration == nil)
+
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(!command.contains("'open'"))
+        #expect(command.contains("'attach-session'"))
+        #expect(command.contains("if-shell"))
+        #expect(command.contains("#{pid},123"))
+        #expect(command.contains("$7"))
+        #expect(command.contains("#{session_created},1721552400"))
+        #expect(command.contains("Ghosthub: tmux session identity changed"))
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -769,6 +769,8 @@ extension WorkspaceTmuxDiscoveryTests {
     ) async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -931,6 +933,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func removeProjectProbesEndpointReplacedByActiveScene() async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-current"
         snapshot.worktrees[0].tmuxSocketName = "kwt-current"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1014,6 +1018,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func removeProjectAllowsAbsentProtectedSession() async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1068,6 +1074,8 @@ extension WorkspaceTmuxDiscoveryTests {
                 isDirectory: true
             )
         snapshot.projects[0].rootPath = missingCheckout.path
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-visible"
         snapshot.worktrees[0].tmuxSocketName = "kwt-visible"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1429,6 +1437,8 @@ extension WorkspaceTmuxDiscoveryTests {
     ) async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1558,6 +1568,8 @@ extension WorkspaceTmuxDiscoveryTests {
                 isDirectory: true
             )
         snapshot.projects[0].rootPath = missingCheckout.path
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1716,6 +1728,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func unverifiedProjectRemovalSuppressesRootOpen() async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -1843,6 +1857,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func sceneOpenedDuringQuarantineResolvesInventory() async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2242,6 +2258,8 @@ extension WorkspaceTmuxDiscoveryTests {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
         snapshot.projects[0].scopedKey = "github.com/kenn-io/ghosthub"
+        snapshot.worktrees[0].generation =
+            "fedcba9876543210fedcba9876543210"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2379,6 +2397,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func protectedAttachmentFencesBeforeRendering() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2419,6 +2439,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func protectedAttachmentRetriesAfterMutation() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2477,6 +2499,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func disconnectedProtectedAttachmentWaitsForReconnect() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2536,6 +2560,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func protectedReconnectFencesEstablishment() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2635,6 +2661,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func removeProjectWaitsForProtectedEstablishment() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2714,6 +2742,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func protectedEstablishmentKeepsProbing() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2752,16 +2782,91 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("Default-socket establishment keeps a finite probe schedule")
-    func defaultSocketEstablishmentStopsProbing() async throws {
+    @Test("Direct workspace publishes only its captured endpoint")
+    func directWorkspacePublishesCapturedEndpoint() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
         let worktree = try #require(snapshot.worktrees.first)
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
         )
-        let probes = Counter()
+        let endpointIdentity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$1",
+            createdAt: "456"
+        )
+        let leaseArguments = ["-F", "/tmp/attachment-config"]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: endpointIdentity),
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution(
+                    "/usr/bin/tmux",
+                    version: "tmux 3.3"
+                )
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(arguments: leaseArguments)
+            },
+            tmuxExactSessionProbe: { _ in
+                Issue.record("KWT confirmation must use its launched client")
+                return .success(false)
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                Issue.record("KWT confirmation must keep the attachment route")
+                return endpointIdentity
+            },
+            tmuxRoutedSessionIdentityReader: { captured, _, arguments in
+                #expect(captured == selection)
+                #expect(arguments == leaseArguments)
+                return endpointIdentity
+            },
+            createdSessionDiscoveryDelays: [.milliseconds(1)]
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(surfaceStore.removedKeys.isEmpty)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("Windows direct workspace confirms its captured endpoint")
+    func windowsDirectWorkspacePublishesCapturedEndpoint() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.hosts[0].platform = .windows
+        snapshot.hosts[0].sshDestination = "operator@windows.example.test"
+        snapshot.worktrees[0].path = #"C:\code\ghosthub"#
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "kwt"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let worktree = try #require(snapshot.worktrees.first)
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+        let endpointIdentity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$1",
+            createdAt: "456"
+        )
+        let leaseArguments = ["-F", "NUL"]
+        let capturedEndpointReads = Counter()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
@@ -2769,21 +2874,116 @@ extension WorkspaceTmuxDiscoveryTests {
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in
-                successfulTmuxResolution("/usr/bin/tmux")
+                successfulTmuxResolution(#"C:\Tools\psmux\tmux.exe"#)
             },
-            tmuxSessionDiscovery: { _ in
-                _ = probes.increment()
-                return .success([])
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(arguments: leaseArguments)
+            },
+            tmuxExactSessionProbe: { _ in
+                Issue.record("KWT confirmation must keep the attachment route")
+                return .success(false)
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                Issue.record("KWT confirmation must keep the attachment route")
+                return endpointIdentity
+            },
+            tmuxRoutedSessionIdentityReader: { captured, host, arguments in
+                #expect(captured == selection)
+                #expect(arguments == leaseArguments)
+                guard case let .ssh(info) = host else {
+                    Issue.record("Expected a Windows SSH host")
+                    return endpointIdentity
+                }
+                #expect(info.platform == .windows)
+                _ = capturedEndpointReads.increment()
+                return endpointIdentity
             },
             createdSessionDiscoveryDelays: [.milliseconds(1)]
         )
 
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
-        await waitUntilMainActor { probes.count >= 2 }
+        await waitUntilMainActor {
+            capturedEndpointReads.count >= 1
+        }
         try await Task.sleep(for: .milliseconds(20))
 
-        #expect(probes.count == 2)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(surfaceStore.removedKeys.isEmpty)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("Direct workspace rejects a client attached to another endpoint")
+    func directWorkspaceRejectsUnconfirmedEndpoint() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let worktree = try #require(snapshot.worktrees.first)
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+        let capturedIdentity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$1",
+            createdAt: "456"
+        )
+        let attachedIdentity = TmuxSessionIdentity(
+            serverPID: "999",
+            sessionID: "$8",
+            createdAt: "654"
+        )
+        let capturedEndpointReads = Counter()
+        let leaseArguments = ["-F", "/tmp/attachment-config"]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: attachedIdentity),
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(arguments: leaseArguments)
+            },
+            tmuxExactSessionProbe: { _ in
+                Issue.record("KWT confirmation must use its launched client")
+                return .success(false)
+            },
+            tmuxSessionIdentityReader: { _, _ in
+                Issue.record("KWT confirmation must keep the attachment route")
+                return capturedIdentity
+            },
+            tmuxRoutedSessionIdentityReader: { captured, _, arguments in
+                #expect(captured == selection)
+                #expect(arguments == leaseArguments)
+                _ = capturedEndpointReads.increment()
+                return capturedIdentity
+            },
+            createdSessionDiscoveryDelays: [.milliseconds(1)]
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        await waitUntilMainActor {
+            capturedEndpointReads.count >= 1
+                && surfaceStore.removedKeys.count == 1
+        }
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(capturedEndpointReads.count == 1)
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.activeBorrowedTmuxSelection == nil)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
         await model.shutdown()
     }
 
@@ -2792,6 +2992,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func pathlessRebindReleasesProtectedEstablishmentFence() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected
@@ -2841,6 +3043,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var refreshedWorktree = try #require(
             environment.snapshot.worktrees.first
         )
+        refreshedWorktree.generation =
+            "0123456789abcdef0123456789abcdef"
         refreshedWorktree.tmuxSessionName = "kwt-ghosthub-pr-94"
         refreshedWorktree.tmuxSocketName = "kwt-pr-94"
         refreshedWorktree.tmuxAttachMode = .protected
@@ -2893,6 +3097,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func removeProjectRevalidatesHostAfterProtectedProbe() async throws {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-pr-94"
         snapshot.worktrees[0].tmuxSocketName = "kwt-pr-94"
         snapshot.worktrees[0].tmuxAttachMode = .protected

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -1277,6 +1277,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let previewGrid = TmuxGridSize(columns: 120, rows: 37)
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
@@ -1867,6 +1868,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
         let firstProbe = BlockingGate()
@@ -2452,6 +2454,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
         let firstProbe = BlockingGate()
@@ -2516,6 +2519,7 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         snapshot.worktrees[0].generation =
             "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
         let discoveries = TmuxDiscoveryResultQueue([
@@ -3280,6 +3284,71 @@ extension WorkspaceTmuxDiscoveryTests {
             model.snapshot.host(id: environment.host.id)?
                 .tmuxSessions.contains { $0.name == "created-work" } == true
         )
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("confirmed direct kwt endpoint fences the reconnect attach")
+    func confirmedDirectKwtEndpointFencesReconnect() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].tmuxSessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSocketName = "kwt-main"
+        snapshot.worktrees[0].tmuxAttachMode = .direct
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        let worktree = try #require(snapshot.worktrees.first)
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+        let endpointIdentity = TmuxSessionIdentity(
+            serverPID: "123",
+            sessionID: "$7",
+            createdAt: "1721552400"
+        )
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport
+                .previewPaneSplitter(identity: endpointIdentity),
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution(
+                    "/usr/bin/tmux",
+                    version: "tmux 3.3"
+                )
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(arguments: ["-F", "/tmp/attachment"])
+            },
+            tmuxExactSessionProbe: { _ in .success(true) },
+            tmuxRoutedSessionIdentityReader: { _, _, _ in endpointIdentity },
+            createdSessionDiscoveryDelays: [.milliseconds(1)],
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
+        let openCommand = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(openCommand.contains("'open'"))
+        let initialRequestCount = surfaceStore.requestCount
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            surfaceStore.requestCount > initialRequestCount
+        }
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(!command.contains("'open'"))
+        #expect(command.contains("if-shell"))
+        #expect(command.contains("#{pid},123"))
+        #expect(command.contains("$7"))
+        #expect(command.contains("#{session_created},1721552400"))
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -1275,6 +1275,8 @@ extension WorkspaceTmuxDiscoveryTests {
     func localDisconnectDuringHiddenSizingResumesOnReconnect() async throws {
         let environment = try setupStandardEnvironment()
         var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let previewGrid = TmuxGridSize(columns: 120, rows: 37)
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
@@ -1345,6 +1347,7 @@ extension WorkspaceTmuxDiscoveryTests {
             name: "kwt-ghosthub-main",
             worktreeID: environment.worktree.id,
             worktreePath: environment.worktree.path,
+            worktreeGeneration: "0123456789abcdef0123456789abcdef",
             tmuxAttachMode: .direct
         )
         let other = WorkspaceTmuxSessionSelection(
@@ -1688,6 +1691,8 @@ extension WorkspaceTmuxDiscoveryTests {
         var snapshot = environment.snapshot
         let sessionName = "kwt-ghosthub-main"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1695,6 +1700,9 @@ extension WorkspaceTmuxDiscoveryTests {
                 windows: []
             ),
         ]
+        let firstProbe = BlockingGate()
+        defer { firstProbe.release() }
+        let discoveries = Counter()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
@@ -1702,7 +1710,24 @@ extension WorkspaceTmuxDiscoveryTests {
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
-            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxSessionDiscovery: { _ in
+                switch discoveries.increment() {
+                case 1:
+                    firstProbe.wait()
+                    return .success([])
+                case 2:
+                    return .success([])
+                default:
+                    return .success([
+                        DiscoveredTmuxSession(
+                            name: sessionName,
+                            windowCount: 1,
+                            createdAt: nil,
+                            managed: true
+                        ),
+                    ])
+                }
+            },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1719,7 +1744,9 @@ extension WorkspaceTmuxDiscoveryTests {
                 == true
         )
 
+        await waitUntilMainActor { firstProbe.didStart }
         surfaceStore.surface.closeObservers.values.first?(false, 255)
+        firstProbe.release()
         await waitUntilMainActor {
             surfaceStore.requestCount == 2
                 && model.activeBorrowedTmuxSessionIsConnected
@@ -1741,6 +1768,8 @@ extension WorkspaceTmuxDiscoveryTests {
         let sessionName = "kwt-ghosthub-main"
         let otherSessionName = "kwt-ghosthub-other"
         snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.hosts[0].tmuxSessions = [
             TmuxSessionSummary(
                 name: sessionName,
@@ -1835,17 +1864,40 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("retryable surface failure relaunches an absent workspace")
     func retryableSurfaceFailureRelaunchesAbsentWorkspace() async throws {
         let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
+        let firstProbe = BlockingGate()
+        defer { firstProbe.release() }
+        let discoveries = Counter()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },
-            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxSessionDiscovery: { _ in
+                switch discoveries.increment() {
+                case 1:
+                    firstProbe.wait()
+                    return .success([])
+                case 2, 3:
+                    return .success([])
+                default:
+                    return .success([
+                        DiscoveredTmuxSession(
+                            name: sessionName,
+                            windowCount: 1,
+                            createdAt: nil,
+                            managed: true
+                        ),
+                    ])
+                }
+            },
             tmuxReconnectIntervals: [.seconds(10)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -1857,10 +1909,12 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { firstProbe.didStart }
 
         surfaceStore.surface.launchError = SceneSurfaceLaunchError.rejected
         surfaceStore.surface.launchFailureIsRetryable = true
         surfaceStore.surface.closeObservers.values.first?(false, 255)
+        firstProbe.release()
         await waitUntilMainActor {
             model.activeBorrowedTmuxRecoveryState?.isReconnecting == true
         }
@@ -2395,15 +2449,38 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("interrupted establishment clears provisional ended state")
     func interruptedEstablishmentClearsEndedState() async throws {
         let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
+        let firstProbe = BlockingGate()
+        defer { firstProbe.release() }
+        let discoveries = Counter()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
-            tmuxSessionDiscovery: { _ in .success([]) },
+            tmuxSessionDiscovery: { _ in
+                switch discoveries.increment() {
+                case 1:
+                    firstProbe.wait()
+                    return .success([])
+                case 2:
+                    return .success([])
+                default:
+                    return .success([
+                        DiscoveredTmuxSession(
+                            name: sessionName,
+                            windowCount: 1,
+                            createdAt: nil,
+                            managed: true
+                        ),
+                    ])
+                }
+            },
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
         let selection = WorkspaceTmuxSessionSelection(
@@ -2415,8 +2492,10 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor { firstProbe.didStart }
 
         surfaceStore.surface.closeObservers.values.first?(false, 255)
+        firstProbe.release()
         await waitUntilMainActor {
             surfaceStore.requestCount == 2
                 && model.activeBorrowedTmuxSessionIsConnected
@@ -2434,6 +2513,9 @@ extension WorkspaceTmuxDiscoveryTests {
     @Test("recovery continues when discovery confirms establishment")
     func discoveryConfirmationContinuesEstablishmentRecovery() async throws {
         let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let sessionName = "kwt-ghosthub-main"
         let discoveries = TmuxDiscoveryResultQueue([
@@ -2450,7 +2532,7 @@ extension WorkspaceTmuxDiscoveryTests {
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
-            snapshot: environment.snapshot,
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
@@ -2592,7 +2674,15 @@ extension WorkspaceTmuxDiscoveryTests {
     @MainActor
     @Test("protected kwt interruption retries establishment")
     func protectedKwtInterruptionRetriesEstablishment() async throws {
-        let environment = try setupRemoteTmuxEnvironment()
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        snapshot.worktrees[0].path = "/srv/ghosthub-pr-42"
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        snapshot.worktrees[0].tmuxSessionName = "protected-work"
+        snapshot.worktrees[0].tmuxSocketName =
+            "kwt-pr-0123456789abcdef"
+        snapshot.worktrees[0].tmuxAttachMode = .protected
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let probes = TmuxExactProbeResultQueue([
             .success(false),
@@ -2601,20 +2691,18 @@ extension WorkspaceTmuxDiscoveryTests {
         ])
         let model = try makeModel(
             database: environment.database,
-            localHostID: environment.localHostID,
-            snapshot: environment.snapshot,
+            localHostID: UUID(),
+            snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
             remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") },
             tmuxExactSessionProbe: { _ in probes.removeFirst() },
             createdSessionDiscoveryDelays: [.seconds(10)],
             tmuxReconnectIntervals: [.milliseconds(1)]
         )
-        let selection = WorkspaceTmuxSessionSelection(
-            hostID: environment.remoteHost.id,
-            name: "protected-work",
-            worktreePath: "/srv/ghosthub-pr-42",
-            socketName: "kwt-pr-0123456789abcdef",
-            tmuxAttachMode: .protected
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(
+                for: snapshot.worktrees[0]
+            )
         )
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
@@ -2673,6 +2761,8 @@ extension WorkspaceTmuxDiscoveryTests {
         let environment = try setupRemoteEnvironment()
         var snapshot = environment.snapshot
         let worktreeIndex = try #require(snapshot.worktrees.indices.first)
+        snapshot.worktrees[worktreeIndex].generation =
+            "0123456789abcdef0123456789abcdef"
         snapshot.worktrees[worktreeIndex].tmuxSessionName =
             "kwt-ghosthub-pr-94"
         snapshot.worktrees[worktreeIndex].tmuxSocketName = "kwt-pr-94"

--- a/Tests/App/WorkspaceWindowStateTests.swift
+++ b/Tests/App/WorkspaceWindowStateTests.swift
@@ -326,6 +326,47 @@ struct WorkspaceWindowStateTests {
         ) == state)
     }
 
+    @Test("legacy KWT descriptors adopt the current owner attachment mode")
+    func legacyKwtDescriptorAdoptsCurrentOwnerAttachmentMode() throws {
+        let fixture = RestorationFixture.local(
+            sessionName: "editor",
+            socketName: "kwt-pr-0123456789abcdef",
+            tmuxAttachMode: .protected
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        let encoded = try JSONEncoder().encode(state)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: encoded)
+                as? [String: Any]
+        )
+        var tmux = try #require(object["tmux"] as? [String: Any])
+        tmux.removeValue(forKey: "tmuxAttachMode")
+        object["tmux"] = tmux
+
+        let legacy = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(
+            WorkspaceWindowState.self,
+            from: legacy
+        )
+
+        guard case let .needsExactTmuxProbe(_, selection) =
+            WorkspaceWindowRestorationResolver.resolve(
+                decoded,
+                in: fixture.snapshot
+            )
+        else {
+            Issue.record("legacy restoration must use the current KWT owner")
+            return
+        }
+        #expect(selection.socketName == "kwt-pr-0123456789abcdef")
+        #expect(selection.tmuxAttachMode == .protected)
+    }
+
     @Test("Herdr descriptor round-trips through scene state")
     func herdrDescriptorRoundTrips() throws {
         let state = WorkspaceWindowState(
@@ -737,6 +778,7 @@ struct WorkspaceWindowStateTests {
         )
         #expect(state.tmux?.sessionName == "kwt-ghosthub-main")
         #expect(state.tmux?.socketName == "kwt-pr-0123456789abcdef")
+        #expect(state.tmux?.tmuxAttachMode == .protected)
         #expect(
             state.tmux?.owner == .worktree(
                 generation: RestorationFixture.worktreeGeneration
@@ -1166,6 +1208,56 @@ struct WorkspaceWindowStateTests {
             Issue.record("named-socket restoration must stay pending")
             return
         }
+    }
+
+    @Test("a direct named endpoint requires an exact restoration probe")
+    func directNamedEndpointRequiresExactProbe() {
+        let fixture = RestorationFixture.local(
+            sessionName: "editor",
+            socketName: "kwt",
+            tmuxAttachMode: .direct
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        var changed = fixture.snapshot
+        changed.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(name: "editor", managed: false, windows: []),
+        ]
+
+        guard case let .needsExactTmuxProbe(_, selection) =
+            WorkspaceWindowRestorationResolver.resolve(state, in: changed)
+        else {
+            Issue.record("direct named restoration must probe its exact socket")
+            return
+        }
+        #expect(selection.socketName == "kwt")
+        #expect(selection.tmuxAttachMode == .direct)
+    }
+
+    @Test("restoration rejects a changed tmux attachment mode")
+    func changedTmuxAttachmentModeStaysPending() {
+        let fixture = RestorationFixture.local(
+            sessionName: "editor",
+            socketName: "kwt-pr-0123456789abcdef",
+            tmuxAttachMode: .direct
+        )
+        let state = WorkspaceWindowState.capture(
+            windowID: UUID(),
+            selection: fixture.selection,
+            activeTmux: fixture.tmuxSelection,
+            snapshot: fixture.snapshot
+        )
+        var changed = fixture.snapshot
+        changed.worktrees[0].tmuxAttachMode = .protected
+
+        #expect(
+            WorkspaceWindowRestorationResolver.resolve(state, in: changed)
+                == .pending(selection: fixture.selection)
+        )
     }
 
     @Test(

--- a/Tests/App/WorkspaceWorktreeRemovalPreflightTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalPreflightTests.swift
@@ -433,6 +433,44 @@ extension WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
+    @Test(
+        "an unresolved protected endpoint blocks removal before tmux review"
+    )
+    func unresolvedProtectedEndpointAbortsPreparation() async throws {
+        let fixture = try removalFixture(
+            socketName: nil,
+            tmuxAttachMode: .protected,
+            sessionBackend: .localTmux,
+            runningSession: true
+        )
+        let reviews = LockedValue(0)
+        let model = try makeModel(
+            database: fixture.environment.database,
+            localHostID: fixture.environment.host.id,
+            snapshot: fixture.snapshot,
+            tmuxSessionIdentityReviewer: { _, _, _ in
+                reviews.withLock { $0 += 1 }
+                return ReviewedTmuxSessionIdentity(
+                    identity: TmuxSessionIdentity(
+                        serverPID: "31415",
+                        sessionID: "$8",
+                        createdAt: "1721552400"
+                    ),
+                    routeIdentity: nil
+                )
+            }
+        )
+
+        await #expect(
+            throws: KwtWorktreeError.removalIdentityUnavailable
+        ) {
+            try await model.prepareWorktreeRemoval(fixture.removable.id)
+        }
+        #expect(reviews.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("kwt availability is checked before terminating a session")
     func unavailableKwtDoesNotKillSession() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceWorktreeRemovalReconciliationTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalReconciliationTests.swift
@@ -279,7 +279,7 @@ extension WorkspaceWorktreeRemovalTests {
             }
         )
         inventoryAfterMove.projects[0]
-            .worktrees[recordIndex].tmuxSocketName = nil
+            .worktrees[recordIndex].tmuxSocketName = "moved-protected"
         let movedInventory = inventoryAfterMove
         let probes = LockedValue<[String?]>([])
         let removals = LockedValue(0)
@@ -309,20 +309,15 @@ extension WorkspaceWorktreeRemovalTests {
         }
 
         #expect(updatedRequest.worktree.path == moved.path)
-        #expect(updatedRequest.worktree.tmuxSocketName == nil)
-        #expect(probes.load() == ["protected", nil])
+        #expect(updatedRequest.worktree.tmuxSocketName == "moved-protected")
+        #expect(probes.load() == ["protected", "moved-protected"])
         #expect(removals.load() == 0)
         await model.shutdown()
     }
 
     @MainActor
-    @Test(
-        "a replacement claiming the confirmed tmux endpoint requires confirmation",
-        arguments: ["protected", nil] as [String?]
-    )
-    func replacementClaimingTmuxEndpointRequiresConfirmation(
-        replacementSocket: String?
-    ) async throws {
+    @Test("a replacement claiming the confirmed tmux endpoint requires confirmation")
+    func replacementClaimingTmuxEndpointRequiresConfirmation() async throws {
         let fixture = try removalFixture(
             path: "/tmp/project-a-feature",
             sessionName: "kwt-project-a-feature",
@@ -342,7 +337,7 @@ extension WorkspaceWorktreeRemovalTests {
             generation: "fedcba9876543210fedcba9876543210"
         )
         replacement.tmuxSessionName = removable.tmuxSessionName
-        replacement.tmuxSocketName = replacementSocket
+        replacement.tmuxSocketName = "protected"
         replacement.tmuxAttachMode = .protected
         let replacementInventory = inventory(
             environment,
@@ -380,7 +375,67 @@ extension WorkspaceWorktreeRemovalTests {
 
         #expect(updatedRequest.worktree.path == replacement.path)
         #expect(updatedRequest.worktree.generation == replacement.generation)
-        #expect(updatedRequest.worktree.tmuxSocketName == replacementSocket)
+        #expect(updatedRequest.worktree.tmuxSocketName == "protected")
+        #expect(kills.load() == 0)
+        #expect(removals.load() == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a replacement without a protected endpoint is rejected")
+    func replacementWithoutProtectedEndpointIsRejected() async throws {
+        let fixture = try removalFixture(
+            path: "/tmp/project-a-feature",
+            sessionName: "kwt-project-a-feature",
+            socketName: "protected",
+            tmuxAttachMode: .protected
+        )
+        let environment = fixture.environment
+        let removable = fixture.removable
+        let snapshot = fixture.snapshot
+        var replacement = WorktreeSummary.fixture(
+            hostID: removable.hostID,
+            projectID: removable.projectID,
+            scopedKey: "/tmp/project-a-replacement",
+            name: removable.name,
+            path: "/tmp/project-a-replacement",
+            branch: removable.branch,
+            generation: "fedcba9876543210fedcba9876543210"
+        )
+        replacement.tmuxSessionName = removable.tmuxSessionName
+        replacement.tmuxSocketName = nil
+        replacement.tmuxAttachMode = .protected
+        let replacementInventory = inventory(
+            environment,
+            including: replacement,
+            generation: replacement.generation
+        )
+        let removals = LockedValue(0)
+        let kills = LockedValue(0)
+        let identity = TmuxSessionIdentity(
+            serverPID: "31415",
+            sessionID: "$8",
+            createdAt: "1721552400"
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            kwtInventoryLoader: { _ in replacementInventory },
+            kwtWorktreeRemover: { _, _, _, _, _ in
+                removals.withLock { $0 += 1 }
+            },
+            tmuxSessionKiller: { _, _, _ in
+                kills.withLock { $0 += 1 }
+            },
+            tmuxSessionIdentityReader: { _, _ in identity }
+        )
+
+        let request = try await model.prepareWorktreeRemoval(removable.id)
+        await #expect(throws: KwtWorktreeError.removalIdentityUnavailable) {
+            try await model.resolveWorktreeRemoval(request)
+        }
+
         #expect(kills.load() == 0)
         #expect(removals.load() == 0)
         await model.shutdown()
@@ -692,8 +747,8 @@ extension WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
-    @Test("an omitted preflight socket requires renewed confirmation")
-    func omittedPreflightSocketRequiresConfirmation() async throws {
+    @Test("an omitted protected preflight socket is rejected")
+    func omittedProtectedPreflightSocketIsRejected() async throws {
         let fixture = try removalFixture(
             path: "/tmp/project-a-feature",
             sessionName: "kwt-project-a-feature",
@@ -712,6 +767,7 @@ extension WorkspaceWorktreeRemovalTests {
         preflight.projects[0].worktrees[recordIndex].tmuxSocketName = nil
         let omissionPreflight = preflight
         let removals = LockedValue(0)
+        let probes = LockedValue<[String?]>([])
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -721,6 +777,7 @@ extension WorkspaceWorktreeRemovalTests {
                 removals.withLock { $0 += 1 }
             },
             tmuxSessionIdentityReader: { selection, host in
+                probes.withLock { $0.append(selection.socketName) }
                 throw TmuxSessionKillError.sessionNotRunning(
                     host: host.displayName,
                     session: selection.name
@@ -729,15 +786,11 @@ extension WorkspaceWorktreeRemovalTests {
         )
 
         let request = try await model.prepareWorktreeRemoval(removable.id)
-        let result = try await model.resolveWorktreeRemoval(request)
-
-        guard case let .confirmationRequired(updatedRequest) = result else {
-            Issue.record("Unresolved endpoint should require confirmation")
-            await model.shutdown()
-            return
+        await #expect(throws: KwtWorktreeError.removalIdentityUnavailable) {
+            try await model.resolveWorktreeRemoval(request)
         }
-        #expect(updatedRequest.worktree.tmuxAttachMode == .protected)
-        #expect(updatedRequest.worktree.tmuxSocketName == nil)
+
+        #expect(probes.load() == ["protected"])
         #expect(removals.load() == 0)
         await model.shutdown()
     }

--- a/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalRecoveryTests.swift
@@ -1583,6 +1583,11 @@ extension WorkspaceWorktreeRemovalTests {
         let interactiveSizingStarted = LockedValue(false)
         let releaseInteractiveSizing = DispatchSemaphore(value: 0)
         defer { releaseInteractiveSizing.signal() }
+        let sessionIdentity = TmuxSessionIdentity(
+            serverPID: "101",
+            sessionID: "$1",
+            createdAt: "1000"
+        )
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
@@ -1614,12 +1619,20 @@ extension WorkspaceWorktreeRemovalTests {
                     status: 1
                 )
             },
-            tmuxSessionIdentityReader: { selection, host in
-                throw TmuxSessionKillError.sessionNotRunning(
-                    host: host.displayName,
-                    session: selection.name
-                )
+            tmuxSessionDiscovery: { _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "kwt-ghosthub-feature",
+                        windowCount: 1,
+                        serverPID: sessionIdentity.serverPID,
+                        sessionID: sessionIdentity.sessionID,
+                        createdAt: sessionIdentity.createdAt,
+                        managed: true
+                    ),
+                ])
             },
+            tmuxSessionKiller: { _, _, _ in },
+            tmuxSessionIdentityReader: { _, _ in sessionIdentity },
             sessionPreviewCoordinator: TmuxSessionPreviewCoordinator(mode: .off)
         )
         let selection = try #require(
@@ -1706,14 +1719,13 @@ extension WorkspaceWorktreeRemovalTests {
     }
 
     @MainActor
-    @Test("failed removal never restores a socketless protected client hidden")
-    func failedRemovalLeavesSocketlessProtectedClientExplicit() async throws {
+    @Test("a socketless protected client cannot start")
+    func socketlessProtectedClientCannotStart() async throws {
         let environment = try setupRemoteEnvironment()
         let removable = protectedRemovableWorktree(
             environment,
             socketName: nil
         )
-        let sessionName = try #require(removable.tmuxSessionName)
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let mutations = WorktreeMutationCoordinator()
         let model = try makeProtectedRemovalModel(
@@ -1722,53 +1734,19 @@ extension WorkspaceWorktreeRemovalTests {
             surfaceStore: surfaceStore,
             mutations: mutations,
             tmuxExactSessionProbe: { _ in .success(false) },
-            tmuxSessionDiscovery: { _ in
-                .success([
-                    DiscoveredTmuxSession(
-                        name: sessionName,
-                        windowCount: 1,
-                        createdAt: nil,
-                        managed: true
-                    ),
-                ])
-            }
+            tmuxSessionDiscovery: { _ in .success([]) }
         )
         let selection = try #require(
             WorkspaceSidebarModel.tmuxSessionSelection(for: removable)
         )
         #expect(selection.socketName == nil)
-        let other = WorkspaceTmuxSessionSelection(
-            hostID: environment.host.id,
-            name: "other"
-        )
-        try await openProtectedThenOther(
-            model,
-            store: surfaceStore,
-            mutations: mutations,
-            selection: selection,
-            other: other,
-            expectedPresentationCount: 1
-        )
-
-        let request = try await model.prepareWorktreeRemoval(removable.id)
-        await #expect(throws: KwtWorktreeError.self) {
-            try await model.removeWorktree(request)
-        }
+        model.openBorrowedTmuxSession(selection)
         try await Task.sleep(for: .milliseconds(100))
 
-        #expect(surfaceStore.requestCount == 2)
+        #expect(surfaceStore.requestCount == 0)
         #expect(model.retainedBorrowedTmuxHandle(for: selection) == nil)
-        #expect(model.retainedBorrowedTmuxPresentationCount == 1)
-        #expect(model.activeBorrowedTmuxSelection == other)
-
-        model.openBorrowedTmuxSession(selection)
-        await waitUntilMainActor {
-            model.prepareActiveBorrowedTmuxSurface()
-            return surfaceStore.requestCount == 3
-        }
-        let reopened = try #require(surfaceStore.lastConfiguration?.command)
-        #expect(reopened.contains("ghosthub_kwt_path"))
-        #expect(!reopened.contains("attach-session"))
+        #expect(model.retainedBorrowedTmuxPresentationCount == 0)
+        #expect(model.activeBorrowedTmuxSelection == nil)
         await model.shutdown()
     }
 
@@ -1778,7 +1756,7 @@ extension WorkspaceWorktreeRemovalTests {
         let environment = try setupRemoteEnvironment()
         let removable = protectedRemovableWorktree(
             environment,
-            socketName: nil
+            socketName: "kwt-pr-94"
         )
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let mutations = WorktreeMutationCoordinator()
@@ -1797,6 +1775,7 @@ extension WorkspaceWorktreeRemovalTests {
         let inactiveSelection = WorkspaceTmuxSessionSelection(
             hostID: selection.hostID,
             name: selection.name,
+            socketName: selection.socketName,
             tmuxAttachMode: .protected
         )
         let other = WorkspaceTmuxSessionSelection(

--- a/Tests/App/WorkspaceWorktreeRemovalTestSupport.swift
+++ b/Tests/App/WorkspaceWorktreeRemovalTestSupport.swift
@@ -110,7 +110,9 @@ func inventory(
                 repository: environment.project.scopedKey,
                 name: environment.project.name,
                 path: environment.project.rootPath,
-                lastTouched: nil
+                lastTouched: nil,
+                registrationFingerprint:
+                environment.snapshot.projects[0].registrationFingerprint
             ),
             worktrees: worktrees,
             warning: nil
@@ -128,7 +130,9 @@ func inventory(
                 repository: environment.project.scopedKey,
                 name: environment.project.name,
                 path: environment.project.rootPath,
-                lastTouched: nil
+                lastTouched: nil,
+                registrationFingerprint:
+                environment.snapshot.projects[0].registrationFingerprint
             ),
             worktrees: [
                 KwtWorktreeRecord(

--- a/Tests/Tmux/TmuxAttachmentInfoTests.swift
+++ b/Tests/Tmux/TmuxAttachmentInfoTests.swift
@@ -7,6 +7,25 @@ import Testing
 
 @Suite("Native tmux attachment")
 struct TmuxAttachmentInfoTests {
+    private static func protectedIdentity(
+        path: String = "/worktrees/pr-32",
+        socketName: String = "kwt-pr-0123456789abcdef"
+    ) -> KwtProtectedWorktreeOpenIdentity {
+        guard let identity = KwtProtectedWorktreeOpenIdentity(
+            path: path,
+            projectPath: "/repos/ghosthub",
+            repository: "github.com/kenn-io/ghosthub",
+            registrationFingerprint: "registration-123",
+            generation: "0123456789abcdef0123456789abcdef",
+            sessionName: "pr-32",
+            socketName: socketName,
+            tmuxAttachMode: "protected"
+        ) else {
+            fatalError("valid protected KWT identity fixture")
+        }
+        return identity
+    }
+
     @Test("preview attachments do not participate in tmux window sizing")
     func previewAttachmentsIgnoreClientSize() {
         let command = TmuxAttachmentInfo(
@@ -338,6 +357,7 @@ struct TmuxAttachmentInfoTests {
             sessionName: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
+            kwtProtectedWorktreeIdentity: Self.protectedIdentity(),
             protectedWorkspacePath: "/worktrees/pr-32",
             presentationStyle: TmuxPresentationStyle(
                 foreground: "#3B4851",
@@ -360,6 +380,11 @@ struct TmuxAttachmentInfoTests {
         if let kwtPosition, let stylePosition {
             #expect(kwtPosition < stylePosition)
         }
+        #expect(command.contains("--expected-repository"))
+        #expect(command.contains("--expected-registration"))
+        #expect(command.contains("--expected-generation"))
+        #expect(command.contains("--expected-session"))
+        #expect(command.contains("--expected-socket"))
     }
 
     @Test("an unresolved tmux name contributes no PATH entry")
@@ -368,6 +393,7 @@ struct TmuxAttachmentInfoTests {
             sessionName: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
+            kwtProtectedWorktreeIdentity: Self.protectedIdentity(),
             protectedWorkspacePath: "/worktrees/pr-32"
         ).attachCommand(
             tmuxPath: "tmux",
@@ -388,11 +414,19 @@ struct TmuxAttachmentInfoTests {
     }
 
     @Test("ordinary local worktree attaches through kwt without a handoff")
-    func localWorktreeAttachesThroughKwt() {
+    func localWorktreeAttachesThroughKwt() throws {
+        let identity = try #require(KwtWorktreeOpenIdentity(
+            repository: "github.com/example/widget",
+            registrationFingerprint: "registration-fingerprint",
+            generation: "0123456789abcdef0123456789abcdef",
+            sessionName: "kwt-widget-feature",
+            tmuxAttachMode: "direct"
+        ))
         let command = TmuxAttachmentInfo(
             sessionName: "kwt-widget-feature",
             host: .local,
-            workspacePath: "/worktrees/widget's feature"
+            workspacePath: "/worktrees/widget's feature",
+            kwtWorktreeIdentity: identity
         ).attachCommand(
             tmuxPath: "/opt/homebrew/bin/tmux",
             kwtPath: "/Applications/Ghosthub.app/Contents/Helpers/kwt"
@@ -403,9 +437,28 @@ struct TmuxAttachmentInfoTests {
         ))
         #expect(command.contains("open"))
         #expect(command.contains("/worktrees/widget"))
+        #expect(command.contains("--expected-repository"))
+        #expect(command.contains("github.com/example/widget"))
+        #expect(command.contains("--expected-registration"))
+        #expect(command.contains("registration-fingerprint"))
+        #expect(command.contains("--expected-generation"))
+        #expect(command.contains("0123456789abcdef0123456789abcdef"))
+        #expect(command.contains("--expected-session"))
+        #expect(command.contains("kwt-widget-feature"))
         #expect(command.contains("exec"))
         #expect(!command.contains("--start-session"))
         #expect(!command.contains("attach-session"))
+    }
+
+    @Test("guarded worktree open accepts only direct attachment mode")
+    func guardedWorktreeOpenRequiresDirectMode() {
+        #expect(KwtWorktreeOpenIdentity(
+            repository: "github.com/example/widget",
+            registrationFingerprint: "registration-fingerprint",
+            generation: "0123456789abcdef0123456789abcdef",
+            sessionName: "kwt-widget-feature",
+            tmuxAttachMode: "protected"
+        ) == nil)
     }
 
     @Test("existing local worktrees receive built-in theme defaults")
@@ -704,6 +757,7 @@ struct TmuxAttachmentInfoTests {
             sessionName: "pr-32",
             host: .local,
             socketName: "kwt-pr-0123456789abcdef",
+            kwtProtectedWorktreeIdentity: Self.protectedIdentity(),
             protectedWorkspacePath: "/worktrees/pr-32",
             presentationStyle: TmuxPresentationStyle(
                 foreground: "#3B4851",
@@ -837,17 +891,19 @@ struct TmuxAttachmentInfoTests {
         #expect(!script.contains("‘"))
     }
 
-    @Test("Windows worktrees run one kwt establishment attempt")
-    func windowsRemoteWorkspaceAttachCommand() throws {
+    @Test("Windows named-server directories run one KWT establishment attempt")
+    func windowsNamedServerDirectoryAttachCommand() throws {
         let command = TmuxAttachmentInfo(
             sessionName: "release work",
             host: .ssh(SSHHostInfo(
-                user: "wesm",
-                hostname: "arm-builder",
+                user: "user-a",
+                hostname: "builder.example.test",
                 port: nil,
                 platform: .windows
             )),
-            workspacePath: #"C:\code\release work"#
+            socketName: "kwt",
+            workspacePath: #"C:\code\release work"#,
+            kwtExpectedSessionName: "release work"
         ).attachCommand(
             tmuxPath: #"C:\Program Files\psmux\tmux.exe"#,
             windowsKwtRelativePath:
@@ -865,12 +921,66 @@ struct TmuxAttachmentInfoTests {
         ))
         #expect(!script.contains("Get-Command kwt.exe"))
         #expect(script.contains(
-            "& $ghosthubKwt 'open' "
+            "& $ghosthubKwt "
+                + powerShellEncodedArgument("open") + " "
                 + powerShellEncodedArgument(#"C:\code\release work"#)
         ))
-        #expect(!script.contains("has-session"))
-        #expect(!script.contains("attach-session"))
+        #expect(script.contains("'--start-session' '--json'"))
+        #expect(script.contains(powerShellEncodedArgument(
+            "--expected-session"
+        )))
+        #expect(script.contains("ConvertFrom-Json"))
+        #expect(script.contains(
+            powerShellEncodedArgument("release work")
+        ))
+        #expect(script.contains(powerShellEncodedArgument("kwt")))
+        for argument in [
+            "-L",
+            "kwt",
+            "attach-session",
+            "-E",
+            "-t",
+            "=release work",
+        ] {
+            #expect(script.contains(powerShellEncodedArgument(argument)))
+        }
         #expect(!script.contains("exec /bin/sh"))
+    }
+
+    @Test("Windows default-server directories validate the KWT endpoint")
+    func windowsDefaultServerDirectoryValidatesEndpoint() throws {
+        let command = TmuxAttachmentInfo(
+            sessionName: "release work",
+            host: .ssh(SSHHostInfo(
+                user: "user-a",
+                hostname: "builder.example.test",
+                port: nil,
+                platform: .windows
+            )),
+            workspacePath: #"C:\code\release work"#,
+            kwtExpectedSessionName: "release work"
+        ).attachCommand(
+            tmuxPath: #"C:\Program Files\psmux\tmux.exe"#,
+            windowsKwtRelativePath:
+            #".ghosthub\helpers\kwt\0123456789012345678901234567890123456789\kwt.exe"#
+        )
+
+        let script = try Self.decodedPowerShellScript(from: command)
+        #expect(script.contains(powerShellEncodedArgument(
+            "--expected-session"
+        )))
+        #expect(script.contains("'--start-session' '--json'"))
+        #expect(script.contains("ConvertFrom-Json"))
+        #expect(script.contains("tmux_socket_name"))
+        for argument in [
+            "attach-session",
+            "-E",
+            "-t",
+            "=release work",
+        ] {
+            #expect(script.contains(powerShellEncodedArgument(argument)))
+        }
+        #expect(!script.contains(powerShellEncodedArgument("-L")))
     }
 
     @Test("isolated remote attachment targets the returned tmux socket")
@@ -881,6 +991,7 @@ struct TmuxAttachmentInfoTests {
                 user: "wesm", hostname: "build-box", port: nil
             )),
             socketName: "kwt-pr-0123456789abcdef",
+            kwtProtectedWorktreeIdentity: Self.protectedIdentity(),
             protectedWorkspacePath: "/worktrees/pr-32",
             presentationStyle: TmuxPresentationStyle(
                 foreground: "#3B4851",
@@ -934,6 +1045,19 @@ struct TmuxAttachmentInfoTests {
         #expect(command.contains("=pr-32"))
         #expect(!command.contains("ghosthub_kwt_path"))
         #expect(!command.contains("/worktrees/pr-32"))
+    }
+
+    @Test("unresolved protected attachment never uses the default server")
+    func unresolvedProtectedAttachOnlyCommand() {
+        let command = TmuxAttachmentInfo(
+            sessionName: "pr-32",
+            host: .local,
+            protectedWorkspacePath: "/worktrees/pr-32",
+            launchMode: .attachOnly
+        ).attachCommand(tmuxPath: "/usr/bin/tmux")
+
+        #expect(command.contains("protected tmux endpoint is unavailable"))
+        #expect(!command.contains("attach-session"))
     }
 
     @Test("confirmed protected Windows session reattaches through psmux only")

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -887,6 +887,99 @@ struct WorkspaceSidebarModelTests {
         )
     }
 
+    @Test("direct named directory workspaces use endpoint liveness")
+    func directNamedDirectoryWorkspaceUsesEndpointLiveness() {
+        let hostID = UUID()
+        let workspace = DirectoryWorkspaceSummary(
+            id: UUID(),
+            hostID: hostID,
+            name: "jibot",
+            path: "/workspaces/jibot",
+            tmuxSessionName: "kwt-workspace-dir-jibot-abc",
+            tmuxSocketName: "kwt",
+            tmuxAttachMode: .direct,
+            sessionLive: true
+        )
+        let snapshot = WorkspaceSnapshot(
+            hosts: [.fixture(id: hostID)],
+            projects: [],
+            worktrees: [],
+            directoryWorkspaces: [workspace]
+        )
+
+        let row = WorkspaceSidebarModel.sections(in: snapshot)[0]
+            .directoryWorkspaceRows[0]
+        #expect(row.sessionIsRunning)
+
+        let selection = WorkspaceSidebarModel.tmuxSessionSelection(
+            for: workspace
+        )
+        #expect(WorkspaceSidebarModel.canRequestKill(selection, in: snapshot))
+        var staleSelection = selection
+        staleSelection.workspacePath = "/workspaces/replacement"
+        #expect(!WorkspaceSidebarModel.canRequestKill(
+            staleSelection,
+            in: snapshot
+        ))
+
+        var stopped = snapshot
+        stopped.directoryWorkspaces[0].sessionLive = false
+        stopped.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: workspace.tmuxSessionName,
+                managed: false,
+                windows: [],
+                serverPID: "123",
+                sessionID: "$1",
+                createdAt: "456"
+            ),
+        ]
+        let stoppedRow = WorkspaceSidebarModel.sections(in: stopped)[0]
+            .directoryWorkspaceRows[0]
+        #expect(!stoppedRow.sessionIsRunning)
+        #expect(!WorkspaceSidebarModel.canRequestKill(selection, in: stopped))
+    }
+
+    @Test("direct named worktree kill uses exact KWT ownership")
+    func directNamedWorktreeKillUsesExactOwnership() throws {
+        let hostID = UUID()
+        let projectID = UUID()
+        var worktree = WorktreeSummary.fixture(
+            hostID: hostID,
+            projectID: projectID,
+            name: "jibot",
+            path: "/worktrees/jibot",
+            branch: "main"
+        )
+        worktree.generation = "0123456789abcdef0123456789abcdef"
+        worktree.tmuxSessionName = "kwt-worktree-jibot-abc"
+        worktree.tmuxSocketName = "kwt"
+        worktree.tmuxAttachMode = .direct
+        var snapshot = WorkspaceSnapshot.fixture(
+            hosts: [.fixture(id: hostID)],
+            projects: [.fixture(id: projectID, hostID: hostID)],
+            worktrees: [worktree]
+        )
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: "kwt-worktree-jibot-abc",
+                managed: false,
+                windows: [],
+                serverPID: "123",
+                sessionID: "$1",
+                createdAt: "456"
+            ),
+        ]
+        let selection = try #require(
+            WorkspaceSidebarModel.tmuxSessionSelection(for: worktree)
+        )
+
+        #expect(WorkspaceSidebarModel.canRequestKill(selection, in: snapshot))
+
+        snapshot.worktrees = []
+        #expect(!WorkspaceSidebarModel.canRequestKill(selection, in: snapshot))
+    }
+
     @Test("hidden patterns remove only standalone tmux session rows")
     func hiddenPatternsRemoveStandaloneSessions() {
         let hostID = UUID()

--- a/Tests/UI/WorkspaceSidebarViewTests.swift
+++ b/Tests/UI/WorkspaceSidebarViewTests.swift
@@ -363,6 +363,37 @@ struct WorkspaceSidebarViewTests {
         ))
     }
 
+    @MainActor
+    @Test("a direct worktree row matches its active unbound endpoint")
+    func directWorktreeRowMatchesActiveUnboundEndpoint() {
+        let hostID = UUID()
+        let worktreeID = UUID()
+        let row = WorkspaceSidebarRow(
+            target: .worktree(worktreeID),
+            icon: .worktree,
+            title: "Feature"
+        )
+        let worktree = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "kwt-project-feature",
+            worktreeID: worktreeID,
+            workspacePath: "/repo/feature",
+            tmuxAttachMode: .direct
+        )
+        let active = WorkspaceTmuxSessionSelection(
+            hostID: hostID,
+            name: "kwt-project-feature"
+        )
+
+        #expect(WorkspaceSidebarView.isRowSelected(
+            row,
+            selection: WorkspaceSelection(selectedHostID: hostID),
+            rowTmuxSession: worktree,
+            activeTmuxSession: active,
+            activeHerdrSession: nil
+        ))
+    }
+
     @Test("Herdr rows expose lifecycle actions by state and identity")
     func herdrRowsExposeLifecycleActions() {
         let hostID = UUID()

--- a/rust/host/src/kwt.rs
+++ b/rust/host/src/kwt.rs
@@ -206,6 +206,14 @@ pub struct KwtWorktree {
     repository: String,
     session_name: String,
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: KwtTmuxAttachMode,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum KwtTmuxAttachMode {
+    Direct,
+    Protected,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -278,6 +286,7 @@ pub struct KwtImportedWorkspace {
     session_name: String,
     #[serde(default)]
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: KwtTmuxAttachMode,
 }
 
 #[derive(Debug, Deserialize)]
@@ -363,6 +372,31 @@ pub struct KwtWorktreeOpen {
     registration_fingerprint: String,
     generation: String,
     session_name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KwtDirectoryWorkspaceOpen {
+    path: String,
+    session_name: String,
+}
+
+impl KwtDirectoryWorkspaceOpen {
+    #[must_use]
+    pub fn new(path: impl Into<String>, session_name: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            session_name: session_name.into(),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn session_name(&self) -> &str {
+        &self.session_name
+    }
 }
 
 impl KwtWorktreeOpen {
@@ -556,6 +590,9 @@ pub(crate) fn parse_pull_request_import(output: &[u8]) -> Result<KwtPullRequestI
     {
         return Err("KWT pull-request import omitted its protected tmux socket".to_owned());
     }
+    if response.workspace.tmux_attach_mode != KwtTmuxAttachMode::Protected {
+        return Err("KWT pull-request import did not require protected attachment".to_owned());
+    }
     Ok(response)
 }
 
@@ -619,6 +656,10 @@ impl KwtImportedWorkspace {
     pub fn tmux_socket_name(&self) -> Option<&str> {
         self.tmux_socket_name.as_deref()
     }
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> KwtTmuxAttachMode {
+        self.tmux_attach_mode
+    }
 }
 
 impl KwtPullRequestImport {
@@ -673,6 +714,10 @@ impl KwtWorktree {
     pub fn tmux_socket_name(&self) -> Option<&str> {
         self.tmux_socket_name.as_deref()
     }
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> KwtTmuxAttachMode {
+        self.tmux_attach_mode
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -682,6 +727,8 @@ pub struct KwtDirectoryWorkspace {
     path: String,
     session_name: String,
     session_live: bool,
+    tmux_socket_name: Option<String>,
+    tmux_attach_mode: KwtTmuxAttachMode,
 }
 
 impl KwtDirectoryWorkspace {
@@ -700,6 +747,14 @@ impl KwtDirectoryWorkspace {
     #[must_use]
     pub const fn session_live(&self) -> bool {
         self.session_live
+    }
+    #[must_use]
+    pub fn tmux_socket_name(&self) -> Option<&str> {
+        self.tmux_socket_name.as_deref()
+    }
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> KwtTmuxAttachMode {
+        self.tmux_attach_mode
     }
 }
 
@@ -775,7 +830,7 @@ impl KwtInventory {
 #[cfg(test)]
 mod tests {
     use super::{
-        KwtBundle, KwtInventory, parse_command_failure, parse_project_mutation,
+        KwtBundle, KwtInventory, KwtTmuxAttachMode, parse_command_failure, parse_project_mutation,
         parse_pull_request_import, parse_pull_requests,
     };
 
@@ -793,17 +848,25 @@ mod tests {
     fn inventory_joins_global_worktrees_without_reordering_projects() {
         let inventory = KwtInventory::parse(
             br#"[{"repository":"two","name":"Second","path":"/r/two","last_touched":null,"registration_fingerprint":"two-fingerprint"},{"repository":"one","name":"First","path":"/r/one","last_touched":"now","registration_fingerprint":"one-fingerprint"}]"#,
-            br#"[{"path":"/w/one","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"one","session_name":"one-main","tmux_socket_name":null},{"path":"/w/two","branch":"topic","commit_hash":"def","is_main":false,"created_at":"then","generation":null,"repository":"two","session_name":"two-topic","tmux_socket_name":"alt"}]"#,
-            br#"[{"name":"scratch","path":"/w/scratch","session_name":"scratch","session_live":false}]"#,
+            br#"[{"path":"/w/one","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"one","session_name":"one-main","tmux_socket_name":null,"tmux_attach_mode":"direct"},{"path":"/w/two","branch":"topic","commit_hash":"def","is_main":false,"created_at":"then","generation":null,"repository":"two","session_name":"two-topic","tmux_socket_name":"alt","tmux_attach_mode":"protected"}]"#,
+            br#"[{"name":"scratch","path":"/w/scratch","session_name":"scratch","session_live":false,"tmux_socket_name":"kwt","tmux_attach_mode":"direct"}]"#,
         ).expect("valid inventory");
 
         assert_eq!(inventory.projects()[0].project().repository(), "two");
         assert_eq!(inventory.projects()[0].worktrees()[0].branch(), "topic");
         assert_eq!(
+            inventory.projects()[0].worktrees()[0].tmux_attach_mode(),
+            KwtTmuxAttachMode::Protected
+        );
+        assert_eq!(
             inventory.projects()[1].worktrees()[0].session_name(),
             "one-main"
         );
         assert_eq!(inventory.directory_workspaces()[0].name(), "scratch");
+        assert_eq!(
+            inventory.directory_workspaces()[0].tmux_socket_name(),
+            Some("kwt")
+        );
     }
 
     #[test]
@@ -860,8 +923,12 @@ mod tests {
         assert_eq!(pull_requests[0].number(), 17);
         assert_eq!(pull_requests[0].source_branch(), "feature/rendering");
 
-        let imported = parse_pull_request_import(br#"{"status":"created","pull_request":{"id":"github:github.com/acme/widget#17","provider":"github","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"number":17,"url":"https://github.com/acme/widget/pull/17","title":"Improve rendering","author":"octocat","source":{"branch":"feature/rendering","repository":{"provider":"github","identity":"github.com/octocat/widget","host":"github.com","owner":"octocat","name":"widget"},"is_fork":true},"target":{"branch":"main","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"is_fork":false},"draft":false,"state":"open","head_sha":"0123456789abcdef0123456789abcdef01234567","imported":true,"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2"}},"project":{"identity":"github.com/acme/widget","name":"widget","path":"/code/widget"},"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2"}}"#).expect("valid import");
+        let imported = parse_pull_request_import(br#"{"status":"created","pull_request":{"id":"github:github.com/acme/widget#17","provider":"github","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"number":17,"url":"https://github.com/acme/widget/pull/17","title":"Improve rendering","author":"octocat","source":{"branch":"feature/rendering","repository":{"provider":"github","identity":"github.com/octocat/widget","host":"github.com","owner":"octocat","name":"widget"},"is_fork":true},"target":{"branch":"main","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"is_fork":false},"draft":false,"state":"open","head_sha":"0123456789abcdef0123456789abcdef01234567","imported":true,"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2","tmux_attach_mode":"protected"}},"project":{"identity":"github.com/acme/widget","name":"widget","path":"/code/widget"},"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2","tmux_attach_mode":"protected"}}"#).expect("valid import");
         assert_eq!(imported.workspace().tmux_socket_name(), Some("kwt-pr-a1b2"));
+        assert_eq!(
+            imported.workspace().tmux_attach_mode(),
+            KwtTmuxAttachMode::Protected
+        );
     }
 
     #[test]

--- a/rust/host/src/lib.rs
+++ b/rust/host/src/lib.rs
@@ -22,10 +22,10 @@ mod wsl;
 mod zellij;
 
 pub use kwt::{
-    KwtBranchCandidate, KwtBundle, KwtDirectoryWorkspace, KwtInventory, KwtProject,
-    KwtProjectInventory, KwtProtectedWorktreeOpen, KwtPullRequest, KwtPullRequestImport,
-    KwtPullRequestImportRequest, KwtWorktree, KwtWorktreeCreate, KwtWorktreeOpen,
-    kwt_command_failure_message,
+    KwtBranchCandidate, KwtBundle, KwtDirectoryWorkspace, KwtDirectoryWorkspaceOpen, KwtInventory,
+    KwtProject, KwtProjectInventory, KwtProtectedWorktreeOpen, KwtPullRequest,
+    KwtPullRequestImport, KwtPullRequestImportRequest, KwtTmuxAttachMode, KwtWorktree,
+    KwtWorktreeCreate, KwtWorktreeOpen, kwt_command_failure_message,
 };
 pub use remote::{
     RemoteSessionInventory, RemoteTmuxConfig, RemoteTmuxError, RemoteTmuxHost, RemoteTmuxSnapshot,

--- a/rust/host/src/wsl.rs
+++ b/rust/host/src/wsl.rs
@@ -23,9 +23,9 @@ use crate::kwt::{
 use crate::zellij;
 use crate::{
     CancellationToken, CommandOutput, CommandPrefix, CommandRunner, KwtBranchCandidate, KwtBundle,
-    KwtInventory, KwtProject, KwtProtectedWorktreeOpen, KwtPullRequest, KwtPullRequestImport,
-    KwtPullRequestImportRequest, KwtWorktreeCreate, KwtWorktreeOpen, RemoteTmuxConfig,
-    RemoteTmuxHost,
+    KwtDirectoryWorkspaceOpen, KwtInventory, KwtProject, KwtProtectedWorktreeOpen, KwtPullRequest,
+    KwtPullRequestImport, KwtPullRequestImportRequest, KwtWorktreeCreate, KwtWorktreeOpen,
+    RemoteTmuxConfig, RemoteTmuxHost,
 };
 
 const DEFAULT_TMUX: &str = "/usr/bin/tmux";
@@ -360,11 +360,11 @@ impl HerdrInventory {
     }
 }
 
-/// Fresh, non-persistable authority to kill one exact live tmux session.
+/// Fresh, non-persistable identity for one exact live tmux session.
 ///
-/// The constructor is private so cached inventory cannot be promoted into
-/// destructive authority. Callers can obtain this value only from a live
-/// tmux query immediately before presenting confirmation.
+/// The constructor is private so attachment and destructive operations must
+/// first confirm the current endpoint. Callers can obtain this value only from
+/// a live tmux query.
 #[derive(Debug)]
 pub struct LiveSessionTarget {
     endpoint: WslEndpoint,
@@ -1241,6 +1241,64 @@ impl<R: CommandRunner> WslHost<R> {
         term: AttachTerm,
         cancellation: &CancellationToken,
     ) -> Result<RepairOrOpenPlan, HostError> {
+        self.kwt_open_plan(
+            endpoint,
+            runtime,
+            request.path(),
+            request.session_name(),
+            &[
+                ("--expected-repository", request.repository()),
+                (
+                    "--expected-registration",
+                    request.registration_fingerprint(),
+                ),
+                ("--expected-generation", request.generation()),
+                ("--expected-session", request.session_name()),
+            ],
+            term,
+            cancellation,
+        )
+    }
+
+    /// Build a re-runnable KWT client for one exact registered directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the helper cannot be verified for the captured
+    /// WSL runtime.
+    pub fn kwt_directory_workspace_open_plan(
+        &self,
+        endpoint: &WslEndpoint,
+        runtime: &WslRuntimeIdentity,
+        request: &KwtDirectoryWorkspaceOpen,
+        term: AttachTerm,
+        cancellation: &CancellationToken,
+    ) -> Result<RepairOrOpenPlan, HostError> {
+        self.kwt_open_plan(
+            endpoint,
+            runtime,
+            request.path(),
+            request.session_name(),
+            &[("--expected-session", request.session_name())],
+            term,
+            cancellation,
+        )
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the shared plan builder keeps captured runtime and KWT endpoint authority explicit"
+    )]
+    fn kwt_open_plan(
+        &self,
+        endpoint: &WslEndpoint,
+        runtime: &WslRuntimeIdentity,
+        path: &str,
+        session_name: &str,
+        expected: &[(&str, &str)],
+        term: AttachTerm,
+        cancellation: &CancellationToken,
+    ) -> Result<RepairOrOpenPlan, HostError> {
         self.require_runtime(endpoint, runtime, cancellation)?;
         let bundle = self.config.kwt_bundle().ok_or_else(|| {
             HostError::new(
@@ -1275,23 +1333,19 @@ impl<R: CommandRunner> WslHost<R> {
                 readiness_path.as_str(),
                 helper.as_str(),
                 "open",
-                request.path(),
-                "--expected-repository",
-                request.repository(),
-                "--expected-registration",
-                request.registration_fingerprint(),
-                "--expected-generation",
-                request.generation(),
-                "--expected-session",
-                request.session_name(),
+                path,
             ]
             .into_iter()
             .map(OsString::from),
         );
+        for (flag, value) in expected {
+            args.push(OsString::from(flag));
+            args.push(OsString::from(value));
+        }
         Ok(RepairOrOpenPlan::worktree(
             self.wsl_executable.as_os_str(),
             args,
-            request.session_name(),
+            session_name,
             &readiness_path,
         ))
     }
@@ -1444,13 +1498,13 @@ impl<R: CommandRunner> WslHost<R> {
         Ok(matched)
     }
 
-    /// Query the exact client on a KWT-owned protected tmux socket.
+    /// Query the exact client on a KWT-owned named tmux socket.
     ///
     /// # Errors
     ///
     /// Returns an error for invalid socket names, runtime changes, malformed
     /// receipts, or unsafe tmux output.
-    pub fn kwt_protected_client_session_identity(
+    pub fn kwt_named_client_session_identity(
         &self,
         endpoint: &WslEndpoint,
         runtime: &WslRuntimeIdentity,
@@ -1476,7 +1530,7 @@ impl<R: CommandRunner> WslHost<R> {
             return Err(classify_command_failure(
                 receipt.status,
                 &receipt.stderr,
-                "read protected KWT client readiness",
+                "read named KWT client readiness",
             ));
         }
         if receipt.stdout.is_empty() {
@@ -1504,7 +1558,7 @@ impl<R: CommandRunner> WslHost<R> {
             return Err(classify_command_failure(
                 output.status,
                 &output.stderr,
-                "query protected KWT tmux client readiness",
+                "query named KWT tmux client readiness",
             ));
         }
         let matched = parse_kwt_client_identity(&output.stdout, client_pid)?;
@@ -1996,6 +2050,39 @@ impl<R: CommandRunner> WslHost<R> {
         session: &DiscoveredSession,
         term: AttachTerm,
     ) -> AttachPlan {
+        self.attach_identity_plan_with_term(
+            endpoint,
+            session.name(),
+            session.identity(),
+            None,
+            term,
+        )
+    }
+
+    /// Build an attach-only plan for a freshly captured tmux endpoint.
+    #[must_use]
+    pub fn attach_live_session_plan_with_term(
+        &self,
+        target: &LiveSessionTarget,
+        term: AttachTerm,
+    ) -> AttachPlan {
+        self.attach_identity_plan_with_term(
+            target.endpoint(),
+            target.name(),
+            target.identity(),
+            target.socket_name(),
+            term,
+        )
+    }
+
+    fn attach_identity_plan_with_term(
+        &self,
+        endpoint: &WslEndpoint,
+        name: &str,
+        identity: &SessionIdentity,
+        socket_name: Option<&str>,
+        term: AttachTerm,
+    ) -> AttachPlan {
         let mut args = pinned_prefix(endpoint);
         append_tmux_environment(
             &mut args,
@@ -2004,7 +2091,9 @@ impl<R: CommandRunner> WslHost<R> {
             &[],
         );
         args.push(OsString::from(&self.config.tmux_binary));
-        let identity = session.identity();
+        if let Some(socket_name) = socket_name {
+            args.extend([OsString::from("-L"), OsString::from(socket_name)]);
+        }
         let target = format!("={}:", identity.session_id());
         let mut condition = String::from("#{&&:");
         condition.push_str(&tmux_identity_equals(
@@ -2033,8 +2122,8 @@ impl<R: CommandRunner> WslHost<R> {
         AttachPlan::attach_only(
             self.wsl_executable.as_os_str(),
             args,
-            session.name(),
-            session.identity().clone(),
+            name,
+            identity.clone(),
         )
     }
 
@@ -5249,7 +5338,7 @@ mod tests {
             } else if args.windows(2).any(|pair| pair == ["pr", "list"]) {
                 br#"{"pull_requests":[{"id":"github:github.com/acme/widget#17","provider":"github","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"number":17,"url":"https://github.com/acme/widget/pull/17","title":"Improve rendering","author":"octocat","source":{"branch":"feature/rendering","repository":{"provider":"github","identity":"github.com/octocat/widget","host":"github.com","owner":"octocat","name":"widget"},"is_fork":true},"target":{"branch":"main","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"is_fork":false},"draft":false,"state":"open","head_sha":"0123456789abcdef0123456789abcdef01234567","imported":false}]}"#.to_vec()
             } else if args.windows(2).any(|pair| pair == ["pr", "import"]) {
-                br#"{"status":"created","pull_request":{"id":"github:github.com/acme/widget#17","provider":"github","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"number":17,"url":"https://github.com/acme/widget/pull/17","title":"Improve rendering","author":"octocat","source":{"branch":"feature/rendering","repository":{"provider":"github","identity":"github.com/octocat/widget","host":"github.com","owner":"octocat","name":"widget"},"is_fork":true},"target":{"branch":"main","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"is_fork":false},"draft":false,"state":"open","head_sha":"0123456789abcdef0123456789abcdef01234567","imported":true},"project":{"identity":"github.com/acme/widget","name":"widget","path":"/code/widget"},"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2"}}"#.to_vec()
+                br#"{"status":"created","pull_request":{"id":"github:github.com/acme/widget#17","provider":"github","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"number":17,"url":"https://github.com/acme/widget/pull/17","title":"Improve rendering","author":"octocat","source":{"branch":"feature/rendering","repository":{"provider":"github","identity":"github.com/octocat/widget","host":"github.com","owner":"octocat","name":"widget"},"is_fork":true},"target":{"branch":"main","repository":{"provider":"github","identity":"github.com/acme/widget","host":"github.com","owner":"acme","name":"widget"},"is_fork":false},"draft":false,"state":"open","head_sha":"0123456789abcdef0123456789abcdef01234567","imported":true},"project":{"identity":"github.com/acme/widget","name":"widget","path":"/code/widget"},"workspace":{"id":"workspace","repository":"github.com/acme/widget","branch":"pr-17-feature-rendering","path":"/worktrees/pr-17","generation":"11111111111111111111111111111111","state":"ready","session_name":"widget-pr-17","tmux_socket_name":"kwt-pr-a1b2","tmux_attach_mode":"protected"}}"#.to_vec()
             } else if (args.iter().any(|argument| argument == "add")
                 && args.iter().any(|argument| argument == "--no-launch"))
                 || (args.iter().any(|argument| argument == "remove")
@@ -5799,6 +5888,64 @@ mod tests {
             .expect("plan uses a private canonical readiness path");
         assert_eq!(plan.target_name(), "widget-topic");
         assert_eq!(plan.clone(), plan);
+    }
+
+    #[test]
+    fn captured_named_session_attach_plan_uses_the_exact_socket_and_identity() {
+        let (host, _runner, endpoint, runtime) = kwt_mutation_host();
+        let identity = SessionIdentity::new(42, "$7", 99);
+        let target = LiveSessionTarget {
+            endpoint,
+            runtime,
+            name: "widget-topic".to_owned(),
+            socket_name: Some("kwt".to_owned()),
+            identity: identity.clone(),
+        };
+
+        let plan = host.attach_live_session_plan_with_term(&target, AttachTerm::Xterm256Color);
+        let args = plan
+            .args()
+            .iter()
+            .map(|argument| argument.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(args.windows(2).any(|args| args == ["-L", "kwt"]));
+        assert!(args.iter().any(|argument| argument == "=$7:"));
+        assert!(
+            args.iter()
+                .any(|argument| argument == "attach-session -E -t =$7")
+        );
+        assert_eq!(plan.target_name(), "widget-topic");
+        assert_eq!(plan.identity(), &identity);
+    }
+
+    #[test]
+    fn kwt_directory_workspace_open_plan_uses_exact_path_and_session() {
+        let (host, _runner, endpoint, runtime) = kwt_mutation_host();
+        let plan = host
+            .kwt_directory_workspace_open_plan(
+                &endpoint,
+                &runtime,
+                &KwtDirectoryWorkspaceOpen::new("/work/scratch", "scratch"),
+                AttachTerm::Xterm256Color,
+                &CancellationToken::new(),
+            )
+            .expect("build directory workspace open plan");
+        let args = plan
+            .args()
+            .iter()
+            .map(|argument| argument.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(
+            args.windows(3)
+                .any(|args| { args == [&test_kwt_helper_path(), "open", "/work/scratch"] })
+        );
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--expected-session", "scratch"])
+        );
+        assert_eq!(plan.target_name(), "scratch");
     }
 
     #[test]

--- a/rust/host/tests/kwt_wsl_live.rs
+++ b/rust/host/tests/kwt_wsl_live.rs
@@ -663,7 +663,7 @@ fn wait_for_exact_protected_client(
     let deadline = Instant::now() + READY_TIMEOUT;
     loop {
         if let Some(identity) = host
-            .kwt_protected_client_session_identity(
+            .kwt_named_client_session_identity(
                 endpoint,
                 runtime,
                 readiness_path,

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -20,9 +20,9 @@ use surface::{CellStyle, CursorShape, Damage, GridSize, Rgb, SurfaceFrame, Surfa
 use workspace::{
     AppearanceSettingsDraft, ConfiguredSshHost, CursorStyle, HerdrSessionState,
     HostConnectionState, HostItem, KeyEvent as InputKeyEvent, KeyInput, KwtProjectAction,
-    Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey, SessionName,
-    SessionSelection, SshHostDraft, SshPromptRequest, TerminalSettingsDraft, TerminalTheme,
-    Workspace, WorkspaceContent, WorkspaceEvent,
+    KwtTmuxAttachMode, Modifiers as InputModifiers, MouseAction, MouseButton, MouseInput, NamedKey,
+    SessionName, SessionSelection, SshHostDraft, SshPromptRequest, TerminalSettingsDraft,
+    TerminalTheme, Workspace, WorkspaceContent, WorkspaceEvent,
 };
 
 pub const WINDOW_TITLE: &str = "Ghosthub";
@@ -996,6 +996,7 @@ struct WorktreeOpenTarget {
     generation: Option<String>,
     session_name: String,
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: KwtTmuxAttachMode,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1305,6 +1306,7 @@ enum WorktreeOpenMode {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct WorktreeOpenContext {
+    attach_mode: KwtTmuxAttachMode,
     authority: WorktreeAuthority,
     socket: WorktreeSocket,
     session: WorktreeSessionPresence,
@@ -1368,6 +1370,12 @@ const fn worktree_open_mode(context: WorktreeOpenContext) -> WorktreeOpenMode {
     };
     if matches!(context.authority, WorktreeAuthority::Generation) && kwt_available {
         WorktreeOpenMode::RepairOrOpen
+    } else if matches!(context.attach_mode, KwtTmuxAttachMode::Direct)
+        && matches!(context.authority, WorktreeAuthority::Generation)
+        && (matches!(context.socket, WorktreeSocket::Custom)
+            || matches!(context.session, WorktreeSessionPresence::Discovered))
+    {
+        WorktreeOpenMode::DirectTmux
     } else if matches!(context.authority, WorktreeAuthority::Generationless)
         && matches!(context.session, WorktreeSessionPresence::Discovered)
     {
@@ -1389,6 +1397,19 @@ const fn can_kill_worktree(
         } else {
             matches!(session, WorktreeSessionPresence::Discovered)
         }
+}
+
+const fn can_open_directory_workspace(
+    is_presented: bool,
+    attach_mode: KwtTmuxAttachMode,
+    socket: WorktreeSocket,
+    session_available: bool,
+    kwt_open_available: bool,
+) -> bool {
+    is_presented
+        || (matches!(attach_mode, KwtTmuxAttachMode::Direct)
+            && ((matches!(socket, WorktreeSocket::Default) && session_available)
+                || kwt_open_available))
 }
 
 fn owns_created_worktree_navigation(
@@ -1827,6 +1848,7 @@ impl RootView {
             target.generation.as_deref(),
             &target.session_name,
             target.tmux_socket_name.as_deref(),
+            target.tmux_attach_mode,
         );
         if let Err(error) = result {
             self.diagnostic = Some(error.to_string());
@@ -2578,6 +2600,7 @@ impl RootView {
                 generation,
                 &target.open.session_name,
                 target.open.tmux_socket_name.as_deref(),
+                target.open.tmux_attach_mode,
             )
         } else {
             target.authority = None;
@@ -2759,6 +2782,7 @@ impl RootView {
                 generation,
                 &open.session_name,
                 open.tmux_socket_name.as_deref(),
+                open.tmux_attach_mode,
             ) {
                 Ok(operation_id) => {
                     if let Some(ProjectDialog::RemoveWorktree { target, error, .. }) =
@@ -3435,6 +3459,7 @@ impl RootView {
                         generation: target.generation().map(str::to_owned),
                         session_name: target.session_name().to_owned(),
                         tmux_socket_name: target.tmux_socket_name().map(str::to_owned),
+                        tmux_attach_mode: target.tmux_attach_mode(),
                     };
                     let dialog_project_path = self.project_dialog.as_ref().map(|dialog| {
                         if let ProjectDialog::NewWorktree { project_path, .. } = dialog {
@@ -3471,6 +3496,7 @@ impl RootView {
                         open.generation.as_deref(),
                         &open.session_name,
                         open.tmux_socket_name.as_deref(),
+                        open.tmux_attach_mode,
                     ) {
                         self.diagnostic = Some(error.to_string());
                     } else {
@@ -7431,25 +7457,20 @@ impl RootView {
             }
             tree = tree.child(row);
             for (worktree_index, worktree) in project.worktrees().iter().enumerate() {
-                let selection = worktree
-                    .tmux_socket_name()
-                    .and_then(|socket| {
-                        worktree.generation().map(|generation| {
-                            SessionSelection::protected_worktree(
-                                host.id(),
-                                host.endpoint(),
-                                worktree.session_name(),
-                                socket,
-                                worktree.path(),
-                                generation,
-                            )
-                        })
-                    })
-                    .unwrap_or_else(|| {
-                        SessionSelection::new(host.id(), host.endpoint(), worktree.session_name())
-                    });
-                let is_active = active == Some(&selection);
-                let is_retained = retained.contains(&selection);
+                let selection = SessionSelection::kwt_workspace(
+                    host.id(),
+                    host.endpoint(),
+                    worktree.session_name(),
+                    worktree.tmux_attach_mode(),
+                    worktree.tmux_socket_name().map(str::to_owned),
+                    worktree.path(),
+                    worktree.generation().map(str::to_owned),
+                );
+                let is_active = active
+                    .is_some_and(|active| kwt_selection_matches_presentation(&selection, active));
+                let is_retained = retained
+                    .iter()
+                    .any(|retained| kwt_selection_matches_presentation(&selection, retained));
                 let has_generation = worktree.generation().is_some();
                 let host_can_attach = host.accepts_session_actions();
                 let authority = if has_generation {
@@ -7467,25 +7488,34 @@ impl RootView {
                 } else {
                     WorktreeSessionPresence::Absent
                 };
-                let open_mode = worktree_open_mode(WorktreeOpenContext {
-                    authority,
-                    socket,
-                    session,
-                    presentation: if is_active || is_retained {
-                        WorktreePresentation::ActiveOrRetained
-                    } else {
-                        WorktreePresentation::Inactive
-                    },
-                    host: if host_can_attach {
-                        WorktreeHostAccess::Ready {
-                            kwt_available: host.kwt_available(),
-                        }
-                    } else {
-                        WorktreeHostAccess::Unavailable
-                    },
-                });
+                let endpoint_is_resolved = worktree.tmux_attach_mode()
+                    != KwtTmuxAttachMode::Protected
+                    || worktree.tmux_socket_name().is_some();
+                let open_mode = if endpoint_is_resolved {
+                    worktree_open_mode(WorktreeOpenContext {
+                        attach_mode: worktree.tmux_attach_mode(),
+                        authority,
+                        socket,
+                        session,
+                        presentation: if is_active || is_retained {
+                            WorktreePresentation::ActiveOrRetained
+                        } else {
+                            WorktreePresentation::Inactive
+                        },
+                        host: if host_can_attach {
+                            WorktreeHostAccess::Ready {
+                                kwt_available: host.kwt_available(),
+                            }
+                        } else {
+                            WorktreeHostAccess::Unavailable
+                        },
+                    })
+                } else {
+                    WorktreeOpenMode::Disabled
+                };
                 let can_open = open_mode != WorktreeOpenMode::Disabled;
-                let can_kill = can_kill_worktree(host_can_attach, socket, session, authority);
+                let can_kill = endpoint_is_resolved
+                    && can_kill_worktree(host_can_attach, socket, session, authority);
                 let open_target = WorktreeOpenTarget {
                     host_id: host.id().to_owned(),
                     endpoint: host.endpoint().to_owned(),
@@ -7496,11 +7526,13 @@ impl RootView {
                     generation: worktree.generation().map(str::to_owned),
                     session_name: worktree.session_name().to_owned(),
                     tmux_socket_name: worktree.tmux_socket_name().map(str::to_owned),
+                    tmux_attach_mode: worktree.tmux_attach_mode(),
                 };
                 let repair_open_target =
                     (open_mode == WorktreeOpenMode::RepairOrOpen).then(|| open_target.clone());
                 let remove_target = (!worktree.is_main()
                     && worktree.generation().is_some()
+                    && endpoint_is_resolved
                     && host.connection() == HostConnectionState::Ready
                     && host.kwt_available()
                     && host.kwt_diagnostic().is_none())
@@ -7562,13 +7594,31 @@ impl RootView {
             );
         }
         for (index, workspace) in host.directory_workspaces().iter().enumerate() {
-            let selection =
-                SessionSelection::new(host.id(), host.endpoint(), workspace.session_name());
-            let is_active = active == Some(&selection);
-            let is_retained = retained.contains(&selection);
-            let can_open = is_active
-                || is_retained
-                || (workspace.session_available() && host.accepts_session_actions());
+            let selection = SessionSelection::kwt_workspace(
+                host.id(),
+                host.endpoint(),
+                workspace.session_name(),
+                workspace.tmux_attach_mode(),
+                workspace.tmux_socket_name().map(str::to_owned),
+                workspace.path(),
+                None,
+            );
+            let is_active =
+                active.is_some_and(|active| kwt_selection_matches_presentation(&selection, active));
+            let is_retained = retained
+                .iter()
+                .any(|retained| kwt_selection_matches_presentation(&selection, retained));
+            let can_open = can_open_directory_workspace(
+                is_active || is_retained,
+                workspace.tmux_attach_mode(),
+                if workspace.tmux_socket_name().is_some() {
+                    WorktreeSocket::Custom
+                } else {
+                    WorktreeSocket::Default
+                },
+                workspace.session_available() && host.accepts_session_actions(),
+                host.kwt_available() && host.accepts_session_actions(),
+            );
             let can_kill = workspace.session_available() && host.accepts_session_actions();
             rows.push(Self::worktree_row(
                 host_index,
@@ -8447,13 +8497,27 @@ fn active_session_selection(content: &WorkspaceContent) -> Option<SessionSelecti
 }
 
 fn host_owns_worktree_presentation(host: &HostItem, selection: &SessionSelection) -> bool {
-    if selection.tmux_socket_name().is_some() {
-        host.kwt_owns_protected_presentation(selection)
+    if selection.tmux_attach_mode().is_some() {
+        host.kwt_owns_workspace_presentation(selection)
     } else {
         selection.host_id() == host.id()
             && selection.endpoint() == host.endpoint()
             && host.kwt_owns_default_tmux_session(selection.session())
     }
+}
+
+fn kwt_selection_matches_presentation(
+    selection: &SessionSelection,
+    presentation: &SessionSelection,
+) -> bool {
+    selection == presentation
+        || (selection.tmux_attach_mode() == Some(KwtTmuxAttachMode::Direct)
+            && selection.tmux_socket_name().is_none()
+            && presentation.tmux_attach_mode().is_none()
+            && presentation.kind() == workspace::SessionKind::Tmux
+            && selection.host_id() == presentation.host_id()
+            && selection.endpoint() == presentation.endpoint()
+            && selection.session() == presentation.session())
 }
 
 fn tree_sessions(
@@ -8502,7 +8566,10 @@ fn tree_sessions(
         .map(|(selection, discovered)| {
             let retained = retained.contains(&selection);
             let is_active = active == Some(&selection);
-            let can_kill = discovered && host_accepts_actions && !host.is_ssh();
+            let has_exact_socket = selection.tmux_socket_name().is_some();
+            let can_kill = host_accepts_actions
+                && !host.is_ssh()
+                && (discovered || (has_exact_socket && (is_active || retained)));
             let state = match (is_active, retained, host_accepts_actions, can_kill) {
                 (true, _, _, true) => TreeSessionState::ActiveKillable,
                 (true, _, _, false) => TreeSessionState::Active,
@@ -9484,16 +9551,18 @@ mod tests {
         advance_settings_focus, appearance_draft_is_persistable, appearance_preview_color,
         application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
         available_herdr_row_actions, can_create_worktree, can_kill_worktree,
-        canonical_terminal_key_with, chrome_palette_for_terminal_theme, clear_terminal_input_state,
-        clears_after_input_delivery, clears_when_input_queue_is_empty, coalesce_last_resize,
-        coalesce_last_wheel, focused_settings_detail, has_ambiguous_worktree_source,
-        herdr_row_actions, herdr_session_menu_actions, host_header_action, host_landing_text,
+        can_open_directory_workspace, canonical_terminal_key_with,
+        chrome_palette_for_terminal_theme, clear_terminal_input_state, clears_after_input_delivery,
+        clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
+        focused_settings_detail, has_ambiguous_worktree_source, herdr_row_actions,
+        herdr_session_menu_actions, host_header_action, host_landing_text,
         input_queue_has_capacity, is_toggle_sidebar_shortcut, kill_confirmation_description,
-        kill_confirmation_title, kwt_operation_failure_owns_dialog, named_key,
-        new_session_validation, normalize_cell_width, owns_created_worktree_navigation,
-        pull_request_import_selector, queued_input_matches_presentation, retained_key_event_with,
-        session_action_menu_position, session_backend_id, session_creation_available,
-        session_group_visibility, session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
+        kill_confirmation_title, kwt_operation_failure_owns_dialog,
+        kwt_selection_matches_presentation, named_key, new_session_validation,
+        normalize_cell_width, owns_created_worktree_navigation, pull_request_import_selector,
+        queued_input_matches_presentation, retained_key_event_with, session_action_menu_position,
+        session_backend_id, session_creation_available, session_group_visibility,
+        session_row_element_id, ssh_host_subtitle, ssh_prompt_input_text,
         terminal_cell_at_with_offset, terminal_font_changed, terminal_key_input,
         terminal_key_input_with_canonical, terminal_line_height, terminal_wheel_steps,
         tmux_row_actions, toggle_session_group_state, transitioned_presentation,
@@ -9507,9 +9576,9 @@ mod tests {
     use workspace::{
         AppearanceSettingsDraft, CursorStyle, HerdrSessionItem, HerdrSessionState,
         HostConnectionState, HostDiagnostic, HostItem, KeyEvent, KeyInput, KwtBranchItem,
-        KwtPullRequestItem, Modifiers, MouseAction, MouseButton, MouseInput, NamedKey, ProjectItem,
-        SessionItem, SessionSelection, SshHostDraft, TerminalSettingsDraft, TerminalTheme,
-        WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
+        KwtPullRequestItem, KwtTmuxAttachMode, Modifiers, MouseAction, MouseButton, MouseInput,
+        NamedKey, ProjectItem, SessionItem, SessionSelection, SshHostDraft, TerminalSettingsDraft,
+        TerminalTheme, WorkspaceContent, WorkspaceSnapshot, WorktreeItem,
     };
 
     #[test]
@@ -9771,6 +9840,7 @@ mod tests {
     fn generationless_worktrees_attach_only_to_a_live_discovered_tmux_session() {
         assert_eq!(
             worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Direct,
                 authority: WorktreeAuthority::Generationless,
                 socket: WorktreeSocket::Default,
                 session: WorktreeSessionPresence::Discovered,
@@ -9783,6 +9853,7 @@ mod tests {
         );
         assert_eq!(
             worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Direct,
                 authority: WorktreeAuthority::Generationless,
                 socket: WorktreeSocket::Default,
                 session: WorktreeSessionPresence::Absent,
@@ -9795,6 +9866,7 @@ mod tests {
         );
         assert_eq!(
             worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Direct,
                 authority: WorktreeAuthority::Generation,
                 socket: WorktreeSocket::Default,
                 session: WorktreeSessionPresence::Absent,
@@ -9808,14 +9880,103 @@ mod tests {
     }
 
     #[test]
+    fn direct_worktrees_attach_without_kwt_when_the_endpoint_is_known() {
+        assert_eq!(
+            worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Direct,
+                authority: WorktreeAuthority::Generation,
+                socket: WorktreeSocket::Custom,
+                session: WorktreeSessionPresence::Absent,
+                presentation: WorktreePresentation::Inactive,
+                host: WorktreeHostAccess::Ready {
+                    kwt_available: false,
+                },
+            }),
+            WorktreeOpenMode::DirectTmux
+        );
+        assert_eq!(
+            worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Direct,
+                authority: WorktreeAuthority::Generation,
+                socket: WorktreeSocket::Default,
+                session: WorktreeSessionPresence::Discovered,
+                presentation: WorktreePresentation::Inactive,
+                host: WorktreeHostAccess::Ready {
+                    kwt_available: false,
+                },
+            }),
+            WorktreeOpenMode::DirectTmux
+        );
+    }
+
+    #[test]
+    fn directory_workspace_open_requires_a_live_default_session_or_kwt() {
+        assert!(can_open_directory_workspace(
+            false,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Default,
+            true,
+            false,
+        ));
+        assert!(can_open_directory_workspace(
+            false,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Default,
+            false,
+            true,
+        ));
+        assert!(!can_open_directory_workspace(
+            false,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Default,
+            false,
+            false,
+        ));
+        assert!(!can_open_directory_workspace(
+            false,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Custom,
+            true,
+            false,
+        ));
+        assert!(can_open_directory_workspace(
+            false,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Custom,
+            false,
+            true,
+        ));
+        assert!(can_open_directory_workspace(
+            true,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Custom,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
     fn retained_worktrees_reactivate_without_current_host_or_kwt_authority() {
-        for (authority, socket) in [
-            (WorktreeAuthority::Generation, WorktreeSocket::Default),
-            (WorktreeAuthority::Generation, WorktreeSocket::Custom),
-            (WorktreeAuthority::Generationless, WorktreeSocket::Default),
+        for (authority, socket, attach_mode) in [
+            (
+                WorktreeAuthority::Generation,
+                WorktreeSocket::Default,
+                KwtTmuxAttachMode::Direct,
+            ),
+            (
+                WorktreeAuthority::Generation,
+                WorktreeSocket::Custom,
+                KwtTmuxAttachMode::Protected,
+            ),
+            (
+                WorktreeAuthority::Generationless,
+                WorktreeSocket::Default,
+                KwtTmuxAttachMode::Direct,
+            ),
         ] {
             assert_eq!(
                 worktree_open_mode(WorktreeOpenContext {
+                    attach_mode,
                     authority,
                     socket,
                     session: WorktreeSessionPresence::Absent,
@@ -9870,6 +10031,7 @@ mod tests {
     fn protected_generation_backed_worktrees_use_kwt_attach() {
         assert_eq!(
             worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Protected,
                 authority: WorktreeAuthority::Generation,
                 socket: WorktreeSocket::Custom,
                 session: WorktreeSessionPresence::Absent,
@@ -9879,6 +10041,19 @@ mod tests {
                 },
             }),
             WorktreeOpenMode::RepairOrOpen
+        );
+        assert_eq!(
+            worktree_open_mode(WorktreeOpenContext {
+                attach_mode: KwtTmuxAttachMode::Protected,
+                authority: WorktreeAuthority::Generation,
+                socket: WorktreeSocket::Custom,
+                session: WorktreeSessionPresence::Absent,
+                presentation: WorktreePresentation::Inactive,
+                host: WorktreeHostAccess::Ready {
+                    kwt_available: false,
+                },
+            }),
+            WorktreeOpenMode::Disabled
         );
     }
 
@@ -10023,6 +10198,7 @@ mod tests {
                     generation: Some("11111111111111111111111111111111".to_owned()),
                     session_name: "widget-topic".to_owned(),
                     tmux_socket_name: None,
+                    tmux_attach_mode: KwtTmuxAttachMode::Direct,
                 },
                 project_name: "widget".to_owned(),
                 branch: "topic".to_owned(),
@@ -10400,6 +10576,26 @@ mod tests {
     }
 
     #[test]
+    fn default_kwt_selection_matches_its_normalized_tmux_presentation() {
+        let worktree = SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "project-topic",
+            KwtTmuxAttachMode::Direct,
+            None,
+            "/work/project/topic",
+            Some("generation".to_owned()),
+        );
+        let presentation = SessionSelection::new("wsl", "Ubuntu", "project-topic");
+
+        assert!(kwt_selection_matches_presentation(&worktree, &presentation));
+        assert!(!kwt_selection_matches_presentation(
+            &worktree,
+            &SessionSelection::new("wsl", "Ubuntu", "other")
+        ));
+    }
+
+    #[test]
     fn active_terminal_context_moves_into_the_native_window_title() {
         let size = GridSize::new(80, 24).expect("valid grid");
         let terminal = WorkspaceContent::Terminal {
@@ -10496,7 +10692,7 @@ mod tests {
                         true,
                         None,
                         "project-main",
-                        None,
+                        (None, KwtTmuxAttachMode::Direct),
                         true,
                     ),
                     WorktreeItem::new(
@@ -10505,7 +10701,7 @@ mod tests {
                         false,
                         None,
                         "custom-socket",
-                        Some("project-socket".to_owned()),
+                        (Some("project-socket".to_owned()), KwtTmuxAttachMode::Direct),
                         false,
                     ),
                 ],
@@ -10548,19 +10744,23 @@ mod tests {
                     false,
                     Some("0123456789abcdef0123456789abcdef".to_owned()),
                     "project-pr-17",
-                    Some("kwt-pr-0123456789abcdef".to_owned()),
+                    (
+                        Some("kwt-pr-0123456789abcdef".to_owned()),
+                        KwtTmuxAttachMode::Protected,
+                    ),
                     false,
                 )],
             )],
             Vec::new(),
         );
-        let active = SessionSelection::protected_worktree(
+        let active = SessionSelection::kwt_workspace(
             "wsl",
             "Ubuntu",
             "project-pr-17",
-            "kwt-pr-0123456789abcdef",
+            KwtTmuxAttachMode::Protected,
+            Some("kwt-pr-0123456789abcdef".to_owned()),
             "/repos/project-pr",
-            "0123456789abcdef0123456789abcdef",
+            Some("0123456789abcdef0123456789abcdef".to_owned()),
         );
         let rows = tree_sessions(&host, Some(&active), &[]);
 
@@ -10586,7 +10786,10 @@ mod tests {
                             false,
                             Some("0123456789abcdef0123456789abcdef".to_owned()),
                             "project-pr-17",
-                            Some("kwt-pr-replacement".to_owned()),
+                            (
+                                Some("kwt-pr-replacement".to_owned()),
+                                KwtTmuxAttachMode::Protected,
+                            ),
                             false,
                         )],
                     )],
@@ -10596,6 +10799,26 @@ mod tests {
         assert_eq!(fallback_rows.len(), 1);
         assert_eq!(fallback_rows[0].selection, active);
         assert!(fallback_rows[0].state.is_active());
+    }
+
+    #[test]
+    fn custom_socket_fallback_rows_remain_killable() {
+        let host = HostItem::wsl("Ubuntu", None, HostConnectionState::Ready, Vec::new(), None);
+        let selection = SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "project-topic",
+            KwtTmuxAttachMode::Direct,
+            Some("kwt-project".to_owned()),
+            "/work/project/topic",
+            Some("generation".to_owned()),
+        );
+
+        let active = tree_sessions(&host, Some(&selection), &[]);
+        let retained = tree_sessions(&host, None, std::slice::from_ref(&selection));
+
+        assert!(active[0].state.can_kill());
+        assert!(retained[0].state.can_kill());
     }
 
     #[test]

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -1406,10 +1406,22 @@ const fn can_open_directory_workspace(
     session_available: bool,
     kwt_open_available: bool,
 ) -> bool {
-    is_presented
-        || (matches!(attach_mode, KwtTmuxAttachMode::Direct)
-            && ((matches!(socket, WorktreeSocket::Default) && session_available)
-                || kwt_open_available))
+    matches!(attach_mode, KwtTmuxAttachMode::Direct)
+        && (is_presented
+            || (matches!(socket, WorktreeSocket::Default) && session_available)
+            || kwt_open_available)
+}
+
+const fn can_kill_directory_workspace(
+    host_can_attach: bool,
+    attach_mode: KwtTmuxAttachMode,
+    socket: WorktreeSocket,
+    session_available: bool,
+) -> bool {
+    host_can_attach
+        && session_available
+        && (matches!(attach_mode, KwtTmuxAttachMode::Direct)
+            || matches!(socket, WorktreeSocket::Custom))
 }
 
 fn owns_created_worktree_navigation(
@@ -7608,18 +7620,25 @@ impl RootView {
             let is_retained = retained
                 .iter()
                 .any(|retained| kwt_selection_matches_presentation(&selection, retained));
+            let socket = if workspace.tmux_socket_name().is_some() {
+                WorktreeSocket::Custom
+            } else {
+                WorktreeSocket::Default
+            };
+            let host_can_attach = host.accepts_session_actions();
             let can_open = can_open_directory_workspace(
                 is_active || is_retained,
                 workspace.tmux_attach_mode(),
-                if workspace.tmux_socket_name().is_some() {
-                    WorktreeSocket::Custom
-                } else {
-                    WorktreeSocket::Default
-                },
-                workspace.session_available() && host.accepts_session_actions(),
-                host.kwt_available() && host.accepts_session_actions(),
+                socket,
+                workspace.session_available() && host_can_attach,
+                host.kwt_available() && host_can_attach,
             );
-            let can_kill = workspace.session_available() && host.accepts_session_actions();
+            let can_kill = can_kill_directory_workspace(
+                host_can_attach,
+                workspace.tmux_attach_mode(),
+                socket,
+                workspace.session_available(),
+            );
             rows.push(Self::worktree_row(
                 host_index,
                 usize::MAX,
@@ -9550,8 +9569,8 @@ mod tests {
         activate_settings_sidebar_pane, active_session_selection, adjacent_appearance_field,
         advance_settings_focus, appearance_draft_is_persistable, appearance_preview_color,
         application_navigation_width, apply_new_worktree_failure, apply_worktree_removal_failure,
-        available_herdr_row_actions, can_create_worktree, can_kill_worktree,
-        can_open_directory_workspace, canonical_terminal_key_with,
+        available_herdr_row_actions, can_create_worktree, can_kill_directory_workspace,
+        can_kill_worktree, can_open_directory_workspace, canonical_terminal_key_with,
         chrome_palette_for_terminal_theme, clear_terminal_input_state, clears_after_input_delivery,
         clears_when_input_queue_is_empty, coalesce_last_resize, coalesce_last_wheel,
         focused_settings_detail, has_ambiguous_worktree_source, herdr_row_actions,
@@ -9910,7 +9929,7 @@ mod tests {
     }
 
     #[test]
-    fn directory_workspace_open_requires_a_live_default_session_or_kwt() {
+    fn directory_workspace_capabilities_follow_attachment_contract() {
         assert!(can_open_directory_workspace(
             false,
             KwtTmuxAttachMode::Direct,
@@ -9952,6 +9971,31 @@ mod tests {
             WorktreeSocket::Custom,
             false,
             false,
+        ));
+        assert!(!can_open_directory_workspace(
+            true,
+            KwtTmuxAttachMode::Protected,
+            WorktreeSocket::Default,
+            true,
+            true,
+        ));
+        assert!(can_kill_directory_workspace(
+            true,
+            KwtTmuxAttachMode::Direct,
+            WorktreeSocket::Default,
+            true,
+        ));
+        assert!(can_kill_directory_workspace(
+            true,
+            KwtTmuxAttachMode::Protected,
+            WorktreeSocket::Custom,
+            true,
+        ));
+        assert!(!can_kill_directory_workspace(
+            true,
+            KwtTmuxAttachMode::Protected,
+            WorktreeSocket::Default,
+            true,
         ));
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use config::{ApplicationConfig, Roots, SshHostSettings, TerminalAppearance};
 pub use config::{CursorStyle, TerminalTheme};
+pub use host::KwtTmuxAttachMode;
 use host::{
     AdmissionAttacher, AttachTerm, CancellationToken, CommandRunner, HerdrInventory, HostError,
     HostSnapshot, KwtInventory, KwtPullRequestImportRequest, KwtSshExecutable, LiveSessionTarget,
@@ -54,12 +55,11 @@ use runtime::{
     reconcile_herdr_lifecycle_fences, refresh_is_in_flight, register_remote_attachment,
     register_remote_constructive, register_scene, release_zellij_kill,
     remember_pending_kwt_creation, remote_constructive_is_current, remote_host_for_connection,
-    remove_killed_zellij_session, require_current_protected_selection,
-    require_host_session_actions, reserve_constructive_inventory, reserve_refresh,
-    reserve_zellij_kill, scene_by_id, set_herdr_inventory, set_remote_herdr_launch_pending,
-    set_remote_host_snapshot, set_remote_host_state, set_zellij_inventory,
-    settle_remote_constructive_task, unregister_scene, with_current_remote_constructive,
-    zellij_kill_is_current,
+    remove_killed_zellij_session, require_current_kwt_selection, require_host_session_actions,
+    reserve_constructive_inventory, reserve_refresh, reserve_zellij_kill, scene_by_id,
+    set_herdr_inventory, set_remote_herdr_launch_pending, set_remote_host_snapshot,
+    set_remote_host_state, set_zellij_inventory, settle_remote_constructive_task, unregister_scene,
+    with_current_remote_constructive, zellij_kill_is_current,
 };
 use scene::{
     NavigationFence, Scene, activate_retained_presentation, attach_scene, begin_refresh,
@@ -293,6 +293,7 @@ pub struct SessionSelection {
     session: String,
     kind: SessionKind,
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: Option<host::KwtTmuxAttachMode>,
     worktree_path: Option<String>,
     worktree_generation: Option<String>,
 }
@@ -330,28 +331,31 @@ impl SessionSelection {
             session: session.into(),
             kind: SessionKind::Tmux,
             tmux_socket_name: None,
+            tmux_attach_mode: None,
             worktree_path: None,
             worktree_generation: None,
         }
     }
 
     #[must_use]
-    pub fn protected_worktree(
+    pub fn kwt_workspace(
         host_id: impl Into<String>,
         endpoint: impl Into<String>,
         session: impl Into<String>,
-        socket_name: impl Into<String>,
+        tmux_attach_mode: host::KwtTmuxAttachMode,
+        socket_name: Option<String>,
         path: impl Into<String>,
-        generation: impl Into<String>,
+        generation: Option<String>,
     ) -> Self {
         Self {
             host_id: host_id.into(),
             endpoint: endpoint.into(),
             session: session.into(),
             kind: SessionKind::Tmux,
-            tmux_socket_name: Some(socket_name.into()),
+            tmux_socket_name: socket_name,
+            tmux_attach_mode: Some(tmux_attach_mode),
             worktree_path: Some(path.into()),
-            worktree_generation: Some(generation.into()),
+            worktree_generation: generation,
         }
     }
 
@@ -367,6 +371,7 @@ impl SessionSelection {
             session: session.into(),
             kind: SessionKind::Herdr,
             tmux_socket_name: None,
+            tmux_attach_mode: None,
             worktree_path: None,
             worktree_generation: None,
         }
@@ -384,6 +389,7 @@ impl SessionSelection {
             session: session.into(),
             kind: SessionKind::Zellij,
             tmux_socket_name: None,
+            tmux_attach_mode: None,
             worktree_path: None,
             worktree_generation: None,
         }
@@ -412,6 +418,11 @@ impl SessionSelection {
     #[must_use]
     pub fn tmux_socket_name(&self) -> Option<&str> {
         self.tmux_socket_name.as_deref()
+    }
+
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> Option<host::KwtTmuxAttachMode> {
+        self.tmux_attach_mode
     }
 
     #[must_use]
@@ -558,6 +569,7 @@ pub struct WorktreeItem {
     generation: Option<String>,
     session_name: String,
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
     session_available: bool,
 }
 
@@ -569,9 +581,10 @@ impl WorktreeItem {
         is_main: bool,
         generation: Option<String>,
         session_name: impl Into<String>,
-        tmux_socket_name: Option<String>,
+        tmux_endpoint: (Option<String>, host::KwtTmuxAttachMode),
         session_available: bool,
     ) -> Self {
+        let (tmux_socket_name, tmux_attach_mode) = tmux_endpoint;
         Self {
             path: path.into(),
             branch: branch.into(),
@@ -579,6 +592,7 @@ impl WorktreeItem {
             generation,
             session_name: session_name.into(),
             tmux_socket_name,
+            tmux_attach_mode,
             session_available,
         }
     }
@@ -614,6 +628,11 @@ impl WorktreeItem {
     }
 
     #[must_use]
+    pub const fn tmux_attach_mode(&self) -> host::KwtTmuxAttachMode {
+        self.tmux_attach_mode
+    }
+
+    #[must_use]
     pub const fn session_available(&self) -> bool {
         self.session_available
     }
@@ -624,6 +643,8 @@ pub struct DirectoryWorkspaceItem {
     name: String,
     path: String,
     session_name: String,
+    tmux_socket_name: Option<String>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
     session_available: bool,
 }
 
@@ -633,12 +654,16 @@ impl DirectoryWorkspaceItem {
         name: impl Into<String>,
         path: impl Into<String>,
         session_name: impl Into<String>,
+        tmux_endpoint: (Option<String>, host::KwtTmuxAttachMode),
         session_available: bool,
     ) -> Self {
+        let (tmux_socket_name, tmux_attach_mode) = tmux_endpoint;
         Self {
             name: name.into(),
             path: path.into(),
             session_name: session_name.into(),
+            tmux_socket_name,
+            tmux_attach_mode,
             session_available,
         }
     }
@@ -656,6 +681,16 @@ impl DirectoryWorkspaceItem {
     #[must_use]
     pub fn session_name(&self) -> &str {
         &self.session_name
+    }
+
+    #[must_use]
+    pub fn tmux_socket_name(&self) -> Option<&str> {
+        self.tmux_socket_name.as_deref()
+    }
+
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> host::KwtTmuxAttachMode {
+        self.tmux_attach_mode
     }
 
     #[must_use]
@@ -974,34 +1009,42 @@ impl HostItem {
     pub fn kwt_owns_default_tmux_session(&self, name: &str) -> bool {
         self.projects.iter().any(|project| {
             project.worktrees.iter().any(|worktree| {
-                worktree.tmux_socket_name.is_none() && worktree.session_name == name
+                worktree.tmux_attach_mode == host::KwtTmuxAttachMode::Direct
+                    && worktree.tmux_socket_name.is_none()
+                    && worktree.session_name == name
             })
-        }) || self
-            .directory_workspaces
-            .iter()
-            .any(|workspace| workspace.session_name == name)
+        }) || self.directory_workspaces.iter().any(|workspace| {
+            workspace.tmux_attach_mode == host::KwtTmuxAttachMode::Direct
+                && workspace.tmux_socket_name.is_none()
+                && workspace.session_name == name
+        })
     }
 
     #[must_use]
-    pub fn kwt_owns_protected_presentation(&self, selection: &SessionSelection) -> bool {
-        let (Some(socket_name), Some(worktree_path), Some(generation)) = (
-            selection.tmux_socket_name(),
-            selection.worktree_path(),
-            selection.worktree_generation(),
-        ) else {
+    pub fn kwt_owns_workspace_presentation(&self, selection: &SessionSelection) -> bool {
+        let (Some(mode), Some(worktree_path)) =
+            (selection.tmux_attach_mode(), selection.worktree_path())
+        else {
             return false;
         };
         selection.kind() == SessionKind::Tmux
             && selection.host_id() == self.id
             && selection.endpoint() == self.endpoint
-            && self.projects.iter().any(|project| {
+            && (self.projects.iter().any(|project| {
                 project.worktrees.iter().any(|worktree| {
                     worktree.session_name == selection.session()
-                        && worktree.tmux_socket_name.as_deref() == Some(socket_name)
+                        && worktree.tmux_socket_name.as_deref() == selection.tmux_socket_name()
+                        && worktree.tmux_attach_mode == mode
                         && worktree.path == worktree_path
-                        && worktree.generation.as_deref() == Some(generation)
+                        && worktree.generation.as_deref() == selection.worktree_generation()
                 })
-            })
+            }) || self.directory_workspaces.iter().any(|workspace| {
+                workspace.session_name == selection.session()
+                    && workspace.tmux_socket_name.as_deref() == selection.tmux_socket_name()
+                    && workspace.tmux_attach_mode == mode
+                    && workspace.path == worktree_path
+                    && selection.worktree_generation().is_none()
+            }))
     }
 }
 
@@ -1444,6 +1487,7 @@ pub struct KwtWorktreeTarget {
     generation: Option<String>,
     session_name: String,
     tmux_socket_name: Option<String>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
 }
 
 impl KwtWorktreeTarget {
@@ -1482,6 +1526,10 @@ impl KwtWorktreeTarget {
     #[must_use]
     pub fn tmux_socket_name(&self) -> Option<&str> {
         self.tmux_socket_name.as_deref()
+    }
+    #[must_use]
+    pub const fn tmux_attach_mode(&self) -> host::KwtTmuxAttachMode {
+        self.tmux_attach_mode
     }
 }
 
@@ -2586,6 +2634,7 @@ struct AttachRequest {
     endpoint: host::WslEndpoint,
     runtime: host::WslRuntimeIdentity,
     target: AttachTarget,
+    exact_worktree_attach: bool,
     name: String,
     inventory_generation: u64,
 }
@@ -2600,12 +2649,21 @@ impl AttachRequest {
     }
 }
 
-fn normalize_attached_worktree_target(
+fn normalize_attached_kwt_target(
     active: &mut ActiveAttachment<AttachRequest>,
     snapshot: &HostSnapshot,
     attached_name: &str,
 ) -> bool {
-    if !matches!(active.request.target, AttachTarget::Worktree { .. }) {
+    if !matches!(
+        active.request.target,
+        AttachTarget::Worktree {
+            tmux_socket_name: None,
+            ..
+        } | AttachTarget::DirectoryWorkspace {
+            tmux_socket_name: None,
+            ..
+        }
+    ) {
         return false;
     }
     let Some(identity) = snapshot
@@ -2626,19 +2684,24 @@ fn normalize_attached_worktree_target(
     true
 }
 
-fn worktree_tmux_presentation_key(
+fn kwt_tmux_presentation_key(
     request: &AttachRequest,
     snapshot: &HostSnapshot,
 ) -> Option<PresentationKey> {
-    let AttachTarget::Worktree { session_name, .. } = &request.target else {
-        return None;
+    let identity = match &request.target {
+        AttachTarget::Worktree {
+            session_name,
+            tmux_socket_name: None,
+            ..
+        } => snapshot
+            .sessions()
+            .iter()
+            .find(|session| session.name() == session_name)?
+            .identity()
+            .clone(),
+        AttachTarget::DiscoveredWorktree { identity, .. } => identity.clone(),
+        _ => return None,
     };
-    let identity = snapshot
-        .sessions()
-        .iter()
-        .find(|session| session.name() == session_name)?
-        .identity()
-        .clone();
     Some(PresentationKey {
         host_id: request.host_id.clone(),
         endpoint: request.endpoint.distro().to_owned(),
@@ -2655,9 +2718,26 @@ fn attach_target_matches_killed_tmux(
     socket_name: Option<&str>,
 ) -> bool {
     match target {
-        AttachTarget::Tmux(target_identity) => target_identity == identity,
-        AttachTarget::Worktree { session_name, .. } => {
-            socket_name.is_none() && name.is_some_and(|name| session_name == name)
+        AttachTarget::Tmux(target_identity)
+        | AttachTarget::DiscoveredWorktree {
+            identity: target_identity,
+            ..
+        } => target_identity == identity,
+        AttachTarget::Worktree {
+            session_name,
+            tmux_socket_name,
+            ..
+        } => {
+            tmux_socket_name.as_deref() == socket_name
+                && name.is_some_and(|name| session_name == name)
+        }
+        AttachTarget::DirectoryWorkspace {
+            session_name,
+            tmux_socket_name,
+            ..
+        } => {
+            tmux_socket_name.as_deref() == socket_name
+                && name.is_some_and(|name| session_name == name)
         }
         AttachTarget::ProtectedWorktree {
             session_name,
@@ -2704,8 +2784,22 @@ enum AttachTarget {
         repository: String,
         registration_fingerprint: String,
         path: String,
+        generation: String,
+        session_name: String,
+        tmux_socket_name: Option<String>,
+    },
+    DiscoveredWorktree {
+        repository: String,
+        registration_fingerprint: String,
+        path: String,
         generation: Option<String>,
         session_name: String,
+        identity: session::SessionIdentity,
+    },
+    DirectoryWorkspace {
+        path: String,
+        session_name: String,
+        tmux_socket_name: Option<String>,
     },
     ProtectedWorktree {
         repository: String,
@@ -2745,9 +2839,11 @@ impl AttachTarget {
 
     const fn kind(&self) -> SessionKind {
         match self {
-            Self::Tmux(_) | Self::Worktree { .. } | Self::ProtectedWorktree { .. } => {
-                SessionKind::Tmux
-            }
+            Self::Tmux(_)
+            | Self::Worktree { .. }
+            | Self::DiscoveredWorktree { .. }
+            | Self::DirectoryWorkspace { .. }
+            | Self::ProtectedWorktree { .. } => SessionKind::Tmux,
             Self::Herdr { .. } => SessionKind::Herdr,
             Self::Zellij { .. } => SessionKind::Zellij,
         }
@@ -2962,13 +3058,64 @@ impl AttachRequest {
             ..
         } = &self.target
         {
-            return SessionSelection::protected_worktree(
+            return SessionSelection::kwt_workspace(
                 &self.host_id,
                 self.endpoint.distro(),
                 &self.name,
-                tmux_socket_name,
+                host::KwtTmuxAttachMode::Protected,
+                Some(tmux_socket_name.clone()),
                 path,
-                generation,
+                Some(generation.clone()),
+            );
+        }
+        if let AttachTarget::Worktree {
+            path,
+            generation,
+            tmux_socket_name,
+            ..
+        } = &self.target
+        {
+            return SessionSelection::kwt_workspace(
+                &self.host_id,
+                self.endpoint.distro(),
+                &self.name,
+                host::KwtTmuxAttachMode::Direct,
+                tmux_socket_name.clone(),
+                path,
+                Some(generation.clone()),
+            );
+        }
+        if let AttachTarget::DiscoveredWorktree {
+            path,
+            generation,
+            session_name,
+            ..
+        } = &self.target
+        {
+            return SessionSelection::kwt_workspace(
+                &self.host_id,
+                self.endpoint.distro(),
+                session_name,
+                host::KwtTmuxAttachMode::Direct,
+                None,
+                path,
+                generation.clone(),
+            );
+        }
+        if let AttachTarget::DirectoryWorkspace {
+            path,
+            tmux_socket_name,
+            ..
+        } = &self.target
+        {
+            return SessionSelection::kwt_workspace(
+                &self.host_id,
+                self.endpoint.distro(),
+                &self.name,
+                host::KwtTmuxAttachMode::Direct,
+                tmux_socket_name.clone(),
+                path,
+                None,
             );
         }
         match self.target.kind() {
@@ -3417,12 +3564,15 @@ fn refreshed_session_name(
         && key.socket_directory.as_deref() == socket_directory
         && key.runtime == *snapshot.runtime())
     .then(|| match &key.target {
-        AttachTarget::Tmux(identity) => snapshot
-            .sessions()
-            .iter()
-            .find(|session| session.identity() == identity)
-            .map(|session| session.name().to_owned()),
+        AttachTarget::Tmux(identity) | AttachTarget::DiscoveredWorktree { identity, .. } => {
+            snapshot
+                .sessions()
+                .iter()
+                .find(|session| session.identity() == identity)
+                .map(|session| session.name().to_owned())
+        }
         AttachTarget::Worktree { session_name, .. }
+        | AttachTarget::DirectoryWorkspace { session_name, .. }
         | AttachTarget::ProtectedWorktree { session_name, .. } => Some(session_name.clone()),
         AttachTarget::Herdr {
             executable,
@@ -5084,6 +5234,7 @@ impl Workspace {
         generation: &str,
         session_name: &str,
         tmux_socket_name: Option<&str>,
+        tmux_attach_mode: host::KwtTmuxAttachMode,
     ) -> Result<u64, WorkspaceError> {
         // Same closed-scene fence as the other destructive confirmations,
         // held from authority creation through the identity-query
@@ -5094,18 +5245,20 @@ impl Workspace {
                 "Refresh KWT inventory before removing this worktree.",
             ));
         }
-        let (host, resolved_endpoint, runtime, socket_name) = capture_kwt_worktree_removal_context(
-            &self.scene.runtime,
-            host_id,
-            endpoint,
-            repository,
-            project_path,
-            registration_fingerprint,
-            worktree_path,
-            generation,
-            session_name,
-            tmux_socket_name,
-        )?;
+        let (host, resolved_endpoint, runtime, socket_name, resolved_attach_mode) =
+            capture_kwt_worktree_removal_context(
+                &self.scene.runtime,
+                host_id,
+                endpoint,
+                repository,
+                project_path,
+                registration_fingerprint,
+                worktree_path,
+                generation,
+                session_name,
+                tmux_socket_name,
+                tmux_attach_mode,
+            )?;
         let mut pending = self
             .scene
             .pending_kwt_removal
@@ -5148,6 +5301,7 @@ impl Workspace {
             generation: generation.to_owned(),
             session_name: session_name.to_owned(),
             socket_name,
+            tmux_attach_mode: resolved_attach_mode,
         };
         let scene = Arc::clone(&self.scene);
         self.scene
@@ -5263,6 +5417,7 @@ impl Workspace {
                 generation: generation.to_owned(),
                 session_name: session_name.to_owned(),
                 socket_name: pending.socket_name.clone(),
+                tmux_attach_mode: pending.tmux_attach_mode,
                 live_target: pending.live_target.clone(),
                 operation_id: authority,
             },
@@ -6048,6 +6203,7 @@ impl Workspace {
         generation: Option<&str>,
         session_name: &str,
         tmux_socket_name: Option<&str>,
+        tmux_attach_mode: host::KwtTmuxAttachMode,
     ) -> Result<(), WorkspaceError> {
         let _snapshot_write = begin_snapshot_write(&self.scene.runtime);
         let _navigation = lock_live_navigation(&self.scene)?;
@@ -6062,6 +6218,7 @@ impl Workspace {
             generation,
             session_name,
             tmux_socket_name,
+            tmux_attach_mode,
         )?;
         let worktree_key = request.presentation_key();
         let equivalent_tmux_key = equivalent_tmux_presentation_key(&self.scene.runtime, &request);
@@ -6749,7 +6906,13 @@ impl Workspace {
         selection: &SessionSelection,
     ) -> Result<(PresentationKey, Option<AttachRequest>), WorkspaceError> {
         let retained = self.retained_key_for_selection(selection);
-        choose_navigation_target(retained, capture_attach_request(&self.scene, selection))
+        let current = capture_attach_request(&self.scene, selection);
+        let equivalent = current
+            .as_ref()
+            .ok()
+            .and_then(|request| equivalent_tmux_presentation_key(&self.scene.runtime, request))
+            .filter(|key| presentation_is_open(&self.scene, key));
+        choose_navigation_target(retained, equivalent, current)
     }
 
     fn supersede_inflight_attachment(&self) -> Result<Option<PresentationKey>, WorkspaceError> {
@@ -7020,8 +7183,9 @@ impl Workspace {
     ///
     /// # Errors
     ///
-    /// Returns an error when the selection is not part of the current WSL
-    /// inventory or the background query cannot be started.
+    /// Returns an error when the selection is neither current inventory nor a
+    /// retained exact-socket presentation, or the background query cannot be
+    /// started.
     pub fn request_session_kill(&self, selection: &SessionSelection) -> Result<(), WorkspaceError> {
         // Destructive confirmations are constructive entries: a retained
         // handle of a closed scene must not re-arm a kill after the close
@@ -8331,8 +8495,12 @@ fn current_remote_context(entry: &RemoteEntry) -> Option<&RemoteHostContext> {
 
 fn choose_navigation_target(
     retained: Option<PresentationKey>,
+    equivalent: Option<PresentationKey>,
     current: Result<AttachRequest, WorkspaceError>,
 ) -> Result<(PresentationKey, Option<AttachRequest>), WorkspaceError> {
+    if let Some(key) = equivalent {
+        return Ok((key, None));
+    }
     match current {
         Ok(request) => {
             let key = request.presentation_key();
@@ -8403,6 +8571,7 @@ enum KwtWorktreeOperation {
         generation: String,
         session_name: String,
         socket_name: Option<String>,
+        tmux_attach_mode: host::KwtTmuxAttachMode,
         live_target: Option<Arc<host::LiveSessionTarget>>,
         operation_id: u64,
     },
@@ -8450,6 +8619,7 @@ struct PendingKwtRemoval {
     generation: String,
     session_name: String,
     socket_name: Option<String>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
     live_target: Option<Arc<host::LiveSessionTarget>>,
 }
 
@@ -8465,6 +8635,7 @@ struct KwtRemovalCapture {
     generation: String,
     session_name: String,
     socket_name: Option<String>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
 }
 
 #[derive(Clone)]
@@ -8504,6 +8675,7 @@ fn validate_kwt_worktree_operation(
         generation,
         session_name,
         socket_name,
+        tmux_attach_mode,
         ..
     } = operation
     else {
@@ -8517,6 +8689,7 @@ fn validate_kwt_worktree_operation(
                 && worktree.generation.as_deref() == Some(generation)
                 && worktree.session_name == *session_name
                 && worktree.tmux_socket_name.as_ref() == socket_name.as_ref()
+                && worktree.tmux_attach_mode == *tmux_attach_mode
         })
         .ok_or_else(|| {
             WorkspaceError::new("the selected worktree changed; refresh and choose it again")
@@ -8574,7 +8747,14 @@ fn preflight_kwt_worktree_remove(
     generation: &str,
     session_name: &str,
     socket_name: Option<&str>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
 ) -> Result<(), String> {
+    if tmux_attach_mode == host::KwtTmuxAttachMode::Protected && socket_name.is_none() {
+        return Err(
+            "the protected worktree endpoint is unresolved; refresh and review the removal again"
+                .to_owned(),
+        );
+    }
     let inventory = task
         .host
         .discover_kwt(&task.endpoint, &task.runtime, &task.cancellation)
@@ -8590,6 +8770,7 @@ fn preflight_kwt_worktree_remove(
                     && worktree.generation() == Some(generation)
                     && worktree.session_name() == session_name
                     && worktree.tmux_socket_name() == socket_name
+                    && worktree.tmux_attach_mode() == tmux_attach_mode
                     && !worktree.is_main()
             })
         })?
@@ -8694,6 +8875,7 @@ fn pending_kwt_creation_target(
         generation: worktree.generation().map(str::to_owned),
         session_name: worktree.session_name().to_owned(),
         tmux_socket_name: worktree.tmux_socket_name().map(str::to_owned),
+        tmux_attach_mode: worktree.tmux_attach_mode(),
     })
 }
 
@@ -9195,6 +9377,7 @@ fn validate_protected_worktree_inventory(
                     && worktree.generation() == Some(generation)
                     && worktree.session_name() == session_name
                     && worktree.tmux_socket_name() == Some(tmux_socket_name)
+                    && worktree.tmux_attach_mode() == host::KwtTmuxAttachMode::Protected
             })
     });
     if exact {
@@ -9525,12 +9708,18 @@ fn reconcile_kwt_session_availability(host: &mut HostItem) {
         .collect::<std::collections::HashSet<_>>();
     for project in &mut host.projects {
         for worktree in &mut project.worktrees {
-            worktree.session_available = worktree.tmux_socket_name.is_none()
+            worktree.session_available = worktree.tmux_attach_mode
+                == host::KwtTmuxAttachMode::Direct
+                && worktree.tmux_socket_name.is_none()
                 && session_names.contains(worktree.session_name.as_str());
         }
     }
     for workspace in &mut host.directory_workspaces {
-        workspace.session_available = session_names.contains(workspace.session_name.as_str());
+        if workspace.tmux_attach_mode == host::KwtTmuxAttachMode::Direct
+            && workspace.tmux_socket_name.is_none()
+        {
+            workspace.session_available = session_names.contains(workspace.session_name.as_str());
+        }
     }
 }
 

--- a/rust/workspace/src/runtime.rs
+++ b/rust/workspace/src/runtime.rs
@@ -14,9 +14,9 @@ use crate::{
     SettingsState, SharedCommandRunner, SshExecutable, SuppressedHerdrPresentation, Weak,
     WorkspaceContent, WorkspaceError, WslConfig, WslDiscovery, WslExecutable, ZellijInventory,
     ZellijSessionName, apply_herdr_inventory, apply_zellij_inventory, current_remote_context,
-    refreshed_session_name, remote_snapshot_authority_matches, resolve_remote_herdr_attach_target,
-    resolve_remote_zellij_attach_target, validate_herdr_launch_precondition,
-    worktree_tmux_presentation_key,
+    kwt_tmux_presentation_key, refreshed_session_name, remote_snapshot_authority_matches,
+    resolve_remote_herdr_attach_target, resolve_remote_zellij_attach_target,
+    validate_herdr_launch_precondition,
 };
 pub(crate) fn equivalent_tmux_presentation_key(
     runtime: &Runtime,
@@ -30,7 +30,7 @@ pub(crate) fn equivalent_tmux_presentation_key(
         published.value.snapshot.endpoint() == &request.endpoint
             && published.value.snapshot.runtime() == &request.runtime
     })?;
-    worktree_tmux_presentation_key(request, &host.value.snapshot)
+    kwt_tmux_presentation_key(request, &host.value.snapshot)
 }
 
 /// Process-wide state: host connections, inventory discovery and
@@ -531,17 +531,18 @@ pub(crate) fn finish_pending_creation(runtime: &Runtime, pending: &PendingCreati
     }
 }
 
-pub(crate) fn require_current_protected_selection(
+pub(crate) fn require_current_kwt_selection(
     runtime: &Runtime,
     selection: &SessionSelection,
 ) -> Result<(), WorkspaceError> {
-    let Some(socket_name) = selection.tmux_socket_name() else {
+    let Some(mode) = selection.tmux_attach_mode() else {
         return Ok(());
     };
-    let exact_worktree = runtime
+    let hosts = runtime
         .hosts
         .read()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let exact_worktree = hosts
         .iter()
         .filter(|host| {
             host.id() == selection.host_id()
@@ -552,15 +553,31 @@ pub(crate) fn require_current_protected_selection(
         .flat_map(ProjectItem::worktrees)
         .any(|worktree| {
             worktree.session_name() == selection.session()
-                && worktree.tmux_socket_name() == Some(socket_name)
+                && worktree.tmux_socket_name() == selection.tmux_socket_name()
+                && worktree.tmux_attach_mode() == mode
                 && worktree.path() == selection.worktree_path().unwrap_or_default()
                 && worktree.generation() == selection.worktree_generation()
-        });
+        })
+        || hosts
+            .iter()
+            .filter(|host| {
+                host.id() == selection.host_id()
+                    && host.endpoint() == selection.endpoint()
+                    && host.connection() == HostConnectionState::Ready
+            })
+            .flat_map(HostItem::directory_workspaces)
+            .any(|workspace| {
+                workspace.session_name() == selection.session()
+                    && workspace.tmux_socket_name() == selection.tmux_socket_name()
+                    && workspace.tmux_attach_mode() == mode
+                    && workspace.path() == selection.worktree_path().unwrap_or_default()
+                    && selection.worktree_generation().is_none()
+            });
     if exact_worktree {
         Ok(())
     } else {
         Err(WorkspaceError::new(
-            "protected worktree is not in the current inventory",
+            "KWT workspace is not in the current inventory",
         ))
     }
 }
@@ -1037,12 +1054,14 @@ pub(crate) fn capture_kwt_worktree_removal_context(
     generation: &str,
     session_name: &str,
     tmux_socket_name: Option<&str>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
 ) -> Result<
     (
         RuntimeHost,
         host::WslEndpoint,
         host::WslRuntimeIdentity,
         Option<String>,
+        host::KwtTmuxAttachMode,
     ),
     WorkspaceError,
 > {
@@ -1095,6 +1114,7 @@ pub(crate) fn capture_kwt_worktree_removal_context(
                     && worktree.generation.as_deref() == Some(generation)
                     && worktree.session_name == session_name
                     && worktree.tmux_socket_name.as_deref() == tmux_socket_name
+                    && worktree.tmux_attach_mode == tmux_attach_mode
             })
         })
         .ok_or_else(|| {
@@ -1105,11 +1125,19 @@ pub(crate) fn capture_kwt_worktree_removal_context(
             "the primary checkout cannot be removed",
         ));
     }
+    if worktree.tmux_attach_mode == host::KwtTmuxAttachMode::Protected
+        && worktree.tmux_socket_name.is_none()
+    {
+        return Err(WorkspaceError::new(
+            "refresh KWT inventory before removing this protected worktree",
+        ));
+    }
     Ok((
         context.0,
         context.1,
         context.2,
         worktree.tmux_socket_name.clone(),
+        worktree.tmux_attach_mode,
     ))
 }
 

--- a/rust/workspace/src/scene.rs
+++ b/rust/workspace/src/scene.rs
@@ -7691,7 +7691,8 @@ pub(crate) fn capture_kwt_worktree_request(
                     tmux_socket_name: worktree.tmux_socket_name.clone(),
                 },
             },
-            exact_worktree_attach: false,
+            exact_worktree_attach: worktree.tmux_attach_mode == host::KwtTmuxAttachMode::Direct
+                && worktree.tmux_socket_name.is_some(),
             name: worktree.session_name.clone(),
             inventory_generation,
         })

--- a/rust/workspace/src/scene.rs
+++ b/rust/workspace/src/scene.rs
@@ -36,7 +36,7 @@ use crate::{
     finish_pending_creation, fmt, for_each_scene, fresh_herdr_session, herdr_launch_result_matches,
     insert_remote_retained_presentation, insert_retained_presentation, invalidate_kwt_inventory,
     kwt_attachment_failure, kwt_pull_request_import_failure, live_scenes, lock_session_operations,
-    next_operation_id, next_presentation_id, next_scene_id, normalize_attached_worktree_target,
+    next_operation_id, next_presentation_id, next_scene_id, normalize_attached_kwt_target,
     pending_kwt_creation, pending_kwt_creation_target, pending_remote_constructive_snapshot,
     poll_session_startup, preflight_kwt_worktree_remove, publish_refresh,
     publish_worker_at_latest_geometry, ready_content, recapture_remote_herdr_attach_request,
@@ -46,7 +46,7 @@ use crate::{
     reconcile_kwt_session_availability, refresh_budget, refreshed_session_name, register_scene,
     remember_pending_kwt_creation, remote_constructive_is_current,
     remote_constructive_target_is_present, remove_cached_kwt_worktree,
-    require_current_protected_selection, require_host_session_actions, require_wsl_host_id,
+    require_current_kwt_selection, require_host_session_actions, require_wsl_host_id,
     reserve_constructive_inventory, reserve_refresh, reserve_retained_attachment,
     resize_terminal_worker, resolve_remote_herdr_attach_target,
     resolve_remote_zellij_attach_target, resolve_retained_retry_request, retain_remote_session,
@@ -1132,6 +1132,65 @@ pub(crate) fn reinsert_retained_presentation(
     insert_retained_presentation(&scene.runtime, &scene.retained_presentations, presentation);
 }
 
+fn direct_worktree_attach_target(
+    snapshot: &HostSnapshot,
+    repository: &str,
+    registration_fingerprint: &str,
+    path: &str,
+    generation: Option<&str>,
+    session_name: &str,
+    tmux_socket_name: Option<&str>,
+) -> Result<AttachTarget, WorkspaceError> {
+    let session = tmux_socket_name
+        .is_none()
+        .then(|| {
+            snapshot
+                .sessions()
+                .iter()
+                .find(|session| session.name() == session_name)
+        })
+        .flatten();
+    if let Some(session) = session {
+        return Ok(AttachTarget::DiscoveredWorktree {
+            repository: repository.to_owned(),
+            registration_fingerprint: registration_fingerprint.to_owned(),
+            path: path.to_owned(),
+            generation: generation.map(str::to_owned),
+            session_name: session_name.to_owned(),
+            identity: session.identity().clone(),
+        });
+    }
+    let Some(generation) = generation else {
+        return Err(WorkspaceError::new(if tmux_socket_name.is_some() {
+            "generationless worktree endpoint is unsupported"
+        } else {
+            "generationless worktree session is not in the current tmux inventory"
+        }));
+    };
+    Ok(AttachTarget::Worktree {
+        repository: repository.to_owned(),
+        registration_fingerprint: registration_fingerprint.to_owned(),
+        path: path.to_owned(),
+        generation: generation.to_owned(),
+        session_name: session_name.to_owned(),
+        tmux_socket_name: tmux_socket_name.map(str::to_owned),
+    })
+}
+
+fn required_kwt_worktree_generation(worktree: &WorktreeItem) -> Result<String, WorkspaceError> {
+    worktree.generation.clone().ok_or_else(|| {
+        let message = match worktree.tmux_attach_mode {
+            host::KwtTmuxAttachMode::Protected => {
+                "protected worktree generation is unavailable; refresh KWT inventory"
+            }
+            host::KwtTmuxAttachMode::Direct => {
+                "worktree generation is unavailable; refresh KWT inventory"
+            }
+        };
+        WorkspaceError::new(message)
+    })
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "the runtime/scene split lengthens shared-state paths without adding logic"
@@ -1166,18 +1225,121 @@ pub(crate) fn capture_attach_request(
         }
         let (target, name) = match selection.kind() {
             SessionKind::Tmux => {
-                let session = context
-                    .snapshot
-                    .sessions()
-                    .iter()
-                    .find(|session| session.name() == selection.session())
-                    .ok_or_else(|| {
-                        WorkspaceError::new("session is not in the current inventory")
-                    })?;
-                (
-                    AttachTarget::Tmux(session.identity().clone()),
-                    session.name().to_owned(),
-                )
+                if let Some(mode) = selection.tmux_attach_mode() {
+                    require_current_kwt_selection(&scene.runtime, selection)?;
+                    let hosts = scene
+                        .runtime
+                        .hosts
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let host_item = hosts
+                        .iter()
+                        .find(|host| {
+                            host.id() == selection.host_id()
+                                && host.endpoint() == selection.endpoint()
+                        })
+                        .ok_or_else(|| {
+                            WorkspaceError::new("the selected WSL host is unavailable")
+                        })?;
+                    if let Some((project, worktree)) = host_item.projects().iter().find_map(|project| {
+                        project.worktrees().iter().find(|worktree| {
+                            worktree.session_name() == selection.session()
+                                && worktree.tmux_socket_name() == selection.tmux_socket_name()
+                                && worktree.tmux_attach_mode() == mode
+                                && worktree.path() == selection.worktree_path().unwrap_or_default()
+                                && worktree.generation() == selection.worktree_generation()
+                        }).map(|worktree| (project, worktree))
+                    }) {
+                        let target = match mode {
+                            host::KwtTmuxAttachMode::Direct => direct_worktree_attach_target(
+                                &context.snapshot,
+                                project.repository(),
+                                project.registration_fingerprint(),
+                                worktree.path(),
+                                worktree.generation(),
+                                worktree.session_name(),
+                                worktree.tmux_socket_name(),
+                            )?,
+                            host::KwtTmuxAttachMode::Protected => {
+                                AttachTarget::ProtectedWorktree {
+                                    repository: project.repository().to_owned(),
+                                    project_path: project.path().to_owned(),
+                                    registration_fingerprint: project
+                                        .registration_fingerprint()
+                                        .to_owned(),
+                                    path: worktree.path().to_owned(),
+                                    generation: worktree.generation().ok_or_else(|| {
+                                        WorkspaceError::new(
+                                            "protected worktree generation is unavailable; refresh KWT inventory",
+                                        )
+                                    })?.to_owned(),
+                                    session_name: worktree.session_name().to_owned(),
+                                    tmux_socket_name: worktree.tmux_socket_name().ok_or_else(|| {
+                                        WorkspaceError::new(
+                                            "protected worktree endpoint is unresolved; refresh KWT inventory",
+                                        )
+                                    })?.to_owned(),
+                                }
+                            }
+                        };
+                        (target, worktree.session_name().to_owned())
+                    } else if let Some(workspace) = host_item
+                        .directory_workspaces()
+                        .iter()
+                        .find(|workspace| {
+                            workspace.session_name() == selection.session()
+                                && workspace.tmux_socket_name() == selection.tmux_socket_name()
+                                && workspace.tmux_attach_mode() == mode
+                                && workspace.path() == selection.worktree_path().unwrap_or_default()
+                        })
+                    {
+                        if mode != host::KwtTmuxAttachMode::Direct {
+                            return Err(WorkspaceError::new(
+                                "directory workspace attachment mode is unsupported",
+                            ));
+                        }
+                        let target = context
+                            .snapshot
+                            .sessions()
+                            .iter()
+                            .find(|session| {
+                                workspace.session_available()
+                                    && workspace.tmux_socket_name().is_none()
+                                    && session.name() == workspace.session_name()
+                            })
+                            .map_or_else(
+                                || AttachTarget::DirectoryWorkspace {
+                                    path: workspace.path().to_owned(),
+                                    session_name: workspace.session_name().to_owned(),
+                                    tmux_socket_name: workspace
+                                        .tmux_socket_name()
+                                        .map(str::to_owned),
+                                },
+                                |session| AttachTarget::Tmux(session.identity().clone()),
+                            );
+                        (
+                            target,
+                            workspace.session_name().to_owned(),
+                        )
+                    } else {
+                        return Err(WorkspaceError::new(
+                            "KWT workspace is not in the current inventory",
+                        ));
+                    }
+                } else {
+                    let session = context
+                        .snapshot
+                        .sessions()
+                        .iter()
+                        .find(|session| session.name() == selection.session())
+                        .ok_or_else(|| {
+                            WorkspaceError::new("session is not in the current inventory")
+                        })?;
+                    (
+                        AttachTarget::Tmux(session.identity().clone()),
+                        session.name().to_owned(),
+                    )
+                }
             }
             SessionKind::Herdr => {
                 let HerdrInventory::Available {
@@ -1231,12 +1393,20 @@ pub(crate) fn capture_attach_request(
                 )
             }
         };
+        let exact_worktree_attach = matches!(
+            &target,
+            AttachTarget::Worktree {
+                tmux_socket_name: Some(_),
+                ..
+            }
+        );
         Ok(AttachRequest {
             host_id: selection.host_id().to_owned(),
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
             target,
+            exact_worktree_attach,
             name,
             inventory_generation,
         })
@@ -1282,7 +1452,20 @@ pub(crate) fn capture_kill_request(
             runtime: request.runtime,
         });
     }
-    require_current_protected_selection(&scene.runtime, selection)?;
+    // A retained named-socket client preserves endpoint authority when its KWT
+    // row disappears. The worker still captures fresh session identity before
+    // it publishes destructive confirmation.
+    let retained_exact_socket = selection.kind() == SessionKind::Tmux
+        && selection.tmux_socket_name().is_some()
+        && scene
+            .retained_presentations
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .key_for_selection(selection)
+            .is_some();
+    if !retained_exact_socket {
+        require_current_kwt_selection(&scene.runtime, selection)?;
+    }
     let host = scene
         .runtime
         .host
@@ -1299,6 +1482,13 @@ pub(crate) fn capture_kill_request(
         }
         match selection.kind() {
             SessionKind::Tmux => {
+                if selection.tmux_attach_mode() == Some(host::KwtTmuxAttachMode::Protected)
+                    && selection.tmux_socket_name().is_none()
+                {
+                    return Err(WorkspaceError::new(
+                        "protected worktree endpoint is unresolved; refresh KWT inventory",
+                    ));
+                }
                 if selection.tmux_socket_name().is_none()
                     && !context
                         .snapshot
@@ -1903,6 +2093,19 @@ pub(crate) fn start_initial_kwt_refresh(scene: &Arc<Scene>) {
 }
 
 pub(crate) fn capture_kwt_removal_authority(scene: &Scene, capture: KwtRemovalCapture) {
+    if capture.tmux_attach_mode == host::KwtTmuxAttachMode::Protected
+        && capture.socket_name.is_none()
+    {
+        publish_kwt_removal_capture_failure(
+            scene,
+            capture.authority,
+            &capture.project_path,
+            &capture.worktree_path,
+            "the protected worktree endpoint is unresolved; refresh and review the removal again"
+                .to_owned(),
+        );
+        return;
+    }
     let cancellation = CancellationToken::new();
     let running = if let Some(socket_name) = capture.socket_name.as_deref() {
         capture.host.session_is_running_on_socket(
@@ -1996,6 +2199,7 @@ pub(crate) fn publish_captured_kwt_removal(
         generation: capture.generation,
         session_name: capture.session_name,
         socket_name: capture.socket_name,
+        tmux_attach_mode: capture.tmux_attach_mode,
         live_target,
     });
     // The capture this intent tracked has published; nothing is in flight.
@@ -2332,6 +2536,7 @@ pub(crate) fn run_kwt_worktree_operation(scene: &Arc<Scene>, task: &KwtWorktreeT
             generation,
             session_name,
             socket_name,
+            tmux_attach_mode,
             live_target,
             ..
         } => run_kwt_worktree_remove(
@@ -2341,6 +2546,7 @@ pub(crate) fn run_kwt_worktree_operation(scene: &Arc<Scene>, task: &KwtWorktreeT
             generation,
             session_name,
             socket_name.as_deref(),
+            *tmux_attach_mode,
             live_target.as_deref(),
         ),
     };
@@ -2452,6 +2658,7 @@ pub(crate) fn run_kwt_pull_request_import(
                         && worktree.generation() == workspace.generation()
                         && worktree.session_name() == workspace.session_name()
                         && worktree.tmux_socket_name() == workspace.tmux_socket_name()
+                        && worktree.tmux_attach_mode() == workspace.tmux_attach_mode()
                 })
             })
             .flatten()
@@ -2486,6 +2693,7 @@ pub(crate) fn run_kwt_pull_request_import(
         generation: exact.generation().map(str::to_owned),
         session_name: exact.session_name().to_owned(),
         tmux_socket_name: exact.tmux_socket_name().map(str::to_owned),
+        tmux_attach_mode: exact.tmux_attach_mode(),
     };
     publish_kwt_inventory(
         scene,
@@ -2503,6 +2711,10 @@ pub(crate) fn run_kwt_pull_request_import(
     KwtWorktreeOutcome::default()
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the removal fence validates each captured identity component explicitly"
+)]
 pub(crate) fn run_kwt_worktree_remove(
     scene: &Arc<Scene>,
     task: &KwtWorktreeTask,
@@ -2510,6 +2722,7 @@ pub(crate) fn run_kwt_worktree_remove(
     generation: &str,
     session_name: &str,
     socket_name: Option<&str>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
     live_target: Option<&host::LiveSessionTarget>,
 ) -> KwtWorktreeOutcome {
     let _session_operation = scene
@@ -2517,9 +2730,14 @@ pub(crate) fn run_kwt_worktree_remove(
         .session_operations
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Err(error) =
-        preflight_kwt_worktree_remove(task, worktree_path, generation, session_name, socket_name)
-    {
+    if let Err(error) = preflight_kwt_worktree_remove(
+        task,
+        worktree_path,
+        generation,
+        session_name,
+        socket_name,
+        tmux_attach_mode,
+    ) {
         fail_kwt_worktree_remove(scene, task, error);
         return KwtWorktreeOutcome::default();
     }
@@ -3930,7 +4148,9 @@ pub(crate) fn publish_kwt_inventory(
                         .worktrees()
                         .iter()
                         .map(|worktree| {
-                            let available = worktree.tmux_socket_name().is_none()
+                            let available = worktree.tmux_attach_mode()
+                                == host::KwtTmuxAttachMode::Direct
+                                && worktree.tmux_socket_name().is_none()
                                 && session_names.contains(worktree.session_name());
                             WorktreeItem::new(
                                 worktree.path(),
@@ -3938,7 +4158,10 @@ pub(crate) fn publish_kwt_inventory(
                                 worktree.is_main(),
                                 worktree.generation().map(str::to_owned),
                                 worktree.session_name(),
-                                worktree.tmux_socket_name().map(str::to_owned),
+                                (
+                                    worktree.tmux_socket_name().map(str::to_owned),
+                                    worktree.tmux_attach_mode(),
+                                ),
                                 available,
                             )
                         })
@@ -3954,7 +4177,13 @@ pub(crate) fn publish_kwt_inventory(
                     workspace.name(),
                     workspace.path(),
                     workspace.session_name(),
-                    workspace.session_live() && session_names.contains(workspace.session_name()),
+                    (
+                        workspace.tmux_socket_name().map(str::to_owned),
+                        workspace.tmux_attach_mode(),
+                    ),
+                    workspace.session_live()
+                        && (workspace.tmux_socket_name().is_some()
+                            || session_names.contains(workspace.session_name())),
                 )
             })
             .collect();
@@ -4146,6 +4375,7 @@ pub(crate) fn run_create(
         endpoint: snapshot.endpoint().clone(),
         runtime: snapshot.runtime().clone(),
         target: AttachTarget::Tmux(session.identity().clone()),
+        exact_worktree_attach: false,
         name: session.name().to_owned(),
         inventory_generation,
     };
@@ -5250,6 +5480,7 @@ pub(crate) fn run_herdr_create(
             session_directory: session.session_directory().to_owned(),
             socket_path: session.socket_path().to_owned(),
         },
+        exact_worktree_attach: false,
         name: session.name().to_owned(),
         inventory_generation,
     };
@@ -5329,6 +5560,7 @@ pub(crate) fn run_zellij_create(
             executable: request.executable.clone(),
             name: session.name().to_owned(),
         },
+        exact_worktree_attach: false,
         name: session.name().to_owned(),
         inventory_generation,
     };
@@ -5858,7 +6090,7 @@ pub(crate) fn run_attach(
                 return;
             }
             if let Some(active) = attachment.active_mut() {
-                normalize_attached_worktree_target(active, &snapshot, &attached_session);
+                normalize_attached_kwt_target(active, &snapshot, &attached_session);
                 active.term = attached_term;
             }
             let surface = worker.surface_handle();
@@ -6181,7 +6413,7 @@ pub(crate) fn run_attach_over_remote(
         return;
     }
     if let Some(active) = attachment.active_mut() {
-        normalize_attached_worktree_target(active, &snapshot, &attached_session);
+        normalize_attached_kwt_target(active, &snapshot, &attached_session);
         active.term = attached_term;
     }
     let surface = worker.surface_handle();
@@ -6947,7 +7179,7 @@ pub(crate) fn attach_fresh<'scene>(
         return Err(AttachFreshError::SceneClosed);
     };
     let (worker, snapshot, name, geometry, actual_term) = match &request.target {
-        AttachTarget::Tmux(identity) => {
+        AttachTarget::Tmux(identity) | AttachTarget::DiscoveredWorktree { identity, .. } => {
             let session = fresh
                 .sessions()
                 .iter()
@@ -6973,27 +7205,17 @@ pub(crate) fn attach_fresh<'scene>(
                 launch_fresh_tmux(scene, request, term, &fresh, &session)?;
             (worker, snapshot, name, geometry, term)
         }
-        AttachTarget::Worktree {
-            repository,
-            registration_fingerprint,
+        AttachTarget::Worktree { .. } => {
+            launch_fresh_worktree_target(scene, request, term, &fresh)?
+        }
+        AttachTarget::DirectoryWorkspace {
             path,
-            generation,
             session_name,
+            tmux_socket_name: _,
         } => {
             let cancellation = CancellationToken::new();
-            let open = host::KwtWorktreeOpen::new(
-                path,
-                repository,
-                registration_fingerprint,
-                generation.as_deref().ok_or_else(|| {
-                    kwt_attachment_failure(
-                        &fresh,
-                        "worktree generation is unavailable; refresh KWT inventory before opening it",
-                    )
-                })?,
-                session_name,
-            );
-            launch_fresh_worktree(scene, request, term, &fresh, &open, &cancellation)?
+            let open = host::KwtDirectoryWorkspaceOpen::new(path, session_name);
+            launch_fresh_directory_workspace(scene, request, term, &fresh, &open, &cancellation)?
         }
         AttachTarget::ProtectedWorktree {
             repository,
@@ -7086,6 +7308,7 @@ pub(crate) fn attach_fresh_retained<'scene>(
             snapshot: Box::new(fresh),
         });
     };
+    let exact_kwt_endpoint = retained_retry_exact_kwt_endpoint(&scene.runtime, &resolved_request);
     // The launch is fenced: a scene closing after the slow, unfenced
     // discovery must not spawn a client that could touch multiplexer
     // focus or sizing before the post-launch check discards it. The guard
@@ -7093,8 +7316,19 @@ pub(crate) fn attach_fresh_retained<'scene>(
     let Ok(navigation) = lock_live_navigation(scene) else {
         return Err(AttachFreshError::SceneClosed);
     };
+    if let Some((session_name, socket_name)) = exact_kwt_endpoint {
+        let (worker, snapshot, _, geometry) = launch_fresh_named_tmux(
+            scene,
+            &resolved_request,
+            AttachTerm::Xterm,
+            &fresh,
+            session_name,
+            socket_name,
+        )?;
+        return Ok((navigation, worker, snapshot, resolved_request, geometry));
+    }
     let (worker, snapshot, _, geometry) = match &retry.key.target {
-        AttachTarget::Tmux(identity) => {
+        AttachTarget::Tmux(identity) | AttachTarget::DiscoveredWorktree { identity, .. } => {
             let session = fresh
                 .sessions()
                 .iter()
@@ -7109,34 +7343,27 @@ pub(crate) fn attach_fresh_retained<'scene>(
                 &session,
             )?
         }
-        AttachTarget::Worktree {
-            repository,
-            registration_fingerprint,
+        AttachTarget::Worktree { .. } => {
+            let (worker, snapshot, name, geometry, _actual_term) =
+                launch_fresh_worktree_target(scene, &resolved_request, AttachTerm::Xterm, &fresh)?;
+            (worker, snapshot, name, geometry)
+        }
+        AttachTarget::DirectoryWorkspace {
             path,
-            generation,
             session_name,
+            tmux_socket_name: _,
         } => {
             let cancellation = CancellationToken::new();
-            let open = host::KwtWorktreeOpen::new(
-                path,
-                repository,
-                registration_fingerprint,
-                generation.as_deref().ok_or_else(|| {
-                    kwt_attachment_failure(
-                        &fresh,
-                        "worktree generation is unavailable; refresh KWT inventory before opening it",
-                    )
-                })?,
-                session_name,
-            );
-            let (worker, snapshot, name, geometry, _actual_term) = launch_fresh_worktree(
-                scene,
-                &resolved_request,
-                AttachTerm::Xterm,
-                &fresh,
-                &open,
-                &cancellation,
-            )?;
+            let open = host::KwtDirectoryWorkspaceOpen::new(path, session_name);
+            let (worker, snapshot, name, geometry, _actual_term) =
+                launch_fresh_directory_workspace(
+                    scene,
+                    &resolved_request,
+                    AttachTerm::Xterm,
+                    &fresh,
+                    &open,
+                    &cancellation,
+                )?;
             (worker, snapshot, name, geometry)
         }
         AttachTarget::ProtectedWorktree {
@@ -7197,6 +7424,49 @@ pub(crate) fn attach_fresh_retained<'scene>(
     Ok((navigation, worker, snapshot, resolved_request, geometry))
 }
 
+pub(crate) fn retained_retry_exact_kwt_endpoint<'request>(
+    runtime: &Runtime,
+    request: &'request AttachRequest,
+) -> Option<(&'request str, &'request str)> {
+    let kwt_unavailable = runtime
+        .hosts
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .find(|host| {
+            host.id() == request.host_id
+                && host.endpoint() == request.endpoint.distro()
+                && host.connection() == HostConnectionState::Ready
+        })
+        .is_some_and(|host| !host.kwt_available());
+    if !kwt_unavailable {
+        return None;
+    }
+    match &request.target {
+        AttachTarget::Worktree {
+            session_name,
+            tmux_socket_name: Some(socket_name),
+            ..
+        }
+        | AttachTarget::DirectoryWorkspace {
+            session_name,
+            tmux_socket_name: Some(socket_name),
+            ..
+        } => Some((session_name, socket_name)),
+        _ => None,
+    }
+}
+
+pub(crate) fn fresh_worktree_exact_kwt_endpoint<'request>(
+    runtime: &Runtime,
+    request: &'request AttachRequest,
+) -> Option<(&'request str, &'request str)> {
+    if !request.exact_worktree_attach {
+        return None;
+    }
+    retained_retry_exact_kwt_endpoint(runtime, request)
+}
+
 pub(crate) fn launch_fresh_tmux(
     scene: &Scene,
     request: &AttachRequest,
@@ -7207,6 +7477,95 @@ pub(crate) fn launch_fresh_tmux(
     let plan = request
         .host
         .attach_plan_with_term(fresh.endpoint(), session, term);
+    let geometry = *scene
+        .terminal_geometry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let worker = TerminalWorker::attach_with_metadata(
+        &plan,
+        geometry.grid,
+        geometry.sequence,
+        geometry.pixels,
+        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_default_colors(&scene.runtime),
+        current_default_cursor_shape(&scene.runtime),
+    )
+    .map_err(|error| AttachFreshError::Host(WorkspaceError::new(error.to_string())))?;
+    Ok((
+        worker,
+        fresh.clone(),
+        plan.target_name().to_owned(),
+        geometry,
+    ))
+}
+
+fn launch_fresh_worktree_target(
+    scene: &Scene,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        String,
+        TerminalGeometry,
+        AttachTerm,
+    ),
+    AttachFreshError,
+> {
+    let AttachTarget::Worktree {
+        repository,
+        registration_fingerprint,
+        path,
+        generation,
+        session_name,
+        tmux_socket_name: _,
+    } = &request.target
+    else {
+        unreachable!("worktree launch requires a worktree target");
+    };
+    if let Some((session_name, socket_name)) =
+        fresh_worktree_exact_kwt_endpoint(&scene.runtime, request)
+    {
+        let (worker, snapshot, name, geometry) =
+            launch_fresh_named_tmux(scene, request, term, fresh, session_name, socket_name)?;
+        Ok((worker, snapshot, name, geometry, term))
+    } else {
+        let cancellation = CancellationToken::new();
+        let open = host::KwtWorktreeOpen::new(
+            path,
+            repository,
+            registration_fingerprint,
+            generation,
+            session_name,
+        );
+        launch_fresh_worktree(scene, request, term, fresh, &open, &cancellation)
+    }
+}
+
+fn launch_fresh_named_tmux(
+    scene: &Scene,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    session_name: &str,
+    socket_name: &str,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), AttachFreshError> {
+    let cancellation = CancellationToken::new();
+    let target = request
+        .host
+        .capture_live_session_on_socket(
+            fresh.endpoint(),
+            fresh.runtime(),
+            socket_name,
+            session_name,
+            &cancellation,
+        )
+        .map_err(|error| kwt_attachment_failure(fresh, error))?;
+    let plan = request
+        .host
+        .attach_live_session_plan_with_term(&target, term);
     let geometry = *scene
         .terminal_geometry
         .lock()
@@ -7241,6 +7600,7 @@ pub(crate) fn capture_kwt_worktree_request(
     generation: Option<&str>,
     session_name: &str,
     tmux_socket_name: Option<&str>,
+    tmux_attach_mode: host::KwtTmuxAttachMode,
 ) -> Result<AttachRequest, WorkspaceError> {
     if host_id != "wsl"
         || scene
@@ -7294,6 +7654,7 @@ pub(crate) fn capture_kwt_worktree_request(
                         && worktree.generation.as_deref() == generation
                         && worktree.session_name == session_name
                         && worktree.tmux_socket_name.as_deref() == tmux_socket_name
+                        && worktree.tmux_attach_mode == tmux_attach_mode
                 })
             })
             .ok_or_else(|| {
@@ -7301,34 +7662,36 @@ pub(crate) fn capture_kwt_worktree_request(
                     "the selected worktree is no longer in authoritative KWT inventory",
                 )
             })?;
+        let generation = required_kwt_worktree_generation(worktree)?;
         Ok(AttachRequest {
             host_id: host_id.to_owned(),
             host: context.host.clone(),
             endpoint: context.snapshot.endpoint().clone(),
             runtime: context.snapshot.runtime().clone(),
-            target: if let Some(tmux_socket_name) = &worktree.tmux_socket_name {
-                AttachTarget::ProtectedWorktree {
+            target: match worktree.tmux_attach_mode {
+                host::KwtTmuxAttachMode::Protected => AttachTarget::ProtectedWorktree {
                     repository: repository.to_owned(),
                     project_path: project_path.to_owned(),
                     registration_fingerprint: registration_fingerprint.to_owned(),
                     path: worktree.path.clone(),
-                    generation: worktree.generation.clone().ok_or_else(|| {
+                    generation: generation.clone(),
+                    session_name: worktree.session_name.clone(),
+                    tmux_socket_name: worktree.tmux_socket_name.clone().ok_or_else(|| {
                         WorkspaceError::new(
-                            "protected worktree generation is unavailable; refresh KWT inventory",
+                            "protected worktree endpoint is unresolved; refresh KWT inventory",
                         )
                     })?,
-                    session_name: worktree.session_name.clone(),
-                    tmux_socket_name: tmux_socket_name.clone(),
-                }
-            } else {
-                AttachTarget::Worktree {
+                },
+                host::KwtTmuxAttachMode::Direct => AttachTarget::Worktree {
                     repository: repository.to_owned(),
                     registration_fingerprint: registration_fingerprint.to_owned(),
                     path: worktree.path.clone(),
-                    generation: worktree.generation.clone(),
+                    generation,
                     session_name: worktree.session_name.clone(),
-                }
+                    tmux_socket_name: worktree.tmux_socket_name.clone(),
+                },
             },
+            exact_worktree_attach: false,
             name: worktree.session_name.clone(),
             inventory_generation,
         })
@@ -7356,6 +7719,41 @@ pub(crate) fn launch_fresh_worktree(
         Ok((worker, snapshot, name, geometry)) => Ok((worker, snapshot, name, geometry, term)),
         Err(WorktreeLaunchError::RetryWithXterm) if term == AttachTerm::Xterm256Color => {
             let (worker, snapshot, name, geometry) = launch_fresh_worktree_once(
+                scene,
+                request,
+                AttachTerm::Xterm,
+                fresh,
+                open,
+                cancellation,
+            )
+            .map_err(WorktreeLaunchError::into_attach_error)?;
+            Ok((worker, snapshot, name, geometry, AttachTerm::Xterm))
+        }
+        Err(error) => Err(error.into_attach_error()),
+    }
+}
+
+pub(crate) fn launch_fresh_directory_workspace(
+    scene: &Scene,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    open: &host::KwtDirectoryWorkspaceOpen,
+    cancellation: &CancellationToken,
+) -> Result<
+    (
+        TerminalWorker,
+        HostSnapshot,
+        String,
+        TerminalGeometry,
+        AttachTerm,
+    ),
+    AttachFreshError,
+> {
+    match launch_fresh_directory_workspace_once(scene, request, term, fresh, open, cancellation) {
+        Ok((worker, snapshot, name, geometry)) => Ok((worker, snapshot, name, geometry, term)),
+        Err(WorktreeLaunchError::RetryWithXterm) if term == AttachTerm::Xterm256Color => {
+            let (worker, snapshot, name, geometry) = launch_fresh_directory_workspace_once(
                 scene,
                 request,
                 AttachTerm::Xterm,
@@ -7450,7 +7848,7 @@ pub(crate) fn launch_fresh_protected_worktree_once(
         || {
             request
                 .host
-                .kwt_protected_client_session_identity(
+                .kwt_named_client_session_identity(
                     fresh.endpoint(),
                     fresh.runtime(),
                     &readiness_path,
@@ -7501,12 +7899,81 @@ pub(crate) fn launch_fresh_worktree_once(
         .host
         .kwt_repair_or_open_plan(fresh.endpoint(), fresh.runtime(), open, term, cancellation)
         .map_err(|error| WorktreeLaunchError::Attach(kwt_attachment_failure(fresh, error)))?;
+    let socket_name = match &request.target {
+        AttachTarget::Worktree {
+            tmux_socket_name, ..
+        } => tmux_socket_name.as_deref(),
+        _ => None,
+    };
+    launch_fresh_direct_kwt_plan(
+        scene,
+        request,
+        term,
+        fresh,
+        &plan,
+        open.session_name(),
+        socket_name,
+        cancellation,
+    )
+}
+
+pub(crate) fn launch_fresh_directory_workspace_once(
+    scene: &Scene,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    open: &host::KwtDirectoryWorkspaceOpen,
+    cancellation: &CancellationToken,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), WorktreeLaunchError> {
+    let plan = request
+        .host
+        .kwt_directory_workspace_open_plan(
+            fresh.endpoint(),
+            fresh.runtime(),
+            open,
+            term,
+            cancellation,
+        )
+        .map_err(|error| WorktreeLaunchError::Attach(kwt_attachment_failure(fresh, error)))?;
+    let socket_name = match &request.target {
+        AttachTarget::DirectoryWorkspace {
+            tmux_socket_name, ..
+        } => tmux_socket_name.as_deref(),
+        _ => None,
+    };
+    launch_fresh_direct_kwt_plan(
+        scene,
+        request,
+        term,
+        fresh,
+        &plan,
+        open.session_name(),
+        socket_name,
+        cancellation,
+    )
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "one launch owns terminal startup, readiness, and exact endpoint validation"
+)]
+fn launch_fresh_direct_kwt_plan(
+    scene: &Scene,
+    request: &AttachRequest,
+    term: AttachTerm,
+    fresh: &HostSnapshot,
+    plan: &session::RepairOrOpenPlan,
+    session_name: &str,
+    socket_name: Option<&str>,
+    cancellation: &CancellationToken,
+) -> Result<(TerminalWorker, HostSnapshot, String, TerminalGeometry), WorktreeLaunchError> {
     let geometry = *scene
         .terminal_geometry
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let worker = TerminalWorker::repair_or_open_with_metadata(
-        &plan,
+        plan,
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
@@ -7530,13 +7997,25 @@ pub(crate) fn launch_fresh_worktree_once(
                 .map_err(|error| WorkspaceError::new(error.to_string()))
         },
         || {
-            request
-                .host
-                .kwt_client_session_identity(
-                    fresh.endpoint(),
-                    fresh.runtime(),
-                    &readiness_path,
-                    cancellation,
+            socket_name
+                .map_or_else(
+                    || {
+                        request.host.kwt_client_session_identity(
+                            fresh.endpoint(),
+                            fresh.runtime(),
+                            &readiness_path,
+                            cancellation,
+                        )
+                    },
+                    |socket_name| {
+                        request.host.kwt_named_client_session_identity(
+                            fresh.endpoint(),
+                            fresh.runtime(),
+                            &readiness_path,
+                            socket_name,
+                            cancellation,
+                        )
+                    },
                 )
                 .map_err(|error| WorkspaceError::new(error.to_string()))
         },
@@ -7569,14 +8048,29 @@ pub(crate) fn launch_fresh_worktree_once(
             "WSL changed while opening the worktree session",
         )));
     }
-    let identity_matches = discovered.sessions().iter().any(|session| {
-        session.name() == open.session_name() && session.identity() == &client_identity
-    });
+    let identity_matches = if let Some(socket_name) = socket_name {
+        request
+            .host
+            .capture_live_session_on_socket(
+                fresh.endpoint(),
+                fresh.runtime(),
+                socket_name,
+                session_name,
+                cancellation,
+            )
+            .map(|target| target.identity() == &client_identity)
+            .map_err(|error| WorktreeLaunchError::Attach(kwt_attachment_failure(fresh, error)))?
+    } else {
+        discovered
+            .sessions()
+            .iter()
+            .any(|session| session.name() == session_name && session.identity() == &client_identity)
+    };
     if !identity_matches {
         drop(worker);
         return Err(WorktreeLaunchError::Attach(kwt_attachment_failure(
             fresh,
-            "KWT attached its client to a session that did not match the worktree inventory",
+            "KWT attached its client to a session that did not match workspace inventory",
         )));
     }
     Ok((worker, discovered, plan.target_name().to_owned(), geometry))

--- a/rust/workspace/src/tests.rs
+++ b/rust/workspace/src/tests.rs
@@ -7,18 +7,22 @@ use crate::scene::{
     broadcast_event, broadcast_event_with_lossless_owner, push_lossless_event, push_operation_event,
 };
 use crate::scene::{
-    drop_matching_kwt_removal_confirmations, invalidate_pending_kill_with_intent,
-    merge_created_inventory, merge_herdr_lifecycle_inventory, publish_attach_inventory,
-    publish_attachment_failure, publish_captured_kwt_removal, publish_kwt_error,
-    publish_kwt_inventory, publish_kwt_mutation_failure, publish_kwt_project_mutation,
+    drop_matching_kwt_removal_confirmations, fresh_worktree_exact_kwt_endpoint,
+    invalidate_pending_kill_with_intent, merge_created_inventory, merge_herdr_lifecycle_inventory,
+    publish_attachment_failure, publish_kwt_error, publish_kwt_inventory,
+    publish_kwt_mutation_failure, publish_kwt_project_mutation,
     publish_kwt_removal_capture_failure, publish_legacy_inventory_state, publish_local_notice,
     publish_remote_inventory, publish_retained_stale_failure, publish_stale_attachment_failure,
-    reconcile_remote_constructive_with_backoff, reconcile_removed_kwt_worktree,
-    reconcile_retained_session_names, reserve_current_constructive_inventory, reserve_kwt_refresh,
-    resolve_pending_kwt_creations, resolve_pending_kwt_creations_at, set_inventory_state,
-    settle_constructive_inventory, settle_removed_kwt_worktree,
-    settle_timed_out_kwt_worktree_remove, tombstone_removed_kwt_worktree,
+    reconcile_remote_constructive_with_backoff, reserve_current_constructive_inventory,
+    reserve_kwt_refresh, resolve_pending_kwt_creations, resolve_pending_kwt_creations_at,
+    retained_retry_exact_kwt_endpoint, set_inventory_state, settle_constructive_inventory,
     with_current_remote_attachment_launch,
+};
+#[cfg(windows)]
+use crate::scene::{
+    publish_attach_inventory, publish_captured_kwt_removal, reconcile_removed_kwt_worktree,
+    reconcile_retained_session_names, settle_removed_kwt_worktree,
+    settle_timed_out_kwt_worktree_remove, tombstone_removed_kwt_worktree,
 };
 use terminal::TerminalEngine;
 
@@ -442,7 +446,10 @@ fn worktree_removal_capture_requires_the_reviewed_tmux_socket() {
             false,
             Some(generation.to_owned()),
             "project-protected",
-            Some("kwt-pr-reviewed".to_owned()),
+            (
+                Some("kwt-pr-reviewed".to_owned()),
+                host::KwtTmuxAttachMode::Protected,
+            ),
             false,
         ));
 
@@ -457,6 +464,7 @@ fn worktree_removal_capture_requires_the_reviewed_tmux_socket() {
         generation,
         "project-protected",
         Some("kwt-pr-reviewed"),
+        host::KwtTmuxAttachMode::Protected,
     )
     .expect("the reviewed protected socket grants removal capture");
     assert_eq!(captured.3.as_deref(), Some("kwt-pr-reviewed"));
@@ -475,9 +483,60 @@ fn worktree_removal_capture_requires_the_reviewed_tmux_socket() {
             generation,
             "project-protected",
             Some("kwt-pr-reviewed"),
+            host::KwtTmuxAttachMode::Protected,
         )
         .is_err(),
         "a changed protected socket requires a fresh removal confirmation"
+    );
+    workspace.scene.runtime.hosts.write().expect("hosts")[0].projects[0].worktrees[1]
+        .tmux_socket_name = Some("kwt-pr-reviewed".to_owned());
+    workspace.scene.runtime.hosts.write().expect("hosts")[0].projects[0].worktrees[1]
+        .tmux_attach_mode = host::KwtTmuxAttachMode::Direct;
+    assert!(
+        capture_kwt_worktree_removal_context(
+            &workspace.scene.runtime,
+            "wsl",
+            "Ubuntu",
+            "project-id",
+            "/repos/project",
+            "project-fingerprint",
+            "/work/project/protected",
+            generation,
+            "project-protected",
+            Some("kwt-pr-reviewed"),
+            host::KwtTmuxAttachMode::Protected,
+        )
+        .is_err(),
+        "a changed attachment mode requires a fresh removal confirmation"
+    );
+
+    workspace.scene.runtime.hosts.write().expect("hosts")[0].projects[0]
+        .worktrees
+        .push(WorktreeItem::new(
+            "/work/project/unresolved",
+            "unresolved",
+            false,
+            Some("33333333333333333333333333333333".to_owned()),
+            "project-unresolved",
+            (None, host::KwtTmuxAttachMode::Protected),
+            false,
+        ));
+    assert!(
+        capture_kwt_worktree_removal_context(
+            &workspace.scene.runtime,
+            "wsl",
+            "Ubuntu",
+            "project-id",
+            "/repos/project",
+            "project-fingerprint",
+            "/work/project/unresolved",
+            "33333333333333333333333333333333",
+            "project-unresolved",
+            None,
+            host::KwtTmuxAttachMode::Protected,
+        )
+        .is_err(),
+        "an unresolved protected endpoint cannot fall back to default tmux"
     );
 }
 
@@ -505,7 +564,7 @@ fn later_kwt_inventory_resolves_a_pending_created_worktree_once() {
         });
     let inventory = KwtInventory::parse(
             br#"[{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"registration"}]"#,
-            br#"[{"path":"/work/widget/new","branch":"feature/new","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-new","tmux_socket_name":null}]"#,
+            br#"[{"path":"/work/widget/new","branch":"feature/new","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-new","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
             b"[]",
         )
         .expect("valid KWT inventory");
@@ -565,7 +624,7 @@ fn pending_creation_ignores_a_preexisting_same_branch_worktree_and_expires() {
         });
     let inventory = KwtInventory::parse(
             br#"[{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"registration"}]"#,
-            br#"[{"path":"/work/widget/existing","branch":"feature/new","commit_hash":"def","is_main":false,"created_at":null,"generation":"fedcba9876543210fedcba9876543210","repository":"github.com/acme/widget","session_name":"widget-existing","tmux_socket_name":null}]"#,
+            br#"[{"path":"/work/widget/existing","branch":"feature/new","commit_hash":"def","is_main":false,"created_at":null,"generation":"fedcba9876543210fedcba9876543210","repository":"github.com/acme/widget","session_name":"widget-existing","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
             b"[]",
         )
         .expect("valid KWT inventory");
@@ -609,7 +668,7 @@ fn confirmed_creation_expiry_rejects_a_late_same_branch_worktree() {
         });
     let inventory = KwtInventory::parse(
             br#"[{"repository":"github.com/acme/widget","name":"widget","path":"/code/widget","last_touched":null,"registration_fingerprint":"registration"}]"#,
-            br#"[{"path":"/work/widget/late","branch":"feature/new","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-late","tmux_socket_name":null}]"#,
+            br#"[{"path":"/work/widget/late","branch":"feature/new","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-late","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
             b"[]",
         )
         .expect("valid KWT inventory");
@@ -666,6 +725,7 @@ fn worktree_removal_authority_can_be_restored_before_dispatch() {
             generation: "0123456789abcdef0123456789abcdef".to_owned(),
             session_name: "widget-topic".to_owned(),
             socket_name: None,
+            tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
             live_target: Some(Arc::new(host::LiveSessionTarget::test_fixture(
                 &snapshot,
                 "widget-topic",
@@ -717,6 +777,10 @@ fn worktree_removal_authority_can_be_restored_before_dispatch() {
 }
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one inventory verifies every field that grants exact worktree removal authority"
+)]
 fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
     let project = ProjectItem::new(
         "github.com/acme/widget",
@@ -730,7 +794,7 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 true,
                 Some("11111111111111111111111111111111".to_owned()),
                 "widget-main",
-                None,
+                (None, host::KwtTmuxAttachMode::Direct),
                 false,
             ),
             WorktreeItem::new(
@@ -739,7 +803,7 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 false,
                 Some("22222222222222222222222222222222".to_owned()),
                 "widget-topic",
-                None,
+                (None, host::KwtTmuxAttachMode::Direct),
                 true,
             ),
             WorktreeItem::new(
@@ -748,17 +812,25 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 false,
                 Some("33333333333333333333333333333333".to_owned()),
                 "widget-protected",
-                Some("protected-socket".to_owned()),
+                (
+                    Some("protected-socket".to_owned()),
+                    host::KwtTmuxAttachMode::Protected,
+                ),
                 false,
             ),
         ],
     );
-    let remove = |path: &str, generation: &str, session: &str, socket_name: Option<&str>| {
+    let remove = |path: &str,
+                  generation: &str,
+                  session: &str,
+                  socket_name: Option<&str>,
+                  tmux_attach_mode: host::KwtTmuxAttachMode| {
         KwtWorktreeOperation::Remove {
             worktree_path: path.to_owned(),
             generation: generation.to_owned(),
             session_name: session.to_owned(),
             socket_name: socket_name.map(str::to_owned),
+            tmux_attach_mode,
             live_target: None,
             operation_id: 1,
         }
@@ -772,6 +844,7 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 "22222222222222222222222222222222",
                 "widget-topic",
                 None,
+                host::KwtTmuxAttachMode::Direct,
             ),
         )
         .is_ok()
@@ -784,6 +857,7 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 "11111111111111111111111111111111",
                 "widget-main",
                 None,
+                host::KwtTmuxAttachMode::Direct,
             ),
         )
         .is_err()
@@ -796,6 +870,7 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 "22222222222222222222222222222222",
                 "replacement",
                 None,
+                host::KwtTmuxAttachMode::Direct,
             ),
         )
         .is_err()
@@ -808,10 +883,25 @@ fn worktree_removal_reservation_requires_the_exact_non_main_inventory_row() {
                 "33333333333333333333333333333333",
                 "widget-protected",
                 Some("protected-socket"),
+                host::KwtTmuxAttachMode::Protected,
             ),
         )
         .is_ok(),
         "custom-socket worktrees are removable only through their exact protected socket"
+    );
+    assert!(
+        validate_kwt_worktree_operation(
+            &project,
+            &remove(
+                "/work/widget/protected",
+                "33333333333333333333333333333333",
+                "widget-protected",
+                Some("protected-socket"),
+                host::KwtTmuxAttachMode::Direct,
+            ),
+        )
+        .is_err(),
+        "a changed attachment mode invalidates the removal"
     );
 }
 
@@ -822,8 +912,9 @@ fn killed_tmux_cleanup_matches_worktree_presentations_by_authoritative_name() {
         repository: "project-id".to_owned(),
         registration_fingerprint: "registration".to_owned(),
         path: "/work/project/topic".to_owned(),
-        generation: Some("generation".to_owned()),
+        generation: "generation".to_owned(),
         session_name: "project-topic".to_owned(),
+        tmux_socket_name: None,
     };
 
     assert!(attach_target_matches_killed_tmux(
@@ -845,7 +936,7 @@ fn killed_tmux_cleanup_matches_worktree_presentations_by_authoritative_name() {
 
 #[cfg(windows)]
 #[test]
-fn worktree_navigation_reuses_the_equivalent_discovered_tmux_identity() {
+fn default_worktree_navigation_reuses_the_equivalent_discovered_tmux_identity() {
     let identity = session::SessionIdentity::new(100, "$1", 200);
     let snapshot = HostSnapshot::test_fixture(
         "Ubuntu",
@@ -863,18 +954,19 @@ fn worktree_navigation_reuses_the_equivalent_discovered_tmux_identity() {
         repository: "project-id".to_owned(),
         registration_fingerprint: "registration".to_owned(),
         path: "/work/project/topic".to_owned(),
-        generation: Some("generation".to_owned()),
+        generation: "generation".to_owned(),
         session_name: "project-topic".to_owned(),
+        tmux_socket_name: None,
     };
 
-    let key = worktree_tmux_presentation_key(&worktree, &snapshot)
+    let key = kwt_tmux_presentation_key(&worktree, &snapshot)
         .expect("the current tmux session supplies a stable presentation key");
     assert_eq!(key, direct.presentation_key());
 }
 
 #[cfg(windows)]
 #[test]
-fn launched_worktree_identity_remains_reusable_after_it_becomes_unbound() {
+fn launched_default_kwt_identity_remains_reusable_after_it_becomes_unbound() {
     let identity = session::SessionIdentity::new(100, "$1", 200);
     let snapshot = HostSnapshot::test_fixture(
         "Ubuntu",
@@ -892,8 +984,9 @@ fn launched_worktree_identity_remains_reusable_after_it_becomes_unbound() {
         repository: "project-id".to_owned(),
         registration_fingerprint: "registration".to_owned(),
         path: "/work/project/topic".to_owned(),
-        generation: Some("generation".to_owned()),
+        generation: "generation".to_owned(),
         session_name: "project-topic".to_owned(),
+        tmux_socket_name: None,
     };
     let worktree_key = worktree.presentation_key();
 
@@ -907,7 +1000,7 @@ fn launched_worktree_identity_remains_reusable_after_it_becomes_unbound() {
             navigation_generation: 0,
         }),
     );
-    assert!(normalize_attached_worktree_target(
+    assert!(normalize_attached_kwt_target(
         active.active_mut().expect("active worktree"),
         &snapshot,
         "project-topic",
@@ -942,6 +1035,40 @@ fn launched_worktree_identity_remains_reusable_after_it_becomes_unbound() {
         presentation_id: 1,
     });
     assert!(retained.contains(&direct.presentation_key()));
+
+    let mut directory = direct.clone();
+    directory.target = AttachTarget::DirectoryWorkspace {
+        path: "/work/scratch".to_owned(),
+        session_name: "project-topic".to_owned(),
+        tmux_socket_name: None,
+    };
+    let mut active = AttachmentState::new();
+    active.reserve(directory, AttachTerm::Xterm256Color);
+    assert!(normalize_attached_kwt_target(
+        active.active_mut().expect("active directory workspace"),
+        &snapshot,
+        "project-topic",
+    ));
+    assert_eq!(
+        active
+            .active()
+            .expect("normalized directory workspace")
+            .request
+            .presentation_key(),
+        direct.presentation_key(),
+    );
+    let active = active
+        .take_active()
+        .expect("retain active directory workspace");
+    let mut retained = RetainedPresentations::new();
+    retained.insert(RetainedPresentation {
+        key: active.request.presentation_key(),
+        selection: active.request.selection(),
+        attachment: active,
+        worker: (),
+        presentation_id: 2,
+    });
+    assert!(retained.contains(&direct.presentation_key()));
 }
 
 #[test]
@@ -959,7 +1086,7 @@ fn successful_worktree_removal_tombstones_only_the_exact_cached_generation() {
                 false,
                 Some("old-generation".to_owned()),
                 "project-topic",
-                None,
+                (None, host::KwtTmuxAttachMode::Direct),
                 false,
             ),
             WorktreeItem::new(
@@ -968,7 +1095,7 @@ fn successful_worktree_removal_tombstones_only_the_exact_cached_generation() {
                 false,
                 Some("replacement-generation".to_owned()),
                 "project-topic",
-                None,
+                (None, host::KwtTmuxAttachMode::Direct),
                 false,
             ),
         ],
@@ -1409,6 +1536,7 @@ fn retained_herdr_recovery_does_not_block_snapshots_during_discovery() {
             session_directory: "/tmp/herdr/review".to_owned(),
             socket_path: "/tmp/herdr/review/herdr.sock".to_owned(),
         },
+        exact_worktree_attach: false,
         name: "review".to_owned(),
         inventory_generation: 1,
     };
@@ -1575,7 +1703,7 @@ fn kwt_worktree_workspace_fixture() -> (Workspace, Arc<ManualRefreshRuntime>) {
         .store(7, Ordering::Release);
     let inventory = KwtInventory::parse(
             br#"[{"repository":"project-id","name":"project","path":"/repos/project","last_touched":null,"registration_fingerprint":"project-fingerprint"}]"#,
-            br#"[{"path":"/repos/project","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"project-id","session_name":"project-main","tmux_socket_name":null}]"#,
+            br#"[{"path":"/repos/project","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"project-id","session_name":"project-main","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
             b"[]",
         )
         .expect("valid KWT inventory");
@@ -1784,6 +1912,7 @@ fn attach_request_fixture_with_runner(
         endpoint: snapshot.endpoint().clone(),
         runtime: snapshot.runtime().clone(),
         target: AttachTarget::Tmux(identity),
+        exact_worktree_attach: false,
         name: name.to_owned(),
         inventory_generation: 1,
     }
@@ -1807,6 +1936,7 @@ fn herdr_attach_request_fixture(snapshot: &HostSnapshot, name: &str) -> AttachRe
             session_directory: "/tmp/herdr/review".to_owned(),
             socket_path: "/tmp/herdr/review/herdr.sock".to_owned(),
         },
+        exact_worktree_attach: false,
         name: name.to_owned(),
         inventory_generation: 1,
     }
@@ -1828,6 +1958,7 @@ fn zellij_attach_request_fixture(snapshot: &HostSnapshot, name: &str) -> AttachR
             executable: "/usr/bin/zellij".to_owned(),
             name: name.to_owned(),
         },
+        exact_worktree_attach: false,
         name: name.to_owned(),
         inventory_generation: 1,
     }
@@ -2206,6 +2337,7 @@ fn hidden_unconfirmed_client_keeps_its_identity_and_fallback_during_terminfo_ret
         endpoint: snapshot.endpoint().clone(),
         runtime: snapshot.runtime().clone(),
         target: AttachTarget::Tmux(identity.clone()),
+        exact_worktree_attach: false,
         name: "replacement".to_owned(),
         inventory_generation: 1,
     };
@@ -2319,6 +2451,137 @@ fn retained_terminfo_retry_resolves_a_renamed_session_by_identity() {
     assert_eq!(retained.entries[0].attachment.request.name, "renamed");
 }
 
+#[test]
+fn retained_custom_socket_actions_work_without_kwt() {
+    let mut host = HostItem::wsl("Ubuntu", None, HostConnectionState::Ready, Vec::new(), None);
+    host.kwt_state = KwtState::Unavailable;
+    let workspace = Workspace::preview(WorkspaceSnapshot::shell(Appearance::default(), vec![host]));
+    let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+    let base = attach_request_fixture_with_runner(
+        &snapshot,
+        session::SessionIdentity::new(100, "$1", 200),
+        "work",
+        Arc::new(StdCommandRunner) as SharedCommandRunner,
+    );
+    let request = |target| AttachRequest {
+        target,
+        ..base.clone()
+    };
+
+    let worktree = request(AttachTarget::Worktree {
+        repository: "project-id".to_owned(),
+        registration_fingerprint: "project-fingerprint".to_owned(),
+        path: "/work/project/topic".to_owned(),
+        generation: "generation-a".to_owned(),
+        session_name: "project-topic".to_owned(),
+        tmux_socket_name: Some("kwt-project".to_owned()),
+    });
+    assert_eq!(
+        retained_retry_exact_kwt_endpoint(&workspace.scene.runtime, &worktree),
+        Some(("project-topic", "kwt-project"))
+    );
+    *workspace.scene.runtime.host.lock().expect("published host") = Some(Published::new(
+        HostContext {
+            host: worktree.host.clone(),
+            snapshot: snapshot.clone(),
+        },
+        1,
+    ));
+    *workspace
+        .scene
+        .selected_host
+        .write()
+        .expect("selected host") = Some("wsl".to_owned());
+    let selection = worktree.selection();
+    let key = worktree.presentation_key();
+    workspace
+        .scene
+        .retained_presentations
+        .lock()
+        .expect("retained presentations")
+        .restarting
+        .push(RetainedRestart {
+            key,
+            selection: selection.clone(),
+            attachment: ActiveAttachment {
+                request: worktree,
+                term: AttachTerm::Xterm,
+                generation: 1,
+                fallback: None,
+            },
+            presentation_id: 7,
+        });
+    assert!(matches!(
+        capture_kill_request(&workspace.scene, &selection, 8)
+            .expect("retained exact socket grants a fresh kill identity capture"),
+        KillCaptureRequest::Tmux { selection, .. }
+            if selection.tmux_socket_name() == Some("kwt-project")
+    ));
+
+    let directory = request(AttachTarget::DirectoryWorkspace {
+        path: "/work/scratch".to_owned(),
+        session_name: "scratch".to_owned(),
+        tmux_socket_name: Some("kwt-directory".to_owned()),
+    });
+    assert_eq!(
+        retained_retry_exact_kwt_endpoint(&workspace.scene.runtime, &directory),
+        Some(("scratch", "kwt-directory"))
+    );
+
+    let default_server = request(AttachTarget::DirectoryWorkspace {
+        path: "/work/default".to_owned(),
+        session_name: "default".to_owned(),
+        tmux_socket_name: None,
+    });
+    assert_eq!(
+        retained_retry_exact_kwt_endpoint(&workspace.scene.runtime, &default_server),
+        None
+    );
+}
+
+#[test]
+fn fresh_custom_socket_worktree_uses_kwt_when_available() {
+    let mut host = HostItem::wsl("Ubuntu", None, HostConnectionState::Ready, Vec::new(), None);
+    host.kwt_state = KwtState::Ready;
+    let workspace = Workspace::preview(WorkspaceSnapshot::shell(Appearance::default(), vec![host]));
+    let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot-id", 42, Vec::new());
+    let request = AttachRequest {
+        target: AttachTarget::Worktree {
+            repository: "project-id".to_owned(),
+            registration_fingerprint: "project-fingerprint".to_owned(),
+            path: "/work/project/topic".to_owned(),
+            generation: "generation-a".to_owned(),
+            session_name: "project-topic".to_owned(),
+            tmux_socket_name: Some("kwt-project".to_owned()),
+        },
+        exact_worktree_attach: true,
+        ..attach_request_fixture_with_runner(
+            &snapshot,
+            session::SessionIdentity::new(100, "$1", 200),
+            "work",
+            Arc::new(StdCommandRunner) as SharedCommandRunner,
+        )
+    };
+
+    assert_eq!(
+        fresh_worktree_exact_kwt_endpoint(&workspace.scene.runtime, &request),
+        None,
+        "KWT-ready worktrees retain repair-or-open authority"
+    );
+    workspace
+        .scene
+        .runtime
+        .hosts
+        .write()
+        .expect("host inventory")[0]
+        .kwt_state = KwtState::Unavailable;
+    assert_eq!(
+        fresh_worktree_exact_kwt_endpoint(&workspace.scene.runtime, &request),
+        Some(("project-topic", "kwt-project")),
+        "KWT-unavailable worktrees retain exact-socket fallback"
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn retained_terminfo_retry_preserves_herdr_selection_kind() {
@@ -2376,7 +2639,7 @@ fn current_inventory_identity_wins_over_a_same_name_retained_session() {
     );
 
     let (selected, request) =
-        choose_navigation_target(Some(stale.presentation_key()), Ok(current.clone()))
+        choose_navigation_target(Some(stale.presentation_key()), None, Ok(current.clone()))
             .expect("current session remains selectable");
 
     assert_eq!(selected, current.presentation_key());
@@ -2607,6 +2870,7 @@ fn detach_invalidates_fallback_authority_before_an_async_failure() {
         endpoint: snapshot.endpoint().clone(),
         runtime: snapshot.runtime().clone(),
         target: AttachTarget::Tmux(session::SessionIdentity::new(100, "$1", 200)),
+        exact_worktree_attach: false,
         name: "replacement".to_owned(),
         inventory_generation: 1,
     };
@@ -4951,6 +5215,7 @@ fn a_herdr_stop_revokes_restarts_and_the_delayed_recovery_re_drives_them() {
             session_directory: "/tmp/herdr/default".to_owned(),
             socket_path: "/tmp/herdr/default/herdr.sock".to_owned(),
         },
+        exact_worktree_attach: false,
         name: "default".to_owned(),
         inventory_generation: 1,
     };
@@ -5570,8 +5835,8 @@ fn kwt_inventory_projects_worktrees_without_replacing_session_state() {
         .store(7, Ordering::Release);
     let inventory = KwtInventory::parse(
             br#"[{"repository":"project-id","name":"project","path":"/repos/project","last_touched":null,"registration_fingerprint":"project-fingerprint"}]"#,
-            br#"[{"path":"/repos/project","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"project-id","session_name":"project-main","tmux_socket_name":null}]"#,
-            br#"[{"name":"scratch","path":"/work/scratch","session_name":"scratch","session_live":false}]"#,
+            br#"[{"path":"/repos/project","branch":"main","commit_hash":"abc","is_main":true,"created_at":null,"generation":"g1","repository":"project-id","session_name":"project-main","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
+            br#"[{"name":"scratch","path":"/work/scratch","session_name":"scratch","session_live":false,"tmux_socket_name":"kwt","tmux_attach_mode":"direct"}]"#,
         )
         .expect("valid KWT inventory");
 
@@ -5648,7 +5913,21 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         TerminalAppearance::default(),
         Some(WslHostSpec::available(config.clone(), executable.clone())),
     );
-    let snapshot = HostSnapshot::test_fixture("Ubuntu", "boot", 42, Vec::new());
+    let generationless_identity = session::SessionIdentity::new(100, "$1", 200);
+    let generation_identity = session::SessionIdentity::new(100, "$2", 201);
+    let directory_identity = session::SessionIdentity::new(100, "$3", 202);
+    let stale_directory_identity = session::SessionIdentity::new(100, "$4", 203);
+    let snapshot = HostSnapshot::test_fixture(
+        "Ubuntu",
+        "boot",
+        42,
+        vec![
+            session::DiscoveredSession::new("project-legacy", generationless_identity.clone(), 0),
+            session::DiscoveredSession::new("project-topic", generation_identity.clone(), 0),
+            session::DiscoveredSession::new("adopted", directory_identity.clone(), 0),
+            session::DiscoveredSession::new("stale", stale_directory_identity, 0),
+        ],
+    );
     *workspace.scene.runtime.host.lock().expect("published host") = Some(Published::new(
         HostContext {
             host: WslHost::new(
@@ -5673,7 +5952,7 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         .store(7, Ordering::Release);
     let inventory = KwtInventory::parse(
             br#"[{"repository":"project-id","name":"project","path":"/repos/project","last_touched":null,"registration_fingerprint":"project-fingerprint"}]"#,
-            br#"[{"path":"/work/project/topic","branch":"topic","commit_hash":"abc","is_main":false,"created_at":null,"generation":"g7","repository":"project-id","session_name":"project-topic","tmux_socket_name":null},{"path":"/work/project/pr-17","branch":"pr-17","commit_hash":"def","is_main":false,"created_at":null,"generation":"g8","repository":"project-id","session_name":"project-pr-17","tmux_socket_name":"kwt-pr-a1b2"}]"#,
+            br#"[{"path":"/work/project/legacy","branch":"legacy","commit_hash":"123","is_main":false,"created_at":null,"generation":null,"repository":"project-id","session_name":"project-legacy","tmux_socket_name":null,"tmux_attach_mode":"direct"},{"path":"/work/project/topic","branch":"topic","commit_hash":"abc","is_main":false,"created_at":null,"generation":"g7","repository":"project-id","session_name":"project-topic","tmux_socket_name":null,"tmux_attach_mode":"direct"},{"path":"/work/project/named","branch":"named","commit_hash":"cab","is_main":false,"created_at":null,"generation":"g9","repository":"project-id","session_name":"project-named","tmux_socket_name":"kwt","tmux_attach_mode":"direct"},{"path":"/work/project/pr-17","branch":"pr-17","commit_hash":"def","is_main":false,"created_at":null,"generation":"g8","repository":"project-id","session_name":"project-pr-17","tmux_socket_name":"kwt-pr-a1b2","tmux_attach_mode":"protected"},{"path":"/work/project/pr-18","branch":"pr-18","commit_hash":"fed","is_main":false,"created_at":null,"generation":"g10","repository":"project-id","session_name":"project-pr-18","tmux_socket_name":null,"tmux_attach_mode":"protected"}]"#,
             b"[]",
         )
         .expect("valid KWT inventory");
@@ -5683,6 +5962,49 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         snapshot.endpoint(),
         snapshot.runtime(),
         &inventory,
+    );
+
+    let generationless = capture_attach_request(
+        &workspace.scene,
+        &SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "project-legacy",
+            host::KwtTmuxAttachMode::Direct,
+            None,
+            "/work/project/legacy",
+            None,
+        ),
+    )
+    .expect("a generationless worktree attaches to its discovered tmux identity");
+    assert!(matches!(
+        generationless.target,
+        AttachTarget::DiscoveredWorktree {
+            ref repository,
+            ref registration_fingerprint,
+            ref path,
+            ref generation,
+            ref session_name,
+            ref identity,
+        } if repository == "project-id"
+            && registration_fingerprint == "project-fingerprint"
+            && path == "/work/project/legacy"
+            && generation.is_none()
+            && session_name == "project-legacy"
+            && identity == &generationless_identity
+    ));
+    assert_eq!(
+        generationless.selection(),
+        SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "project-legacy",
+            host::KwtTmuxAttachMode::Direct,
+            None,
+            "/work/project/legacy",
+            None,
+        ),
+        "the presentation remains owned by the generationless KWT row"
     );
 
     let request = capture_kwt_worktree_request(
@@ -5696,10 +6018,90 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         Some("g7"),
         "project-topic",
         None,
+        host::KwtTmuxAttachMode::Direct,
     )
     .expect("KWT identity grants repair-or-open authority");
     assert!(matches!(request.target, AttachTarget::Worktree { .. }));
+    assert!(!request.exact_worktree_attach);
     assert_eq!(request.name, "project-topic");
+    let direct_named = capture_kwt_worktree_request(
+        &workspace.scene,
+        "wsl",
+        "Ubuntu",
+        "project-id",
+        "/repos/project",
+        "project-fingerprint",
+        "/work/project/named",
+        Some("g9"),
+        "project-named",
+        Some("kwt"),
+        host::KwtTmuxAttachMode::Direct,
+    )
+    .expect("a direct named endpoint grants ordinary KWT open authority");
+    assert!(matches!(direct_named.target, AttachTarget::Worktree { .. }));
+    assert!(!direct_named.exact_worktree_attach);
+    let direct_named_selection = direct_named.selection();
+    assert_eq!(direct_named_selection.tmux_socket_name(), Some("kwt"));
+    assert_eq!(
+        direct_named_selection.tmux_attach_mode(),
+        Some(host::KwtTmuxAttachMode::Direct)
+    );
+    assert_ne!(
+        direct_named_selection,
+        SessionSelection::new("wsl", "Ubuntu", "project-named")
+    );
+    assert!(matches!(
+        capture_kill_request(&workspace.scene, &direct_named_selection, 8)
+            .expect("direct named selection grants an exact socket kill query"),
+        KillCaptureRequest::Tmux { selection, .. }
+            if selection.tmux_socket_name() == Some("kwt")
+                && selection.tmux_attach_mode()
+                    == Some(host::KwtTmuxAttachMode::Direct)
+    ));
+    workspace
+        .scene
+        .runtime
+        .hosts
+        .write()
+        .expect("host inventory")
+        .first_mut()
+        .expect("WSL host")
+        .kwt_state = KwtState::Unavailable;
+    let attached_default = capture_attach_request(&workspace.scene, &request.selection())
+        .expect("a live default-server worktree captures its tmux identity");
+    assert!(matches!(
+        attached_default.target,
+        AttachTarget::DiscoveredWorktree {
+            ref generation,
+            ref identity,
+            ..
+        } if generation.as_deref() == Some("g7")
+            && identity == &generation_identity
+    ));
+    assert!(!attached_default.exact_worktree_attach);
+    let attached_named = capture_attach_request(&workspace.scene, &direct_named_selection)
+        .expect("a direct named worktree captures its exact tmux endpoint");
+    assert!(matches!(
+        attached_named.target,
+        AttachTarget::Worktree {
+            ref path,
+            ref session_name,
+            ref tmux_socket_name,
+            ..
+        } if path == "/work/project/named"
+            && session_name == "project-named"
+            && tmux_socket_name.as_deref() == Some("kwt")
+    ));
+    assert!(attached_named.exact_worktree_attach);
+    workspace
+        .scene
+        .runtime
+        .hosts
+        .write()
+        .expect("host inventory")
+        .first_mut()
+        .expect("WSL host")
+        .kwt_state = KwtState::Ready;
     let protected = capture_kwt_worktree_request(
         &workspace.scene,
         "wsl",
@@ -5711,6 +6113,7 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         Some("g8"),
         "project-pr-17",
         Some("kwt-pr-a1b2"),
+        host::KwtTmuxAttachMode::Protected,
     )
     .expect("KWT identity grants protected attach authority");
     assert!(matches!(
@@ -5733,10 +6136,28 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
             "project-id",
             "/repos/project",
             "project-fingerprint",
+            "/work/project/pr-18",
+            Some("g10"),
+            "project-pr-18",
+            None,
+            host::KwtTmuxAttachMode::Protected,
+        )
+        .is_err(),
+        "an unresolved protected endpoint cannot fall through to direct attachment"
+    );
+    assert!(
+        capture_kwt_worktree_request(
+            &workspace.scene,
+            "wsl",
+            "Ubuntu",
+            "project-id",
+            "/repos/project",
+            "project-fingerprint",
             "/work/project/pr-17",
             Some("g8"),
             "project-pr-17",
             Some("kwt-pr-replaced"),
+            host::KwtTmuxAttachMode::Protected,
         )
         .is_err(),
         "a stale protected-socket action cannot open the replacement server"
@@ -5759,9 +6180,95 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
             Some("stale"),
             "project-topic",
             None,
+            host::KwtTmuxAttachMode::Direct,
         )
         .is_err()
     );
+    let directory_inventory = KwtInventory::parse(
+        b"[]",
+        b"[]",
+        br#"[{"name":"scratch","path":"/work/scratch","session_name":"scratch","session_live":true,"tmux_socket_name":"kwt","tmux_attach_mode":"direct"},{"name":"adopted","path":"/work/adopted","session_name":"adopted","session_live":true,"tmux_socket_name":null,"tmux_attach_mode":"direct"},{"name":"stale","path":"/work/stale","session_name":"stale","session_live":false,"tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#,
+    )
+    .expect("valid directory workspace inventory");
+    workspace
+        .scene
+        .runtime
+        .kwt_refresh_generation
+        .store(8, Ordering::Release);
+    publish_kwt_inventory(
+        &workspace.scene,
+        8,
+        snapshot.endpoint(),
+        snapshot.runtime(),
+        &directory_inventory,
+    );
+    let directory = capture_attach_request(
+        &workspace.scene,
+        &SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "scratch",
+            host::KwtTmuxAttachMode::Direct,
+            Some("kwt".to_owned()),
+            "/work/scratch",
+            None,
+        ),
+    )
+    .expect("a direct named directory workspace opens through KWT");
+    assert!(matches!(
+        directory.target,
+        AttachTarget::DirectoryWorkspace {
+            ref path,
+            ref session_name,
+            ref tmux_socket_name,
+        } if path == "/work/scratch"
+            && session_name == "scratch"
+            && tmux_socket_name.as_deref() == Some("kwt")
+    ));
+    let adopted = capture_attach_request(
+        &workspace.scene,
+        &SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "adopted",
+            host::KwtTmuxAttachMode::Direct,
+            None,
+            "/work/adopted",
+            None,
+        ),
+    )
+    .expect("a live default-server directory workspace attaches without KWT");
+    assert!(matches!(
+        adopted.target,
+        AttachTarget::Tmux(ref identity) if identity == &directory_identity
+    ));
+    let stale = capture_attach_request(
+        &workspace.scene,
+        &SessionSelection::kwt_workspace(
+            "wsl",
+            "Ubuntu",
+            "stale",
+            host::KwtTmuxAttachMode::Direct,
+            None,
+            "/work/stale",
+            None,
+        ),
+    )
+    .expect("a stale default-server directory workspace opens through KWT");
+    let equivalent = kwt_tmux_presentation_key(&stale, &snapshot);
+    assert!(equivalent.is_none());
+    let (key, request) = choose_navigation_target(None, equivalent, Ok(stale.clone()))
+        .expect("stale directory navigation remains available through KWT");
+    assert_eq!(key, stale.presentation_key());
+    assert!(request.is_some());
+    assert!(matches!(
+        stale.target,
+        AttachTarget::DirectoryWorkspace {
+            ref path,
+            ref session_name,
+            tmux_socket_name: None,
+        } if path == "/work/stale" && session_name == "stale"
+    ));
 }
 
 #[test]
@@ -8281,6 +8788,7 @@ fn removed_kwt_worktree_drops_matching_confirmations_in_every_scene() {
         generation: generation.to_owned(),
         session_name: "widget-topic".to_owned(),
         socket_name: None,
+        tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
         live_target: None,
     };
     *b.scene
@@ -8336,7 +8844,7 @@ fn removed_kwt_worktree_drops_matching_confirmations_in_every_scene() {
 fn kwt_removal_reconciliation_branches_gate_confirmation_drops() {
     fn widget_inventory(with_topic_worktree: bool) -> KwtInventory {
         let worktrees: &[u8] = if with_topic_worktree {
-            br#"[{"path":"/work/widget/topic","branch":"topic","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-topic","tmux_socket_name":null}]"#
+            br#"[{"path":"/work/widget/topic","branch":"topic","commit_hash":"abc","is_main":false,"created_at":null,"generation":"0123456789abcdef0123456789abcdef","repository":"github.com/acme/widget","session_name":"widget-topic","tmux_socket_name":null,"tmux_attach_mode":"direct"}]"#
         } else {
             b"[]"
         };
@@ -8367,6 +8875,7 @@ fn kwt_removal_reconciliation_branches_gate_confirmation_drops() {
             generation: generation.to_owned(),
             session_name: "widget-topic".to_owned(),
             socket_name: None,
+            tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
             live_target: None,
         });
     };
@@ -8421,6 +8930,7 @@ fn kwt_removal_reconciliation_branches_gate_confirmation_drops() {
             generation: generation.to_owned(),
             session_name: "widget-topic".to_owned(),
             socket_name: None,
+            tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
             live_target: None,
             operation_id: 9,
         },
@@ -9341,6 +9851,7 @@ fn removal_completing_during_identity_capture_cannot_publish_a_stale_confirmatio
         generation: generation.to_owned(),
         session_name: "widget-topic".to_owned(),
         socket_name: None,
+        tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
     };
     // Both scenes' removal requests recorded their capture intents (the
     // request registration writes exactly this shape) and the captured
@@ -10843,6 +11354,7 @@ fn created_worktree_target() -> KwtWorktreeTarget {
         generation: Some("0123456789abcdef0123456789abcdef".to_owned()),
         session_name: "widget-topic".to_owned(),
         tmux_socket_name: None,
+        tmux_attach_mode: host::KwtTmuxAttachMode::Direct,
     }
 }
 
@@ -11824,6 +12336,7 @@ fn destructive_lifecycle_paths_refuse_a_closed_scene() {
             &"a".repeat(40),
             "ghosthub/web",
             None,
+            host::KwtTmuxAttachMode::Direct,
         )
         .expect_err("a closed scene arms no worktree removal");
     assert!(error.to_string().contains("closed"), "{error}");
@@ -12291,6 +12804,7 @@ fn closure_during_a_retry_launch_suppresses_the_failure_publication() {
     );
 }
 
+#[cfg(windows)]
 #[test]
 fn retained_retries_never_hold_navigation_while_waiting_on_operations() {
     // Mimic a remote attach: hold session_operations, then acquire the

--- a/rust/workspace/src/tests.rs
+++ b/rust/workspace/src/tests.rs
@@ -6039,7 +6039,12 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
     )
     .expect("a direct named endpoint grants ordinary KWT open authority");
     assert!(matches!(direct_named.target, AttachTarget::Worktree { .. }));
-    assert!(!direct_named.exact_worktree_attach);
+    assert!(direct_named.exact_worktree_attach);
+    assert_eq!(
+        fresh_worktree_exact_kwt_endpoint(&workspace.scene.runtime, &direct_named),
+        None,
+        "a KWT-ready direct endpoint retains repair-or-open authority"
+    );
     let direct_named_selection = direct_named.selection();
     assert_eq!(direct_named_selection.tmux_socket_name(), Some("kwt"));
     assert_eq!(
@@ -6067,6 +6072,11 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         .first_mut()
         .expect("WSL host")
         .kwt_state = KwtState::Unavailable;
+    assert_eq!(
+        fresh_worktree_exact_kwt_endpoint(&workspace.scene.runtime, &direct_named),
+        Some(("project-named", "kwt")),
+        "the captured direct endpoint becomes the KWT-unavailable fallback"
+    );
     let attached_default = capture_attach_request(&workspace.scene, &request.selection())
         .expect("a live default-server worktree captures its tmux identity");
     assert!(matches!(
@@ -6116,6 +6126,7 @@ fn worktree_open_uses_durable_kwt_identity_even_without_a_live_tmux_session() {
         host::KwtTmuxAttachMode::Protected,
     )
     .expect("KWT identity grants protected attach authority");
+    assert!(!protected.exact_worktree_attach);
     assert!(matches!(
         protected.target,
         AttachTarget::ProtectedWorktree { ref tmux_socket_name, .. }


### PR DESCRIPTION
KWT now puts normal managed workspaces on a named tmux server. Ghosthub used to treat every named server as protected, so a normal workspace could fail to open or attach to a same-named session on the default server.

- Uses KWT's direct or protected attachment mode instead of guessing from the socket name.
- Opens worktrees and registered directory workspaces on the exact tmux server that KWT reports.
- Keeps the server and attachment mode through navigation, previews, reconnects, session kills, and worktree removal.
- Opens generationless worktrees through an identity-checked tmux attachment and lets KWT create or repair stopped directory sessions.
- Keeps protected pull-request workspaces closed when their generation, session, mode, or socket no longer matches.

For manual QA, open a normal KWT worktree, a registered directory workspace, and a protected pull-request workspace on the same host. Navigate away and reconnect to each one, then confirm that Ghosthub never opens a same-named session from another tmux server.
