### PR TITLE
Rust Port: Strip and CR-normalize pasted input per the contract

### DIFF
--- a/contracts/clipboard/paste-sanitize-v1.json
+++ b/contracts/clipboard/paste-sanitize-v1.json
@@ -54,19 +54,13 @@
       "id": "bracketed-crlf-normalizes-to-cr",
       "input": "one\r\ntwo",
       "bracketed_paste": true,
-      "expected": "\u001b[200~one\rtwo\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Bracketed pastes currently normalize line endings to LF instead of CR."
-      }
+      "expected": "\u001b[200~one\rtwo\u001b[201~"
     },
     {
       "id": "bracketed-lone-lf-normalizes-to-cr",
       "input": "one\ntwo",
       "bracketed_paste": true,
-      "expected": "\u001b[200~one\rtwo\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Bracketed pastes currently normalize line endings to LF instead of CR."
-      }
+      "expected": "\u001b[200~one\rtwo\u001b[201~"
     },
     {
       "id": "tab-is-preserved",
@@ -78,92 +72,62 @@
       "id": "escape-is-stripped",
       "input": "red\u001b[31mtext",
       "bracketed_paste": false,
-      "expected": "red[31mtext",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "red[31mtext"
     },
     {
       "id": "csi-c1-is-stripped",
       "input": "a\u009b31mb",
       "bracketed_paste": false,
-      "expected": "a31mb",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "a31mb"
     },
     {
       "id": "c0-controls-are-stripped",
       "input": "a\u0000b\u0007c\bd\u000be\ff",
       "bracketed_paste": false,
-      "expected": "abcdef",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "abcdef"
     },
     {
       "id": "del-is-stripped",
       "input": "a\u007fb",
       "bracketed_paste": false,
-      "expected": "ab",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "ab"
     },
     {
       "id": "c1-controls-are-stripped",
       "input": "a\u0080b\u0085c\u009fd",
       "bracketed_paste": false,
-      "expected": "abcd",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "abcd"
     },
     {
       "id": "bracketed-escape-is-stripped",
       "input": "red\u001b[31mtext",
       "bracketed_paste": true,
-      "expected": "\u001b[200~red[31mtext\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "\u001b[200~red[31mtext\u001b[201~"
     },
     {
       "id": "bracketed-csi-c1-is-stripped",
       "input": "a\u009b31mb",
       "bracketed_paste": true,
       "expected": "\u001b[200~a31mb\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      },
       "notes": "U+009B is a single-byte end-marker equivalent on terminals that interpret C1."
     },
     {
       "id": "bracketed-c0-controls-are-stripped",
       "input": "a\u0000b\u0007c\bd",
       "bracketed_paste": true,
-      "expected": "\u001b[200~abcd\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "\u001b[200~abcd\u001b[201~"
     },
     {
       "id": "bracketed-del-and-c1-are-stripped",
       "input": "a\u007fb\u0085c",
       "bracketed_paste": true,
-      "expected": "\u001b[200~abc\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "Control characters are gated behind a paste confirmation instead of being stripped."
-      }
+      "expected": "\u001b[200~abc\u001b[201~"
     },
     {
       "id": "bracketed-end-marker-is-defused",
       "input": "safe\u001b[201~rm -rf /",
       "bracketed_paste": true,
-      "expected": "\u001b[200~safe[201~rm -rf /\u001b[201~",
-      "known_gaps": {
-        "ghosthub-input": "An embedded end marker is gated behind a paste confirmation and sent intact instead of having its escape stripped."
-      }
+      "expected": "\u001b[200~safe[201~rm -rf /\u001b[201~"
     },
     {
       "id": "multibyte-text-is-preserved",

--- a/rust/input/src/lib.rs
+++ b/rust/input/src/lib.rs
@@ -242,18 +242,16 @@ pub fn encode_input(input: &KeyInput, modes: TerminalModes) -> EncodedInput {
             event,
         } => EncodedInput::ready(encode_named(*key, *modifiers, *event, modes)),
         KeyInput::Paste(text) if modes.bracketed_paste => {
-            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-            let mut bytes = Vec::with_capacity(normalized.len() + 12);
+            let sanitized = sanitize_paste(text);
+            let mut bytes = Vec::with_capacity(sanitized.len() + 12);
             bytes.extend_from_slice(b"\x1b[200~");
-            bytes.extend_from_slice(normalized.as_bytes());
+            bytes.extend_from_slice(sanitized.as_bytes());
             bytes.extend_from_slice(b"\x1b[201~");
-            // Any embedded control other than the normalized newline or a
-            // tab is gated, matching the unbracketed arm: ESC can smuggle
-            // an end marker, and the single-byte C1 CSI (U+009B) is an
-            // end-marker equivalent on terminals that interpret C1.
-            let embedded_control = normalized
-                .chars()
-                .any(|character| character.is_control() && character != '\n' && character != '\t');
+            // The sanitized bytes above carry no smuggled controls, but an
+            // embedded control in the source still gates the paste: it is a
+            // signal the user pasted something that was rewritten. Newlines
+            // and tabs are ordinary paste content, not that signal.
+            let embedded_control = text.chars().any(is_unsafe_control);
             if embedded_control {
                 EncodedInput::confirmation_required(bytes)
             } else {
@@ -261,14 +259,46 @@ pub fn encode_input(input: &KeyInput, modes: TerminalModes) -> EncodedInput {
             }
         }
         KeyInput::Paste(text) => {
-            let normalized = text.replace("\r\n", "\n").replace('\n', "\r");
+            let sanitized = sanitize_paste(text);
+            // A bare (unbracketed) paste reaches the shell as typed input, so
+            // any control in the source — a newline auto-executes — gates it.
+            // The delivered bytes are sanitized regardless.
             if text.chars().any(char::is_control) {
-                EncodedInput::confirmation_required(normalized.into_bytes())
+                EncodedInput::confirmation_required(sanitized.into_bytes())
             } else {
-                EncodedInput::ready(normalized.into_bytes())
+                EncodedInput::ready(sanitized.into_bytes())
             }
         }
     }
+}
+
+/// A control the paste policy strips: every C0/C1/DEL control except the tab
+/// and the carriage return and line feed that newline normalization keeps.
+fn is_unsafe_control(character: char) -> bool {
+    character.is_control() && character != '\t' && character != '\r' && character != '\n'
+}
+
+/// Apply the shared paste-sanitization policy: normalize every line ending to
+/// a lone carriage return (CRLF and bare LF both become CR; a bare CR is
+/// kept), then drop unsafe controls by code point. Stripping ESC also defuses
+/// an embedded bracketed-paste end marker.
+fn sanitize_paste(text: &str) -> String {
+    let mut sanitized = String::with_capacity(text.len());
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        match character {
+            '\r' => {
+                if characters.peek() == Some(&'\n') {
+                    characters.next();
+                }
+                sanitized.push('\r');
+            }
+            '\n' => sanitized.push('\r'),
+            other if is_unsafe_control(other) => {}
+            other => sanitized.push(other),
+        }
+    }
+    sanitized
 }
 
 /// Encode one terminal-grid mouse event using SGR 1006 coordinates.

--- a/rust/input/tests/encoding_contract.rs
+++ b/rust/input/tests/encoding_contract.rs
@@ -463,7 +463,7 @@ fn bracketed_paste_is_mode_dependent() {
                 ..TerminalModes::default()
             },
         ),
-        b"\x1b[200~line one\nline two\x1b[201~"
+        b"\x1b[200~line one\rline two\x1b[201~"
     );
 }
 
