### PR TITLE
Rust Port: Content-hash and embed the web SPA assets

### DIFF
--- a/docs/web-ui-prior-art.md
+++ b/docs/web-ui-prior-art.md
@@ -63,12 +63,15 @@ simpler — see the state-authority principle in [Web UI](web-ui.md).
 
 ## Worth adopting later (mainly for the SPA pipeline, `y5d7`)
 
-- **Asset-cache discipline.** Serve `index.html` with `no-store`, hashed assets
-  as `immutable`, and — importantly — a **missing hashed asset must 404, never
-  fall back to the SPA shell**, so version skew fails loudly instead of serving
-  a broken bundle. Pair with a protocol-mismatch close that tells a stale client
-  to reload. Ghosthub embeds assets in the binary rather than serving from disk,
-  but the cache rules still apply.
+- **Asset-cache discipline.** *(Adopted, `y5d7`.)* Serve `index.html` with
+  `no-store`, hashed assets as `immutable`, and — importantly — a **missing
+  hashed asset must 404, never fall back to the SPA shell**, so version skew
+  fails loudly instead of serving a broken bundle. Ghosthub embeds assets in the
+  binary rather than serving from disk, but the cache rules still apply:
+  `build.rs` content-hashes each asset into a `stem.<hash>.ext` name and rewrites
+  the page to match, and `service.rs` serves those names `immutable` and 404s an
+  unknown one. A protocol-mismatch close that tells a stale client to reload is
+  still worth pairing with this once the versioned frontend ships.
 - **Typed gap frames instead of silent loss.** Where bytes can be dropped
   (queue overflow, replay eviction), freshell emits a typed frame telling the
   client scrollback was truncated rather than losing it silently. Low priority

--- a/rust/web/build.rs
+++ b/rust/web/build.rs
@@ -1,0 +1,107 @@
+//! Content-hash the embedded frontend assets at build time.
+//!
+//! Each static asset gets a content-derived filename (`app.<hash>.js`), so
+//! the server can serve it `immutable` and a stale reference fails as a 404
+//! instead of silently loading the wrong bytes. `index.html` is rewritten to
+//! point at the hashed names and stays unhashed and `no-store`. The hash is a
+//! non-cryptographic content digest — it only needs to change when the bytes
+//! change — so no build dependency is pulled into the crate's linked graph.
+
+use std::env;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+/// FNV-1a 64-bit, rendered as zero-padded hex. Enough to bust caches on any
+/// content change; not a security primitive.
+fn content_hash(bytes: &[u8]) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn main() {
+    let manifest = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR");
+
+    // (served file name, source path under the crate, content type). The
+    // served name is flat even for vendored sources, matching the routes the
+    // page requests.
+    let assets = [
+        ("app.css", "assets/app.css", "text/css; charset=utf-8"),
+        ("app.js", "assets/app.js", "text/javascript; charset=utf-8"),
+        (
+            "xterm.css",
+            "assets/vendor/xterm.css",
+            "text/css; charset=utf-8",
+        ),
+        (
+            "xterm.js",
+            "assets/vendor/xterm.js",
+            "text/javascript; charset=utf-8",
+        ),
+        (
+            "addon-fit.js",
+            "assets/vendor/addon-fit.js",
+            "text/javascript; charset=utf-8",
+        ),
+        (
+            "addon-unicode11.js",
+            "assets/vendor/addon-unicode11.js",
+            "text/javascript; charset=utf-8",
+        ),
+    ];
+
+    println!("cargo:rerun-if-changed=assets/index.html");
+
+    let mut index = fs::read_to_string(Path::new(&manifest).join("assets/index.html"))
+        .expect("read index.html");
+    let mut entries = String::new();
+
+    for (file, source, content_type) in assets {
+        println!("cargo:rerun-if-changed={source}");
+        let path = Path::new(&manifest).join(source);
+        let bytes = fs::read(&path).unwrap_or_else(|error| panic!("read {source}: {error}"));
+        let hash = content_hash(&bytes);
+        let (stem, ext) = file.rsplit_once('.').expect("asset name has an extension");
+        let hashed = format!("{stem}.{hash}.{ext}");
+
+        // Rewrite the page's reference. The quotes anchor the match so one
+        // asset name is never a prefix of another's replacement.
+        index = index.replace(
+            &format!("\"/assets/{file}\""),
+            &format!("\"/assets/{hashed}\""),
+        );
+
+        // `include_bytes!` accepts forward slashes on every platform.
+        let include_path = path.to_string_lossy().replace('\\', "/");
+        writeln!(
+            entries,
+            "    EmbeddedAsset {{ file: \"{hashed}\", content_type: \"{content_type}\", \
+             body: include_bytes!(\"{include_path}\") }},"
+        )
+        .expect("write asset table entry");
+    }
+
+    let index_out = Path::new(&out_dir).join("index.html");
+    fs::write(&index_out, index).expect("write rewritten index.html");
+    let index_include = index_out.to_string_lossy().replace('\\', "/");
+
+    let generated = format!(
+        "pub(crate) struct EmbeddedAsset {{\n\
+         \x20   pub(crate) file: &'static str,\n\
+         \x20   pub(crate) content_type: &'static str,\n\
+         \x20   pub(crate) body: &'static [u8],\n\
+         }}\n\
+         \n\
+         pub(crate) static EMBEDDED_ASSETS: &[EmbeddedAsset] = &[\n\
+         {entries}\
+         ];\n\
+         \n\
+         pub(crate) const INDEX_PAGE: &str = include_str!(\"{index_include}\");\n"
+    );
+    fs::write(Path::new(&out_dir).join("assets.rs"), generated).expect("write assets.rs");
+}

