### PR TITLE
Stop Xcode services before trusted runner cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,24 @@ jobs:
       - name: Run essential kwt and tmux workflows
         run: make test-essential-workflows
 
+      - name: Stop Xcode background services
+        if: ${{ always() && runner.environment == 'self-hosted' }}
+        shell: bash
+        run: |
+          uid="$(/usr/bin/id -u)"
+          for label in \
+            com.apple.CoreSimulator.SimLaunchHost-arm64 \
+            com.apple.CoreSimulator.SimLaunchHost-x86 \
+            com.apple.CoreSimulator.SimulatorTrampoline \
+            com.apple.CoreSimulator.CoreSimulatorService \
+            com.apple.CoreDevice.CoreDeviceService; do
+            target="gui/$uid/$label"
+            if /bin/launchctl print "$target" >/dev/null 2>&1; then
+              /bin/launchctl bootout "$target" ||
+                ! /bin/launchctl print "$target" >/dev/null 2>&1
+            fi
+          done
+
       - name: Remove isolated macOS test state
         if: ${{ always() && runner.environment == 'self-hosted' }}
         shell: bash


### PR DESCRIPTION
Trusted macOS CI now unloads the Xcode CoreSimulator and CoreDevice services that Swift tests leave in the Aqua session. This lets the job return the host to its reviewed idle state before runner containment starts, instead of requiring a quarantine cleanup.

- Runs only on the self-hosted lane; hosted jobs and fork pull requests are unchanged.
- Targets only the five service labels observed during live acceptance and fails if a loaded service remains registered.
