### PR TITLE
Prevent clipboard writes from deadlocking terminal input

### DIFF
--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -1072,7 +1072,7 @@ public final class LibghosttyRuntime: ObservableObject,
             // Confirmed writes require user approval UI. Deny rather
             // than silently allowing remote clipboard overwrites.
             if isOSC52Write {
-                dispatchToMainSync {
+                DispatchQueue.main.async {
                     recordOSC52ClipboardWriteDiagnostic(
                         .confirmationRequired
                     )
@@ -1080,7 +1080,10 @@ public final class LibghosttyRuntime: ObservableObject,
             }
             return
         }
-        dispatchToMainSync {
+        // libghostty may call this while holding its renderer lock. Waiting
+        // synchronously for AppKit can deadlock with main-thread input events
+        // that call back into the same surface.
+        DispatchQueue.main.async {
             guard surfaceView(from: userdataValue) != nil else {
                 if isOSC52Write {
                     recordOSC52ClipboardWriteDiagnostic(

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -1051,8 +1051,13 @@ public final class LibghosttyRuntime: ObservableObject,
         len: Int,
         confirm: Bool
     ) {
-        let userdataValue = userdata.map { UInt(bitPattern: $0) }
         guard let content, len > 0 else { return }
+        // Resolve userdata while libghostty still guarantees its lifetime.
+        // The queued write captures this token across the async hop.
+        let token = userdata.map {
+            Unmanaged<SurfaceCallbackToken>.fromOpaque($0)
+                .takeUnretainedValue()
+        }
         let entries: [ClipboardWriteEntry] = (0 ..< len).compactMap { index in
             let item = content[index]
             guard let mimePtr = item.mime,
@@ -1084,7 +1089,7 @@ public final class LibghosttyRuntime: ObservableObject,
         // synchronously for AppKit can deadlock with main-thread input events
         // that call back into the same surface.
         DispatchQueue.main.async {
-            guard surfaceView(from: userdataValue) != nil else {
+            guard token?.view != nil else {
                 if isOSC52Write {
                     recordOSC52ClipboardWriteDiagnostic(
                         .surfaceUnavailable

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1242,10 +1242,9 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
                 }
             }
         }
-        XCTAssertEqual(
-            pasteboard.string(forType: .string),
-            "selected text"
-        )
+        waitUntil {
+            self.pasteboard.string(forType: .string) == "selected text"
+        }
 
         "text/plain".withCString { mime in
             "remote payload".withCString { data in
@@ -1268,11 +1267,69 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
                 }
             }
         }
-        XCTAssertEqual(
-            pasteboard.string(forType: .string),
-            "remote payload",
-            "OSC 52 copy must reach the clipboard from an SSH surface"
+        waitUntil {
+            self.pasteboard.string(forType: .string) == "remote payload"
+        }
+    }
+
+    func testClipboardWriteCallbackDoesNotWaitForMainQueue() throws {
+        try skipUnlessLibghosttyReady()
+        let runtime = retainedRuntime()
+        let appHandle = try XCTUnwrap(runtime.unsafeAppHandle)
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
         )
+        let userdataValue = UInt(bitPattern: Unmanaged.passUnretained(
+            view.callbackToken
+        ).toOpaque())
+        let mainQueueBlocked = DispatchSemaphore(value: 0)
+        let releaseMainQueue = DispatchSemaphore(value: 0)
+        let callbackReturned = expectation(
+            description: "clipboard callback returned"
+        )
+        let callbackReleasedMainQueue = expectation(
+            description: "callback returned before main queue resumed"
+        )
+
+        DispatchQueue.main.async {
+            mainQueueBlocked.signal()
+            if releaseMainQueue.wait(timeout: .now() + 1) == .success {
+                callbackReleasedMainQueue.fulfill()
+            }
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            mainQueueBlocked.wait()
+            "text/plain".withCString { mime in
+                "nonblocking copy".withCString { data in
+                    let contents = [ghostty_clipboard_content_s(
+                        mime: mime,
+                        data: data
+                    )]
+                    contents.withUnsafeBufferPointer { buffer in
+                        LibghosttyRuntime.handleWriteClipboard(
+                            userdata: UnsafeMutableRawPointer(
+                                bitPattern: userdataValue
+                            ),
+                            location: GHOSTTY_CLIPBOARD_STANDARD,
+                            content: buffer.baseAddress,
+                            len: buffer.count,
+                            confirm: false
+                        )
+                    }
+                }
+            }
+            callbackReturned.fulfill()
+            releaseMainQueue.signal()
+        }
+
+        wait(
+            for: [callbackReturned, callbackReleasedMainQueue],
+            timeout: 2
+        )
+        waitUntil {
+            self.pasteboard.string(forType: .string) == "nonblocking copy"
+        }
     }
 
     func testGhosthubShimContainsConfigFileDirectives() throws {

--- a/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
+++ b/Tests/TerminalSmoke/LibghosttyRuntimeSmokeTests.swift
@@ -1332,6 +1332,48 @@ final class LibghosttyRuntimeSmokeTests: XCTestCase {
         }
     }
 
+    func testClipboardWriteCallbackRetainsTokenUntilMainDispatch() throws {
+        try skipUnlessLibghosttyReady()
+        let runtime = retainedRuntime()
+        let appHandle = try XCTUnwrap(runtime.unsafeAppHandle)
+        let view = TerminalSurfaceView(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration()
+        )
+        var token: SurfaceCallbackToken? = SurfaceCallbackToken(view: view)
+        let userdata = token.map {
+            Unmanaged.passUnretained($0).toOpaque()
+        }
+        XCTAssertTrue(isKnownUniquelyReferenced(&token))
+
+        "text/plain".withCString { mime in
+            "owned callback token".withCString { data in
+                let contents = [ghostty_clipboard_content_s(
+                    mime: mime,
+                    data: data
+                )]
+                contents.withUnsafeBufferPointer { buffer in
+                    LibghosttyRuntime.handleWriteClipboard(
+                        userdata: userdata,
+                        location: GHOSTTY_CLIPBOARD_STANDARD,
+                        content: buffer.baseAddress,
+                        len: buffer.count,
+                        confirm: false
+                    )
+                }
+            }
+        }
+
+        XCTAssertFalse(
+            isKnownUniquelyReferenced(&token),
+            "The queued clipboard write must own its callback token"
+        )
+        waitUntil {
+            self.pasteboard.string(forType: .string) == "owned callback token"
+        }
+        XCTAssertTrue(isKnownUniquelyReferenced(&token))
+    }
+
     func testGhosthubShimContainsConfigFileDirectives() throws {
         let ctx = try makeIsolatedRuntime()
 


### PR DESCRIPTION
Ghosthub could beachball when a clipboard write held libghostty's renderer lock while synchronously waiting for the main queue, as a main-thread input event could wait for the same renderer lock. This change copies the callback payload, strongly retains its `SurfaceCallbackToken`, and queues the write-only AppKit work without waiting. Clipboard reads remain synchronous because libghostty needs their result immediately; queued writes are dropped when the token's weak view has closed.

The smoke coverage blocks the main queue to verify that the write callback returns, and separately verifies that the queued continuation owns its callback token until dispatch completes. `LibghosttyRuntimeSmokeTests` passes 32 tests, and `make build` succeeds.
