### PR TITLE
Keep transient SSH failures in automatic recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ test, and documentation-only changes are omitted.
   packaged application and libghostty runtime checked on a hosted Sequoia
   runner before release changes merge.
 
+### Fixed
+
+- Remote inventory retries a transient OpenSSH session-channel refusal instead
+  of reporting the host as unreachable when concurrent commands briefly fill
+  the server's multiplexed-session limit.
+
 ## [0.9.0] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ test, and documentation-only changes are omitted.
 - Remote inventory retries a transient OpenSSH session-channel refusal instead
   of reporting the host as unreachable when concurrent commands briefly fill
   the server's multiplexed-session limit.
+- SSH transport outages stay in automatic session reconnect instead of opening
+  an authentication sheet that interrupts work and waits for manual retry.
 
 ## [0.9.0] - 2026-08-15
 

--- a/Sources/App/AccountCommandRunner.swift
+++ b/Sources/App/AccountCommandRunner.swift
@@ -79,6 +79,11 @@ private final class AccountCommandOutputCollector: @unchecked Sendable {
 }
 
 struct AccountCommandRunner: Sendable {
+    enum RemoteRetryPolicy: Sendable {
+        case never
+        case idempotent
+    }
+
     static let timedOutStatus: Int32 = -124
     static let outputExceededStatus: Int32 = -125
     static let cancelledStatus: Int32 = -130
@@ -120,7 +125,8 @@ struct AccountCommandRunner: Sendable {
         host: SSHHostInfo,
         connectionArguments: [String],
         command: String,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        retryPolicy: RemoteRetryPolicy = .never
     ) -> AccountCommandOutput {
         let invocation = (["/usr/bin/ssh"] + Self.remoteLoginArguments(
             host: host,
@@ -128,6 +134,7 @@ struct AccountCommandRunner: Sendable {
             command: command
         )).map(shellQuotedCommandArgument).joined(separator: " ")
         var output = runLocalLoginShell(command: invocation, timeout: timeout)
+        guard case .idempotent = retryPolicy else { return output }
         for delay in Self.sessionOpenRetryDelays {
             guard SSHConnectionFailure.indicatesRefusedSessionOpen(
                 status: output.status,

--- a/Sources/App/AccountCommandRunner.swift
+++ b/Sources/App/AccountCommandRunner.swift
@@ -83,6 +83,7 @@ struct AccountCommandRunner: Sendable {
     static let outputExceededStatus: Int32 = -125
     static let cancelledStatus: Int32 = -130
     private static let maximumOutputBytes = 1 * 1_024 * 1_024
+    private static let sessionOpenRetryDelays: [useconds_t] = [100_000, 250_000]
 
     typealias ProcessRunner = @Sendable (
         _ executable: String,
@@ -126,7 +127,16 @@ struct AccountCommandRunner: Sendable {
             connectionArguments: connectionArguments,
             command: command
         )).map(shellQuotedCommandArgument).joined(separator: " ")
-        return runLocalLoginShell(command: invocation, timeout: timeout)
+        var output = runLocalLoginShell(command: invocation, timeout: timeout)
+        for delay in Self.sessionOpenRetryDelays {
+            guard SSHConnectionFailure.indicatesRefusedSessionOpen(
+                status: output.status,
+                output: output.stderr
+            ) else { break }
+            usleep(delay)
+            output = runLocalLoginShell(command: invocation, timeout: timeout)
+        }
+        return output
     }
 
     static func loginShell() -> String {

--- a/Sources/App/HerdrInventoryClient.swift
+++ b/Sources/App/HerdrInventoryClient.swift
@@ -170,7 +170,8 @@ struct HerdrInventoryClient: Sendable {
                 host: info,
                 connectionArguments: sshConnectionArguments,
                 command: command,
-                timeout: processTimeout
+                timeout: processTimeout,
+                retryPolicy: .idempotent
             )
         }
     }

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -273,7 +273,8 @@ struct KwtInventoryClient: Sendable {
                 host: host,
                 connectionArguments: arguments,
                 command: command,
-                timeout: processTimeout
+                timeout: processTimeout,
+                retryPolicy: .idempotent
             )
         }
         self.loginShellProvider = loginShellProvider

--- a/Sources/App/KwtSSHConnectionSession.swift
+++ b/Sources/App/KwtSSHConnectionSession.swift
@@ -48,8 +48,18 @@ final class KwtSSHConnectionSession: ObservableObject {
             return true
         }
         switch state {
-        case .failed, .configurationChanged:
+        case .configurationChanged:
             return true
+        case .failed:
+            guard let connectionFailure else { return false }
+            switch SSHConnectionFailure.classify(
+                leaseError: connectionFailure
+            ).kind {
+            case .authenticationRequired, .hostKeyReviewRequired:
+                return true
+            case .transport, .hostKeyChanged, .configurationChanged:
+                return false
+            }
         case .starting, .prompt, .verifying, .connected:
             return false
         }
@@ -252,11 +262,14 @@ final class KwtSSHConnectionSession: ObservableObject {
                 state = error as? KwtSSHLeaseError == .routeChanged
                     ? .configurationChanged
                     : .failed(error.localizedDescription)
-                onPresentationRequired()
+                let retainsRetryWaiters = needsPresentation
+                if retainsRetryWaiters {
+                    onPresentationRequired()
+                }
                 publishRequirement()
                 publishConnection(
                     .failure(error),
-                    retainingRetryWaiters: true
+                    retainingRetryWaiters: retainsRetryWaiters
                 )
             }
         }
@@ -470,14 +483,17 @@ final class KwtSSHConnectionSession: ObservableObject {
             state = .failed(
                 failure.localizedDescription
             )
-            onPresentationRequired()
+            let retainsRetryWaiters = needsPresentation
+            if retainsRetryWaiters {
+                onPresentationRequired()
+            }
             if self.acquisitionID == acquisitionID {
                 self.acquisitionID = nil
             }
             publishRequirement()
             publishConnection(
                 .failure(failure),
-                retainingRetryWaiters: true
+                retainingRetryWaiters: retainsRetryWaiters
             )
             Task { try? await connection.release() }
         }

--- a/Sources/App/NativeHerdrSessionCoordinator.swift
+++ b/Sources/App/NativeHerdrSessionCoordinator.swift
@@ -288,7 +288,17 @@ final class NativeHerdrSessionCoordinator {
                 }
                 try? await sshConnection?.release()
             }
-            attachmentClosures[handle.id] = .launchFailed
+            attachmentClosures[handle.id] = switch error {
+            case let .commandFailed(status, stderr)
+                where host.isRemote && status == 255
+                && SSHConnectionFailure.classify(
+                    status: status,
+                    output: stderr
+                ).kind == .transport:
+                .retryableTransportFailure
+            default:
+                .launchFailed
+            }
             onStateChanged?(
                 handle,
                 .disconnected(reason: error.localizedDescription)

--- a/Sources/App/NativeHerdrSessionCoordinator.swift
+++ b/Sources/App/NativeHerdrSessionCoordinator.swift
@@ -16,6 +16,8 @@ enum BorrowedHerdrAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// SSH transport failed before the terminal client could start.
+    case retryableTransportFailure
     /// The terminal surface could not be created. Transient — no display was
     /// available to render it — so recovery keeps trying instead of latching.
     case surfaceUnavailable
@@ -301,7 +303,10 @@ final class NativeHerdrSessionCoordinator {
         provisioningTasks.removeValue(forKey: handle.id)
         provisioningHandles.remove(handle.id)
         guard handlesByKey[sessionKey(handle)] == handle else { return }
-        attachmentClosures[handle.id] = .launchFailed
+        attachmentClosures[handle.id] =
+            SSHConnectionFailure.retryableTransportFailure(error) == nil
+                ? .launchFailed
+                : .retryableTransportFailure
         onStateChanged?(
             handle,
             .disconnected(reason: error.localizedDescription)

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -457,7 +457,13 @@ final class NativeTmuxSessionCoordinator {
                 }
                 try? await sshConnection?.release()
             }
-            attachmentClosures[handle.id] = .launchFailed
+            attachmentClosures[handle.id] = switch error {
+            case let .sshConnectionFailed(_, classification)
+                where classification.kind == .transport:
+                .retryableTransportFailure
+            default:
+                .launchFailed
+            }
             interactiveSizingHandles.remove(handle.id)
             onStateChanged?(
                 handle,

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -34,6 +34,8 @@ enum BorrowedTmuxAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// SSH transport failed before the terminal client could start.
+    case retryableTransportFailure
     /// The terminal surface could not be created. Transient — no display was
     /// available to render it — so recovery keeps trying instead of latching.
     case surfaceUnavailable
@@ -471,7 +473,10 @@ final class NativeTmuxSessionCoordinator {
         provisioningTasks.removeValue(forKey: handle.id)
         provisioningHandles.remove(handle.id)
         guard handlesByKey[sessionKey(handle)] == handle else { return }
-        attachmentClosures[handle.id] = .launchFailed
+        attachmentClosures[handle.id] =
+            SSHConnectionFailure.retryableTransportFailure(error) == nil
+                ? .launchFailed
+                : .retryableTransportFailure
         interactiveSizingHandles.remove(handle.id)
         onStateChanged?(
             handle,

--- a/Sources/App/NativeZellijSessionCoordinator.swift
+++ b/Sources/App/NativeZellijSessionCoordinator.swift
@@ -16,6 +16,8 @@ enum BorrowedZellijAttachmentClosure: Equatable {
     case detached
     case processExited(code: UInt32?)
     case launchFailed
+    /// SSH transport failed before the terminal client could start.
+    case retryableTransportFailure
     /// The terminal surface could not be created. Transient — no display was
     /// available to render it — so recovery keeps trying instead of latching.
     case surfaceUnavailable
@@ -255,7 +257,10 @@ final class NativeZellijSessionCoordinator {
     ) {
         provisioningTasks.removeValue(forKey: handle.id)
         guard handlesByKey[sessionKey(handle)] == handle else { return }
-        attachmentClosures[handle.id] = .launchFailed
+        attachmentClosures[handle.id] =
+            SSHConnectionFailure.retryableTransportFailure(error) == nil
+                ? .launchFailed
+                : .retryableTransportFailure
         onStateChanged?(handle, .disconnected(
             reason: error.localizedDescription
         ))

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -91,6 +91,17 @@ enum SSHConnectionFailure {
         )
     }
 
+    static func retryableTransportFailure(
+        _ error: Error
+    ) -> Classification? {
+        guard let leaseError = error as? KwtSSHLeaseError,
+              case let .operationFailed(_, _, retryable) = leaseError,
+              retryable
+        else { return nil }
+        let classification = classify(leaseError: leaseError)
+        return classification.kind == .transport ? classification : nil
+    }
+
     /// True when OpenSSH could not reach the daemon-owned master and fell
     /// through to the lease's fail-closed proxy, so the master must be
     /// re-established before the route is used again.

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -115,8 +115,10 @@ enum SSHConnectionFailure {
             || normalized.contains("control socket connect(")
     }
 
-    /// OpenSSH failed before it opened the remote command's session channel.
-    /// A bounded retry is safe because the requested command did not start.
+    /// Matches OpenSSH's multiplexed session-channel refusal diagnostic.
+    ///
+    /// The captured stream also contains remote stderr, so callers must opt in
+    /// only when repeating the requested command is safe.
     static func indicatesRefusedSessionOpen(
         status: Int32,
         output: String

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -104,6 +104,19 @@ enum SSHConnectionFailure {
             || normalized.contains("control socket connect(")
     }
 
+    /// OpenSSH failed before it opened the remote command's session channel.
+    /// A bounded retry is safe because the requested command did not start.
+    static func indicatesRefusedSessionOpen(
+        status: Int32,
+        output: String
+    ) -> Bool {
+        guard status == 255 else { return false }
+        return output.lowercased().contains(
+            "mux_client_request_session: session request failed: "
+                + "session open refused by peer"
+        )
+    }
+
     static func indicatesUnusableConnection(
         _ error: ZellijCommandError
     ) -> Bool {

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -109,7 +109,9 @@ enum SSHConnectionFailure {
         status: Int32,
         output: String
     ) -> Bool {
-        guard status == 255 else { return false }
+        guard status == 255,
+              !indicatesRefusedSessionOpen(status: status, output: output)
+        else { return false }
         let normalized = output.lowercased()
         return normalized.contains("connection closed by unknown port 65535")
             || normalized.contains("control socket connect(")

--- a/Sources/App/SSHConnectionFailure.swift
+++ b/Sources/App/SSHConnectionFailure.swift
@@ -94,10 +94,21 @@ enum SSHConnectionFailure {
     static func retryableTransportFailure(
         _ error: Error
     ) -> Classification? {
-        guard let leaseError = error as? KwtSSHLeaseError,
-              case let .operationFailed(_, _, retryable) = leaseError,
-              retryable
-        else { return nil }
+        guard let leaseError = error as? KwtSSHLeaseError else { return nil }
+        switch leaseError {
+        case let .operationFailed(_, _, retryable):
+            guard retryable else { return nil }
+        case .acquisitionTimedOut:
+            break
+        case let .commandFailed(status):
+            // 255 is OpenSSH's own exit status, so the helper died on the
+            // transport; any other status is a helper defect.
+            guard status == 255 else { return nil }
+        case .helperUnavailable, .launchFailed, .malformedEvent,
+             .persistentUnsupported, .cleanupFailed, .routeChanged,
+             .releaseTimedOut, .poolClosed:
+            return nil
+        }
         let classification = classify(leaseError: leaseError)
         return classification.kind == .transport ? classification : nil
     }
@@ -263,6 +274,17 @@ enum SSHConnectionFailure {
                     summary: "The effective SSH configuration changed or cannot be reviewed.",
                     recoverySuggestion:
                     "Review the host's SSH configuration before reconnecting."
+                )
+            )
+        case "ssh_acquisition_timed_out":
+            return Classification(
+                kind: .transport,
+                diagnostic: RemoteHostDiagnostic(
+                    code: .sshConnectionFailed,
+                    severity: .error,
+                    summary: "The SSH connection timed out.",
+                    recoverySuggestion:
+                    "Check the destination, network access, and SSH server, then retry."
                 )
             )
         case "ssh_unsupported_version", "ssh_persistent_unsupported":

--- a/Sources/App/TmuxBinaryResolver.swift
+++ b/Sources/App/TmuxBinaryResolver.swift
@@ -131,7 +131,8 @@ struct TmuxBinaryResolver: Sendable {
                 host: host,
                 connectionArguments: sshConnectionArguments,
                 command: command,
-                timeout: processTimeout
+                timeout: processTimeout,
+                retryPolicy: .idempotent
             )
             return (result.status, result.stdout, result.stderr)
         }

--- a/Sources/App/TmuxSessionActivityProbe.swift
+++ b/Sources/App/TmuxSessionActivityProbe.swift
@@ -90,7 +90,8 @@ struct TmuxSessionActivityProbe: Sendable {
                     host: info,
                     connectionArguments: connectionArguments ?? [],
                     command: command,
-                    timeout: 10
+                    timeout: 10,
+                    retryPolicy: .idempotent
                 )
             }
         }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -455,9 +455,8 @@ final class WorkspaceSceneModel: ObservableObject {
         var routeIdentity: String?
         var phase: RemoteTmuxEstablishmentPhase
         var surfaceExitCode: UInt32?
-        /// The previous attempt could not create a terminal surface, so no
-        /// client ever ran and there is no exit code to inspect. Recovery is
-        /// still legitimate: the transport failure that started it stands.
+        /// The previous attempt failed before the terminal client could start,
+        /// so there is no exit code to inspect and replay is still safe.
         var surfaceLaunchFailed = false
     }
 
@@ -10597,7 +10596,9 @@ final class WorkspaceSceneModel: ObservableObject {
            alwaysLiveManagedTmuxPresentationKeys.contains(key),
            !nativeTmuxSessionCoordinator.hasLaunched(handle),
            nativeTmuxSessionCoordinator.attachmentClosure(handle)
-           != .surfaceUnavailable {
+           != .surfaceUnavailable,
+           nativeTmuxSessionCoordinator.attachmentClosure(handle)
+           != .retryableTransportFailure {
             // Identity exclusion is for permanent launch and setup failures.
             // A retryable surface failure (for example the display vanished
             // during creation) keeps the policy-owned presentation so
@@ -10641,6 +10642,18 @@ final class WorkspaceSceneModel: ObservableObject {
             tmuxActivityEnrollmentTasks.removeValue(
                 forKey: handle.id
             )?.cancel()
+        }
+        if case .disconnected = state,
+           nativeTmuxSessionCoordinator.attachmentClosure(handle)
+           == .retryableTransportFailure,
+           var context = presentation.reconnectContext,
+           context.handleID == handle.id {
+            // SSH failed before the tmux client could start, so retrying the
+            // original attachment cannot replay remote client side effects.
+            context.surfaceLaunchFailed = true
+            presentation.reconnectContext = context
+            startTmuxReconnect(presentation, context: context)
+            return
         }
         if case .disconnected = state,
            presentation.recoveryState != nil,
@@ -11588,7 +11601,8 @@ final class WorkspaceSceneModel: ObservableObject {
                   retainedTmuxPresentation(for: presentation.handle)
                   === presentation
             else { return .stop }
-            guard snapshot.routeIdentity == context.routeIdentity else {
+            if let expectedRouteIdentity = context.routeIdentity,
+               snapshot.routeIdentity != expectedRouteIdentity {
                 stopTmuxReconnectWithUnableToAttach(
                     presentation,
                     "The SSH connection changed while Ghosthub was checking the tmux session. Reopen it to use the current connection."
@@ -11678,7 +11692,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 guard probe.outcome == .present else { return .retry }
             }
         }
-        guard let decisionContext = presentation.reconnectContext else {
+        guard var decisionContext = presentation.reconnectContext else {
             return .stop
         }
         let discoveryAdvancedToAttachOnly =
@@ -11694,6 +11708,19 @@ final class WorkspaceSceneModel: ObservableObject {
         guard decisionContext == currentContext
             || discoveryAdvancedToAttachOnly
         else { return .stop }
+        if decisionContext.routeIdentity == nil,
+           let frozenConnection {
+            switch probe.outcome {
+            case .present, .absent:
+                // Initial attachment recovery has no route to fence until its
+                // first successful probe. Bind that stable route before any
+                // relaunch so the new client cannot switch SSH destinations.
+                decisionContext.routeIdentity = frozenConnection.routeIdentity
+                presentation.reconnectContext = decisionContext
+            case .failure:
+                break
+            }
+        }
         return reconnectDecision(
             for: presentation,
             context: decisionContext,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -5972,7 +5972,11 @@ final class WorkspaceSceneModel: ObservableObject {
             removePresentationSSHSession(sessionID, cancel: false)
             return connection
         } catch {
-            presentationSSHSessionNeedsAttention(sessionID)
+            if session.needsPresentation {
+                presentationSSHSessionNeedsAttention(sessionID)
+            } else {
+                removePresentationSSHSession(sessionID, cancel: false)
+            }
             throw error
         }
     }
@@ -11571,11 +11575,10 @@ final class WorkspaceSceneModel: ObservableObject {
                       retainedTmuxPresentation(for: presentation.handle)
                       === presentation
                 else { return .stop }
-                stopTmuxReconnectWithUnableToAttach(
+                return tmuxSSHAcquisitionFailureDecision(
                     presentation,
-                    error.localizedDescription
+                    error: error
                 )
-                return .stop
             }
             let snapshot = SSHConnectionArgumentsSnapshot(connection)
             guard !Task.isCancelled else { return .retry }
@@ -11636,11 +11639,10 @@ final class WorkspaceSceneModel: ObservableObject {
                       retainedTmuxPresentation(for: presentation.handle)
                       === presentation
                 else { return .stop }
-                stopTmuxReconnectWithUnableToAttach(
+                return tmuxSSHAcquisitionFailureDecision(
                     presentation,
-                    error.localizedDescription
+                    error: error
                 )
-                return .stop
             }
             let afterRouteIdentity = after.routeIdentity
             try? await after.release()
@@ -11696,6 +11698,26 @@ final class WorkspaceSceneModel: ObservableObject {
             context: decisionContext,
             outcome: probe.outcome
         )
+    }
+
+    private func tmuxSSHAcquisitionFailureDecision(
+        _ presentation: RetainedTmuxPresentation,
+        error: Error
+    ) -> SessionReconnectDecision {
+        if let classification = SSHConnectionFailure
+            .retryableTransportFailure(error) {
+            presentation.recoveryState = .reconnecting(
+                message: classification.diagnostic.summary + " "
+                    + "Ghosthub will reconnect automatically."
+            )
+            publishActiveState(for: presentation)
+            return .retry
+        }
+        stopTmuxReconnectWithUnableToAttach(
+            presentation,
+            error.localizedDescription
+        )
+        return .stop
     }
 
     private func tmuxReconnectProbe(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -8100,6 +8100,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 return
             }
             let failureReason: String
+            var retryableTransportFailure = false
             switch validation.result {
             case let .available(names):
                 let sessionIsActive = names.contains(selection.name)
@@ -8131,11 +8132,24 @@ final class WorkspaceSceneModel: ObservableObject {
                     .localizedDescription
             case let .failure(error):
                 failureReason = error.localizedDescription
+                if case let .commandFailed(status, stderr) = error,
+                   host.isRemote,
+                   validation.connection.routeIdentity != nil,
+                   status == 255,
+                   SSHConnectionFailure.classify(
+                       status: status,
+                       output: stderr
+                   ).kind == .transport {
+                    retryableTransportFailure = true
+                }
             }
             retainFailedZellijSession(
                 selection,
                 host: host,
-                reason: failureReason
+                reason: failureReason,
+                routeIdentity: retryableTransportFailure
+                    ? validation.connection.routeIdentity : nil,
+                reconnectsAutomatically: retryableTransportFailure
             )
             scheduleZellijSessionDiscovery()
         }
@@ -8206,7 +8220,9 @@ final class WorkspaceSceneModel: ObservableObject {
     private func retainFailedZellijSession(
         _ selection: WorkspaceZellijSessionSelection,
         host: CommandHost,
-        reason: String
+        reason: String,
+        routeIdentity: String? = nil,
+        reconnectsAutomatically: Bool = false
     ) {
         guard activeBorrowedTmuxSelection == nil,
               activeBorrowedHerdrSelection == nil,
@@ -8230,10 +8246,16 @@ final class WorkspaceSceneModel: ObservableObject {
                 selection: selection,
                 handleID: handle.id,
                 host: host,
-                routeIdentity: nil,
+                routeIdentity: routeIdentity,
                 surfaceExitCode: nil
             )
             : nil
+        if reconnectsAutomatically,
+           var context = activeZellijReconnectContext {
+            context.surfaceLaunchFailed = true
+            activeZellijReconnectContext = context
+            startZellijReconnect(context)
+        }
     }
 
     func prepareZellijSessionKill(
@@ -11590,6 +11612,42 @@ final class WorkspaceSceneModel: ObservableObject {
               === presentation
         else { return .stop }
         guard canAttachToDisplay else { return .retry }
+        if case let .ssh(info) = context.host,
+           context.routeIdentity == nil {
+            let routeIdentity: String
+            do {
+                routeIdentity = try await sshRouteIdentityResolver(info)
+            } catch {
+                guard !Task.isCancelled else { return .retry }
+                guard presentation.reconnectContext == context,
+                      presentation.handle.id == context.handleID,
+                      retainedTmuxPresentation(for: presentation.handle)
+                      === presentation
+                else { return .stop }
+                stopTmuxReconnectWithUnableToAttach(
+                    presentation,
+                    "Ghosthub could not verify the SSH route before reconnecting. Reopen the session to use the current connection. \(error.localizedDescription)"
+                )
+                return .stop
+            }
+            guard !Task.isCancelled else { return .retry }
+            guard presentation.reconnectContext == context,
+                  presentation.handle.id == context.handleID,
+                  retainedTmuxPresentation(for: presentation.handle)
+                  === presentation,
+                  snapshot.host(id: context.selection.hostID)
+                  .flatMap(CommandHostResolver.resolve) == context.host
+            else { return .stop }
+            var anchoredContext = context
+            anchoredContext.routeIdentity = routeIdentity
+            presentation.reconnectContext = anchoredContext
+            startTmuxReconnect(
+                presentation,
+                context: anchoredContext,
+                waitBeforeFirstAttempt: false
+            )
+            return .stop
+        }
         var frozenConnection: SSHConnectionArgumentsSnapshot?
         if case let .ssh(info) = context.host {
             let connection: KwtSSHConnection

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -392,9 +392,8 @@ final class WorkspaceSceneModel: ObservableObject {
         var host: CommandHost
         var routeIdentity: String?
         var surfaceExitCode: UInt32?
-        /// The previous attempt could not create a terminal surface, so no
-        /// client ever ran and there is no exit code to inspect. Recovery is
-        /// still legitimate: the transport failure that started it stands.
+        /// The previous attempt failed before the terminal client could start,
+        /// so there is no exit code to inspect and reattachment is still safe.
         var surfaceLaunchFailed = false
 
     }
@@ -569,9 +568,8 @@ final class WorkspaceSceneModel: ObservableObject {
         var host: CommandHost
         var routeIdentity: String?
         var surfaceExitCode: UInt32?
-        /// The previous attempt could not create a terminal surface, so no
-        /// client ever ran and there is no exit code to inspect. Recovery is
-        /// still legitimate: the transport failure that started it stands.
+        /// The previous attempt failed before the terminal client could start,
+        /// so there is no exit code to inspect and reattachment is still safe.
         var surfaceLaunchFailed = false
     }
     private var activeHerdrReconnectContext: ActiveHerdrReconnectContext?
@@ -10790,6 +10788,15 @@ final class WorkspaceSceneModel: ObservableObject {
         }) {
             return
         }
+        if nativeHerdrSessionCoordinator.attachmentClosure(handle)
+            == .retryableTransportFailure,
+            var context = activeHerdrReconnectContext,
+            context.handleID == handle.id {
+            context.surfaceLaunchFailed = true
+            activeHerdrReconnectContext = context
+            startHerdrReconnect(context)
+            return
+        }
         // Checked before `hasLaunched`: a surface that failed to be created
         // never launched, so the guard below would drop this transient failure
         // and the session would latch. See the tmux path.
@@ -10826,7 +10833,7 @@ final class WorkspaceSceneModel: ObservableObject {
             context.surfaceExitCode = code
             activeHerdrReconnectContext = context
             startHerdrReconnect(context)
-        case .surfaceUnavailable:
+        case .retryableTransportFailure, .surfaceUnavailable:
             // Recoverable failures are re-armed above, before `hasLaunched`.
             // Reaching here means no matching reconnect context survives.
             cancelHerdrReconnect()
@@ -10859,6 +10866,15 @@ final class WorkspaceSceneModel: ObservableObject {
             sessionConnectionRecoveryRequest = nil
             scheduleZellijSessionDiscovery()
         case .disconnected:
+            if nativeZellijSessionCoordinator.attachmentClosure(handle)
+                == .retryableTransportFailure,
+                var context = activeZellijReconnectContext,
+                context.handleID == handle.id {
+                context.surfaceLaunchFailed = true
+                activeZellijReconnectContext = context
+                startZellijReconnect(context)
+                return
+            }
             // Checked before `hasLaunched`: a surface that failed to be created
             // never launched, so the guard below would drop this transient
             // failure and the session would latch. See the tmux path.
@@ -10912,7 +10928,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 context.surfaceExitCode = code
                 activeZellijReconnectContext = context
                 startZellijReconnect(context)
-            case .surfaceUnavailable:
+            case .retryableTransportFailure, .surfaceUnavailable:
                 // Recoverable failures are re-armed above, before
                 // `hasLaunched`. Reaching here means no matching reconnect
                 // context survives.

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1324,7 +1324,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 host: host,
                 connectionArguments: connectionArguments,
                 command: command,
-                timeout: 10
+                timeout: 10,
+                retryPolicy: .idempotent
             )
             return (output.status, output.stdout, output.stderr)
         },

--- a/Sources/App/ZellijInventoryClient.swift
+++ b/Sources/App/ZellijInventoryClient.swift
@@ -179,7 +179,8 @@ struct ZellijInventoryClient: Sendable {
                 host: info,
                 connectionArguments: sshConnectionArguments,
                 command: command,
-                timeout: processTimeout
+                timeout: processTimeout,
+                retryPolicy: .idempotent
             )
         }
     }

--- a/Sources/App/ZellijInventoryClient.swift
+++ b/Sources/App/ZellijInventoryClient.swift
@@ -45,7 +45,8 @@ struct ZellijInventoryClient: Sendable {
         let output = run(
             ZellijExecutable.command(),
             on: host,
-            sshConnectionArguments: sshConnectionArguments
+            sshConnectionArguments: sshConnectionArguments,
+            retryPolicy: .idempotent
         )
         switch ZellijExecutable.parse(
             status: output.status,
@@ -110,7 +111,8 @@ struct ZellijInventoryClient: Sendable {
         let output = run(
             ZellijSessionList.command(zellijPath: zellijPath),
             on: host,
-            sshConnectionArguments: sshConnectionArguments
+            sshConnectionArguments: sshConnectionArguments,
+            retryPolicy: .idempotent
         )
         return ZellijSessionList.parse(
             status: output.status,
@@ -163,7 +165,8 @@ struct ZellijInventoryClient: Sendable {
     private func run(
         _ command: String,
         on host: CommandHost,
-        sshConnectionArguments: [String]?
+        sshConnectionArguments: [String]?,
+        retryPolicy: AccountCommandRunner.RemoteRetryPolicy = .never
     ) -> AccountCommandOutput {
         switch host {
         case .local:
@@ -180,7 +183,7 @@ struct ZellijInventoryClient: Sendable {
                 connectionArguments: sshConnectionArguments,
                 command: command,
                 timeout: processTimeout,
-                retryPolicy: .idempotent
+                retryPolicy: retryPolicy
             )
         }
     }

--- a/Tests/App/AccountCommandRunnerTests.swift
+++ b/Tests/App/AccountCommandRunnerTests.swift
@@ -97,7 +97,7 @@ struct AccountCommandRunnerTests {
         #expect(command.contains("${SHELL:-/bin/sh}"))
     }
 
-    @Test("remote commands retry a refused multiplexed session")
+    @Test("idempotent remote commands retry a refused multiplexed session")
     func remoteLoginShellRetriesRefusedSession() {
         let attempts = Mutex(0)
         let runner = AccountCommandRunner(
@@ -133,12 +133,46 @@ struct AccountCommandRunnerTests {
             ),
             connectionArguments: ["-S", "/tmp/kwt.sock"],
             command: "printf ready",
-            timeout: 6
+            timeout: 6,
+            retryPolicy: .idempotent
         )
 
         #expect(result.status == 0)
         #expect(result.stdout == "ready\n")
         #expect(attempts.withLock { $0 } == 2)
+    }
+
+    @Test("remote commands do not retry refused sessions by default")
+    func remoteLoginShellDoesNotRetryRefusedSessionByDefault() {
+        let attempts = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                attempts.withLock { $0 += 1 }
+                return AccountCommandOutput(
+                    status: 255,
+                    stdout: "",
+                    stderr: """
+                    mux_client_request_session: session request failed: Session open refused by peer
+                    Connection closed by UNKNOWN port 65535
+                    """
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+
+        let result = runner.runRemoteLoginShell(
+            host: SSHHostInfo(
+                user: "dev",
+                hostname: "build.example",
+                port: 22
+            ),
+            connectionArguments: ["-S", "/tmp/kwt.sock"],
+            command: "printf ready",
+            timeout: 6
+        )
+
+        #expect(result.status == 255)
+        #expect(attempts.withLock { $0 } == 1)
     }
 
     @Test("remote commands do not retry other SSH failures")
@@ -164,7 +198,8 @@ struct AccountCommandRunnerTests {
             ),
             connectionArguments: ["-S", "/tmp/kwt.sock"],
             command: "printf ready",
-            timeout: 6
+            timeout: 6,
+            retryPolicy: .idempotent
         )
 
         #expect(result.status == 255)
@@ -197,7 +232,8 @@ struct AccountCommandRunnerTests {
             ),
             connectionArguments: ["-S", "/tmp/kwt.sock"],
             command: "printf ready",
-            timeout: 6
+            timeout: 6,
+            retryPolicy: .idempotent
         )
 
         #expect(result.status == 255)

--- a/Tests/App/AccountCommandRunnerTests.swift
+++ b/Tests/App/AccountCommandRunnerTests.swift
@@ -97,6 +97,113 @@ struct AccountCommandRunnerTests {
         #expect(command.contains("${SHELL:-/bin/sh}"))
     }
 
+    @Test("remote commands retry a refused multiplexed session")
+    func remoteLoginShellRetriesRefusedSession() {
+        let attempts = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                let attempt = attempts.withLock { value in
+                    value += 1
+                    return value
+                }
+                if attempt == 1 {
+                    return AccountCommandOutput(
+                        status: 255,
+                        stdout: "",
+                        stderr: """
+                        mux_client_request_session: session request failed: Session open refused by peer
+                        Connection closed by UNKNOWN port 65535
+                        """
+                    )
+                }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "ready\n",
+                    stderr: ""
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+
+        let result = runner.runRemoteLoginShell(
+            host: SSHHostInfo(
+                user: "dev",
+                hostname: "build.example",
+                port: 22
+            ),
+            connectionArguments: ["-S", "/tmp/kwt.sock"],
+            command: "printf ready",
+            timeout: 6
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout == "ready\n")
+        #expect(attempts.withLock { $0 } == 2)
+    }
+
+    @Test("remote commands do not retry other SSH failures")
+    func remoteLoginShellDoesNotRetryOtherFailures() {
+        let attempts = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                attempts.withLock { $0 += 1 }
+                return AccountCommandOutput(
+                    status: 255,
+                    stdout: "",
+                    stderr: "Permission denied (publickey).\n"
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+
+        let result = runner.runRemoteLoginShell(
+            host: SSHHostInfo(
+                user: "dev",
+                hostname: "build.example",
+                port: 22
+            ),
+            connectionArguments: ["-S", "/tmp/kwt.sock"],
+            command: "printf ready",
+            timeout: 6
+        )
+
+        #expect(result.status == 255)
+        #expect(attempts.withLock { $0 } == 1)
+    }
+
+    @Test("remote commands bound refused session retries")
+    func remoteLoginShellBoundsRefusedSessionRetries() {
+        let attempts = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, _, _, _ in
+                attempts.withLock { $0 += 1 }
+                return AccountCommandOutput(
+                    status: 255,
+                    stdout: "",
+                    stderr: """
+                    mux_client_request_session: session request failed: Session open refused by peer
+                    Connection closed by UNKNOWN port 65535
+                    """
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+
+        let result = runner.runRemoteLoginShell(
+            host: SSHHostInfo(
+                user: "dev",
+                hostname: "build.example",
+                port: 22
+            ),
+            connectionArguments: ["-S", "/tmp/kwt.sock"],
+            command: "printf ready",
+            timeout: 6
+        )
+
+        #expect(result.status == 255)
+        #expect(attempts.withLock { $0 } == 3)
+    }
+
     @Test("subprocesses do not inherit enclosing multiplexer clients")
     func sanitizedEnvironment() {
         let sanitized = AccountCommandRunner.sanitizedProcessEnvironment([

--- a/Tests/App/SSHConnectionFailureTests.swift
+++ b/Tests/App/SSHConnectionFailureTests.swift
@@ -197,6 +197,66 @@ struct SSHConnectionFailureTests {
     }
 
     @Test(
+        "only transport-class lease failures allow automatic retry",
+        arguments: [
+            (KwtSSHLeaseError.acquisitionTimedOut, true),
+            (KwtSSHLeaseError.commandFailed(status: 255), true),
+            (KwtSSHLeaseError.commandFailed(status: 1), false),
+            (KwtSSHLeaseError.helperUnavailable, false),
+            (KwtSSHLeaseError.launchFailed, false),
+            (KwtSSHLeaseError.poolClosed, false),
+            (
+                KwtSSHLeaseError.operationFailed(
+                    code: "ssh_connection_failed",
+                    message: "ssh: connect to host example.test port 22: No route to host",
+                    retryable: true
+                ),
+                true
+            ),
+            (
+                KwtSSHLeaseError.operationFailed(
+                    code: "ssh_connection_failed",
+                    message: "ssh: connect to host example.test port 22: No route to host",
+                    retryable: false
+                ),
+                false
+            ),
+            (
+                KwtSSHLeaseError.operationFailed(
+                    code: "ssh_connection_failed",
+                    message: "Permission denied (publickey,password).",
+                    retryable: true
+                ),
+                false
+            ),
+        ]
+    )
+    func classifiesRetryableTransportFailures(
+        error: KwtSSHLeaseError,
+        retryable: Bool
+    ) {
+        let classification = SSHConnectionFailure.retryableTransportFailure(
+            error
+        )
+
+        #expect((classification != nil) == retryable)
+        #expect(classification.map(\.kind) == (retryable ? .transport : nil))
+    }
+
+    @Test("an acquisition timeout keeps its specific connection diagnosis")
+    func classifiesAcquisitionTimeout() {
+        let classification = SSHConnectionFailure.classify(
+            leaseError: KwtSSHLeaseError.acquisitionTimedOut
+        )
+
+        #expect(classification.kind == .transport)
+        #expect(
+            classification.diagnostic.summary
+                == "The SSH connection timed out."
+        )
+    }
+
+    @Test(
         "generic lease failures preserve native recovery signals",
         arguments: [
             (

--- a/Tests/App/SSHConnectionFailureTests.swift
+++ b/Tests/App/SSHConnectionFailureTests.swift
@@ -126,6 +126,14 @@ struct SSHConnectionFailureTests {
                 "Control socket connect(/tmp/kwt.sock): Connection refused",
                 true
             ),
+            (
+                255,
+                """
+                mux_client_request_session: session request failed: Session open refused by peer
+                Connection closed by UNKNOWN port 65535
+                """,
+                false
+            ),
             (255, "Permission denied (publickey,password).", false),
             (1, "Connection closed by UNKNOWN port 65535", false),
             (

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1831,6 +1831,67 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("initial Herdr executable probe transport failure reconnects")
+    func initialHerdrExecutableProbeTransportFailureReconnects() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolutions = Mutex(0)
+        let displays = Mutex(1)
+        let route = SSHConnectionArgumentsSnapshot(testKwtSSHAttachment(
+            routeIdentity: "sha256:stable-route"
+        ))
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in .present },
+            sshConnectionSnapshotProvider: { _ in route },
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(routeIdentity: "sha256:stable-route")
+            },
+            nativeHerdrPathProvider: { _ in
+                let attempt = resolutions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    displays.withLock { $0 = 0 }
+                    return .failure(.commandFailed(
+                        status: 255,
+                        stderr: "ssh: connect to host build.example.test port 22: Network is unreachable"
+                    ))
+                }
+                return .success("/usr/bin/herdr")
+            },
+            activeDisplayCount: { displays.withLock { $0 } }
+        )
+        let selection = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+
+        try await model.openBorrowedHerdrSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedHerdrRecoveryState?.isReconnecting == true
+        }
+
+        #expect(resolutions.withLock { $0 } == 1)
+        #expect(model.herdrReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+
+        displays.withLock { $0 = 1 }
+        model.reconnectActiveHerdrSessionNow()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 1
+                && model.activeBorrowedHerdrConnectionState == .connected
+        }
+
+        #expect(resolutions.withLock { $0 } == 2)
+        #expect(model.activeBorrowedHerdrConnectionState == .connected)
+        #expect(model.activeBorrowedHerdrRecoveryState == nil)
+        await model.shutdown()
+    }
+
     @Test("retryable Herdr surface failure keeps recovering instead of latching")
     func retryableHerdrSurfaceFailureKeepsRecovering() async throws {
         let environment = try remoteEnvironment()

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1770,6 +1770,67 @@ struct WorkspaceHerdrPresentationTests {
         await model.shutdown()
     }
 
+    @Test("initial Herdr transport failure starts automatic reconnect")
+    func initialHerdrTransportFailureStartsReconnect() async throws {
+        let environment = try remoteEnvironment()
+        let store = RecordingNativeSessionSurfaceStore()
+        let acquisitions = Mutex(0)
+        let displays = Mutex(1)
+        let route = SSHConnectionArgumentsSnapshot(testKwtSSHAttachment(
+            routeIdentity: "sha256:stable-route"
+        ))
+        let model = try makeHerdrModel(
+            environment,
+            store: store,
+            exactProbe: { _, _, _ in .present },
+            sshConnectionSnapshotProvider: { _ in route },
+            presentationSSHConnectionProvider: { _, _ in
+                let attempt = acquisitions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    displays.withLock { $0 = 0 }
+                    throw KwtSSHLeaseError.operationFailed(
+                        code: "ssh_connection_failed",
+                        message: "ssh: connect to host build.example.test port 22: No route to host",
+                        retryable: true
+                    )
+                }
+                return testKwtSSHAttachment(
+                    routeIdentity: "sha256:stable-route"
+                )
+            },
+            activeDisplayCount: { displays.withLock { $0 } }
+        )
+        let selection = WorkspaceHerdrSessionSelection(
+            hostID: environment.hostID,
+            name: "api"
+        )
+
+        try await model.openBorrowedHerdrSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedHerdrRecoveryState?.isReconnecting == true
+        }
+
+        #expect(acquisitions.withLock { $0 } == 1)
+        #expect(model.herdrReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+
+        displays.withLock { $0 = 1 }
+        model.reconnectActiveHerdrSessionNow()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 1
+                && model.activeBorrowedHerdrConnectionState == .connected
+        }
+
+        #expect(acquisitions.withLock { $0 } == 2)
+        #expect(model.activeBorrowedHerdrConnectionState == .connected)
+        #expect(model.activeBorrowedHerdrRecoveryState == nil)
+        await model.shutdown()
+    }
+
     @Test("retryable Herdr surface failure keeps recovering instead of latching")
     func retryableHerdrSurfaceFailureKeepsRecovering() async throws {
         let environment = try remoteEnvironment()

--- a/Tests/App/WorkspaceTmuxCreationTests.swift
+++ b/Tests/App/WorkspaceTmuxCreationTests.swift
@@ -273,13 +273,7 @@ extension WorkspaceTmuxDiscoveryTests {
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
             remoteTmuxPathProvider: { _, _ in
-                .failure(.sshConnectionFailed(
-                    host: "office-linux",
-                    classification: SSHConnectionFailure.classify(
-                        status: 255,
-                        output: ""
-                    )
-                ))
+                .failure(.notFound(shell: "office-linux"))
             }
         )
         let selection = WorkspaceTmuxSessionSelection(

--- a/Tests/App/WorkspaceTmuxInventoryTests.swift
+++ b/Tests/App/WorkspaceTmuxInventoryTests.swift
@@ -1347,6 +1347,62 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("transport failures do not request SSH presentation")
+    func transportFailureDoesNotRequestSSHPresentation() async throws {
+        let environment = try setupStandardEnvironment()
+        let host = SSHHostInfo(
+            user: "dev",
+            hostname: "offline.example.test",
+            port: nil
+        )
+        let route = KwtSSHRouteSnapshot.fixture(
+            logicalTarget: KwtSSHTarget(
+                hostname: host.hostname,
+                user: host.user
+            )
+        )
+        let coordinator = KwtSSHAcquisitionCoordinator(
+            resolve: { _ in route },
+            pool: KwtSSHConnectionPool { _, _ in
+                throw KwtSSHLeaseError.operationFailed(
+                    code: "ssh_connection_failed",
+                    message: "ssh: connect to host offline.example.test port 22: No route to host",
+                    retryable: true
+                )
+            }
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            presentationSSHConnectionProvider: nil,
+            presentationSSHAcquisitionCoordinator: coordinator
+        )
+
+        let acquisitionFailed = LockedValue(false)
+        let acquisition = Task {
+            do {
+                _ = try await model.acquirePresentationSSHConnection(
+                    hostID: UUID(),
+                    info: host
+                )
+                Issue.record("offline SSH acquisition unexpectedly succeeded")
+            } catch {
+                acquisitionFailed.store(true)
+            }
+        }
+        await waitUntilMainActor {
+            acquisitionFailed.load()
+                || model.presentationSSHSession != nil
+        }
+
+        #expect(model.presentationSSHSession == nil)
+        #expect(acquisitionFailed.load())
+        acquisition.cancel()
+        await acquisition.value
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test(
         "failed presentation acquisitions resume after retry",
         arguments: [true, false]

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -407,6 +407,65 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("initial tmux resolution transport failure reconnects")
+    func initialTmuxResolutionTransportFailureReconnects() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let resolutions = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { host, _ in
+                let attempt = resolutions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    return .failure(.sshConnectionFailed(
+                        host: host.hostname,
+                        classification: SSHConnectionFailure.classify(
+                            status: 255,
+                            output: "ssh: connect to host build.example.test port 22: Network is unreachable"
+                        )
+                    ))
+                }
+                return successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionValidationDiscovery: { _, _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        model.prepareActiveBorrowedTmuxSurface()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            surfaceStore.requestCount == 1
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(resolutions.withLock { $0 } == 2)
+        #expect(surfaceStore.requestCount == 1)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(model.activeBorrowedTmuxRecoveryState == nil)
+        #expect(model.presentationSSHSession == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("reconnect rejects a different SSH route before probing")
     func reconnectRejectsDifferentSSHRouteBeforeProbing() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -274,6 +274,77 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("initial SSH transport failure starts tmux reconnect")
+    func initialSSHTransportFailureStartsTmuxReconnect() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let acquisitions = Mutex(0)
+        let transportUnavailable = Mutex(true)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionValidationDiscovery: { _, _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                acquisitions.withLock { $0 += 1 }
+                if transportUnavailable.withLock({ $0 }) {
+                    throw KwtSSHLeaseError.operationFailed(
+                        code: "ssh_connection_failed",
+                        message: "ssh: connect to host build.example.test port 22: No route to host",
+                        retryable: true
+                    )
+                }
+                return testKwtSSHAttachment(
+                    routeIdentity: "sha256:recovered-route"
+                )
+            },
+            tmuxReconnectIntervals: [.seconds(30)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        model.prepareActiveBorrowedTmuxSurface()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            acquisitions.withLock { $0 } >= 2
+        }
+
+        #expect(acquisitions.withLock { $0 } >= 2)
+        #expect(model.activeBorrowedTmuxRecoveryState?.isReconnecting == true)
+        #expect(model.activeBorrowedTmuxRecoveryState?.allowsReconnectNow == true)
+        #expect(model.anyTmuxReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        #expect(surfaceStore.requestCount == 0)
+
+        transportUnavailable.withLock { $0 = false }
+        model.reconnectActiveTmuxSessionNow()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            surfaceStore.requestCount == 1
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        #expect(surfaceStore.requestCount == 1)
+        #expect(model.activeBorrowedTmuxSessionIsConnected)
+        #expect(!model.anyTmuxReconnectSupervisorIsRunning)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("retryable SSH transport acquisition keeps tmux reconnecting")
     func retryableSSHTransportAcquisitionKeepsTmuxReconnect() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -288,6 +288,9 @@ extension WorkspaceTmuxDiscoveryTests {
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },
+            sshRouteIdentityResolver: { _ in
+                "sha256:recovered-route"
+            },
             tmuxSessionValidationDiscovery: { _, _ in
                 .success([
                     DiscoveredTmuxSession(
@@ -462,6 +465,76 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(model.activeBorrowedTmuxSessionIsConnected)
         #expect(model.activeBorrowedTmuxRecoveryState == nil)
         #expect(model.presentationSSHSession == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("initial tmux recovery anchors its SSH route before probing")
+    func initialTmuxRecoveryAnchorsRouteBeforeProbing() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let acquisitions = Mutex(0)
+        let routeResolutions = Mutex(0)
+        let probes = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            sshRouteIdentityResolver: { _ in
+                routeResolutions.withLock { $0 += 1 }
+                return "sha256:original-route"
+            },
+            tmuxSessionValidationDiscovery: { _, _ in
+                probes.withLock { $0 += 1 }
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                let attempt = acquisitions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    throw KwtSSHLeaseError.operationFailed(
+                        code: "ssh_connection_failed",
+                        message: "ssh: connect to host build.example.test port 22: Network is unreachable",
+                        retryable: true
+                    )
+                }
+                return testKwtSSHAttachment(
+                    routeIdentity: "sha256:replacement-route"
+                )
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+
+        model.openBorrowedTmuxSession(selection)
+        model.prepareActiveBorrowedTmuxSurface()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            acquisitions.withLock { $0 } >= 2
+                && !model.anyTmuxReconnectSupervisorIsRunning
+        }
+
+        #expect(routeResolutions.withLock { $0 } == 1)
+        #expect(acquisitions.withLock { $0 } == 2)
+        #expect(probes.withLock { $0 } == 0)
+        #expect(surfaceStore.requestCount == 0)
+        #expect(!model.activeBorrowedTmuxSessionIsConnected)
+        #expect(!model.anyTmuxReconnectSupervisorIsRunning)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -274,8 +274,21 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("initial SSH transport failure starts tmux reconnect")
-    func initialSSHTransportFailureStartsTmuxReconnect() async throws {
+    @Test(
+        "initial SSH transport failure starts tmux reconnect",
+        arguments: [
+            KwtSSHLeaseError.operationFailed(
+                code: "ssh_connection_failed",
+                message: "ssh: connect to host build.example.test port 22: No route to host",
+                retryable: true
+            ),
+            .acquisitionTimedOut,
+            .commandFailed(status: 255),
+        ]
+    )
+    func initialSSHTransportFailureStartsTmuxReconnect(
+        transportError: KwtSSHLeaseError
+    ) async throws {
         let environment = try setupRemoteTmuxEnvironment()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let acquisitions = Mutex(0)
@@ -304,11 +317,7 @@ extension WorkspaceTmuxDiscoveryTests {
             presentationSSHConnectionProvider: { _, _ in
                 acquisitions.withLock { $0 += 1 }
                 if transportUnavailable.withLock({ $0 }) {
-                    throw KwtSSHLeaseError.operationFailed(
-                        code: "ssh_connection_failed",
-                        message: "ssh: connect to host build.example.test port 22: No route to host",
-                        retryable: true
-                    )
+                    throw transportError
                 }
                 return testKwtSSHAttachment(
                     routeIdentity: "sha256:recovered-route"

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -274,6 +274,68 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("retryable SSH transport acquisition keeps tmux reconnecting")
+    func retryableSSHTransportAcquisitionKeepsTmuxReconnect() async throws {
+        let environment = try setupRemoteTmuxEnvironment()
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let acquisitions = Mutex(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.localHostID,
+            snapshot: environment.snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            tmuxSessionDiscovery: { _ in
+                .success([
+                    DiscoveredTmuxSession(
+                        name: "release-work",
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: false
+                    ),
+                ])
+            },
+            presentationSSHConnectionProvider: { _, _ in
+                let attempt = acquisitions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt == 1 else {
+                    throw KwtSSHLeaseError.operationFailed(
+                        code: "ssh_connection_failed",
+                        message: "ssh: connect to host build.example.test port 22: No route to host",
+                        retryable: true
+                    )
+                }
+                return testKwtSSHAttachment()
+            },
+            tmuxReconnectIntervals: [.seconds(30)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.remoteHost.id,
+            name: "release-work"
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        surfaceStore.surface.closeObservers.values.first?(false, 255)
+        await waitUntilMainActor {
+            acquisitions.withLock { $0 } == 2
+        }
+
+        guard case .reconnecting = model.activeBorrowedTmuxRecoveryState else {
+            Issue.record("expected automatic tmux reconnect to remain active")
+            await model.shutdown()
+            return
+        }
+        #expect(model.anyTmuxReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("reconnect rejects a different SSH route before probing")
     func reconnectRejectsDifferentSSHRouteBeforeProbing() async throws {
         let environment = try setupRemoteTmuxEnvironment()

--- a/Tests/App/WorkspaceZellijRecoveryTests.swift
+++ b/Tests/App/WorkspaceZellijRecoveryTests.swift
@@ -12,6 +12,88 @@ import Testing
 @testable import GhosthubApp
 
 extension WorkspaceZellijTests {
+    @Test("initial Zellij transport failure starts automatic reconnect")
+    func initialZellijTransportFailureStartsReconnect() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let acquisitions = Mutex(0)
+        let displays = Mutex(1)
+        let route = SSHConnectionArgumentsSnapshot(testKwtSSHAttachment(
+            routeIdentity: "sha256:stable-route"
+        ))
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in .success("/usr/bin/zellij") },
+            activeDisplayCount: { displays.withLock { $0 } },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in route },
+            presentationSSHConnectionProvider: { _, _ in
+                let attempt = acquisitions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    displays.withLock { $0 = 0 }
+                    throw KwtSSHLeaseError.operationFailed(
+                        code: "ssh_connection_failed",
+                        message: "ssh: connect to host build.example.test port 22: No route to host",
+                        retryable: true
+                    )
+                }
+                return testKwtSSHAttachment(
+                    routeIdentity: "sha256:stable-route"
+                )
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijRecoveryState?.isReconnecting == true
+        }
+
+        #expect(acquisitions.withLock { $0 } == 1)
+        #expect(model.zellijReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+
+        displays.withLock { $0 = 1 }
+        model.reconnectActiveZellijSessionNow()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 1
+                && model.activeBorrowedZellijConnectionState == .connected
+        }
+
+        #expect(acquisitions.withLock { $0 } == 2)
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
+        await model.shutdown()
+    }
+
     @Test("remote transport loss reconnects an active Zellij session")
     func remoteReconnect() async throws {
         let database = try WorkspaceDatabase.inMemory()

--- a/Tests/App/WorkspaceZellijRecoveryTests.swift
+++ b/Tests/App/WorkspaceZellijRecoveryTests.swift
@@ -94,6 +94,87 @@ extension WorkspaceZellijTests {
         await model.shutdown()
     }
 
+    @Test("initial Zellij executable probe transport failure reconnects")
+    func initialZellijExecutableProbeTransportFailureReconnects() async throws {
+        let database = try WorkspaceDatabase.inMemory()
+        let host = HostSummary(
+            id: UUID(),
+            configKey: "builder",
+            name: "Builder",
+            kind: .remote,
+            platform: .linux,
+            sshDestination: "dev@builder",
+            zellijSessions: [ZellijSessionSummary(name: "api")],
+            zellijAvailable: true
+        )
+        let store = RecordingNativeSessionSurfaceStore()
+        let resolutions = Mutex(0)
+        let displays = Mutex(1)
+        let route = SSHConnectionArgumentsSnapshot(testKwtSSHAttachment(
+            routeIdentity: "sha256:stable-route"
+        ))
+        let model = try makeModel(
+            database: database,
+            localHostID: UUID(),
+            snapshot: WorkspaceSnapshot(
+                hosts: [host],
+                projects: [],
+                worktrees: []
+            ),
+            nativeZellijSurfaceStore: store,
+            nativeZellijPathProvider: { _ in
+                let attempt = resolutions.withLock {
+                    $0 += 1
+                    return $0
+                }
+                guard attempt > 1 else {
+                    displays.withLock { $0 = 0 }
+                    return .failure(.commandFailed(
+                        status: 255,
+                        stderr: "ssh: connect to host build.example.test port 22: Network is unreachable"
+                    ))
+                }
+                return .success("/usr/bin/zellij")
+            },
+            activeDisplayCount: { displays.withLock { $0 } },
+            zellijSessionValidationDiscovery: { _, _ in
+                .available(["api"])
+            },
+            zellijSSHConnectionSnapshotProvider: { _ in route },
+            presentationSSHConnectionProvider: { _, _ in
+                testKwtSSHAttachment(routeIdentity: "sha256:stable-route")
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)],
+            tmuxReconnectProbeDeadline: .seconds(1)
+        )
+        let selection = WorkspaceZellijSessionSelection(
+            hostID: host.id,
+            name: "api"
+        )
+
+        model.openBorrowedZellijSession(selection)
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            model.activeBorrowedZellijRecoveryState?.isReconnecting == true
+        }
+
+        #expect(resolutions.withLock { $0 } == 1)
+        #expect(model.zellijReconnectSupervisorIsRunning)
+        #expect(model.presentationSSHSession == nil)
+        #expect(store.requestedConfigurations.isEmpty)
+
+        displays.withLock { $0 = 1 }
+        model.reconnectActiveZellijSessionNow()
+        await waitUntilMainActor(timeout: .seconds(1)) {
+            store.requestedConfigurations.count == 1
+                && model.activeBorrowedZellijConnectionState == .connected
+        }
+
+        #expect(resolutions.withLock { $0 } == 2)
+        #expect(model.activeBorrowedZellijConnectionState == .connected)
+        #expect(model.activeBorrowedZellijRecoveryState == nil)
+        await model.shutdown()
+    }
+
     @Test("remote transport loss reconnects an active Zellij session")
     func remoteReconnect() async throws {
         let database = try WorkspaceDatabase.inMemory()

--- a/Tests/App/ZellijInventoryClientTests.swift
+++ b/Tests/App/ZellijInventoryClientTests.swift
@@ -122,6 +122,54 @@ struct ZellijInventoryClientTests {
         #expect(calls.withLock { $0 } == 0)
     }
 
+    @Test("remote kill does not retry a refused SSH session")
+    func remoteKillDoesNotRetryRefusedSSHSession() {
+        let killAttempts = Mutex(0)
+        let runner = AccountCommandRunner(
+            processRunner: { _, arguments, _, _ in
+                let command = arguments.last ?? ""
+                if command.contains("command -v zellij") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_ZELLIJ_PATH\n/usr/bin/zellij\n",
+                        stderr: ""
+                    )
+                }
+                killAttempts.withLock { $0 += 1 }
+                return AccountCommandOutput(
+                    status: 255,
+                    stdout: "",
+                    stderr: """
+                    mux_client_request_session: session request failed: Session open refused by peer
+                    Connection closed by UNKNOWN port 65535
+                    """
+                )
+            },
+            loginShellProvider: { "/bin/account-shell" }
+        )
+        let client = ZellijInventoryClient(
+            commandRunner: runner,
+            connectionArgumentsProvider: { _ in ["-S", "/tmp/kwt.sock"] }
+        )
+        let host = SSHHostInfo(
+            user: "dev",
+            hostname: "build.example",
+            port: 22
+        )
+
+        let result = client.kill(
+            sessionName: "api",
+            on: .ssh(host),
+            sshConnectionArguments: ["-S", "/tmp/kwt.sock"]
+        )
+
+        guard case .failure = result else {
+            Issue.record("refused remote kill unexpectedly succeeded")
+            return
+        }
+        #expect(killAttempts.withLock { $0 } == 1)
+    }
+
     private func commandRunner(
         capturing commands: ZellijCommandRecorder
     ) -> AccountCommandRunner {

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -79,7 +79,11 @@ identity and generation. Reconnect resolves and acquires again; it never
 reuses stored control-socket arguments. A presentation whose OpenSSH client
 itself exits with status 255 marks a shared lease unusable so no other caller
 joins the dead master. A masterless lease is unsupported and fails before a
-terminal surface launches.
+terminal surface launches. A short remote command that OpenSSH rejects with
+`session open refused by peer` retries twice with bounded backoff because that
+diagnostic proves the remote command did not start. Other command failures are
+never retried, and a persistent refusal continues through normal shared-lease
+invalidation and host diagnostics.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, attachment mode, and session name. Navigating to
 another host,

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -84,6 +84,11 @@ terminal surface launches. A short remote command that OpenSSH rejects with
 diagnostic proves the remote command did not start. Other command failures are
 never retried, and a persistent refusal continues through normal shared-lease
 invalidation and host diagnostics.
+Presentation lease failures open a modal only when OpenSSH needs host review,
+authentication, or explicit configuration recovery. Ordinary transport
+failures return to the session reconnect supervisor, which keeps retrying in
+the background and exposes its immediate Reconnect Now action without taking
+window focus.
 Each workspace window retains every presentation it explicitly opens, keyed by
 the exact host, tmux socket, attachment mode, and session name. Navigating to
 another host,

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -79,11 +79,12 @@ identity and generation. Reconnect resolves and acquires again; it never
 reuses stored control-socket arguments. A presentation whose OpenSSH client
 itself exits with status 255 marks a shared lease unusable so no other caller
 joins the dead master. A masterless lease is unsupported and fails before a
-terminal surface launches. A short remote command that OpenSSH rejects with
-`session open refused by peer` retries twice with bounded backoff because that
-diagnostic proves the remote command did not start. Other command failures are
-never retried, and a persistent refusal continues through normal shared-lease
-invalidation and host diagnostics.
+terminal surface launches. Read-only inventory and probe commands opt into two
+bounded retries when OpenSSH reports `session open refused by peer`. Mutating
+commands never use this retry because remote command diagnostics share
+OpenSSH's standard-error stream. Other command failures are never retried, and
+a persistent refusal continues through normal shared-lease invalidation and
+host diagnostics.
 Presentation lease failures open a modal only when OpenSSH needs host review,
 authentication, or explicit configuration recovery. Ordinary transport
 failures return to the session reconnect supervisor, which keeps retrying in


### PR DESCRIPTION
Transient SSH failures now stay within Ghosthub's normal recovery flow instead of reporting a reachable host as unavailable or opening an authentication sheet that steals focus.

- Retries OpenSSH's exact `session open refused by peer` failure only for explicitly idempotent inventory and probe commands, with two short bounded delays; lifecycle commands such as Zellij kill remain single-attempt.
- Keeps a channel-capacity refusal from invalidating an otherwise healthy shared SSH connection, even when OpenSSH also prints its generic `UNKNOWN port 65535` closure diagnostic.
- Routes pre-launch SSH transport failures through each backend's reconnect supervisor for tmux, Herdr, and Zellij: connection acquisition timeouts, status-255 lease helper exits, and executable-probe outages all reconnect automatically. Local helper defects, protocol errors, and configuration changes remain permanent launch failures. Tmux recovery freezes the expected SSH route before its first host probe, and route checks still gate every reattachment.
- Preserves background retry and **Reconnect Now** without presenting a modal for ordinary transport loss. Host-key review, authentication prompts, explicit configuration recovery, and other SSH failures keep their existing interactive diagnostics.
- Adds behavior coverage for retry success and exhaustion, non-retryable errors, modal suppression, route-fenced initial recovery across all three backends, and destructive-command replay prevention.
- `make python-test` reports 426 passes plus the existing #197 Go standard-library/toolchain mismatch failure; the Swift suite, essential remote workflows, terminal bootstrap checks, formatting, and the app build pass locally.
