### PR TITLE
Rust Port: Scene credentials for the web attach websocket

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,11 @@ GPUI while preserving the same product and session model. Its crate
 boundaries, dependency findings, platform roots, substrate gates, and delivery
 order are maintained in [Windows and Linux Rust Port](rust-port.md). The
 locked v1 contract for the loopback web UI served by the Rust application is
-maintained in [Web UI](web-ui.md).
+maintained in [Web UI](web-ui.md). The web UI relays an attach client to the
+multiplexer rather than a bare shell, so the multiplexer remains the authority
+for scrollback, mode state, history, and session lifetime; the web relay is a
+parserless byte transport with no server-side replay or resume, and a
+reconnect is always a fresh attachment.
 
 ## Mental Model
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -205,21 +205,22 @@ applicable until a remote-bind feature changes this section first. Attacks
 that require the user to hand the one-time bootstrap URL to the attacker.
 
 **Interim acceptance (tied to a gate).** Scene credentials now gate the demo
-attach: the attach hello requires a per-scene secret, the ambient session
-cookie alone can neither attach nor mint a scene, and the single-use mint
-code is delivered in the URL fragment — never sent to the server and not
-exposed to a service worker's request URL, so a stale worker on a reused
-origin cannot read it. One weakness in the same
-reusable-loopback-origin shape remains: the demo bootstrap still carries the
-startup bearer token in the query string of an
-`http://127.0.0.1:<ephemeral-port>` origin, which a service worker a local
-actor registered on a previously-bound instance of that port could intercept
-before any server-side check runs, yielding the bearer and thus scene
-establishment (the attach websocket handshake itself is not
-worker-interceptable, so the lever is the HTTP bootstrap). It closes when the
-bootstrap moves the bearer out of the URL and binds it to a per-instance
-origin (a high-entropy hostname or equivalent, chosen to resolve on every
-supported browser including Safari), tracked as a blocker of the
+attach: the attach hello requires a per-scene secret, and the ambient session
+cookie alone can neither attach nor mint a scene. The single-use, seconds-TTL
+mint code rides the URL fragment, which keeps it out of the bootstrap
+navigation, server logs, history, and referrers. The residual weakness is the
+reusable loopback origin itself: a service worker a local actor registered on
+a previously-bound instance of `http://127.0.0.1:<ephemeral-port>` controls
+that origin and intercepts every same-origin HTTP request before any
+server-side check runs — the bootstrap query carrying the startup bearer, and
+the `POST /api/v1/scene` exchange carrying the mint code in a header and
+returning the scene secret in its body. The fragment keeps the mint code off
+the navigation but not out of that exchange fetch, so a stale worker still
+reaches both the bearer and the exchanged scene credentials. (The attach
+websocket handshake itself is not worker-interceptable.) It closes when the
+bootstrap and the scene exchange move to a per-instance origin — a
+high-entropy hostname or equivalent one-time handoff, chosen to resolve on
+every supported browser including Safari — tracked as a blocker of the
 browser-terminal milestone (kata#09w1). Until then the deployment posture
 above bounds the exposure: the only actors who can run a loopback service and
 register a service worker are local, and Ghosthub is run only where local

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -204,23 +204,27 @@ non-loopback bind exists in v1, so transport-security findings are not
 applicable until a remote-bind feature changes this section first. Attacks
 that require the user to hand the one-time bootstrap URL to the attacker.
 
-**Interim acceptances (each tied to a gate).** The current demo attach
-endpoint accepts the ambient session cookie, diverging from the scene-secret
-rule above; this is accepted only while the web UI serves fixture data and
-local demo shells, is tracked as a blocker of the browser-terminal milestone,
-and closes when scene credentials land. The same milestone owns the
-credential's transport: the demo bootstrap carries a bearer token in the
-query string of an `http://127.0.0.1:<ephemeral-port>` origin, which a
-service worker a local actor registered on a previously-bound instance of
-that port could intercept before any server-side check runs. Both weaknesses
-are the same ambient-credential-over-a-reusable-loopback-origin shape and
-close together when scene credentials move the credential out of the URL and
-bind it to a per-instance origin (a high-entropy hostname or equivalent,
-chosen to resolve on every supported browser including Safari). Until then
-the deployment posture above bounds the exposure: the only actors who can run
-a loopback service and register a service worker are local, and Ghosthub is
-run only where local actors are trusted. The acceptance does not extend to
-any release that exposes real multiplexer sessions to a browser.
+**Interim acceptance (tied to a gate).** Scene credentials now gate the demo
+attach: the attach hello requires a per-scene secret, the ambient session
+cookie alone can neither attach nor mint a scene, and the single-use mint
+code is delivered in the URL fragment — never sent to the server and not
+exposed to a service worker's request URL, so a stale worker on a reused
+origin cannot read it. One weakness in the same
+reusable-loopback-origin shape remains: the demo bootstrap still carries the
+startup bearer token in the query string of an
+`http://127.0.0.1:<ephemeral-port>` origin, which a service worker a local
+actor registered on a previously-bound instance of that port could intercept
+before any server-side check runs, yielding the bearer and thus scene
+establishment (the attach websocket handshake itself is not
+worker-interceptable, so the lever is the HTTP bootstrap). It closes when the
+bootstrap moves the bearer out of the URL and binds it to a per-instance
+origin (a high-entropy hostname or equivalent, chosen to resolve on every
+supported browser including Safari), tracked as a blocker of the
+browser-terminal milestone (kata#09w1). Until then the deployment posture
+above bounds the exposure: the only actors who can run a loopback service and
+register a service worker are local, and Ghosthub is run only where local
+actors are trusted. The acceptance does not extend to any release that
+exposes real multiplexer sessions to a browser.
 
 Browser-side clipboard behavior is likewise gated by that milestone. Paste
 sanitization implements the shared contract vectors today. OSC 52 clipboard

--- a/docs/web-ui-prior-art.md
+++ b/docs/web-ui-prior-art.md
@@ -1,0 +1,91 @@
+# Web UI prior art: freshell
+
+Architectural notes from studying [freshell](https://github.com/danshapiro/freshell)
+(MIT license), an adjacent browser-terminal system with the same "run at home,
+reach it over VPN / Tailscale / SSH" posture as Ghosthub's web UI. We studied
+its architecture; **no code was copied.** This document records what the study
+validated, what we deliberately do differently, and what is worth adopting, so
+the next person does not re-derive it. It is a design-rationale reference, not a
+contract — [Web UI](web-ui.md) and [Threat model](threat-model.md) remain the
+authorities.
+
+## The load-bearing difference
+
+freshell relays a **bare shell PTY**; Ghosthub relays an **attach client to a
+multiplexer** (tmux / Zellij / Herdr). Almost every architectural divergence
+follows from that one fact. Because freshell owns the raw stream, it must build
+scrollback, replay, resume, and terminal-mode resync itself. Because Ghosthub
+attaches to a multiplexer that already owns all of those, its relay can be far
+simpler — see the state-authority principle in [Web UI](web-ui.md).
+
+## What the study validated (we already do this)
+
+- **Process-group teardown.** freshell kills the child's whole process group
+  (`kill(-pid, SIGKILL)`), not just the direct child, and guards against a
+  recycled pid, because a backgrounded grandchild otherwise leaks and can hold
+  the PTY slave open. Ghosthub's PTY teardown independently arrived at the same
+  design (non-reaping `waitid` pins the zombie leader, then the group is swept,
+  then reaped). Convergent designs are reassuring here.
+- **Two-tier output backpressure.** A bounded, drop-oldest per-connection queue
+  guarantees bounded server memory; a sustained-overflow disconnect sheds a
+  truly dead peer. Ghosthub has the bounded output queue plus a stalled-send
+  timeout that cuts a non-draining viewer.
+- **Ordering: `exit` behind queued output.** A terminal-exit signal must not
+  overtake still-queued output, or the client tears down and renders a blank
+  exited pane. freshell threads exit through the same FIFO; Ghosthub's close
+  frame is sent only after teardown, as the teardown acknowledgment.
+- **In-band, non-ambient credential for the websocket** (presented in the hello
+  frame, never a cookie or URL). Ghosthub's scene secret travels the same way,
+  and its fragment-delivered single-use mint code is stronger than freshell's
+  `?token=` (a fragment never reaches the server at all).
+
+## What we deliberately do NOT copy
+
+- **A single global bearer token for everything.** freshell authenticates the
+  page, every request, and the websocket with one long-lived shared secret and
+  has **no per-session isolation, no expiry, and no revocation** — any
+  authenticated client owns every shell on the host. Ghosthub's scene
+  credentials are the opposite: per-scene secrets, idle and absolute lifetimes,
+  established only from a single-use mint code. This is the gap that motivated
+  building scene credentials at all.
+- **Server-side UTF-8 decoding of the PTY stream into JSON strings.** freshell
+  is not byte-transparent — invalid UTF-8 becomes U+FFFD, and it juggles UTF-8
+  bytes versus UTF-16 code units for eviction (a real premature-eviction bug for
+  box-drawing TUIs). Ghosthub relays raw **binary** frames; the browser is the
+  only interpreter. Byte fidelity is the whole point of a parserless relay.
+- **Server-side VT scanners** (batch-boundary, mode-projection, idle
+  fingerprint). These exist in freshell only because it owns the raw stream and
+  a bounded replay window; a reconnecting xterm would otherwise render wrong.
+  Ghosthub's multiplexer redraws on reattach, so none of this is needed.
+- **Advisory-only Origin.** freshell's TypeScript server logs Origin mismatches
+  but never rejects (its Rust port hardened this). Ghosthub enforces exact Host
+  and Origin from the start.
+
+## Worth adopting later (mainly for the SPA pipeline, `y5d7`)
+
+- **Asset-cache discipline.** Serve `index.html` with `no-store`, hashed assets
+  as `immutable`, and — importantly — a **missing hashed asset must 404, never
+  fall back to the SPA shell**, so version skew fails loudly instead of serving
+  a broken bundle. Pair with a protocol-mismatch close that tells a stale client
+  to reload. Ghosthub embeds assets in the binary rather than serving from disk,
+  but the cache rules still apply.
+- **Typed gap frames instead of silent loss.** Where bytes can be dropped
+  (queue overflow, replay eviction), freshell emits a typed frame telling the
+  client scrollback was truncated rather than losing it silently. Low priority
+  for Ghosthub — reconnect re-attaches to the multiplexer, which redraws — but a
+  clean idea if the demo raw-shell path is ever kept long-term.
+- **Index-don't-own for history.** freshell never persists agent transcripts; it
+  indexes each CLI's own on-disk history and shells out to the CLI's native
+  `resume`. This is already Ghosthub's philosophy (kwt / tmux / Herdr / Zellij
+  own identity and history; Ghosthub discovers), and it is why "resume from any
+  device" is nearly free for both.
+
+## Things to avoid outright
+
+- **A dual TypeScript + Rust implementation kept in lockstep.** freshell is
+  mid-port and maintains both, byte-matched. The parity tax is real; Ghosthub
+  has one implementation.
+- **No document CSP.** freshell renders untrusted terminal output and proxies
+  arbitrary dev servers yet sets no document CSP — the study flags this as a
+  gap. Ghosthub ships a strict CSP (script-src stays strict; inline styles are
+  allowed only for the embedded terminal library's runtime stylesheet).

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -25,6 +25,19 @@ Explicitly excluded from v1 (see [V1 exclusions](#v1-exclusions)): output
 replay, PTY pooling and multi-viewer arbitration, constructive and destructive
 session operations, and any non-loopback access.
 
+**Design principle — the multiplexer is the session-state authority.**
+Ghosthub never relays a bare shell; it relays an *attach client* to tmux,
+Zellij, or Herdr, which already owns scrollback, cursor and DEC-mode state,
+history, and session lifetime. That single fact justifies most of the
+exclusions above: there is no server-side replay ring, no mode-resync
+preamble, and no cross-device resume protocol because the backend already
+provides them — a reconnect is a fresh attach and the multiplexer redraws.
+The relay is deliberately parserless and byte-transparent for the same
+reason: the browser's xterm.js is the one VT interpreter, and a second
+interpreter on the server would be a liability, not a feature. Adjacent
+raw-shell terminals must build all of this themselves; see
+[Web UI prior art](web-ui-prior-art.md) for that contrast and its lessons.
+
 ## Ownership: Runtime, Scene, TerminalRelay
 
 The current Rust `Workspace` mixes durable runtime state with what is really
@@ -263,6 +276,9 @@ configuration:
   credential, and closes websockets with proper close frames.
 
 ### Scene credentials
+
+*Implemented in `ghosthub-web` (`scenes.rs`, the exchange endpoint, and the
+attach hello gate); the contract below is the authority.*
 
 Scene identity is a credential, not an inference, and it is never minted
 from ambient state alone. The bootstrap redirect mints a single-use

--- a/rust/web/assets/app.js
+++ b/rust/web/assets/app.js
@@ -30,9 +30,45 @@ const state = {
   // The unresolved teardown acknowledgment, shared so every later attach
   // awaits it — not only the attach that initiated the teardown.
   pendingClose: null,
+  // The in-memory scene credential { id, secret }. Established once from
+  // the bootstrap mint code; presented only in the attach hello, never in
+  // a cookie or URL.
+  scene: null,
 };
 
 let attachSequence = 0;
+
+// Redeem the single-use bootstrap mint code (delivered in the URL
+// fragment) for a scene credential. The fragment is stripped from history
+// immediately whether or not the exchange succeeds — the code is one-shot.
+async function establishScene() {
+  const hash = location.hash || "";
+  const match = hash.match(/(?:^|[#&])mint=([0-9a-f]+)/);
+  const code = match ? match[1] : null;
+  if (hash) {
+    history.replaceState(null, "", location.pathname + location.search);
+  }
+  if (!code) {
+    return false;
+  }
+  try {
+    const response = await fetch("/api/v1/scene", {
+      method: "POST",
+      headers: { "x-ghosthub-mint": code },
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const body = await response.json();
+    if (typeof body.scene_id !== "string" || typeof body.scene_secret !== "string") {
+      return false;
+    }
+    state.scene = { id: body.scene_id, secret: body.scene_secret };
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const elements = {
   inventory: document.getElementById("inventory"),
@@ -223,6 +259,10 @@ function geometry(gridLimit) {
 }
 
 async function attach(label, row) {
+  if (!state.scene) {
+    showDisconnect("Session not established. Reopen the bootstrap link to reconnect.");
+    return;
+  }
   attachSequence += 1;
   const sequence = attachSequence;
   const acknowledged = await teardown();
@@ -328,6 +368,8 @@ async function attach(label, row) {
       socket.send(
         JSON.stringify({
           protocol: PROTOCOL_VERSION,
+          scene_id: state.scene.id,
+          scene_secret: state.scene.secret,
           capabilities: {
             unicode_width: 11,
             ignores_conpty_mode_requests: true,
@@ -585,4 +627,9 @@ async function load() {
   }
 }
 
-load();
+async function boot() {
+  await establishScene();
+  await load();
+}
+
+boot();

--- a/rust/web/src/attach.rs
+++ b/rust/web/src/attach.rs
@@ -71,12 +71,11 @@ pub(crate) async fn ws_attach(
         return StatusCode::FORBIDDEN.into_response();
     }
     let shutdown = state.shutdown.clone();
-    let serial = Arc::clone(&state.attach_serial);
     let scenes = Arc::clone(&state.scenes);
     upgrade
         .max_frame_size(MAX_FRAME_BYTES)
         .max_message_size(MAX_FRAME_BYTES)
-        .on_upgrade(move |socket| attach_session(socket, shutdown, serial, scenes))
+        .on_upgrade(move |socket| attach_session(socket, shutdown, scenes))
 }
 
 #[allow(
@@ -86,7 +85,6 @@ pub(crate) async fn ws_attach(
 async fn attach_session(
     mut socket: WebSocket,
     mut shutdown: watch::Receiver<bool>,
-    serial: Arc<tokio::sync::Mutex<()>>,
     scenes: Arc<SceneRegistry>,
 ) {
     if socket
@@ -114,6 +112,10 @@ async fn attach_session(
     // is buffered (bounded) and replayed into the shell once it launches,
     // so a reconnecting viewer that types before the lock frees loses no
     // keystrokes.
+    // Serialize per scene, not server-wide: a replacement in this scene
+    // waits for its own predecessor's teardown, but a different scene's
+    // viewer is never blocked.
+    let serial = scenes.serialization_lock(&scene_id);
     let mut lock = std::pin::pin!(serial.lock());
     let mut queued_input: Vec<u8> = Vec::new();
     let _serial = loop {
@@ -126,6 +128,15 @@ async fn attach_session(
                 close(&mut socket, close_code::AWAY, "server shutting down").await;
                 return;
             }
+            () = tokio::time::sleep(SCENE_DEADLINE_POLL) => {
+                // A queued attachment whose scene expired while it waited
+                // for the lock closes instead of buffering input on a dead
+                // scene until its predecessor finally releases.
+                if !scenes.is_live(&scene_id, Instant::now()) {
+                    close(&mut socket, close_code::POLICY, "scene expired").await;
+                    return;
+                }
+            }
             message = socket.recv() => match message {
                 Some(Ok(Message::Text(frame))) => {
                     // A post-hello text frame is a resize control; enforce
@@ -136,9 +147,19 @@ async fn attach_session(
                         close(&mut socket, close_code::POLICY, "invalid resize").await;
                         return;
                     };
+                    if !scenes.refresh(&scene_id, Instant::now()) {
+                        close(&mut socket, close_code::POLICY, "scene expired").await;
+                        return;
+                    }
                     geometry = resize;
                 }
                 Some(Ok(Message::Binary(bytes))) => {
+                    // Client activity refreshes the scene's idle clock even
+                    // while queued; an expired scene fails closed.
+                    if !scenes.refresh(&scene_id, Instant::now()) {
+                        close(&mut socket, close_code::POLICY, "scene expired").await;
+                        return;
+                    }
                     // Bounded: a viewer cannot make a queued attachment
                     // buffer unbounded pre-launch input. Past the bound the
                     // connection is cut rather than silently truncated.

--- a/rust/web/src/attach.rs
+++ b/rust/web/src/attach.rs
@@ -55,7 +55,7 @@ const OUTBOUND_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 /// How often the relay loop re-checks that the bound scene is still
 /// live, so an idle session is closed at its deadline even without any
 /// client activity to trigger a refresh.
-const SCENE_DEADLINE_POLL: Duration = Duration::from_mins(1);
+pub(crate) const SCENE_DEADLINE_POLL: Duration = Duration::from_mins(1);
 
 struct Geometry {
     size: GridSize,
@@ -72,10 +72,11 @@ pub(crate) async fn ws_attach(
     }
     let shutdown = state.shutdown.clone();
     let scenes = Arc::clone(&state.scenes);
+    let deadline_poll = state.scene_deadline_poll;
     upgrade
         .max_frame_size(MAX_FRAME_BYTES)
         .max_message_size(MAX_FRAME_BYTES)
-        .on_upgrade(move |socket| attach_session(socket, shutdown, scenes))
+        .on_upgrade(move |socket| attach_session(socket, shutdown, scenes, deadline_poll))
 }
 
 #[allow(
@@ -86,6 +87,7 @@ async fn attach_session(
     mut socket: WebSocket,
     mut shutdown: watch::Receiver<bool>,
     scenes: Arc<SceneRegistry>,
+    scene_deadline_poll: Duration,
 ) {
     if socket
         .send(Message::Text(server_hello().into()))
@@ -118,6 +120,13 @@ async fn attach_session(
     let serial = scenes.serialization_lock(&scene_id);
     let mut lock = std::pin::pin!(serial.lock());
     let mut queued_input: Vec<u8> = Vec::new();
+    // One persistent timer, not a fresh `sleep` per iteration: a
+    // per-iteration timer is dropped and restarted whenever another
+    // select branch fires, so a viewer that keeps the loop busy (steady
+    // input or pings) could otherwise hold an expired scene open forever.
+    let mut deadline_poll = tokio::time::interval(scene_deadline_poll);
+    deadline_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    deadline_poll.reset();
     let _serial = loop {
         tokio::select! {
             // Biased: an uncontended lock wins immediately, so a prompt
@@ -128,7 +137,7 @@ async fn attach_session(
                 close(&mut socket, close_code::AWAY, "server shutting down").await;
                 return;
             }
-            () = tokio::time::sleep(SCENE_DEADLINE_POLL) => {
+            _ = deadline_poll.tick() => {
                 // A queued attachment whose scene expired while it waited
                 // for the lock closes instead of buffering input on a dead
                 // scene until its predecessor finally releases.
@@ -265,6 +274,9 @@ async fn attach_session(
         }
     });
 
+    let mut deadline_poll = tokio::time::interval(scene_deadline_poll);
+    deadline_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    deadline_poll.reset();
     let pending_close: Option<(u16, &'static str)> = loop {
         tokio::select! {
             delivery = output.recv() => match delivery {
@@ -294,7 +306,7 @@ async fn attach_session(
             () = stopped(&mut shutdown) => {
                 break Some((close_code::AWAY, "server shutting down"));
             }
-            () = tokio::time::sleep(SCENE_DEADLINE_POLL) => {
+            _ = deadline_poll.tick() => {
                 // A non-refreshing check so an idle scene actually reaches
                 // its deadline even while the shell keeps producing output.
                 if !scenes.is_live(&scene_id, Instant::now()) {

--- a/rust/web/src/attach.rs
+++ b/rust/web/src/attach.rs
@@ -52,6 +52,11 @@ const OUTPUT_POLL: Duration = Duration::from_millis(250);
 /// instead of holding it while a wedged peer refuses to read.
 const OUTBOUND_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How often the relay loop re-checks that the bound scene is still
+/// live, so an idle session is closed at its deadline even without any
+/// client activity to trigger a refresh.
+const SCENE_DEADLINE_POLL: Duration = Duration::from_mins(1);
+
 struct Geometry {
     size: GridSize,
     pixels: PixelSize,
@@ -91,7 +96,8 @@ async fn attach_session(
     {
         return;
     }
-    let Some(mut geometry) = client_hello_geometry(&mut socket, &mut shutdown, &scenes).await
+    let Some((mut geometry, scene_id)) =
+        client_hello_geometry(&mut socket, &mut shutdown, &scenes).await
     else {
         return;
     };
@@ -179,6 +185,10 @@ async fn attach_session(
             _ => return,
         }
     }
+    if !scenes.is_live(&scene_id, Instant::now()) {
+        close(&mut socket, close_code::POLICY, "scene expired").await;
+        return;
+    }
     let spawned = tokio::task::spawn_blocking(move || {
         let (program, args) = local_client();
         ByteRelayWorker::attach_command(
@@ -263,8 +273,20 @@ async fn attach_session(
             () = stopped(&mut shutdown) => {
                 break Some((close_code::AWAY, "server shutting down"));
             }
+            () = tokio::time::sleep(SCENE_DEADLINE_POLL) => {
+                // A non-refreshing check so an idle scene actually reaches
+                // its deadline even while the shell keeps producing output.
+                if !scenes.is_live(&scene_id, Instant::now()) {
+                    break Some((close_code::POLICY, "scene expired"));
+                }
+            }
             message = socket.recv() => match message {
                 Some(Ok(Message::Binary(bytes))) => {
+                    // Authenticated client activity refreshes the scene's
+                    // idle clock; an expired scene fails closed.
+                    if !scenes.refresh(&scene_id, Instant::now()) {
+                        break Some((close_code::POLICY, "scene expired"));
+                    }
                     if let Err(error) = worker.send_bytes(bytes.to_vec())
                         && error.is_backpressure()
                     {
@@ -286,6 +308,9 @@ async fn attach_session(
                     let Some(resize) = parse_resize(&frame) else {
                         break Some((close_code::POLICY, "invalid resize"));
                     };
+                    if !scenes.refresh(&scene_id, Instant::now()) {
+                        break Some((close_code::POLICY, "scene expired"));
+                    }
                     if let Err(error) = worker.resize(resize.size, resize.pixels)
                         && error.is_backpressure()
                     {
@@ -326,7 +351,7 @@ async fn client_hello_geometry(
     socket: &mut WebSocket,
     shutdown: &mut watch::Receiver<bool>,
     scenes: &SceneRegistry,
-) -> Option<Geometry> {
+) -> Option<(Geometry, String)> {
     let deadline = tokio::time::sleep(CLIENT_HELLO_TIMEOUT);
     tokio::pin!(deadline);
     loop {
@@ -345,22 +370,23 @@ async fn client_hello_geometry(
                         // The scene credential in the hello is the per-scene
                         // gate — validated before any PTY work, and never
                         // from the ambient cookie the upgrade carried.
-                        let scene_ok = hello_scene_credential(&frame).is_some_and(
-                            |(scene_id, scene_secret)| {
-                                scenes.validate(&scene_id, &scene_secret, Instant::now())
-                            },
-                        );
-                        if !scene_ok {
+                        let Some((scene_id, scene_secret)) = hello_scene_credential(&frame)
+                        else {
+                            close(socket, close_code::POLICY, "invalid scene credential").await;
+                            return None;
+                        };
+                        if !scenes.validate(&scene_id, &scene_secret, Instant::now()) {
                             close(socket, close_code::POLICY, "invalid scene credential").await;
                             return None;
                         }
-                        let geometry = valid_client_hello(&frame)
+                        let Some(geometry) = valid_client_hello(&frame)
                             .then(|| hello_geometry(&frame))
-                            .flatten();
-                        if geometry.is_none() {
+                            .flatten()
+                        else {
                             close(socket, close_code::POLICY, "invalid client hello").await;
-                        }
-                        return geometry;
+                            return None;
+                        };
+                        return Some((geometry, scene_id));
                     }
                     Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
                     _ => return None,

--- a/rust/web/src/attach.rs
+++ b/rust/web/src/attach.rs
@@ -15,7 +15,7 @@
 
 use std::ffi::OsString;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::extract::State;
 use axum::extract::ws::{CloseFrame, Message, Utf8Bytes, WebSocket, WebSocketUpgrade, close_code};
@@ -25,7 +25,10 @@ use surface::{GridSize, PixelSize};
 use terminal::{ByteRelayWorker, RelayDisconnect, RelayOutput};
 use tokio::sync::{mpsc, watch};
 
-use crate::service::{ServerState, exact_origin, server_hello, stopped, valid_client_hello};
+use crate::scenes::SceneRegistry;
+use crate::service::{
+    ServerState, exact_origin, hello_scene_credential, server_hello, stopped, valid_client_hello,
+};
 use crate::{CLIENT_HELLO_TIMEOUT, MAX_FRAME_BYTES, MAX_QUEUED_OUTPUT_BYTES};
 
 /// Largest grid dimension a viewer may request; anything bigger is a
@@ -64,10 +67,11 @@ pub(crate) async fn ws_attach(
     }
     let shutdown = state.shutdown.clone();
     let serial = Arc::clone(&state.attach_serial);
+    let scenes = Arc::clone(&state.scenes);
     upgrade
         .max_frame_size(MAX_FRAME_BYTES)
         .max_message_size(MAX_FRAME_BYTES)
-        .on_upgrade(move |socket| attach_session(socket, shutdown, serial))
+        .on_upgrade(move |socket| attach_session(socket, shutdown, serial, scenes))
 }
 
 #[allow(
@@ -78,6 +82,7 @@ async fn attach_session(
     mut socket: WebSocket,
     mut shutdown: watch::Receiver<bool>,
     serial: Arc<tokio::sync::Mutex<()>>,
+    scenes: Arc<SceneRegistry>,
 ) {
     if socket
         .send(Message::Text(server_hello().into()))
@@ -86,7 +91,8 @@ async fn attach_session(
     {
         return;
     }
-    let Some(mut geometry) = client_hello_geometry(&mut socket, &mut shutdown).await else {
+    let Some(mut geometry) = client_hello_geometry(&mut socket, &mut shutdown, &scenes).await
+    else {
         return;
     };
 
@@ -319,6 +325,7 @@ async fn attach_session(
 async fn client_hello_geometry(
     socket: &mut WebSocket,
     shutdown: &mut watch::Receiver<bool>,
+    scenes: &SceneRegistry,
 ) -> Option<Geometry> {
     let deadline = tokio::time::sleep(CLIENT_HELLO_TIMEOUT);
     tokio::pin!(deadline);
@@ -335,6 +342,18 @@ async fn client_hello_geometry(
             message = socket.recv() => {
                 match message {
                     Some(Ok(Message::Text(frame))) => {
+                        // The scene credential in the hello is the per-scene
+                        // gate — validated before any PTY work, and never
+                        // from the ambient cookie the upgrade carried.
+                        let scene_ok = hello_scene_credential(&frame).is_some_and(
+                            |(scene_id, scene_secret)| {
+                                scenes.validate(&scene_id, &scene_secret, Instant::now())
+                            },
+                        );
+                        if !scene_ok {
+                            close(socket, close_code::POLICY, "invalid scene credential").await;
+                            return None;
+                        }
                         let geometry = valid_client_hello(&frame)
                             .then(|| hello_geometry(&frame))
                             .flatten();

--- a/rust/web/src/lib.rs
+++ b/rust/web/src/lib.rs
@@ -11,6 +11,7 @@
 
 mod attach;
 mod credential;
+mod scenes;
 mod service;
 
 use std::io;
@@ -24,6 +25,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use crate::credential::Credential;
+use crate::scenes::SceneRegistry;
 use crate::service::{ServerState, router};
 
 pub use crate::service::{AUTH_QUERY_PARAMETER, CLIENT_HELLO_TIMEOUT, auth_cookie_name};
@@ -47,6 +49,7 @@ pub struct Server {
     addr: SocketAddr,
     token: String,
     credential: Arc<Credential>,
+    scenes: Arc<SceneRegistry>,
     shutdown: watch::Sender<bool>,
     running: Option<(Runtime, JoinHandle<io::Result<()>>)>,
 }
@@ -70,6 +73,7 @@ impl Server {
 
         let (credential, token) = Credential::mint()?;
         let credential = Arc::new(credential);
+        let scenes = Arc::new(SceneRegistry::new());
         let (shutdown, stopping) = watch::channel(false);
         let state = ServerState {
             attach_serial: Arc::new(tokio::sync::Mutex::new(())),
@@ -77,6 +81,7 @@ impl Server {
             origin: Arc::from(format!("http://{addr}")),
             cookie_name: Arc::from(service::auth_cookie_name(addr.port())),
             credential: Arc::clone(&credential),
+            scenes: Arc::clone(&scenes),
             shutdown: stopping.clone(),
         };
 
@@ -100,6 +105,7 @@ impl Server {
             addr,
             token,
             credential,
+            scenes,
             shutdown,
             running: Some((runtime, serve)),
         })
@@ -137,6 +143,7 @@ impl Server {
 
     fn stop(&mut self) {
         self.credential.invalidate();
+        self.scenes.invalidate();
         self.shutdown.send_replace(true);
         if let Some((runtime, mut serve)) = self.running.take() {
             // Every attachment handler awaits its relay teardown before it

--- a/rust/web/src/lib.rs
+++ b/rust/web/src/lib.rs
@@ -63,6 +63,17 @@ impl Server {
     /// Fails when the runtime cannot start, the loopback bind fails, or the
     /// operating system entropy source is unavailable.
     pub fn start() -> io::Result<Self> {
+        Self::start_inner(crate::attach::SCENE_DEADLINE_POLL)
+    }
+
+    /// Start with an explicit scene-deadline poll interval so a test can
+    /// drive scene expiry in milliseconds instead of the production minute.
+    #[doc(hidden)]
+    pub fn start_for_test(scene_deadline_poll: Duration) -> io::Result<Self> {
+        Self::start_inner(scene_deadline_poll)
+    }
+
+    fn start_inner(scene_deadline_poll: Duration) -> io::Result<Self> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .enable_io()
@@ -81,6 +92,7 @@ impl Server {
             cookie_name: Arc::from(service::auth_cookie_name(addr.port())),
             credential: Arc::clone(&credential),
             scenes: Arc::clone(&scenes),
+            scene_deadline_poll,
             shutdown: stopping.clone(),
         };
 
@@ -108,6 +120,13 @@ impl Server {
             shutdown,
             running: Some((runtime, serve)),
         })
+    }
+
+    /// Force every live scene past its deadline, so a test can observe
+    /// expiry enforcement without waiting out the real idle/absolute bounds.
+    #[doc(hidden)]
+    pub fn expire_scenes(&self) {
+        self.scenes.expire_all();
     }
 
     /// The bound loopback address.

--- a/rust/web/src/lib.rs
+++ b/rust/web/src/lib.rs
@@ -76,7 +76,6 @@ impl Server {
         let scenes = Arc::new(SceneRegistry::new());
         let (shutdown, stopping) = watch::channel(false);
         let state = ServerState {
-            attach_serial: Arc::new(tokio::sync::Mutex::new(())),
             authority: Arc::from(addr.to_string()),
             origin: Arc::from(format!("http://{addr}")),
             cookie_name: Arc::from(service::auth_cookie_name(addr.port())),

--- a/rust/web/src/scenes.rs
+++ b/rust/web/src/scenes.rs
@@ -1,0 +1,341 @@
+//! In-memory scene registry: per-scene secrets established from single-use
+//! mint codes, bounded by idle and absolute lifetimes.
+//!
+//! A scene is the browser-side authority unit. Its secret is minted only
+//! from a single-use, seconds-scale mint code (delivered in the bootstrap
+//! redirect fragment) — never from the ambient session cookie alone — so a
+//! sibling loopback service that captured the cookie holds no scene
+//! authority. The secret lives only here in memory and travels only in a
+//! request header or the first websocket frame; it is never placed in a
+//! cookie or URL.
+//!
+//! Time is injected as an `Instant` on every call so expiry is exercised
+//! deterministically in tests rather than against the wall clock.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// How long a bootstrap mint code remains redeemable. Seconds-scale: the
+/// code is handed to the page in the redirect fragment and exchanged
+/// immediately, so a short window bounds a captured code's value.
+const MINT_CODE_TTL: Duration = Duration::from_secs(30);
+
+/// Idle bound: a scene expires this long after its last authenticated use.
+const SCENE_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
+
+/// Absolute bound: a scene expires this long after minting regardless of
+/// use, forcing a fresh establishment from bootstrap.
+const SCENE_ABSOLUTE_LIFETIME: Duration = Duration::from_hours(24);
+
+/// The credential a browser presents for scene-scoped operations.
+pub(crate) struct SceneCredential {
+    pub(crate) scene_id: String,
+    pub(crate) scene_secret: String,
+}
+
+struct Scene {
+    secret: String,
+    minted_at: Instant,
+    last_used_at: Instant,
+}
+
+impl Scene {
+    /// A scene is live only while it is within BOTH bounds. Either bound
+    /// alone expires it.
+    fn is_live(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.last_used_at) <= SCENE_IDLE_TIMEOUT
+            && now.saturating_duration_since(self.minted_at) <= SCENE_ABSOLUTE_LIFETIME
+    }
+}
+
+#[derive(Default)]
+struct Registry {
+    /// Redeemable mint codes and their expiry. A code is removed on the
+    /// first redemption attempt, success or not.
+    mint_codes: HashMap<String, Instant>,
+    scenes: HashMap<String, Scene>,
+}
+
+/// The live scene registry. All state is in memory and dies with the
+/// server.
+pub(crate) struct SceneRegistry {
+    inner: Mutex<Registry>,
+}
+
+impl SceneRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(Registry::default()),
+        }
+    }
+
+    /// Mint one single-use bootstrap code, redeemable until `now +
+    /// MINT_CODE_TTL`.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the operating system entropy source is unavailable.
+    pub(crate) fn mint_code(&self, now: Instant) -> io::Result<String> {
+        let code = random_hex()?;
+        let mut registry = self.lock();
+        registry.sweep(now);
+        registry
+            .mint_codes
+            .insert(code.clone(), now + MINT_CODE_TTL);
+        Ok(code)
+    }
+
+    /// Redeem a mint code for a fresh scene credential. The code is
+    /// consumed on this attempt whether or not it was still valid, so a
+    /// captured code cannot be retried.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the operating system entropy source is unavailable while
+    /// minting the new scene. Returns `Ok(None)` for an unknown or expired
+    /// code.
+    pub(crate) fn redeem(&self, code: &str, now: Instant) -> io::Result<Option<SceneCredential>> {
+        let mut registry = self.lock();
+        registry.sweep(now);
+        // Single-use: remove regardless of validity so a replay of the
+        // same code finds nothing.
+        let Some(expires_at) = registry.mint_codes.remove(code) else {
+            return Ok(None);
+        };
+        if now > expires_at {
+            return Ok(None);
+        }
+        drop(registry);
+
+        let scene_id = random_hex()?;
+        let secret = random_hex()?;
+        let mut registry = self.lock();
+        registry.scenes.insert(
+            scene_id.clone(),
+            Scene {
+                secret: secret.clone(),
+                minted_at: now,
+                last_used_at: now,
+            },
+        );
+        Ok(Some(SceneCredential {
+            scene_id,
+            scene_secret: secret,
+        }))
+    }
+
+    /// Establish a scene directly from the startup bearer credential, for
+    /// non-browser clients that never pass through the bootstrap flow.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the operating system entropy source is unavailable.
+    pub(crate) fn establish_direct(&self, now: Instant) -> io::Result<SceneCredential> {
+        let scene_id = random_hex()?;
+        let secret = random_hex()?;
+        let mut registry = self.lock();
+        registry.sweep(now);
+        registry.scenes.insert(
+            scene_id.clone(),
+            Scene {
+                secret: secret.clone(),
+                minted_at: now,
+                last_used_at: now,
+            },
+        );
+        Ok(SceneCredential {
+            scene_id,
+            scene_secret: secret,
+        })
+    }
+
+    /// Validate a presented scene credential in constant time and, on
+    /// success, refresh the idle clock. Expiry is refreshed only here — on
+    /// a successful authenticated use — never on a failed match.
+    pub(crate) fn validate(&self, scene_id: &str, scene_secret: &str, now: Instant) -> bool {
+        let mut registry = self.lock();
+        let Some(scene) = registry.scenes.get(scene_id) else {
+            return false;
+        };
+        if !scene.is_live(now) {
+            registry.scenes.remove(scene_id);
+            return false;
+        }
+        if !constant_time_eq(scene.secret.as_bytes(), scene_secret.as_bytes()) {
+            return false;
+        }
+        registry
+            .scenes
+            .get_mut(scene_id)
+            .expect("scene was just read under the lock")
+            .last_used_at = now;
+        true
+    }
+
+    /// Permanently drop every scene and mint code. Called on shutdown.
+    pub(crate) fn invalidate(&self) {
+        let mut registry = self.lock();
+        registry.mint_codes.clear();
+        registry.scenes.clear();
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Registry> {
+        self.inner.lock().expect("scene registry lock poisoned")
+    }
+}
+
+impl Registry {
+    /// Drop expired mint codes and scenes. Cheap and opportunistic — run
+    /// on every mutating call so a long-idle server never accumulates dead
+    /// entries.
+    fn sweep(&mut self, now: Instant) {
+        self.mint_codes.retain(|_, expires_at| now <= *expires_at);
+        self.scenes.retain(|_, scene| scene.is_live(now));
+    }
+}
+
+fn random_hex() -> io::Result<String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).map_err(io::Error::other)?;
+    Ok(hex::encode(bytes))
+}
+
+/// Byte-wise comparison whose duration does not depend on where the inputs
+/// first differ.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b)
+        .fold(0_u8, |acc, (left, right)| acc | (left ^ right))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> Instant {
+        Instant::now()
+    }
+
+    #[test]
+    fn a_minted_code_redeems_once_for_a_scene() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+
+        let credential = registry
+            .redeem(&code, t)
+            .expect("redeem")
+            .expect("valid code yields a scene");
+        assert_eq!(credential.scene_id.len(), 64);
+        assert_eq!(credential.scene_secret.len(), 64);
+        assert!(registry.validate(&credential.scene_id, &credential.scene_secret, t));
+
+        // Single-use: a replay of the same code finds nothing.
+        assert!(registry.redeem(&code, t).expect("redeem").is_none());
+    }
+
+    #[test]
+    fn a_failed_redeem_still_consumes_the_code() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+
+        // Redeemed after its TTL: rejected, but consumed.
+        let expired = t + MINT_CODE_TTL + Duration::from_secs(1);
+        assert!(registry.redeem(&code, expired).expect("redeem").is_none());
+        // Even at a valid time now, the code is gone.
+        assert!(registry.redeem(&code, t).expect("redeem").is_none());
+    }
+
+    #[test]
+    fn an_unknown_code_yields_no_scene() {
+        let registry = SceneRegistry::new();
+        assert!(
+            registry
+                .redeem("not-a-code", base())
+                .expect("redeem")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_wrong_secret_never_validates_or_refreshes() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let credential = registry.redeem(&code, t).expect("redeem").expect("scene");
+
+        assert!(!registry.validate(&credential.scene_id, "wrong", t));
+        assert!(!registry.validate("unknown-scene", &credential.scene_secret, t));
+        // The real credential still validates — a failed attempt changed
+        // nothing.
+        assert!(registry.validate(&credential.scene_id, &credential.scene_secret, t));
+    }
+
+    #[test]
+    fn a_scene_expires_on_the_idle_bound_and_use_refreshes_it() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let credential = registry.redeem(&code, t).expect("redeem").expect("scene");
+
+        // Use just before the idle bound refreshes the clock.
+        let near_idle = t + SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_secs(1));
+        assert!(registry.validate(&credential.scene_id, &credential.scene_secret, near_idle));
+
+        // Another near-idle span from the refreshed point is still live.
+        let refreshed = near_idle + SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_secs(1));
+        assert!(registry.validate(&credential.scene_id, &credential.scene_secret, refreshed));
+
+        // Past the idle bound from the last use, it is gone.
+        let idle_out = refreshed + SCENE_IDLE_TIMEOUT + Duration::from_secs(1);
+        assert!(!registry.validate(&credential.scene_id, &credential.scene_secret, idle_out));
+    }
+
+    #[test]
+    fn a_scene_expires_on_the_absolute_bound_despite_use() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let credential = registry.redeem(&code, t).expect("redeem").expect("scene");
+
+        // Kept warm across the whole day at sub-idle intervals.
+        let mut moment = t;
+        let step = SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_mins(1));
+        while moment.saturating_duration_since(t) < SCENE_ABSOLUTE_LIFETIME {
+            assert!(registry.validate(&credential.scene_id, &credential.scene_secret, moment));
+            moment += step;
+        }
+        // Just past the absolute lifetime, active use cannot save it.
+        let absolute_out = t + SCENE_ABSOLUTE_LIFETIME + Duration::from_secs(1);
+        assert!(!registry.validate(&credential.scene_id, &credential.scene_secret, absolute_out));
+    }
+
+    #[test]
+    fn direct_establishment_needs_no_code() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let credential = registry.establish_direct(t).expect("establish");
+        assert!(registry.validate(&credential.scene_id, &credential.scene_secret, t));
+    }
+
+    #[test]
+    fn invalidation_drops_every_scene_and_code() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let credential = registry.redeem(&code, t).expect("redeem").expect("scene");
+        let live_code = registry.mint_code(t).expect("mint code");
+
+        registry.invalidate();
+
+        assert!(!registry.validate(&credential.scene_id, &credential.scene_secret, t));
+        assert!(registry.redeem(&live_code, t).expect("redeem").is_none());
+    }
+}

--- a/rust/web/src/scenes.rs
+++ b/rust/web/src/scenes.rs
@@ -231,6 +231,13 @@ impl SceneRegistry {
         registry.serials.clear();
     }
 
+    /// Drop every scene so any bound attachment's next liveness check
+    /// fails closed. A test hook for observing deadline enforcement
+    /// without waiting out the real idle/absolute bounds.
+    pub(crate) fn expire_all(&self) {
+        self.lock().scenes.clear();
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, Registry> {
         self.inner.lock().expect("scene registry lock poisoned")
     }

--- a/rust/web/src/scenes.rs
+++ b/rust/web/src/scenes.rs
@@ -14,8 +14,11 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex as AsyncMutex;
 
 /// How long a bootstrap mint code remains redeemable. Seconds-scale: the
 /// code is handed to the page in the redirect fragment and exchanged
@@ -56,6 +59,9 @@ struct Registry {
     /// first redemption attempt, success or not.
     mint_codes: HashMap<String, Instant>,
     scenes: HashMap<String, Scene>,
+    /// Per-scene attachment serialization: a scene's replacement waits for
+    /// its own predecessor's teardown, but scenes never block each other.
+    serials: HashMap<String, Arc<AsyncMutex<()>>>,
 }
 
 /// The live scene registry. All state is in memory and dies with the
@@ -208,11 +214,21 @@ impl SceneRegistry {
         }
     }
 
+    /// The attachment serialization lock for one scene, created on first
+    /// use. Two attachments in the same scene serialize on it (so a
+    /// replacement waits for its predecessor's teardown); attachments in
+    /// different scenes hold different locks and never block each other.
+    pub(crate) fn serialization_lock(&self, scene_id: &str) -> Arc<AsyncMutex<()>> {
+        let mut registry = self.lock();
+        Arc::clone(registry.serials.entry(scene_id.to_owned()).or_default())
+    }
+
     /// Permanently drop every scene and mint code. Called on shutdown.
     pub(crate) fn invalidate(&self) {
         let mut registry = self.lock();
         registry.mint_codes.clear();
         registry.scenes.clear();
+        registry.serials.clear();
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Registry> {
@@ -227,6 +243,9 @@ impl Registry {
     fn sweep(&mut self, now: Instant) {
         self.mint_codes.retain(|_, expires_at| now <= *expires_at);
         self.scenes.retain(|_, scene| scene.is_live(now));
+        // A serialization lock for a scene that is gone is dead weight; an
+        // in-flight attachment keeps its own clone regardless.
+        self.serials.retain(|id, _| self.scenes.contains_key(id));
     }
 }
 

--- a/rust/web/src/scenes.rs
+++ b/rust/web/src/scenes.rs
@@ -174,6 +174,40 @@ impl SceneRegistry {
         true
     }
 
+    /// Refresh a live scene's idle clock on authenticated client activity
+    /// (a websocket data frame), returning whether it is still live. An
+    /// expired scene is dropped and reports `false`. Terminal output and
+    /// keepalives never call this, so they do not keep an idle scene alive.
+    pub(crate) fn refresh(&self, scene_id: &str, now: Instant) -> bool {
+        let mut registry = self.lock();
+        match registry.scenes.get_mut(scene_id) {
+            Some(scene) if scene.is_live(now) => {
+                scene.last_used_at = now;
+                true
+            }
+            Some(_) => {
+                registry.scenes.remove(scene_id);
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Whether a scene is still within its bounds, WITHOUT refreshing the
+    /// idle clock — for a periodic deadline check that must let an idle
+    /// scene actually expire. An expired scene is dropped.
+    pub(crate) fn is_live(&self, scene_id: &str, now: Instant) -> bool {
+        let mut registry = self.lock();
+        match registry.scenes.get(scene_id) {
+            Some(scene) if scene.is_live(now) => true,
+            Some(_) => {
+                registry.scenes.remove(scene_id);
+                false
+            }
+            None => false,
+        }
+    }
+
     /// Permanently drop every scene and mint code. Called on shutdown.
     pub(crate) fn invalidate(&self) {
         let mut registry = self.lock();
@@ -323,6 +357,40 @@ mod tests {
         let t = base();
         let credential = registry.establish_direct(t).expect("establish");
         assert!(registry.validate(&credential.scene_id, &credential.scene_secret, t));
+    }
+
+    #[test]
+    fn refresh_extends_the_idle_clock_but_is_live_does_not() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let c = registry.redeem(&code, t).expect("redeem").expect("scene");
+
+        // is_live near the idle bound reports live but does NOT refresh, so
+        // the scene still expires on schedule.
+        let near = t + SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_secs(1));
+        assert!(registry.is_live(&c.scene_id, near));
+        let idle_out = t + SCENE_IDLE_TIMEOUT + Duration::from_secs(1);
+        assert!(!registry.is_live(&c.scene_id, idle_out));
+    }
+
+    #[test]
+    fn refresh_keeps_a_scene_alive_across_activity() {
+        let registry = SceneRegistry::new();
+        let t = base();
+        let code = registry.mint_code(t).expect("mint code");
+        let c = registry.redeem(&code, t).expect("redeem").expect("scene");
+
+        let near = t + SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_secs(1));
+        assert!(registry.refresh(&c.scene_id, near));
+        // Refreshed: another near-idle span is still live.
+        let again = near + SCENE_IDLE_TIMEOUT.saturating_sub(Duration::from_secs(1));
+        assert!(registry.is_live(&c.scene_id, again));
+
+        // Past the idle bound from the last refresh, both report expired.
+        let out = again + SCENE_IDLE_TIMEOUT + Duration::from_secs(1);
+        assert!(!registry.refresh(&c.scene_id, out));
+        assert!(!registry.is_live(&c.scene_id, out));
     }
 
     #[test]

--- a/rust/web/src/service.rs
+++ b/rust/web/src/service.rs
@@ -2,7 +2,7 @@
 //! websocket.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::extract::State;
@@ -64,6 +64,7 @@ pub(crate) struct ServerState {
     /// The port-suffixed session cookie name for this instance.
     pub(crate) cookie_name: Arc<str>,
     pub(crate) credential: Arc<Credential>,
+    pub(crate) scenes: Arc<crate::scenes::SceneRegistry>,
     pub(crate) shutdown: watch::Receiver<bool>,
 }
 
@@ -79,6 +80,7 @@ pub(crate) fn router(state: ServerState) -> Router {
         .route("/assets/addon-fit.js", get(addon_fit_js))
         .route("/assets/addon-unicode11.js", get(addon_unicode11_js))
         .route("/api/v1/inventory", get(inventory))
+        .route("/api/v1/scene", axum::routing::post(scene_exchange))
         .route("/ws/v1/hello", get(ws_hello))
         .route("/ws/v1/attach", get(crate::attach::ws_attach))
         .layer(middleware::from_fn_with_state(
@@ -137,11 +139,17 @@ async fn require_credential(
             if state.credential.matches_token(presented)
                 && let Some(session) = state.credential.session_value()
             {
+                // Mint a single-use scene code and hand it to the
+                // page in the redirect fragment (browsers never send a
+                // fragment to a server), so the credential the page
+                // exchanges is not the ambient cookie.
+                let mint = state.scenes.mint_code(Instant::now()).ok();
                 return bootstrap_redirect(
                     request.uri().path(),
                     query,
                     &state.cookie_name,
                     &session,
+                    mint.as_deref(),
                 );
             }
             return StatusCode::UNAUTHORIZED.into_response();
@@ -203,7 +211,61 @@ fn query_token(query: &str) -> Option<&str> {
 /// Store the session value in the cookie and redirect to the same path with
 /// the credential parameter stripped, so the token never stays in the
 /// location bar or browser history.
-fn bootstrap_redirect(path: &str, query: &str, cookie_name: &str, session: &str) -> Response {
+/// Header carrying the single-use bootstrap mint code from the page to
+/// the scene-exchange endpoint. A header (not a query param) keeps the
+/// code out of the request line that access logs capture.
+pub(crate) const MINT_CODE_HEADER: &str = "x-ghosthub-mint";
+
+/// Exchange authority for a scene credential: a browser redeems its
+/// single-use mint code (the authenticating session cookie alone cannot);
+/// a non-browser bearer client establishes a scene directly. Reached only
+/// after the credential and exact-Origin gates in `require_credential`.
+async fn scene_exchange(State(state): State<ServerState>, headers: HeaderMap) -> Response {
+    if let Some(presented) = bearer_token(&headers)
+        && state.credential.matches_token(presented)
+    {
+        return match state.scenes.establish_direct(Instant::now()) {
+            Ok(credential) => scene_credential_response(&credential),
+            Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        };
+    }
+    let Some(code) = headers
+        .get(MINT_CODE_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+    match state.scenes.redeem(code, Instant::now()) {
+        Ok(Some(credential)) => scene_credential_response(&credential),
+        Ok(None) => StatusCode::UNAUTHORIZED.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+fn scene_credential_response(credential: &crate::scenes::SceneCredential) -> Response {
+    let body = serde_json::json!({
+        "scene_id": credential.scene_id,
+        "scene_secret": credential.scene_secret,
+    })
+    .to_string();
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/json; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+fn bootstrap_redirect(
+    path: &str,
+    query: &str,
+    cookie_name: &str,
+    session: &str,
+    mint_code: Option<&str>,
+) -> Response {
     let remainder = query
         .split('&')
         .filter(|pair| {
@@ -212,11 +274,17 @@ fn bootstrap_redirect(path: &str, query: &str, cookie_name: &str, session: &str)
         })
         .collect::<Vec<_>>()
         .join("&");
-    let location = if remainder.is_empty() {
+    let mut location = if remainder.is_empty() {
         path.to_owned()
     } else {
         format!("{path}?{remainder}")
     };
+    // The mint code rides in the fragment: browsers do not transmit it to
+    // the server, and the page strips it from history immediately.
+    if let Some(code) = mint_code {
+        location.push_str("#mint=");
+        location.push_str(code);
+    }
     let cookie = format!("{cookie_name}={session}; HttpOnly; SameSite=Strict; Path=/");
     (
         StatusCode::SEE_OTHER,
@@ -395,6 +463,16 @@ const UNICODE_WIDTH_VERSION: u32 = 11;
 /// A client hello must state the protocol version and declare the required
 /// capabilities: Unicode-11 width tables and tolerance for ConPTY-injected
 /// mode requests. Anything else closes with a policy code.
+/// Extract a borrowed (`scene_id`, `scene_secret`) pair from a client hello,
+/// or None when either is absent or not a string. The caller validates
+/// them against the scene registry.
+pub(crate) fn hello_scene_credential(frame: &Utf8Bytes) -> Option<(String, String)> {
+    let hello = serde_json::from_str::<serde_json::Value>(frame.as_str()).ok()?;
+    let scene_id = hello.get("scene_id")?.as_str()?.to_owned();
+    let scene_secret = hello.get("scene_secret")?.as_str()?.to_owned();
+    Some((scene_id, scene_secret))
+}
+
 pub(crate) fn valid_client_hello(frame: &Utf8Bytes) -> bool {
     let Ok(hello) = serde_json::from_str::<serde_json::Value>(frame.as_str()) else {
         return false;

--- a/rust/web/src/service.rs
+++ b/rust/web/src/service.rs
@@ -59,6 +59,9 @@ pub(crate) struct ServerState {
     pub(crate) cookie_name: Arc<str>,
     pub(crate) credential: Arc<Credential>,
     pub(crate) scenes: Arc<crate::scenes::SceneRegistry>,
+    /// How often an attachment re-checks its bound scene's deadline. A
+    /// field, not the constant directly, so a test can drive expiry fast.
+    pub(crate) scene_deadline_poll: Duration,
     pub(crate) shutdown: watch::Receiver<bool>,
 }
 

--- a/rust/web/src/service.rs
+++ b/rust/web/src/service.rs
@@ -51,12 +51,6 @@ const ADDON_UNICODE11_JS: &str = include_str!("../assets/vendor/addon-unicode11.
 
 #[derive(Clone)]
 pub(crate) struct ServerState {
-    /// Serializes attachments: a replacement waits until its predecessor's
-    /// relay threads have joined and its PTY child is reaped, so an
-    /// abnormal browser-side closure cannot race an un-reaped client.
-    /// Scene-scoped serialization replaces this per-server lock when scene
-    /// credentials land.
-    pub(crate) attach_serial: Arc<tokio::sync::Mutex<()>>,
     /// The literal bound authority, e.g. `127.0.0.1:49152`.
     pub(crate) authority: Arc<str>,
     /// The only acceptable `Origin`, e.g. `http://127.0.0.1:49152`.

--- a/rust/web/tests/server.rs
+++ b/rust/web/tests/server.rs
@@ -1071,6 +1071,59 @@ fn input_overflow_closes_the_connection_with_policy() {
     }
 }
 
+/// An expired scene is closed even while the connection is continuously
+/// busy. The relay loop's liveness check runs on a persistent timer, so a
+/// hot `recv` branch cannot starve it; a fresh per-iteration timer would
+/// cancel and restart on every frame and never fire, holding it open.
+///
+/// Pings are the vector: they are the one client frame the relay ignores
+/// without refreshing the scene, so a steady stream of them keeps the loop
+/// busy without itself renewing the deadline.
+#[test]
+fn continuous_activity_does_not_starve_the_scene_deadline_check() {
+    // A poll interval far shorter than the real minute so the deadline check
+    // is observable within the test, and shorter still than the ping cadence
+    // below so the buggy per-iteration timer would provably never elapse;
+    // expiry is forced directly rather than waiting out the real bounds.
+    let server = Server::start_for_test(Duration::from_millis(200)).expect("start server");
+    let scene = establish_scene(&server);
+    let mut socket = attach_shell_in_scene(&server, &scene);
+    await_echo(&mut socket, "deadline-ready");
+
+    // Read in short slices so each loop turn sends another ping; the server
+    // then sees a data frame far more often than every 200ms.
+    socket
+        .get_ref()
+        .set_read_timeout(Some(Duration::from_millis(5)))
+        .expect("short read timeout");
+    server.expire_scenes();
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "the deadline check never closed the continuously busy attachment"
+        );
+        socket
+            .send(Message::Ping(Vec::new().into()))
+            .expect("send keepalive ping");
+        match socket.read() {
+            Ok(Message::Close(Some(frame))) => {
+                assert_eq!(u16::from(frame.code), 1008, "policy close");
+                assert_eq!(frame.reason.as_str(), "scene expired");
+                return;
+            }
+            Ok(_) => {}
+            Err(tungstenite::Error::Io(error))
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(error) => panic!("unexpected read error: {error:?}"),
+        }
+    }
+}
+
 /// Input typed by a viewer queued behind the serialization lock is
 /// buffered and replayed into its shell once the lock frees, so a
 /// reconnecting viewer loses no keystrokes while it waits.

--- a/rust/web/tests/server.rs
+++ b/rust/web/tests/server.rs
@@ -154,7 +154,9 @@ fn query_bootstrap_sets_the_cookie_and_strips_the_parameter() {
         &[("Host", &host(server.addr()))],
     );
     assert_eq!(reply.status, 303);
-    assert_eq!(reply.header("location"), Some("/"));
+    let location = reply.header("location").expect("redirect location");
+    assert!(location.starts_with("/#mint="), "{location}");
+    assert_eq!(location.len(), "/#mint=".len() + 64, "64-hex mint code");
     let cookie = reply.header("set-cookie").expect("bootstrap cookie");
     let cookie_name = auth_cookie_name(server.addr().port());
     assert!(cookie.starts_with(&format!("{cookie_name}=")));
@@ -188,7 +190,9 @@ fn bootstrap_redirects_even_when_already_authenticated() {
         reply.status, 303,
         "an authenticated revisit must still strip the token from the location"
     );
-    assert_eq!(reply.header("location"), Some("/"));
+    let location = reply.header("location").expect("redirect location");
+    assert!(location.starts_with("/#mint="), "{location}");
+    assert_eq!(location.len(), "/#mint=".len() + 64, "64-hex mint code");
 }
 
 #[test]
@@ -277,7 +281,8 @@ fn bootstrap_preserves_other_query_parameters() {
         &[("Host", &host(server.addr()))],
     );
     assert_eq!(reply.status, 303);
-    assert_eq!(reply.header("location"), Some("/?view=hosts"));
+    let location = reply.header("location").expect("redirect location");
+    assert!(location.starts_with("/?view=hosts#mint="), "{location}");
 }
 
 #[test]
@@ -427,8 +432,9 @@ fn hello_websocket_exchanges_capabilities_and_closes() {
     assert_eq!(hello["limits"]["max_message_bytes"], MAX_FRAME_BYTES);
     assert!(hello["limits"]["max_queued_output_bytes"].is_u64());
 
+    let scene = establish_scene(&server);
     socket
-        .send(Message::Text(compatible_client_hello().into()))
+        .send(Message::Text(compatible_client_hello(&scene).into()))
         .expect("client hello");
 
     match socket.read().expect("close frame") {
@@ -439,9 +445,11 @@ fn hello_websocket_exchanges_capabilities_and_closes() {
     }
 }
 
-fn compatible_client_hello() -> String {
+fn compatible_client_hello(scene: &(String, String)) -> String {
+    let (scene_id, scene_secret) = scene;
     format!(
-        "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\
+        "{{\"protocol\":{PROTOCOL_VERSION},\"scene_id\":\"{scene_id}\",\
+         \"scene_secret\":\"{scene_secret}\",\"capabilities\":{{\"unicode_width\":11,\
          \"ignores_conpty_mode_requests\":true}}}}"
     )
 }
@@ -462,9 +470,14 @@ fn client_hello_without_required_capabilities_is_rejected() {
         panic!("expected server hello");
     };
 
+    let (scene_id, scene_secret) = establish_scene(&server);
     socket
         .send(Message::Text(
-            format!("{{\"protocol\":{PROTOCOL_VERSION}}}").into(),
+            format!(
+                "{{\"protocol\":{PROTOCOL_VERSION},\"scene_id\":\"{scene_id}\",\
+                 \"scene_secret\":\"{scene_secret}\"}}"
+            )
+            .into(),
         ))
         .expect("client hello without capabilities");
 
@@ -715,9 +728,8 @@ fn attach_websocket_runs_a_live_shell() {
         panic!("expected server hello");
     };
 
-    let hello = format!(
-        "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\"pixel_width\":800,\"pixel_height\":480}}}}"
-    );
+    let scene = establish_scene(&server);
+    let hello = full_hello(&scene);
     socket
         .send(Message::Text(hello.into()))
         .expect("client hello");
@@ -803,9 +815,8 @@ fn attach_accepts_chunked_input_beyond_the_message_limit() {
     let Message::Text(_) = socket.read().expect("server hello") else {
         panic!("expected server hello");
     };
-    let hello = format!(
-        "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\"pixel_width\":800,\"pixel_height\":480}}}}"
-    );
+    let scene = establish_scene(&server);
+    let hello = full_hello(&scene);
     socket
         .send(Message::Text(hello.into()))
         .expect("client hello");
@@ -854,6 +865,7 @@ fn attach_accepts_chunked_input_beyond_the_message_limit() {
 #[test]
 fn attachments_serialize_across_an_abrupt_closure() {
     let server = Server::start().expect("start server");
+    let scene = establish_scene(&server);
     let attach = |timeout: Duration| {
         let (status, socket) = upgrade_at(
             server.addr(),
@@ -872,9 +884,7 @@ fn attachments_serialize_across_an_abrupt_closure() {
         let Message::Text(_) = socket.read().expect("server hello") else {
             panic!("expected server hello");
         };
-        let hello = format!(
-            "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\"pixel_width\":800,\"pixel_height\":480}}}}"
-        );
+        let hello = full_hello(&scene);
         socket
             .send(Message::Text(hello.into()))
             .expect("client hello");
@@ -1187,6 +1197,191 @@ fn a_queued_attachment_that_closes_does_not_wedge_the_lock() {
 }
 
 /// Open an authenticated attach socket and complete the hello exchange.
+/// A hello without a scene credential is refused before any PTY work,
+/// even though it authenticated the upgrade with a valid bearer.
+#[test]
+fn an_attach_hello_without_a_scene_credential_is_refused() {
+    let server = Server::start().expect("start server");
+    let (status, socket) = upgrade_at(
+        server.addr(),
+        "/ws/v1/attach",
+        &[
+            ("Origin", &origin(server.addr())),
+            ("Authorization", &bearer(&server)),
+        ],
+    );
+    assert_eq!(status, 101);
+    let mut socket = socket.expect("upgraded socket");
+    socket
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("read timeout");
+    let Message::Text(_) = socket.read().expect("server hello") else {
+        panic!("expected server hello");
+    };
+    let hello = format!(
+        "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\"pixel_width\":800,\"pixel_height\":480}}}}"
+    );
+    socket
+        .send(Message::Text(hello.into()))
+        .expect("scene-less hello");
+    match socket.read().expect("close frame") {
+        Message::Close(Some(frame)) => {
+            assert_eq!(u16::from(frame.code), 1008, "policy close");
+            assert_eq!(frame.reason.as_str(), "invalid scene credential");
+        }
+        other => panic!("expected close frame, got {other:?}"),
+    }
+}
+
+/// A hello with an unknown or wrong scene credential is refused.
+#[test]
+fn an_attach_hello_with_a_wrong_scene_credential_is_refused() {
+    let server = Server::start().expect("start server");
+    let (status, socket) = upgrade_at(
+        server.addr(),
+        "/ws/v1/attach",
+        &[
+            ("Origin", &origin(server.addr())),
+            ("Authorization", &bearer(&server)),
+        ],
+    );
+    assert_eq!(status, 101);
+    let mut socket = socket.expect("upgraded socket");
+    socket
+        .get_mut()
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("read timeout");
+    let Message::Text(_) = socket.read().expect("server hello") else {
+        panic!("expected server hello");
+    };
+    let forged = ("f".repeat(64), "0".repeat(64));
+    socket
+        .send(Message::Text(full_hello(&forged).into()))
+        .expect("forged-scene hello");
+    match socket.read().expect("close frame") {
+        Message::Close(Some(frame)) => {
+            assert_eq!(u16::from(frame.code), 1008, "policy close");
+            assert_eq!(frame.reason.as_str(), "invalid scene credential");
+        }
+        other => panic!("expected close frame, got {other:?}"),
+    }
+}
+
+/// The session cookie alone cannot mint a scene: with no bearer and no
+/// mint code, the exchange is unauthorized.
+#[test]
+fn the_session_cookie_alone_cannot_mint_a_scene() {
+    let server = Server::start().expect("start server");
+    let cookie = bootstrap_cookie(&server);
+    let reply = request(
+        server.addr(),
+        "POST",
+        "/api/v1/scene",
+        &[
+            ("Host", &host(server.addr())),
+            ("Origin", &origin(server.addr())),
+            ("Cookie", &cookie),
+        ],
+    );
+    assert_eq!(
+        reply.status, 401,
+        "cookie without a mint code mints nothing"
+    );
+}
+
+/// A bootstrap mint code, delivered in the redirect fragment, exchanges
+/// once for a scene and never again.
+#[test]
+fn a_bootstrap_mint_code_exchanges_once() {
+    let server = Server::start().expect("start server");
+    let target = format!("/?auth_token={}", server.token());
+    let redirect = request(
+        server.addr(),
+        "GET",
+        &target,
+        &[("Host", &host(server.addr()))],
+    );
+    assert_eq!(redirect.status, 303);
+    let location = redirect.header("location").expect("redirect location");
+    let code = location
+        .split("#mint=")
+        .nth(1)
+        .expect("mint code in fragment");
+    let set_cookie = redirect.header("set-cookie").expect("bootstrap cookie");
+    let cookie = set_cookie
+        .split(';')
+        .next()
+        .expect("cookie pair")
+        .to_owned();
+
+    let exchange = request(
+        server.addr(),
+        "POST",
+        "/api/v1/scene",
+        &[
+            ("Host", &host(server.addr())),
+            ("Origin", &origin(server.addr())),
+            ("Cookie", &cookie),
+            ("x-ghosthub-mint", code),
+        ],
+    );
+    assert_eq!(exchange.status, 200, "the mint code redeems for a scene");
+    let scene: serde_json::Value = serde_json::from_str(&exchange.body).expect("scene json");
+    assert_eq!(scene["scene_id"].as_str().expect("scene_id").len(), 64);
+
+    // Single-use: the same code is spent.
+    let replay = request(
+        server.addr(),
+        "POST",
+        "/api/v1/scene",
+        &[
+            ("Host", &host(server.addr())),
+            ("Origin", &origin(server.addr())),
+            ("Cookie", &cookie),
+            ("x-ghosthub-mint", code),
+        ],
+    );
+    assert_eq!(replay.status, 401, "a spent mint code mints nothing");
+}
+
+/// Establish a scene via the exchange endpoint (bearer path) and return
+/// its (`scene_id`, `scene_secret`), for hellos that must carry a valid scene
+/// credential.
+fn establish_scene(server: &Server) -> (String, String) {
+    let reply = request(
+        server.addr(),
+        "POST",
+        "/api/v1/scene",
+        &[
+            ("Host", &host(server.addr())),
+            ("Origin", &origin(server.addr())),
+            ("Authorization", &bearer(server)),
+        ],
+    );
+    assert_eq!(reply.status, 200, "scene exchange");
+    let body: serde_json::Value = serde_json::from_str(&reply.body).expect("scene json");
+    (
+        body["scene_id"].as_str().expect("scene_id").to_owned(),
+        body["scene_secret"]
+            .as_str()
+            .expect("scene_secret")
+            .to_owned(),
+    )
+}
+
+/// A complete, valid client hello carrying the scene credential plus the
+/// standard capabilities and geometry.
+fn full_hello(scene: &(String, String)) -> String {
+    let (scene_id, scene_secret) = scene;
+    format!(
+        "{{\"protocol\":{PROTOCOL_VERSION},\"scene_id\":\"{scene_id}\",\
+         \"scene_secret\":\"{scene_secret}\",\"capabilities\":{{\"unicode_width\":11,\
+         \"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\
+         \"pixel_width\":800,\"pixel_height\":480}}}}"
+    )
+}
+
 fn attach_shell(server: &Server) -> WebSocket<TcpStream> {
     let (status, socket) = upgrade_at(
         server.addr(),
@@ -1205,9 +1400,8 @@ fn attach_shell(server: &Server) -> WebSocket<TcpStream> {
     let Message::Text(_) = socket.read().expect("server hello") else {
         panic!("expected server hello");
     };
-    let hello = format!(
-        "{{\"protocol\":{PROTOCOL_VERSION},\"capabilities\":{{\"unicode_width\":11,\"ignores_conpty_mode_requests\":true}},\"initial\":{{\"columns\":100,\"rows\":30,\"pixel_width\":800,\"pixel_height\":480}}}}"
-    );
+    let scene = establish_scene(server);
+    let hello = full_hello(&scene);
     socket
         .send(Message::Text(hello.into()))
         .expect("client hello");
@@ -1247,8 +1441,9 @@ fn attach_hello_without_geometry_is_rejected() {
         panic!("expected server hello");
     };
 
+    let scene = establish_scene(&server);
     socket
-        .send(Message::Text(compatible_client_hello().into()))
+        .send(Message::Text(compatible_client_hello(&scene).into()))
         .expect("client hello without geometry");
 
     match socket.read().expect("close frame") {

--- a/rust/web/tests/server.rs
+++ b/rust/web/tests/server.rs
@@ -1077,12 +1077,13 @@ fn input_overflow_closes_the_connection_with_policy() {
 #[test]
 fn queued_input_replays_into_the_shell_after_the_lock_frees() {
     let server = Server::start().expect("start server");
-    let mut first = attach_shell(&server);
+    let scene = establish_scene(&server);
+    let mut first = attach_shell_in_scene(&server, &scene);
     await_echo(&mut first, "first-live");
 
     // The second attachment completes its hello, then waits on the lock the
     // first still holds. Input sent now must be buffered, not discarded.
-    let mut second = attach_shell(&server);
+    let mut second = attach_shell_in_scene(&server, &scene);
     second
         .get_mut()
         .set_read_timeout(Some(Duration::from_secs(30)))
@@ -1127,12 +1128,13 @@ fn queued_input_replays_into_the_shell_after_the_lock_frees() {
 #[test]
 fn a_queued_attachments_invalid_resize_closes_with_policy() {
     let server = Server::start().expect("start server");
-    let mut first = attach_shell(&server);
+    let scene = establish_scene(&server);
+    let mut first = attach_shell_in_scene(&server, &scene);
     await_echo(&mut first, "first-live");
 
     // The second completes its hello, then waits on the lock the first
     // holds; a malformed control frame sent now must be refused.
-    let mut second = attach_shell(&server);
+    let mut second = attach_shell_in_scene(&server, &scene);
     second
         .get_mut()
         .set_read_timeout(Some(Duration::from_secs(30)))
@@ -1149,7 +1151,8 @@ fn a_queued_attachments_invalid_resize_closes_with_policy() {
 #[test]
 fn a_stalled_reader_releases_the_attachment_lock() {
     let server = Server::start().expect("start server");
-    let mut first = attach_shell(&server);
+    let scene = establish_scene(&server);
+    let mut first = attach_shell_in_scene(&server, &scene);
     await_echo(&mut first, "first-live");
     // Make the shell emit far more than the socket buffer plus the relay
     // output queue, then never read `first` again: the bridge's outbound
@@ -1161,7 +1164,7 @@ fn a_stalled_reader_releases_the_attachment_lock() {
 
     // Queued behind the lock the stalled first still holds; it can only
     // reach a live shell once that first is torn down and the lock frees.
-    let mut second = attach_shell(&server);
+    let mut second = attach_shell_in_scene(&server, &scene);
     second
         .get_mut()
         .set_read_timeout(Some(Duration::from_mins(1)))
@@ -1177,13 +1180,14 @@ fn a_stalled_reader_releases_the_attachment_lock() {
 #[test]
 fn a_queued_attachment_that_closes_does_not_wedge_the_lock() {
     let server = Server::start().expect("start server");
-    let mut first = attach_shell(&server);
+    let scene = establish_scene(&server);
+    let mut first = attach_shell_in_scene(&server, &scene);
     await_echo(&mut first, "first-live");
 
     // Two more complete their hellos and queue behind the lock the first
     // holds; the middle one then abandons its connection.
-    let abandoned = attach_shell(&server);
-    let mut third = attach_shell(&server);
+    let abandoned = attach_shell_in_scene(&server, &scene);
+    let mut third = attach_shell_in_scene(&server, &scene);
     third
         .get_mut()
         .set_read_timeout(Some(Duration::from_mins(1)))
@@ -1383,6 +1387,14 @@ fn full_hello(scene: &(String, String)) -> String {
 }
 
 fn attach_shell(server: &Server) -> WebSocket<TcpStream> {
+    let scene = establish_scene(server);
+    attach_shell_in_scene(server, &scene)
+}
+
+/// Complete an attach in a specific scene. Two attachments in the same
+/// scene serialize on that scene's lock (a replacement waits for its
+/// predecessor's teardown); separate scenes never block each other.
+fn attach_shell_in_scene(server: &Server, scene: &(String, String)) -> WebSocket<TcpStream> {
     let (status, socket) = upgrade_at(
         server.addr(),
         "/ws/v1/attach",
@@ -1400,10 +1412,8 @@ fn attach_shell(server: &Server) -> WebSocket<TcpStream> {
     let Message::Text(_) = socket.read().expect("server hello") else {
         panic!("expected server hello");
     };
-    let scene = establish_scene(server);
-    let hello = full_hello(&scene);
     socket
-        .send(Message::Text(hello.into()))
+        .send(Message::Text(full_hello(scene).into()))
         .expect("client hello");
     socket
 }


### PR DESCRIPTION
Closes the ambient-cookie shell-access hole: Ghosthub's web attach accepted the hostname-scoped session cookie, so a sibling loopback service that captured it could open a shell. Attach now requires a non-ambient scene credential per `docs/web-ui.md`.

- **Single-use bootstrap mint code** in the redirect **fragment** (never sent to a server); the page strips it from history and exchanges it — with the session cookie and exact Origin, in a state-changing POST — for an opaque scene id and secret.
- **In-memory scene secret**, bounded by a 30-minute idle and 24-hour absolute lifetime, refreshed only on authenticated use. It travels only in the attach client hello — never a cookie or URL.
- The **session cookie alone mints nothing**; non-browser clients establish a scene with the startup bearer directly.
- The **attach hello now carries `scene_id`/`scene_secret`**, validated before any PTY work.

Behaviour is unchanged for the user — the demo shell attaches exactly as before; the security change is invisible by design.

Docs: names the multiplexer-as-state-authority invariant (why the relay is parserless with no replay/resume) in `web-ui.md`/`architecture.md`, and adds a freshell prior-art reference (MIT; studied for architecture, no code copied).

Verified: scene-registry unit tests (single-use codes, idle/absolute expiry, constant-time validate) and wire tests (scene-less and forged hellos refused, cookie-only exchange denied, mint code single-use); clippy clean on Windows and the Linux target.