@@ -479,7 +479,7 @@ fn bracketed_paste_normalizes_windows_line_endings() {
                 ..TerminalModes::default()
             },
         ),
-        b"\x1b[200~first\nsecond\nthird\nfourth\x1b[201~"
+        b"\x1b[200~first\rsecond\rthird\rfourth\x1b[201~"
     );
 }
 
@@ -496,8 +496,10 @@ fn control_characters_require_confirmation_without_bracketed_mode() {
 
     let encoded = encode_input(&input, TerminalModes::default());
 
+    // The control still gates the paste, and the delivered bytes have the
+    // ESC stripped rather than passing the control sequence through.
     assert!(encoded.requires_confirmation());
-    assert_eq!(encoded.approve(), b"echo safe\x1b[2J");
+    assert_eq!(encoded.approve(), b"echo safe[2J");
 }
 
 #[test]

--- a/rust/input/tests/paste_gating.rs
+++ b/rust/input/tests/paste_gating.rs
@@ -1,7 +1,7 @@
-//! The confirmation gate for bracketed pastes: embedded controls that
-//! could smuggle an end marker (or its single-byte C1 equivalent) never
-//! reach the PTY without explicit approval, while ordinary multi-line or
-//! tabbed pastes flow through.
+//! The confirmation gate for bracketed pastes: embedded controls that could
+//! smuggle an end marker (or its single-byte C1 equivalent) are stripped from
+//! the delivered bytes and still gate the paste behind explicit approval,
+//! while ordinary multi-line or tabbed pastes flow through.
 
 use input::{KeyInput, TerminalModes, encode_input};
 


### PR DESCRIPTION
Aligns the `ghosthub-input` paste path with the shared clipboard sanitization contract (`contracts/clipboard/paste-sanitize-v1.json`) and removes its `known_gaps` markers — one of three areas under kata jrz8.

- Delivered paste bytes now normalize every line ending to a lone carriage return (CRLF and bare LF both become CR; a bare CR is kept), matching the parsed native path.
- C0/C1/DEL controls are stripped by code point (tab is kept). Stripping ESC also defuses an embedded bracketed-paste end marker, so a paste can no longer smuggle `ESC[201~` back out of bracketed mode.
- The user confirmation gate is unchanged — a paste containing a control still prompts — but the bytes released on approval are sanitized rather than passed through raw.

The contract harness flips from asserting divergence to asserting the exact expected bytes as each marker is removed; the 12 `ghosthub-input` paste cases now pass positively. The OSC 52 and gesture-provenance areas of jrz8 remain (separate changes).