### PR TITLE
Stop Xcode services in the correct launchd domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
             com.apple.CoreSimulator.SimulatorTrampoline \
             com.apple.CoreSimulator.CoreSimulatorService \
             com.apple.CoreDevice.CoreDeviceService; do
-            target="gui/$uid/$label"
+            target="user/$uid/$label"
             if /bin/launchctl print "$target" >/dev/null 2>&1; then
               /bin/launchctl bootout "$target" ||
                 ! /bin/launchctl print "$target" >/dev/null 2>&1


### PR DESCRIPTION
Trusted macOS jobs now remove the CoreSimulator and CoreDevice services that Xcode leaves in the account's Aqua session before runner containment starts.

- Targets the user launchd domain where the services are registered, instead of the separate GUI domain that the existing cleanup checked.
- Keeps the cleanup limited to the self-hosted lane; hosted jobs and fork pull requests are unchanged.
- Preserves the existing fail-closed check when a service remains registered.