--- a/rust/web/src/service.rs
+++ b/rust/web/src/service.rs
@@ -39,15 +39,11 @@ const CSP_PREFIX: &str = "default-src 'none'; script-src 'self'; style-src 'self
      img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; \
      connect-src 'self'";
 
-/// Embedded single-page app. Every asset is compiled into the binary; the
-/// strict CSP means nothing else can load.
-const INDEX_PAGE: &str = include_str!("../assets/index.html");
-const APP_CSS: &str = include_str!("../assets/app.css");
-const APP_JS: &str = include_str!("../assets/app.js");
-const XTERM_JS: &str = include_str!("../assets/vendor/xterm.js");
-const XTERM_CSS: &str = include_str!("../assets/vendor/xterm.css");
-const ADDON_FIT_JS: &str = include_str!("../assets/vendor/addon-fit.js");
-const ADDON_UNICODE11_JS: &str = include_str!("../assets/vendor/addon-unicode11.js");
+// Embedded single-page app. `build.rs` content-hashes every static asset,
+// rewrites the page to point at the hashed names, and generates the
+// `EMBEDDED_ASSETS` table and rewritten `INDEX_PAGE` below. Every asset is
+// compiled into the binary; the strict CSP means nothing else can load.
+include!(concat!(env!("OUT_DIR"), "/assets.rs"));
 
 #[derive(Clone)]
 pub(crate) struct ServerState {
@@ -70,12 +66,7 @@ pub(crate) fn router(state: ServerState) -> Router {
     // validation runs before authentication, and both run before routing.
     Router::new()
         .route("/", get(index))
-        .route("/assets/app.css", get(app_css))
-        .route("/assets/app.js", get(app_js))
-        .route("/assets/xterm.js", get(xterm_js))
-        .route("/assets/xterm.css", get(xterm_css))
-        .route("/assets/addon-fit.js", get(addon_fit_js))
-        .route("/assets/addon-unicode11.js", get(addon_unicode11_js))
+        .route("/assets/{file}", get(hashed_asset))
         .route("/api/v1/inventory", get(inventory))
         .route("/api/v1/scene", axum::routing::post(scene_exchange))
         .route("/ws/v1/hello", get(ws_hello))
@@ -313,39 +304,22 @@ async fn index(State(state): State<ServerState>) -> Response {
         .into_response()
 }
 
-fn asset(content_type: &'static str, body: &'static str) -> Response {
+/// Serve one content-hashed asset by its exact filename. A name the table
+/// does not know is a 404 — never a fallback to the SPA shell — so a stale
+/// reference after a rebuild fails loudly instead of loading wrong bytes.
+/// Hashed names are content-addressed, so the response is `immutable`.
+async fn hashed_asset(axum::extract::Path(file): axum::extract::Path<String>) -> Response {
+    let Some(asset) = EMBEDDED_ASSETS.iter().find(|asset| asset.file == file) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
     (
         [
-            (header::CONTENT_TYPE, content_type),
-            (header::CACHE_CONTROL, "no-store"),
+            (header::CONTENT_TYPE, asset.content_type),
+            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
         ],
-        body,
+        asset.body,
     )
         .into_response()
-}
-
-async fn app_css() -> Response {
-    asset("text/css; charset=utf-8", APP_CSS)
-}
-
-async fn app_js() -> Response {
-    asset("text/javascript; charset=utf-8", APP_JS)
-}
-
-async fn xterm_js() -> Response {
-    asset("text/javascript; charset=utf-8", XTERM_JS)
-}
-
-async fn xterm_css() -> Response {
-    asset("text/css; charset=utf-8", XTERM_CSS)
-}
-
-async fn addon_fit_js() -> Response {
-    asset("text/javascript; charset=utf-8", ADDON_FIT_JS)
-}
-
-async fn addon_unicode11_js() -> Response {
-    asset("text/javascript; charset=utf-8", ADDON_UNICODE11_JS)
 }
 
 /// Demo inventory: the real local host carries a live console entry; every

--- a/rust/web/tests/server.rs
+++ b/rust/web/tests/server.rs
@@ -115,6 +115,77 @@ fn bearer_token_fetches_the_page_with_a_strict_csp() {
 }
 
 #[test]
+fn hashed_assets_are_served_immutable_and_coherent_with_the_page() {
+    let server = Server::start().expect("start server");
+    let page = request(
+        server.addr(),
+        "GET",
+        "/",
+        &[
+            ("Host", &host(server.addr())),
+            ("Authorization", &bearer(&server)),
+        ],
+    );
+    assert_eq!(page.status, 200);
+
+    // Pull a hashed asset path out of the served page and prove it is
+    // actually served — end to end, not a source-string assertion.
+    let start = page
+        .body
+        .find("/assets/")
+        .expect("the page references a hashed asset");
+    let reference = &page.body[start..];
+    let end = reference.find('"').expect("the asset reference is quoted");
+    let asset_path = &reference[..end];
+    assert_ne!(asset_path, "/assets/", "the reference carries a filename");
+    assert!(
+        asset_path.matches('.').count() >= 2,
+        "the reference is content-hashed (stem.hash.ext): {asset_path}"
+    );
+
+    let asset = request(
+        server.addr(),
+        "GET",
+        asset_path,
+        &[
+            ("Host", &host(server.addr())),
+            ("Authorization", &bearer(&server)),
+        ],
+    );
+    assert_eq!(asset.status, 200, "hashed asset {asset_path} is served");
+    assert_eq!(
+        asset.header("cache-control"),
+        Some("public, max-age=31536000, immutable"),
+        "content-addressed assets are immutable"
+    );
+    let content_type = asset.header("content-type").expect("asset content type");
+    assert!(
+        content_type.starts_with("text/javascript") || content_type.starts_with("text/css"),
+        "unexpected asset content type: {content_type}"
+    );
+}
+
+#[test]
+fn an_unknown_asset_name_returns_404_not_the_spa_shell() {
+    let server = Server::start().expect("start server");
+    // A well-formed but stale hashed name: nothing in the table matches.
+    let reply = request(
+        server.addr(),
+        "GET",
+        "/assets/app.0000000000000000.js",
+        &[
+            ("Host", &host(server.addr())),
+            ("Authorization", &bearer(&server)),
+        ],
+    );
+    assert_eq!(reply.status, 404, "a stale hashed name must fail loudly");
+    assert!(
+        !reply.body.contains("Ghosthub"),
+        "a missing asset must never fall back to the page shell"
+    );
+}
+
+#[test]
 fn wrong_bearer_token_is_denied() {
     let server = Server::start().expect("start server");
     let reply = request(


### PR DESCRIPTION
Serves the browser UI's static assets as content-addressed, immutably cacheable files embedded in the binary — the asset-cache discipline the web UI needs before a versioned frontend ships (kata y5d7).

- `build.rs` content-hashes each asset into a `stem.<hash>.ext` name and rewrites `index.html` to reference the hashed names; the crate embeds the result at compile time, so no UI code is fetched at runtime.
- `/assets/{file}` is served from the generated table with a long-lived `immutable` cache. An unknown or stale hashed name returns 404 instead of falling back to the page shell, so version skew fails loudly rather than loading wrong bytes.
- `index.html` stays unhashed and `no-store`. The strict CSP is unchanged — hashed assets are same-origin, so `script-src 'self'` still covers them.
- No JS build toolchain and no new dependency: the digest is a small FNV-1a in the build script, so every CI lane builds the assets with nothing extra installed.

Scope note: this is the Rust-native pipeline (hashing, embedding, cache discipline), chosen over standing up Bun/Vite for the current vanilla frontend. The eventual Svelte frontend and its bundler are separate milestone work; a Vite build simply emits files this embedder hashes.