### PR TITLE
Keep remote kwt maintenance out of terminal recovery

### DIFF
--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -958,7 +958,8 @@ enum HostInventoryOverlay {
             updated.hosts[index].remoteDiagnostics.removeAll {
                 $0.code == .missingKwt
             }
-            if !isAvailable {
+            if !isAvailable,
+               updated.hosts[index].platform == .windows {
                 updated.hosts[index].remoteDiagnostics.append(
                     .missingKwtCapability
                 )

--- a/Sources/App/KwtRemoteInstaller.swift
+++ b/Sources/App/KwtRemoteInstaller.swift
@@ -488,7 +488,7 @@ actor KwtRemoteProvisioningCoordinator {
     private struct InFlight {
         let intent: Intent
         let task: Task<Void, Error>
-        var waiters: Set<UUID>
+        var waiters: [UUID: Intent]
     }
 
     private var inFlight: [HostKey: InFlight] = [:]
@@ -515,29 +515,23 @@ actor KwtRemoteProvisioningCoordinator {
             platform: host.platform.rawValue,
             sshDestination: host.sshDestination
         )
+        let waiterID = UUID()
         while true {
-            let waiterID = UUID()
             let task: Task<Void, Error>
             let runningIntent: Intent
             if var existing = inFlight[key] {
-                existing.waiters.insert(waiterID)
-                inFlight[key] = existing
+                if existing.waiters[waiterID] == nil {
+                    existing.waiters[waiterID] = requestedIntent
+                    inFlight[key] = existing
+                }
                 task = existing.task
                 runningIntent = existing.intent
             } else {
-                let installer = installer
-                task = Task {
-                    switch requestedIntent {
-                    case .ensureInstalled:
-                        try await installer.ensureInstalled(on: host)
-                    case .install:
-                        try await installer.install(on: host)
-                    }
-                }
+                task = provisioningTask(on: host, intent: requestedIntent)
                 inFlight[key] = InFlight(
                     intent: requestedIntent,
                     task: task,
-                    waiters: [waiterID]
+                    waiters: [waiterID: requestedIntent]
                 )
                 runningIntent = requestedIntent
             }
@@ -552,31 +546,64 @@ actor KwtRemoteProvisioningCoordinator {
                         await self.releaseWaiter(waiterID, for: key)
                     }
                 }
-                releaseWaiter(waiterID, for: key)
             } catch {
-                releaseWaiter(waiterID, for: key)
                 guard requestedIntent == .install,
                       runningIntent == .ensureInstalled,
                       !Task.isCancelled
-                else { throw error }
-                if inFlight[key]?.intent == .ensureInstalled {
-                    inFlight.removeValue(forKey: key)
+                else {
+                    releaseWaiter(waiterID, for: key)
+                    throw error
                 }
+                promoteEnsureToInstall(on: host, for: key)
                 continue
             }
 
             guard requestedIntent == .install,
                   runningIntent == .ensureInstalled
-            else { return }
-            if inFlight[key]?.intent == .ensureInstalled {
-                inFlight.removeValue(forKey: key)
+            else {
+                releaseWaiter(waiterID, for: key)
+                return
+            }
+            promoteEnsureToInstall(on: host, for: key)
+        }
+    }
+
+    private func provisioningTask(
+        on host: SSHHost,
+        intent: Intent
+    ) -> Task<Void, Error> {
+        let installer = installer
+        return Task {
+            switch intent {
+            case .ensureInstalled:
+                try await installer.ensureInstalled(on: host)
+            case .install:
+                try await installer.install(on: host)
             }
         }
     }
 
+    private func promoteEnsureToInstall(
+        on host: SSHHost,
+        for key: HostKey
+    ) {
+        guard let existing = inFlight[key],
+              existing.intent == .ensureInstalled
+        else { return }
+        let forcedWaiters = existing.waiters.filter {
+            $0.value == .install
+        }
+        guard !forcedWaiters.isEmpty else { return }
+        inFlight[key] = InFlight(
+            intent: .install,
+            task: provisioningTask(on: host, intent: .install),
+            waiters: forcedWaiters
+        )
+    }
+
     private func releaseWaiter(_ waiterID: UUID, for key: HostKey) {
         guard var existing = inFlight[key],
-              existing.waiters.remove(waiterID) != nil
+              existing.waiters.removeValue(forKey: waiterID) != nil
         else { return }
         guard !existing.waiters.isEmpty else {
             inFlight.removeValue(forKey: key)

--- a/Sources/App/KwtRemoteInstaller.swift
+++ b/Sources/App/KwtRemoteInstaller.swift
@@ -474,6 +474,11 @@ struct KwtRemoteInstaller: Sendable {
 actor KwtRemoteProvisioningCoordinator {
     static let shared = KwtRemoteProvisioningCoordinator()
 
+    private enum Intent: Equatable {
+        case ensureInstalled
+        case install
+    }
+
     private struct HostKey: Hashable {
         let configKey: String
         let platform: String
@@ -481,6 +486,7 @@ actor KwtRemoteProvisioningCoordinator {
     }
 
     private struct InFlight {
+        let intent: Intent
         let task: Task<Void, Error>
         var waiters: Set<UUID>
     }
@@ -493,42 +499,78 @@ actor KwtRemoteProvisioningCoordinator {
     }
 
     func ensureInstalled(on host: SSHHost) async throws {
+        try await provision(on: host, intent: .ensureInstalled)
+    }
+
+    func install(on host: SSHHost) async throws {
+        try await provision(on: host, intent: .install)
+    }
+
+    private func provision(
+        on host: SSHHost,
+        intent requestedIntent: Intent
+    ) async throws {
         let key = HostKey(
             configKey: host.configKey,
             platform: host.platform.rawValue,
             sshDestination: host.sshDestination
         )
-        let waiterID = UUID()
-        let task: Task<Void, Error>
-        if var existing = inFlight[key] {
-            existing.waiters.insert(waiterID)
-            inFlight[key] = existing
-            task = existing.task
-        } else {
-            let installer = installer
-            task = Task {
-                try await installer.ensureInstalled(on: host)
-            }
-            inFlight[key] = InFlight(
-                task: task,
-                waiters: [waiterID]
-            )
-        }
-
-        do {
-            try await withTaskCancellationHandler {
-                try Task.checkCancellation()
-                try await task.value
-                try Task.checkCancellation()
-            } onCancel: {
-                Task {
-                    await self.releaseWaiter(waiterID, for: key)
+        while true {
+            let waiterID = UUID()
+            let task: Task<Void, Error>
+            let runningIntent: Intent
+            if var existing = inFlight[key] {
+                existing.waiters.insert(waiterID)
+                inFlight[key] = existing
+                task = existing.task
+                runningIntent = existing.intent
+            } else {
+                let installer = installer
+                task = Task {
+                    switch requestedIntent {
+                    case .ensureInstalled:
+                        try await installer.ensureInstalled(on: host)
+                    case .install:
+                        try await installer.install(on: host)
+                    }
                 }
+                inFlight[key] = InFlight(
+                    intent: requestedIntent,
+                    task: task,
+                    waiters: [waiterID]
+                )
+                runningIntent = requestedIntent
             }
-            releaseWaiter(waiterID, for: key)
-        } catch {
-            releaseWaiter(waiterID, for: key)
-            throw error
+
+            do {
+                try await withTaskCancellationHandler {
+                    try Task.checkCancellation()
+                    try await task.value
+                    try Task.checkCancellation()
+                } onCancel: {
+                    Task {
+                        await self.releaseWaiter(waiterID, for: key)
+                    }
+                }
+                releaseWaiter(waiterID, for: key)
+            } catch {
+                releaseWaiter(waiterID, for: key)
+                guard requestedIntent == .install,
+                      runningIntent == .ensureInstalled,
+                      !Task.isCancelled
+                else { throw error }
+                if inFlight[key]?.intent == .ensureInstalled {
+                    inFlight.removeValue(forKey: key)
+                }
+                continue
+            }
+
+            guard requestedIntent == .install,
+                  runningIntent == .ensureInstalled
+            else { return }
+            if inFlight[key]?.intent == .ensureInstalled {
+                inFlight.removeValue(forKey: key)
+            }
         }
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2601,6 +2601,7 @@ final class WorkspaceSceneModel: ObservableObject {
         }
 
         do {
+            try await ensureRemoteKwtForOperation(hostID: project.hostID)
             try await kwtWorktreeCreator(request, project.rootPath, host)
             cancelPendingRestoration()
 
@@ -2646,6 +2647,7 @@ final class WorkspaceSceneModel: ObservableObject {
         else {
             throw KwtWorktreeError.projectUnavailable
         }
+        try await ensureRemoteKwtForOperation(hostID: project.hostID)
         return try await kwtBranchLister(project.rootPath, host)
     }
 
@@ -2671,6 +2673,7 @@ final class WorkspaceSceneModel: ObservableObject {
         ) else {
             throw KwtWorktreeError.removalIdentityUnavailable
         }
+        try await ensureRemoteKwtForOperation(hostID: project.hostID)
         let changes = try await kwtWorktreeChangeReader(
             worktree.path,
             project.rootPath,
@@ -2812,6 +2815,9 @@ final class WorkspaceSceneModel: ObservableObject {
 
         let preflight: KwtHostInventory
         do {
+            try await ensureRemoteKwtForOperation(
+                hostID: requestedProject.hostID
+            )
             preflight = try await kwtInventoryLoader(confirmedHost)
         } catch {
             recordKwtUnavailability(
@@ -3468,6 +3474,7 @@ final class WorkspaceSceneModel: ObservableObject {
             throw KwtPullRequestError.projectUnavailable
         }
         do {
+            try await ensureRemoteKwtForOperation(hostID: project.hostID)
             return try await kwtPullRequestLister(
                 project.scopedKey,
                 host
@@ -3519,6 +3526,7 @@ final class WorkspaceSceneModel: ObservableObject {
 
         let result: KwtPullRequestImportResult
         do {
+            try await ensureRemoteKwtForOperation(hostID: project.hostID)
             result = try await kwtPullRequestImporter(
                 request.pullRequestID,
                 project.scopedKey,
@@ -3983,25 +3991,15 @@ final class WorkspaceSceneModel: ObservableObject {
                             publish: false
                         )
                     case let .failure(error):
-                        if error is KwtRemoteInstallError {
-                            // Provisioning failures disable worktree actions
-                            // but remain visible because they require a
-                            // packaging, transport, or remote-host repair.
+                        if sourceHost.isRemote {
+                            // Remote kwt is optional. Keep its readiness
+                            // private so terminal inventory and recovery stay
+                            // independent while explicit worktree actions can
+                            // repair the managed helper when they need it.
                             self.kwtAvailabilityByHost[hostID] = false
-                            self.kwtInventoryFailuresByHost[hostID] =
-                                error.localizedDescription
-                        } else if self.isRemoteKwtUnavailable(
-                            error,
-                            hostID: hostID
-                        ) {
-                            // SSH hosts remain useful for ordinary tmux even
-                            // when kwt is not installed. Keep any last-known
-                            // project inventory without presenting the absent
-                            // optional capability as a host failure.
                             self.kwtInventoryFailuresByHost.removeValue(
                                 forKey: hostID
                             )
-                            self.kwtAvailabilityByHost[hostID] = false
                         } else {
                             self.kwtInventoryFailuresByHost[hostID] =
                                 error.localizedDescription
@@ -6314,6 +6312,37 @@ final class WorkspaceSceneModel: ObservableObject {
         )
     }
 
+    private func ensureRemoteKwtForOperation(
+        on host: SSHHost,
+        hostID: UUID? = nil
+    ) async throws {
+        guard host.platform == .macOS || host.platform == .linux else {
+            return
+        }
+        do {
+            try await kwtRemoteProvisioner(host)
+            if let hostID {
+                kwtAvailabilityByHost[hostID] = true
+                kwtInventoryFailuresByHost.removeValue(forKey: hostID)
+                applyInventoryOverlayIfNeeded()
+                updateWorkspaceInventoryState()
+            }
+        } catch {
+            if let hostID {
+                kwtAvailabilityByHost[hostID] = false
+                kwtInventoryFailuresByHost.removeValue(forKey: hostID)
+                applyInventoryOverlayIfNeeded()
+                updateWorkspaceInventoryState()
+            }
+            throw error
+        }
+    }
+
+    private func ensureRemoteKwtForOperation(hostID: UUID) async throws {
+        guard let host = configuredSSHHost(for: hostID) else { return }
+        try await ensureRemoteKwtForOperation(on: host, hostID: hostID)
+    }
+
     private func resolvedSSHHost(
         _ host: SSHHost
     ) -> (info: SSHHostInfo, destination: String)? {
@@ -6507,7 +6536,7 @@ final class WorkspaceSceneModel: ObservableObject {
                     "Run the tmux version command on the host and resolve "
                         + "the reported error, then test again."
                 )]
-            } else if !kwtAvailable {
+            } else if !kwtAvailable, host.platform == .windows {
                 diagnostics = [.missingKwtCapability]
             } else {
                 diagnostics = []
@@ -6588,7 +6617,10 @@ final class WorkspaceSceneModel: ObservableObject {
         on host: SSHHost
     ) async -> Result<Void, HostProbeError> {
         do {
-            try await KwtRemoteInstaller().install(on: host)
+            let hostID = snapshot.hosts.first {
+                $0.configKey == host.configKey
+            }?.id
+            try await ensureRemoteKwtForOperation(on: host, hostID: hostID)
             refreshHosts()
             refreshKwtInventory()
             return .success(())
@@ -6630,7 +6662,11 @@ final class WorkspaceSceneModel: ObservableObject {
         ))
         return await performProjectRegistration(
             projectPath,
-            on: target
+            on: target,
+            provisioningHost: host,
+            hostID: snapshot.hosts.first {
+                $0.configKey == host.configKey
+            }?.id
         )
     }
 
@@ -6651,13 +6687,17 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         return await performProjectRegistration(
             projectPath,
-            on: currentTarget
+            on: currentTarget,
+            provisioningHost: configuredSSHHost(for: host.id),
+            hostID: host.kind == .remote ? host.id : nil
         )
     }
 
     private func performProjectRegistration(
         _ projectPath: String,
-        on target: CommandHost
+        on target: CommandHost,
+        provisioningHost: SSHHost?,
+        hostID: UUID?
     ) async -> Result<String, HostProbeError> {
         let registryHost = projectRegistryHost(for: target)
         guard worktreeMutationCoordinator.acquireProjectRegistry(
@@ -6673,6 +6713,12 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         }
         do {
+            if let provisioningHost {
+                try await ensureRemoteKwtForOperation(
+                    on: provisioningHost,
+                    hostID: hostID
+                )
+            }
             let project = try await kwtProjectRegistration(
                 projectPath,
                 target
@@ -6819,6 +6865,9 @@ final class WorkspaceSceneModel: ObservableObject {
         }
 
         do {
+            try await ensureRemoteKwtForOperation(
+                hostID: initial.project.hostID
+            )
             let refreshed = try await kwtInventoryLoader(initial.host)
             if let warning = refreshed.projectsWarning {
                 return .failure(projectRemovalInventoryError(warning))
@@ -9325,9 +9374,8 @@ final class WorkspaceSceneModel: ObservableObject {
             ?? host.tmuxSessions
         let sessionIsDiscovered = selection.socketName == nil
             && knownSessions.contains { $0.name == selection.name }
-        let managedKwtUnavailable = host.remoteDiagnostics.contains {
-            $0.code == .missingKwt
-        }
+        let managedKwtUnavailable =
+            kwtAvailabilityByHost[selection.hostID] == false
         let openWorkspace = intent == .userInitiated
             && effectiveLaunchMode == .attach
             && selection.tmuxAttachMode == .direct
@@ -12144,9 +12192,8 @@ final class WorkspaceSceneModel: ObservableObject {
             ?? host.tmuxSessions
         let sessionIsDiscovered = selection.socketName == nil
             && knownSessions.contains { $0.name == selection.name }
-        let managedKwtUnavailable = host.remoteDiagnostics.contains {
-            $0.code == .missingKwt
-        }
+        let managedKwtUnavailable =
+            kwtAvailabilityByHost[selection.hostID] == false
         let openWorkspace = intent == .userInitiated
             && launchMode == .attach
             && selection.tmuxAttachMode == .direct

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -463,6 +463,7 @@ final class WorkspaceSceneModel: ObservableObject {
         var routeIdentity: String?
         var phase: RemoteTmuxEstablishmentPhase
         var surfaceExitCode: UInt32?
+        var usesKwtWorkspaceCommand = false
         /// The previous attempt failed before the terminal client could start,
         /// so there is no exit code to inspect and replay is still safe.
         var surfaceLaunchFailed = false
@@ -3530,6 +3531,10 @@ final class WorkspaceSceneModel: ObservableObject {
         hostID: UUID
     ) {
         guard isRemoteKwtUnavailable(error, hostID: hostID) else { return }
+        markRemoteKwtUnavailable(hostID: hostID)
+    }
+
+    private func markRemoteKwtUnavailable(hostID: UUID) {
         kwtAvailabilityByHost[hostID] = false
         kwtInventoryFailuresByHost.removeValue(forKey: hostID)
         applyInventoryOverlayIfNeeded()
@@ -6434,12 +6439,11 @@ final class WorkspaceSceneModel: ObservableObject {
                 applyInventoryOverlayIfNeeded()
                 updateWorkspaceInventoryState()
             }
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             if let hostID {
-                kwtAvailabilityByHost[hostID] = false
-                kwtInventoryFailuresByHost.removeValue(forKey: hostID)
-                applyInventoryOverlayIfNeeded()
-                updateWorkspaceInventoryState()
+                markRemoteKwtUnavailable(hostID: hostID)
             }
             throw error
         }
@@ -9592,7 +9596,8 @@ final class WorkspaceSceneModel: ObservableObject {
                 routeIdentity: nativeTmuxSessionCoordinator
                     .attachmentRouteIdentity(handle),
                 phase: phase,
-                surfaceExitCode: nil
+                surfaceExitCode: nil,
+                usesKwtWorkspaceCommand: openWorkspace
             )
             : nil
         let presentation = RetainedTmuxPresentation(
@@ -10925,6 +10930,11 @@ final class WorkspaceSceneModel: ObservableObject {
                nativeTmuxSessionCoordinator.attachmentClosure(handle) {
                 presentation.establishmentConfirmationTask?.cancel()
                 presentation.establishmentConfirmationTask = nil
+                if code == 127, context.usesKwtWorkspaceCommand {
+                    markRemoteKwtUnavailable(
+                        hostID: context.selection.hostID
+                    )
+                }
                 context.surfaceExitCode = code
                 presentation.reconnectContext = context
                 startTmuxReconnect(presentation, context: context)
@@ -12242,6 +12252,8 @@ final class WorkspaceSceneModel: ObservableObject {
         case .present:
             guard context.surfaceExitCode == 255
                 || context.surfaceLaunchFailed
+                || (context.surfaceExitCode == 127
+                    && context.usesKwtWorkspaceCommand)
             else {
                 stopTmuxReconnectWithUnableToAttach(
                     presentation,
@@ -12419,7 +12431,8 @@ final class WorkspaceSceneModel: ObservableObject {
             host: attachmentHost,
             routeIdentity: routeIdentity,
             phase: phase,
-            surfaceExitCode: nil
+            surfaceExitCode: nil,
+            usesKwtWorkspaceCommand: openWorkspace
         )
         borrowedTmuxConnectionStates[handle.id] = .connecting
         if activeBorrowedTmuxHandle == previousHandle {

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2637,12 +2637,7 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             scheduleTmuxSessionDiscovery()
         } catch {
-            if isRemoteKwtUnavailable(error, hostID: project.hostID) {
-                kwtAvailabilityByHost[project.hostID] = false
-                kwtInventoryFailuresByHost.removeValue(forKey: project.hostID)
-                applyInventoryOverlayIfNeeded()
-                updateWorkspaceInventoryState()
-            }
+            recordKwtUnavailability(error, hostID: project.hostID)
             throw error
         }
 
@@ -2672,17 +2667,22 @@ final class WorkspaceSceneModel: ObservableObject {
         else {
             throw KwtWorktreeError.projectUnavailable
         }
-        try await ensureRemoteKwtForOperation(hostID: project.hostID)
-        guard let current = validatedProjectOperationTarget(
-            project,
-            capturedHost: host
-        ) else {
-            throw KwtWorktreeError.projectUnavailable
+        do {
+            try await ensureRemoteKwtForOperation(hostID: project.hostID)
+            guard let current = validatedProjectOperationTarget(
+                project,
+                capturedHost: host
+            ) else {
+                throw KwtWorktreeError.projectUnavailable
+            }
+            return try await kwtBranchLister(
+                current.project.rootPath,
+                current.host
+            )
+        } catch {
+            recordKwtUnavailability(error, hostID: project.hostID)
+            throw error
         }
-        return try await kwtBranchLister(
-            current.project.rootPath,
-            current.host
-        )
     }
 
     func prepareWorktreeRemoval(
@@ -2707,18 +2707,24 @@ final class WorkspaceSceneModel: ObservableObject {
         ) else {
             throw KwtWorktreeError.removalIdentityUnavailable
         }
-        try await ensureRemoteKwtForOperation(hostID: project.hostID)
-        guard validatedProjectOperationTarget(
-            project,
-            capturedHost: host
-        ) != nil else {
-            throw KwtWorktreeError.removalHostChanged
+        let changes: WorktreeChangeSummary
+        do {
+            try await ensureRemoteKwtForOperation(hostID: project.hostID)
+            guard validatedProjectOperationTarget(
+                project,
+                capturedHost: host
+            ) != nil else {
+                throw KwtWorktreeError.removalHostChanged
+            }
+            changes = try await kwtWorktreeChangeReader(
+                worktree.path,
+                project.rootPath,
+                host
+            )
+        } catch {
+            recordKwtUnavailability(error, hostID: project.hostID)
+            throw error
         }
-        let changes = try await kwtWorktreeChangeReader(
-            worktree.path,
-            project.rootPath,
-            host
-        )
 
         let sessionKillRequest: TmuxSessionKillRequest?
         if let session = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -2889,11 +2895,17 @@ final class WorkspaceSceneModel: ObservableObject {
             throw KwtWorktreeError.removalTargetChanged
         }
         if !checkoutAlreadyAbsent {
-            let currentChanges = try await kwtWorktreeChangeReader(
-                worktree.path,
-                project.rootPath,
-                confirmedHost
-            )
+            let currentChanges: WorktreeChangeSummary
+            do {
+                currentChanges = try await kwtWorktreeChangeReader(
+                    worktree.path,
+                    project.rootPath,
+                    confirmedHost
+                )
+            } catch {
+                recordKwtUnavailability(error, hostID: project.hostID)
+                throw error
+            }
             guard removalHostEndpointMatches(request) else {
                 throw KwtWorktreeError.removalHostChanged
             }
@@ -2984,14 +2996,34 @@ final class WorkspaceSceneModel: ObservableObject {
                     let killedRestorationTarget = terminatedSession
                         ? outcome.restorationTargets?.first
                         : nil
+                    let shouldReadChanges: Bool
                     if !request.forceRemoval,
                        let worktreeError = removalError as? KwtWorktreeError,
-                       case .removalFailed = worktreeError,
-                       let changes = try? await kwtWorktreeChangeReader(
-                           worktree.path,
-                           project.rootPath,
-                           confirmedHost
-                       ),
+                       case .removalFailed = worktreeError {
+                        shouldReadChanges = true
+                    } else {
+                        shouldReadChanges = false
+                    }
+                    let changes: WorktreeChangeSummary?
+                    if shouldReadChanges {
+                        do {
+                            changes = try await kwtWorktreeChangeReader(
+                                worktree.path,
+                                project.rootPath,
+                                confirmedHost
+                            )
+                        } catch {
+                            recordKwtUnavailability(
+                                error,
+                                hostID: project.hostID
+                            )
+                            changes = nil
+                        }
+                    } else {
+                        changes = nil
+                    }
+                    if shouldReadChanges,
+                       let changes,
                        removalHostEndpointMatches(request),
                        !terminatedSession || killedRestorationTarget != nil,
                        changes.hasUncommittedChanges {
@@ -3031,9 +3063,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 ]
             )
         } catch {
-            if isRemoteKwtUnavailable(error, hostID: project.hostID) {
-                kwtAvailabilityByHost[project.hostID] = false
-            }
+            recordKwtUnavailability(error, hostID: project.hostID)
             kwtInventoryFailuresByHost[project.hostID] =
                 "The worktree was removed, but inventory refresh failed: "
                     + error.localizedDescription
@@ -3529,11 +3559,7 @@ final class WorkspaceSceneModel: ObservableObject {
                 current.host
             )
         } catch {
-            if isRemoteKwtUnavailable(error, hostID: project.hostID) {
-                kwtAvailabilityByHost[project.hostID] = false
-                applyInventoryOverlayIfNeeded()
-                updateWorkspaceInventoryState()
-            }
+            recordKwtUnavailability(error, hostID: project.hostID)
             throw error
         }
     }
@@ -3594,17 +3620,11 @@ final class WorkspaceSceneModel: ObservableObject {
             operation = (result, current.project, current.host)
             cancelPendingRestoration()
         } catch {
-            if isRemoteKwtUnavailable(error, hostID: project.hostID) {
-                kwtAvailabilityByHost[project.hostID] = false
-                kwtInventoryFailuresByHost.removeValue(
-                    forKey: project.hostID
-                )
-                applyInventoryOverlayIfNeeded()
-                updateWorkspaceInventoryState()
-            }
+            recordKwtUnavailability(error, hostID: project.hostID)
             throw error
         }
 
+        kwtAvailabilityByHost[operation.project.hostID] = true
         do {
             let refreshed = try await kwtInventoryLoader(operation.host)
             applyAuthoritativeKwtInventory(
@@ -3612,6 +3632,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 hostID: operation.project.hostID
             )
         } catch {
+            recordKwtUnavailability(
+                error,
+                hostID: operation.project.hostID
+            )
             kwtInventoryFailuresByHost[operation.project.hostID] =
                 error.localizedDescription
         }
@@ -3620,7 +3644,6 @@ final class WorkspaceSceneModel: ObservableObject {
             operation.result.workspace,
             project: operation.project
         )
-        kwtAvailabilityByHost[operation.project.hostID] = true
         applyInventoryOverlayIfNeeded()
         annotateImportedPullRequest(
             operation.result.pullRequest,
@@ -5100,8 +5123,16 @@ final class WorkspaceSceneModel: ObservableObject {
            case .removalFailed(_, 127) = worktreeError {
             return true
         }
+        if let worktreeError = error as? KwtWorktreeError,
+           case .changeStatusFailed(_, 127) = worktreeError {
+            return true
+        }
         if let pullRequestError = error as? KwtPullRequestError,
            case .commandFailed(_, 127, _, _, _) = pullRequestError {
+            return true
+        }
+        if let projectError = error as? KwtProjectCommandError,
+           case .commandFailed(_, 127, _, _, _, _) = projectError {
             return true
         }
         return false
@@ -6825,6 +6856,9 @@ final class WorkspaceSceneModel: ObservableObject {
             refreshKwtInventory()
             return .success(project.name)
         } catch {
+            if let hostID {
+                recordKwtUnavailability(error, hostID: hostID)
+            }
             return .failure(.message(error.localizedDescription))
         }
     }
@@ -7078,6 +7112,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 return .success(removed.name)
             } catch {
                 let removalError = error
+                recordKwtUnavailability(
+                    removalError,
+                    hostID: removal.project.hostID
+                )
                 if case let .commandFailed(
                     _, _, code, _, _, _
                 ) = removalError as? KwtProjectCommandError,
@@ -7150,6 +7188,10 @@ final class WorkspaceSceneModel: ObservableObject {
                 }
             }
         } catch {
+            recordKwtUnavailability(
+                error,
+                hostID: initial.project.hostID
+            )
             return .failure(.message(error.localizedDescription))
         }
     }
@@ -7249,6 +7291,7 @@ final class WorkspaceSceneModel: ObservableObject {
             )
             return .removed
         } catch {
+            recordKwtUnavailability(error, hostID: project.hostID)
             return .unverified
         }
     }

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -2602,13 +2602,23 @@ final class WorkspaceSceneModel: ObservableObject {
 
         do {
             try await ensureRemoteKwtForOperation(hostID: project.hostID)
-            try await kwtWorktreeCreator(request, project.rootPath, host)
+            guard let current = validatedProjectOperationTarget(
+                project,
+                capturedHost: host
+            ) else {
+                throw KwtWorktreeError.projectUnavailable
+            }
+            try await kwtWorktreeCreator(
+                request,
+                current.project.rootPath,
+                current.host
+            )
             cancelPendingRestoration()
 
-            let refreshed = try await kwtInventoryLoader(host)
+            let refreshed = try await kwtInventoryLoader(current.host)
             applyAuthoritativeKwtInventory(
                 refreshed,
-                hostID: project.hostID
+                hostID: current.project.hostID
             )
             scheduleTmuxSessionDiscovery()
         } catch {
@@ -2648,7 +2658,16 @@ final class WorkspaceSceneModel: ObservableObject {
             throw KwtWorktreeError.projectUnavailable
         }
         try await ensureRemoteKwtForOperation(hostID: project.hostID)
-        return try await kwtBranchLister(project.rootPath, host)
+        guard let current = validatedProjectOperationTarget(
+            project,
+            capturedHost: host
+        ) else {
+            throw KwtWorktreeError.projectUnavailable
+        }
+        return try await kwtBranchLister(
+            current.project.rootPath,
+            current.host
+        )
     }
 
     func prepareWorktreeRemoval(
@@ -2674,6 +2693,12 @@ final class WorkspaceSceneModel: ObservableObject {
             throw KwtWorktreeError.removalIdentityUnavailable
         }
         try await ensureRemoteKwtForOperation(hostID: project.hostID)
+        guard validatedProjectOperationTarget(
+            project,
+            capturedHost: host
+        ) != nil else {
+            throw KwtWorktreeError.removalHostChanged
+        }
         let changes = try await kwtWorktreeChangeReader(
             worktree.path,
             project.rootPath,
@@ -2818,6 +2843,9 @@ final class WorkspaceSceneModel: ObservableObject {
             try await ensureRemoteKwtForOperation(
                 hostID: requestedProject.hostID
             )
+            guard removalHostEndpointMatches(request) else {
+                throw KwtWorktreeError.removalHostChanged
+            }
             preflight = try await kwtInventoryLoader(confirmedHost)
         } catch {
             recordKwtUnavailability(
@@ -3475,9 +3503,15 @@ final class WorkspaceSceneModel: ObservableObject {
         }
         do {
             try await ensureRemoteKwtForOperation(hostID: project.hostID)
+            guard let current = validatedProjectOperationTarget(
+                project,
+                capturedHost: host
+            ) else {
+                throw KwtPullRequestError.projectUnavailable
+            }
             return try await kwtPullRequestLister(
-                project.scopedKey,
-                host
+                current.project.scopedKey,
+                current.host
             )
         } catch {
             if isRemoteKwtUnavailable(error, hostID: project.hostID) {
@@ -3524,14 +3558,25 @@ final class WorkspaceSceneModel: ObservableObject {
             )
         }
 
-        let result: KwtPullRequestImportResult
+        let operation: (
+            result: KwtPullRequestImportResult,
+            project: ProjectSummary,
+            host: CommandHost
+        )
         do {
             try await ensureRemoteKwtForOperation(hostID: project.hostID)
-            result = try await kwtPullRequestImporter(
+            guard let current = validatedProjectOperationTarget(
+                project,
+                capturedHost: host
+            ) else {
+                throw KwtPullRequestError.projectUnavailable
+            }
+            let result = try await kwtPullRequestImporter(
                 request.pullRequestID,
-                project.scopedKey,
-                host
+                current.project.scopedKey,
+                current.host
             )
+            operation = (result, current.project, current.host)
             cancelPendingRestoration()
         } catch {
             if isRemoteKwtUnavailable(error, hostID: project.hostID) {
@@ -3546,42 +3591,42 @@ final class WorkspaceSceneModel: ObservableObject {
         }
 
         do {
-            let refreshed = try await kwtInventoryLoader(host)
+            let refreshed = try await kwtInventoryLoader(operation.host)
             applyAuthoritativeKwtInventory(
                 refreshed,
-                hostID: project.hostID
+                hostID: operation.project.hostID
             )
         } catch {
-            kwtInventoryFailuresByHost[project.hostID] =
+            kwtInventoryFailuresByHost[operation.project.hostID] =
                 error.localizedDescription
         }
 
         mergeImportedWorkspace(
-            result.workspace,
-            project: project
+            operation.result.workspace,
+            project: operation.project
         )
-        kwtAvailabilityByHost[project.hostID] = true
+        kwtAvailabilityByHost[operation.project.hostID] = true
         applyInventoryOverlayIfNeeded()
         annotateImportedPullRequest(
-            result.pullRequest,
-            workspace: result.workspace,
-            hostID: project.hostID
+            operation.result.pullRequest,
+            workspace: operation.result.workspace,
+            hostID: operation.project.hostID
         )
         updateWorkspaceInventoryState()
         scheduleTmuxSessionDiscovery()
 
-        guard let imported = snapshot.worktrees.first(where: {
-            $0.hostID == project.hostID
+        guard let importedWorktree = snapshot.worktrees.first(where: {
+            $0.hostID == operation.project.hostID
                 && normalizedWorkspacePath($0.path)
-                == normalizedWorkspacePath(result.workspace.path)
+                == normalizedWorkspacePath(operation.result.workspace.path)
         }) else {
             throw KwtPullRequestError.importedWorkspaceMissing(
-                path: result.workspace.path
+                path: operation.result.workspace.path
             )
         }
         var importedSelection = selection
         importedSelection.select(
-            .worktree(imported.id),
+            .worktree(importedWorktree.id),
             in: snapshot,
             visibility: worktreeVisibility
         )
@@ -6666,7 +6711,8 @@ final class WorkspaceSceneModel: ObservableObject {
             provisioningHost: host,
             hostID: snapshot.hosts.first {
                 $0.configKey == host.configKey
-            }?.id
+            }?.id,
+            revalidatingHostID: nil
         )
     }
 
@@ -6689,7 +6735,8 @@ final class WorkspaceSceneModel: ObservableObject {
             projectPath,
             on: currentTarget,
             provisioningHost: configuredSSHHost(for: host.id),
-            hostID: host.kind == .remote ? host.id : nil
+            hostID: host.kind == .remote ? host.id : nil,
+            revalidatingHostID: host.id
         )
     }
 
@@ -6697,7 +6744,8 @@ final class WorkspaceSceneModel: ObservableObject {
         _ projectPath: String,
         on target: CommandHost,
         provisioningHost: SSHHost?,
-        hostID: UUID?
+        hostID: UUID?,
+        revalidatingHostID: UUID?
     ) async -> Result<String, HostProbeError> {
         let registryHost = projectRegistryHost(for: target)
         guard worktreeMutationCoordinator.acquireProjectRegistry(
@@ -6718,6 +6766,18 @@ final class WorkspaceSceneModel: ObservableObject {
                     on: provisioningHost,
                     hostID: hostID
                 )
+            }
+            if let revalidatingHostID {
+                guard let currentHost = snapshot.host(
+                    id: revalidatingHostID
+                ),
+                    CommandHostResolver.resolve(currentHost) == target
+                else {
+                    return .failure(.message(
+                        "The host connection changed. "
+                            + "Close Add Project and try again."
+                    ))
+                }
             }
             let project = try await kwtProjectRegistration(
                 projectPath,
@@ -6868,6 +6928,13 @@ final class WorkspaceSceneModel: ObservableObject {
             try await ensureRemoteKwtForOperation(
                 hostID: initial.project.hostID
             )
+            guard validatedProjectRemovalTarget(
+                project,
+                confirmedHostID: confirmedHost.id,
+                capturedTarget: capturedTarget
+            ) != nil else {
+                return .failure(projectRemovalTargetChangedError)
+            }
             let refreshed = try await kwtInventoryLoader(initial.host)
             if let warning = refreshed.projectsWarning {
                 return .failure(projectRemovalInventoryError(warning))
@@ -7161,6 +7228,24 @@ final class WorkspaceSceneModel: ObservableObject {
         .message(
             "The project or host connection changed. Try removing it again."
         )
+    }
+
+    private func validatedProjectOperationTarget(
+        _ capturedProject: ProjectSummary,
+        capturedHost: CommandHost
+    ) -> (project: ProjectSummary, host: CommandHost)? {
+        guard let currentProject = snapshot.project(id: capturedProject.id),
+              currentProject.hostID == capturedProject.hostID,
+              currentProject.scopedKey == capturedProject.scopedKey,
+              currentProject.registryID == capturedProject.registryID,
+              currentProject.rootPath == capturedProject.rootPath,
+              currentProject.registrationFingerprint
+              == capturedProject.registrationFingerprint,
+              let currentHost = snapshot.host(id: capturedProject.hostID),
+              let currentTarget = CommandHostResolver.resolve(currentHost),
+              currentTarget == capturedHost
+        else { return nil }
+        return (currentProject, currentTarget)
     }
 
     private func projectRemovalInventoryError(

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -6720,10 +6720,12 @@ final class WorkspaceSceneModel: ObservableObject {
             port: sshHost.port,
             platform: host.platform == .windows ? .windows : .posix
         ))
+        var provisioningHost = host
+        provisioningHost.sshDestination = destination
         return await performProjectRegistration(
             projectPath,
             on: target,
-            provisioningHost: host,
+            provisioningHost: provisioningHost,
             hostID: snapshot.hosts.first {
                 $0.configKey == host.configKey
             }?.id,

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -6779,14 +6779,15 @@ final class WorkspaceSceneModel: ObservableObject {
         ))
         var provisioningHost = host
         provisioningHost.sshDestination = destination
+        let hostID = snapshot.hosts.first {
+            $0.configKey == host.configKey
+        }?.id
         return await performProjectRegistration(
             projectPath,
             on: target,
             provisioningHost: provisioningHost,
-            hostID: snapshot.hosts.first {
-                $0.configKey == host.configKey
-            }?.id,
-            revalidatingHostID: nil
+            hostID: hostID,
+            revalidatingHostID: hostID
         )
     }
 

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -58,6 +58,9 @@ final class WorkspaceSceneModel: ObservableObject {
     typealias KwtRemoteProvisioner = @Sendable (
         SSHHost
     ) async throws -> Void
+    typealias KwtRemoteInstalling = @Sendable (
+        SSHHost
+    ) async throws -> Void
     typealias KwtWorktreeCreator = @Sendable (
         WorktreeCreateRequest, String, CommandHost
     ) async throws -> Void
@@ -813,6 +816,7 @@ final class WorkspaceSceneModel: ObservableObject {
     private let kwtInventoryLoader: KwtInventoryLoader
     private let kwtConditionalInventoryLoader: KwtConditionalInventoryLoader
     private let kwtRemoteProvisioner: KwtRemoteProvisioner
+    private let kwtRemoteInstaller: KwtRemoteInstalling
     private let kwtWorktreeCreator: KwtWorktreeCreator
     private let kwtWorktreeRemover: KwtWorktreeRemover
     private let kwtForceWorktreeRemover: KwtWorktreeRemover
@@ -1054,6 +1058,10 @@ final class WorkspaceSceneModel: ObservableObject {
         kwtRemoteProvisioner: @escaping KwtRemoteProvisioner = { host in
             try await KwtRemoteProvisioningCoordinator.shared
                 .ensureInstalled(on: host)
+        },
+        kwtRemoteInstaller: @escaping KwtRemoteInstalling = { host in
+            try await KwtRemoteProvisioningCoordinator.shared
+                .install(on: host)
         },
         kwtWorktreeCreator: @escaping KwtWorktreeCreator = {
             request, projectPath, host in
@@ -1391,6 +1399,7 @@ final class WorkspaceSceneModel: ObservableObject {
         self.kwtInventoryLoader = kwtInventoryLoader
         self.kwtConditionalInventoryLoader = kwtConditionalInventoryLoader
         self.kwtRemoteProvisioner = kwtRemoteProvisioner
+        self.kwtRemoteInstaller = kwtRemoteInstaller
         self.kwtWorktreeCreator = kwtWorktreeCreator
         self.kwtWorktreeRemover = kwtWorktreeRemover
         self.kwtForceWorktreeRemover = kwtForceWorktreeRemover
@@ -6665,7 +6674,13 @@ final class WorkspaceSceneModel: ObservableObject {
             let hostID = snapshot.hosts.first {
                 $0.configKey == host.configKey
             }?.id
-            try await ensureRemoteKwtForOperation(on: host, hostID: hostID)
+            try await kwtRemoteInstaller(host)
+            if let hostID {
+                kwtAvailabilityByHost[hostID] = true
+                kwtInventoryFailuresByHost.removeValue(forKey: hostID)
+                applyInventoryOverlayIfNeeded()
+                updateWorkspaceInventoryState()
+            }
             refreshHosts()
             refreshKwtInventory()
             return .success(())

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -43,6 +43,12 @@ private func presentGhosthubAlert(
 
 @MainActor
 final class WorkspaceSceneModel: ObservableObject {
+    private enum KwtInventoryRefreshOutcome: Sendable {
+        case loaded(KwtHostInventory)
+        case provisioningFailed
+        case inventoryFailed(any Error)
+    }
+
     nonisolated static func runReconnectValidationProbe<Value: Sendable>(
         _ operation: @escaping @Sendable () -> Value
     ) async -> Value {
@@ -4003,36 +4009,44 @@ final class WorkspaceSceneModel: ObservableObject {
                 of: (
                     UUID,
                     CommandHost,
-                    Result<KwtHostInventory, Error>
+                    KwtInventoryRefreshOutcome
                 ).self
             ) { group in
                 for (hostID, host) in targets {
                     group.addTask {
-                        do {
-                            if let remoteHost =
-                                automaticProvisioningHosts[hostID] {
+                        if let remoteHost =
+                            automaticProvisioningHosts[hostID] {
+                            do {
                                 try await kwtRemoteProvisioner(remoteHost)
+                            } catch {
+                                return (
+                                    hostID,
+                                    host,
+                                    .provisioningFailed
+                                )
                             }
+                        }
+                        do {
                             return await (
                                 hostID,
                                 host,
-                                .success(
+                                .loaded(
                                     try kwtInventoryLoader(host)
                                 )
                             )
                         } catch {
-                            return (hostID, host, .failure(error))
+                            return (hostID, host, .inventoryFailed(error))
                         }
                     }
                 }
-                for await (hostID, sourceHost, result) in group {
+                for await (hostID, sourceHost, outcome) in group {
                     guard let self, !Task.isCancelled,
                           generation == self.kwtInventoryGeneration else {
                         group.cancelAll()
                         return
                     }
-                    switch result {
-                    case let .success(inventory):
+                    switch outcome {
+                    case let .loaded(inventory):
                         let tombstones =
                             self.activeRemovalTombstones(
                                 after: inventory,
@@ -4044,12 +4058,20 @@ final class WorkspaceSceneModel: ObservableObject {
                             excludingWorktrees: tombstones,
                             publish: false
                         )
-                    case let .failure(error):
-                        if sourceHost.isRemote {
-                            // Remote kwt is optional. Keep its readiness
-                            // private so terminal inventory and recovery stay
-                            // independent while explicit worktree actions can
-                            // repair the managed helper when they need it.
+                    case .provisioningFailed:
+                        // Remote kwt is optional. Keep passive maintenance
+                        // failures private so terminal inventory and recovery
+                        // stay independent while explicit worktree actions can
+                        // repair the managed helper when they need it.
+                        self.kwtAvailabilityByHost[hostID] = false
+                        self.kwtInventoryFailuresByHost.removeValue(
+                            forKey: hostID
+                        )
+                    case let .inventoryFailed(error):
+                        if self.isRemoteKwtUnavailable(
+                            error,
+                            hostID: hostID
+                        ) {
                             self.kwtAvailabilityByHost[hostID] = false
                             self.kwtInventoryFailuresByHost.removeValue(
                                 forKey: hostID
@@ -4063,7 +4085,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         hostID: hostID,
                         includeKwtInventory: true
                     )
-                    if case let .success(inventory) = result {
+                    if case let .loaded(inventory) = outcome {
                         self.reconcileRetainedTmuxPresentations(
                             afterAuthoritativeInventoryFor: hostID
                         )

--- a/Tests/App/KwtRemoteInstallerTests.swift
+++ b/Tests/App/KwtRemoteInstallerTests.swift
@@ -112,6 +112,139 @@ struct KwtRemoteInstallerTests {
         #expect(recorder.destination == nil)
     }
 
+    @Test("explicit coordinator install replaces an exact helper")
+    func coordinatorPreservesForcedInstall() async throws {
+        let revision = String(repeating: "8", count: 40)
+        let helperURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try Data("pinned kwt".utf8).write(to: helperURL)
+        defer { try? FileManager.default.removeItem(at: helperURL) }
+        let recorder = KwtInstallRecorder()
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, _, command in
+                recorder.record(command: command)
+                if command == KwtRemoteInstaller.targetProbeCommand {
+                    return installOutput(
+                        0,
+                        "GHOSTHUB_KWT_TARGET\tLinux\taarch64\n"
+                    )
+                }
+                if command.contains("GHOSTHUB_KWT_UPLOAD") {
+                    return installOutput(
+                        0,
+                        "GHOSTHUB_KWT_UPLOAD\t/var/tmp/ghosthub/"
+                            + "helpers/kwt/\(revision)/.incoming-test\n"
+                    )
+                }
+                return installOutput(0, "GHOSTHUB_KWT_INSTALLED\n")
+            },
+            uploadRunner: { host, source, destination, _ in
+                recorder.record(
+                    host: host,
+                    source: source,
+                    destination: destination
+                )
+                return installOutput(0)
+            },
+            resourceProvider: { _ in helperURL }
+        )
+        let coordinator = KwtRemoteProvisioningCoordinator(
+            installer: installer
+        )
+
+        try await coordinator.install(on: SSHHost(
+            configKey: "linux-build",
+            name: "Linux Build Host",
+            platform: .linux,
+            sshDestination: "operator@build.example.test"
+        ))
+
+        #expect(!recorder.commands.contains(
+            KwtRemoteInstaller.readyProbeCommand(revision: revision)
+        ))
+        #expect(recorder.destination != nil)
+    }
+
+    @Test("explicit install retries after a concurrent passive failure")
+    func forcedInstallFollowsFailedPassiveProvisioning() async throws {
+        let revision = String(repeating: "7", count: 40)
+        let helperURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try Data("pinned kwt".utf8).write(to: helperURL)
+        defer { try? FileManager.default.removeItem(at: helperURL) }
+        let firstProbe = BlockingGate()
+        let targetProbeCalls = LockedValue(0)
+        let recorder = KwtInstallRecorder()
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, _, command in
+                recorder.record(command: command)
+                if command == KwtRemoteInstaller.readyProbeCommand(
+                    revision: revision
+                ) {
+                    return installOutput(1)
+                }
+                if command == KwtRemoteInstaller.targetProbeCommand {
+                    targetProbeCalls.withLock { $0 += 1 }
+                    let call = targetProbeCalls.load()
+                    if call == 1 {
+                        firstProbe.block()
+                        return installOutput(1)
+                    }
+                    return installOutput(
+                        0,
+                        "GHOSTHUB_KWT_TARGET\tLinux\taarch64\n"
+                    )
+                }
+                if command.contains("GHOSTHUB_KWT_UPLOAD") {
+                    return installOutput(
+                        0,
+                        "GHOSTHUB_KWT_UPLOAD\t/var/tmp/ghosthub/"
+                            + "helpers/kwt/\(revision)/.incoming-test\n"
+                    )
+                }
+                return installOutput(0, "GHOSTHUB_KWT_INSTALLED\n")
+            },
+            uploadRunner: { host, source, destination, _ in
+                recorder.record(
+                    host: host,
+                    source: source,
+                    destination: destination
+                )
+                return installOutput(0)
+            },
+            resourceProvider: { _ in helperURL }
+        )
+        let coordinator = KwtRemoteProvisioningCoordinator(
+            installer: installer
+        )
+        let host = SSHHost(
+            configKey: "linux-build",
+            name: "Linux Build Host",
+            platform: .linux,
+            sshDestination: "operator@build.example.test"
+        )
+
+        let passive = Task {
+            try await coordinator.ensureInstalled(on: host)
+        }
+        await firstProbe.waitUntilBlocked()
+        let forced = Task {
+            try await coordinator.install(on: host)
+        }
+        firstProbe.open()
+
+        await #expect {
+            try await passive.value
+        } throws: {
+            $0 as? KwtRemoteInstallError == .targetProbeFailed(status: 1)
+        }
+        try await forced.value
+        #expect(targetProbeCalls.load() == 2)
+        #expect(recorder.destination != nil)
+    }
+
     @Test("cancelling the last provisioning waiter stops before upload")
     func cancellationStopsProvisioningBeforeUpload() async throws {
         let revision = String(repeating: "b", count: 40)

--- a/Tests/App/KwtRemoteInstallerTests.swift
+++ b/Tests/App/KwtRemoteInstallerTests.swift
@@ -246,11 +246,10 @@ struct KwtRemoteInstallerTests {
         #expect(recorder.destination != nil)
     }
 
-    @Test("concurrent explicit installs await a replacement install failure")
+    @Test("concurrent explicit installs share a fast replacement failure")
     func concurrentForcedInstallsAwaitReplacementFailure() async throws {
         let revision = String(repeating: "6", count: 40)
         let passiveProbe = BlockingGate()
-        let forcedProbe = BlockingGate()
         let targetProbeCalls = Mutex(0)
         let forcedStarts = Mutex(0)
         let installer = KwtRemoteInstaller(
@@ -273,7 +272,6 @@ struct KwtRemoteInstallerTests {
                     passiveProbe.block()
                     return installOutput(1)
                 case 2:
-                    forcedProbe.block()
                     return installOutput(23)
                 default:
                     return installOutput(24)
@@ -306,29 +304,28 @@ struct KwtRemoteInstallerTests {
                 return status
             }
         }
-        let firstForced = Task {
-            await forcedInstall()
-        }
-        let secondForced = Task {
-            await forcedInstall()
+        let forcedCount = 64
+        let forcedInstalls = (0 ..< forcedCount).map { index in
+            Task(priority: index == 0 ? .high : .background) {
+                await forcedInstall()
+            }
         }
         await waitUntil {
-            forcedStarts.withLock { $0 } == 2
+            forcedStarts.withLock { $0 } == forcedCount
         }
-        passiveProbe.open()
-        await forcedProbe.waitUntilBlocked()
-        for _ in 0 ..< 100 {
+        for _ in 0 ..< 1_000 {
             await Task.yield()
         }
-        forcedProbe.open()
+        passiveProbe.open()
 
         await #expect {
             try await passive.value
         } throws: {
             $0 as? KwtRemoteInstallError == .targetProbeFailed(status: 1)
         }
-        #expect(await firstForced.value == 23)
-        #expect(await secondForced.value == 23)
+        for forcedInstall in forcedInstalls {
+            #expect(await forcedInstall.value == 23)
+        }
         #expect(targetProbeCalls.withLock { $0 } == 2)
     }
 

--- a/Tests/App/KwtRemoteInstallerTests.swift
+++ b/Tests/App/KwtRemoteInstallerTests.swift
@@ -3,6 +3,7 @@ import CryptoKit
 import Foundation
 import GhosthubSettings
 import GhosthubTmux
+import Synchronization
 import Testing
 @testable import GhosthubApp
 
@@ -243,6 +244,92 @@ struct KwtRemoteInstallerTests {
         try await forced.value
         #expect(targetProbeCalls.load() == 2)
         #expect(recorder.destination != nil)
+    }
+
+    @Test("concurrent explicit installs await a replacement install failure")
+    func concurrentForcedInstallsAwaitReplacementFailure() async throws {
+        let revision = String(repeating: "6", count: 40)
+        let passiveProbe = BlockingGate()
+        let forcedProbe = BlockingGate()
+        let targetProbeCalls = Mutex(0)
+        let forcedStarts = Mutex(0)
+        let installer = KwtRemoteInstaller(
+            revision: revision,
+            remoteRunner: { _, _, command in
+                if command == KwtRemoteInstaller.readyProbeCommand(
+                    revision: revision
+                ) {
+                    return installOutput(1)
+                }
+                guard command == KwtRemoteInstaller.targetProbeCommand else {
+                    return installOutput(0)
+                }
+                let call = targetProbeCalls.withLock { calls in
+                    calls += 1
+                    return calls
+                }
+                switch call {
+                case 1:
+                    passiveProbe.block()
+                    return installOutput(1)
+                case 2:
+                    forcedProbe.block()
+                    return installOutput(23)
+                default:
+                    return installOutput(24)
+                }
+            }
+        )
+        let coordinator = KwtRemoteProvisioningCoordinator(
+            installer: installer
+        )
+        let host = SSHHost(
+            configKey: "linux-build",
+            name: "Linux Build Host",
+            platform: .linux,
+            sshDestination: "operator@build.example.test"
+        )
+
+        let passive = Task {
+            try await coordinator.ensureInstalled(on: host)
+        }
+        await passiveProbe.waitUntilBlocked()
+        let forcedInstall: @Sendable () async -> Int32? = {
+            forcedStarts.withLock { $0 += 1 }
+            do {
+                try await coordinator.install(on: host)
+                return nil
+            } catch {
+                guard case let .targetProbeFailed(status) =
+                    error as? KwtRemoteInstallError
+                else { return -1 }
+                return status
+            }
+        }
+        let firstForced = Task {
+            await forcedInstall()
+        }
+        let secondForced = Task {
+            await forcedInstall()
+        }
+        await waitUntil {
+            forcedStarts.withLock { $0 } == 2
+        }
+        passiveProbe.open()
+        await forcedProbe.waitUntilBlocked()
+        for _ in 0 ..< 100 {
+            await Task.yield()
+        }
+        forcedProbe.open()
+
+        await #expect {
+            try await passive.value
+        } throws: {
+            $0 as? KwtRemoteInstallError == .targetProbeFailed(status: 1)
+        }
+        #expect(await firstForced.value == 23)
+        #expect(await secondForced.value == 23)
+        #expect(targetProbeCalls.withLock { $0 } == 2)
     }
 
     @Test("cancelling the last provisioning waiter stops before upload")

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -338,6 +338,8 @@ func makeModel(
     WorkspaceSceneModel.KwtConditionalInventoryLoader? = nil,
     kwtRemoteProvisioner:
     @escaping WorkspaceSceneModel.KwtRemoteProvisioner = { _ in },
+    kwtRemoteInstaller:
+    @escaping WorkspaceSceneModel.KwtRemoteInstalling = { _ in },
     kwtWorktreeCreator: @escaping WorkspaceSceneModel.KwtWorktreeCreator = {
         request, projectPath, host in
         try await KwtWorktreeClient().create(
@@ -568,6 +570,7 @@ func makeModel(
             try await kwtInventoryLoader(host)
         },
         kwtRemoteProvisioner: kwtRemoteProvisioner,
+        kwtRemoteInstaller: kwtRemoteInstaller,
         kwtWorktreeCreator: kwtWorktreeCreator,
         kwtWorktreeRemover: kwtWorktreeRemover,
         kwtForceWorktreeRemover: kwtForceWorktreeRemover,

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -384,6 +384,13 @@ func makeModel(
     @escaping WorkspaceSceneModel.SSHConnectionSnapshotProvider = {
         _ in SSHConnectionArgumentsSnapshot(arguments: [])
     },
+    kwtBranchLister: @escaping WorkspaceSceneModel.KwtBranchLister = {
+        projectPath, host in
+        try await KwtWorktreeClient().branches(
+            projectPath: projectPath,
+            on: host
+        )
+    },
     kwtPullRequestLister:
     @escaping WorkspaceSceneModel.KwtPullRequestLister = {
         projectIdentity, host in
@@ -573,6 +580,7 @@ func makeModel(
         herdrSessionMutator: herdrSessionMutator,
         herdrSSHConnectionSnapshotProvider:
         herdrSSHConnectionSnapshotProvider,
+        kwtBranchLister: kwtBranchLister,
         kwtPullRequestLister: kwtPullRequestLister,
         kwtPullRequestImporter: kwtPullRequestImporter,
         kwtProjectRegistration: kwtProjectRegistration,

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1701,7 +1701,7 @@ struct WorkspaceHerdrPresentationTests {
         current.withLock { $0 = dead }
         let close = try #require(store.surface.closeObservers.values.first)
         close(false, 255)
-        await waitUntilMainActor(timeout: .seconds(1)) {
+        await waitUntilMainActor {
             invalidations.withLock { $0 } == 1
                 || deadAttempts.withLock { $0 } >= 3
         }
@@ -1712,7 +1712,7 @@ struct WorkspaceHerdrPresentationTests {
             withExtendedLifetime(deadConnection) {}
             return
         }
-        await waitUntilMainActor(timeout: .seconds(1)) {
+        await waitUntilMainActor {
             store.requestedConfigurations.count == 2
                 && model.activeBorrowedHerdrConnectionState == .connected
         }

--- a/Tests/App/WorkspaceTmuxInventoryTests.swift
+++ b/Tests/App/WorkspaceTmuxInventoryTests.swift
@@ -246,15 +246,73 @@ extension WorkspaceTmuxDiscoveryTests {
                     $0.configKey == remote.configKey
                         && $0.tmuxSessions.map(\.name) == ["build"]
                 }
-                && !model.workspaceInventoryWarningsByHost.isEmpty
+                && model.isWorkspaceInventoryRefreshComplete
         }
 
         #expect(remoteInventoryLoads.count == 0)
         let remoteSummary = try #require(
             model.snapshot.hosts.first { $0.configKey == remote.configKey }
         )
-        #expect(remoteSummary.primaryDiagnostic?.code == .missingKwt)
-        #expect(!remoteSummary.canCreateWorktree)
+        #expect(model.workspaceInventoryWarningsByHost[remoteSummary.id] == nil)
+        #expect(remoteSummary.primaryDiagnostic == nil)
+        #expect(remoteSummary.connectionState == .online)
+        #expect(remoteSummary.lastKnownReachable)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("remote kwt inventory failure stays out of terminal host health")
+    func remoteKwtInventoryFailureIsSilent() async throws {
+        let environment = try setupStandardEnvironment()
+        let remote = SSHHost(
+            configKey: "build-box",
+            name: "Build Box",
+            platform: .linux,
+            sshDestination: "build-box"
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            kwtInventoryLoader: { host in
+                guard host.isRemote else {
+                    return KwtHostInventory(projects: [])
+                }
+                throw KwtInventoryError.commandFailed(
+                    host: host.displayName,
+                    status: 1
+                )
+            },
+            tmuxSessionDiscovery: { host in
+                .success(host.isRemote ? [
+                    DiscoveredTmuxSession(
+                        name: "build",
+                        windowCount: 1,
+                        createdAt: "1721552400",
+                        managed: false
+                    ),
+                ] : [])
+            },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            configuredSSHHostsPublisher:
+            configuredHosts.eraseToAnyPublisher(),
+            startServices: true
+        )
+
+        await waitUntilMainActor {
+            model.isWorkspaceInventoryRefreshComplete
+                && model.snapshot.hosts.contains {
+                    $0.configKey == remote.configKey
+                        && $0.tmuxSessions.map(\.name) == ["build"]
+                }
+        }
+
+        let remoteSummary = try #require(
+            model.snapshot.hosts.first { $0.configKey == remote.configKey }
+        )
+        #expect(remoteSummary.tmuxSessions.map(\.name) == ["build"])
+        #expect(remoteSummary.primaryDiagnostic == nil)
+        #expect(model.workspaceInventoryWarningsByHost[remoteSummary.id] == nil)
         await model.shutdown()
     }
 
@@ -488,16 +546,16 @@ extension WorkspaceTmuxDiscoveryTests {
         let remoteSummary = try #require(
             model.snapshot.host(id: remoteHostID)
         )
-        #expect(remoteSummary.primaryDiagnostic?.code == .missingKwt)
+        #expect(remoteSummary.primaryDiagnostic == nil)
         #expect(remoteSummary.lastKnownReachable)
-        #expect(remoteSummary.connectionState == .degraded)
-        #expect(!remoteSummary.canCreateWorktree)
+        #expect(remoteSummary.connectionState == .online)
+        #expect(remoteSummary.canCreateWorktree)
         await model.shutdown()
     }
 
     @MainActor
-    @Test("losing remote kwt retains cached inventory but disables creation")
-    func remoteKwtLossDisablesCreation() async throws {
+    @Test("losing remote kwt repairs before branch listing")
+    func remoteKwtLossRepairsBeforeBranchListing() async throws {
         let environment = try setupStandardEnvironment()
         let remote = SSHHost(
             configKey: "build-box",
@@ -506,29 +564,41 @@ extension WorkspaceTmuxDiscoveryTests {
             sshDestination: "build-box"
         )
         let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
-        let availability = KwtAvailabilityState(
-            remoteInventory: KwtHostInventory(projects: [
-                KwtProjectInventory(
-                    project: KwtProjectRecord(
-                        repository: "github.com/kenn-io/docbank",
-                        name: "docbank",
-                        path: "/srv/docbank",
-                        lastTouched: nil
-                    ),
-                    worktrees: [],
-                    warning: nil
+        let inventory = KwtHostInventory(projects: [
+            KwtProjectInventory(
+                project: KwtProjectRecord(
+                    repository: "github.com/kenn-io/docbank",
+                    name: "docbank",
+                    path: "/srv/docbank",
+                    lastTouched: nil
                 ),
-            ])
+                worktrees: [],
+                warning: nil
+            ),
+        ])
+        let provisioningShouldFail = LockedValue(false)
+        let provisioningAttempts = Counter()
+        let branchListAttempts = Counter()
+        let branch = WorktreeBranchCandidate(
+            name: "feature/repaired",
+            source: "feature/repaired",
+            isRemote: false
         )
-        let creationAttempts = Counter()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             kwtInventoryLoader: { host in
-                try availability.load(host)
+                host.isRemote ? inventory : KwtHostInventory(projects: [])
             },
-            kwtWorktreeCreator: { _, _, _ in
-                _ = creationAttempts.increment()
+            kwtRemoteProvisioner: { _ in
+                _ = provisioningAttempts.increment()
+                if provisioningShouldFail.load() {
+                    throw KwtRemoteInstallError.bundleIncomplete
+                }
+            },
+            kwtBranchLister: { _, _ in
+                _ = branchListAttempts.increment()
+                return [branch]
             },
             tmuxSessionDiscovery: { host in
                 .success(host.isRemote ? [
@@ -558,51 +628,71 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         #expect(model.snapshot.canCreateWorktree(in: cachedProject))
 
-        availability.markRemoteKwtUnavailable()
+        provisioningShouldFail.store(true)
+        let attemptsBeforeFailure = provisioningAttempts.count
         model.refreshKwtInventory()
         await waitUntilMainActor {
-            model.snapshot.host(id: cachedProject.hostID)?
-                .primaryDiagnostic?.code == .missingKwt
+            provisioningAttempts.count > attemptsBeforeFailure
+                && model.isWorkspaceInventoryRefreshComplete
         }
 
         let unavailableHost = try #require(
             model.snapshot.host(id: cachedProject.hostID)
         )
-        #expect(!unavailableHost.canCreateWorktree)
-        #expect(!model.snapshot.canCreateWorktree(in: cachedProject))
+        #expect(unavailableHost.canCreateWorktree)
+        #expect(model.snapshot.canCreateWorktree(in: cachedProject))
         #expect(model.snapshot.project(id: cachedProject.id) != nil)
         #expect(unavailableHost.tmuxSessions.map(\.name) == ["docbank"])
+        #expect(unavailableHost.primaryDiagnostic == nil)
         #expect(model.workspaceInventoryWarningsByHost[unavailableHost.id] == nil)
 
-        do {
-            try await model.createWorktree(WorktreeCreateRequest(
-                projectID: cachedProject.id,
-                branchName: "feature/should-not-run",
-                createsBranch: true
-            ))
-            Issue.record("Expected unavailable kwt to reject creation")
-        } catch let error as KwtWorktreeError {
-            #expect(error == .projectUnavailable)
-        }
-        #expect(creationAttempts.count == 0)
+        provisioningShouldFail.store(false)
+        let attemptsBeforeAction = provisioningAttempts.count
+        let branches = try await model.branches(for: cachedProject.id)
 
-        availability.markRemoteKwtAvailable()
-        model.refreshKwtInventory()
-        await waitUntilMainActor {
-            let host = model.snapshot.host(id: cachedProject.hostID)
-            return host?.primaryDiagnostic?.code != .missingKwt
-                && host?.canCreateWorktree == true
+        #expect(provisioningAttempts.count == attemptsBeforeAction + 1)
+        #expect(branches == [branch])
+        #expect(branchListAttempts.count == 1)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("repair failure prevents branch listing")
+    func repairFailurePreventsBranchListing() async throws {
+        let environment = try setupRemoteEnvironment()
+        let branchListAttempts = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { _ in
+                throw KwtRemoteInstallError.bundleIncomplete
+            },
+            kwtBranchLister: { _, _ in
+                _ = branchListAttempts.increment()
+                return [
+                    WorktreeBranchCandidate(
+                        name: "feature/should-not-run",
+                        source: "feature/should-not-run",
+                        isRemote: false
+                    ),
+                ]
+            }
+        )
+
+        await #expect(throws: KwtRemoteInstallError.bundleIncomplete) {
+            try await model.branches(for: environment.project.id)
         }
-        #expect(model.snapshot.canCreateWorktree(in: cachedProject))
+        #expect(branchListAttempts.count == 0)
         await model.shutdown()
     }
 
     @MainActor
     @Test(
-        "status 127 during creation disables kwt and schedules discovery",
+        "status 127 during creation keeps repair actions available",
         arguments: CreationKwtFailurePhase.allCases
     )
-    private func creationKwtLossDisablesCapability(
+    private func creationKwtLossKeepsCapability(
         phase: CreationKwtFailurePhase
     ) async throws {
         let environment = try setupStandardEnvironment()
@@ -688,12 +778,14 @@ extension WorkspaceTmuxDiscoveryTests {
 
         await waitUntilMainActor {
             availability.remoteLoadCount >= 2
-                && model.snapshot.host(id: cachedProject.hostID)?
-                .primaryDiagnostic?.code == .missingKwt
         }
         #expect(creationAttempts.count == 1)
         #expect(model.snapshot.project(id: cachedProject.id) != nil)
-        #expect(!model.snapshot.canCreateWorktree(in: cachedProject))
+        #expect(model.snapshot.canCreateWorktree(in: cachedProject))
+        #expect(
+            model.snapshot.host(id: cachedProject.hostID)?
+                .primaryDiagnostic == nil
+        )
         await model.shutdown()
     }
 
@@ -818,13 +910,7 @@ extension WorkspaceTmuxDiscoveryTests {
 
         #expect(summary.connectionState == .online)
         #expect(summary.host.lastKnownReachable)
-        #expect(summary.diagnostics.count == 1)
-        #expect(summary.diagnostics.first?.code == .missingKwt)
-        #expect(summary.diagnostics.first?.severity == .warning)
-        #expect(
-            summary.diagnostics.first?.recoverySuggestion
-                .contains("Tmux sessions remain available") == true
-        )
+        #expect(summary.diagnostics.isEmpty)
         #expect(released.load())
         await model.shutdown()
     }

--- a/Tests/App/WorkspaceTmuxInventoryTests.swift
+++ b/Tests/App/WorkspaceTmuxInventoryTests.swift
@@ -261,14 +261,18 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("remote kwt inventory failure stays out of terminal host health")
-    func remoteKwtInventoryFailureIsSilent() async throws {
+    @Test("Windows kwt inventory failure preserves the actual error")
+    func windowsKwtInventoryFailurePreservesError() async throws {
         let environment = try setupStandardEnvironment()
         let remote = SSHHost(
             configKey: "build-box",
             name: "Build Box",
-            platform: .linux,
+            platform: .windows,
             sshDestination: "build-box"
+        )
+        let inventoryFailure = KwtInventoryError.commandFailed(
+            host: remote.sshDestination,
+            status: 1
         )
         let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
         let model = try makeModel(
@@ -278,10 +282,7 @@ extension WorkspaceTmuxDiscoveryTests {
                 guard host.isRemote else {
                     return KwtHostInventory(projects: [])
                 }
-                throw KwtInventoryError.commandFailed(
-                    host: host.displayName,
-                    status: 1
-                )
+                throw inventoryFailure
             },
             tmuxSessionDiscovery: { host in
                 .success(host.isRemote ? [
@@ -300,7 +301,9 @@ extension WorkspaceTmuxDiscoveryTests {
         )
 
         await waitUntilMainActor {
-            model.isWorkspaceInventoryRefreshComplete
+            model.workspaceInventoryWarningsByHost.values.contains(
+                inventoryFailure.localizedDescription
+            )
                 && model.snapshot.hosts.contains {
                     $0.configKey == remote.configKey
                         && $0.tmuxSessions.map(\.name) == ["build"]
@@ -312,7 +315,11 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         #expect(remoteSummary.tmuxSessions.map(\.name) == ["build"])
         #expect(remoteSummary.primaryDiagnostic == nil)
-        #expect(model.workspaceInventoryWarningsByHost[remoteSummary.id] == nil)
+        #expect(remoteSummary.canCreateWorktree)
+        #expect(
+            model.workspaceInventoryWarningsByHost[remoteSummary.id]
+                == inventoryFailure.localizedDescription
+        )
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -1012,6 +1012,51 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("cancelling kwt provisioning preserves workspace-aware attach")
+    func cancelledProvisioningPreservesWorkspaceOpen() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtRemoteProvisioner: { _ in throw CancellationError() }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .direct
+        )
+
+        await #expect(throws: CancellationError.self) {
+            try await model.branches(for: environment.project.id)
+        }
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'open'"))
+        #expect(command.contains(environment.worktree.path))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("a missing helper during branch listing restores direct attach")
     func branchStatus127FallsBackToDirectAttach() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -889,14 +889,40 @@ extension WorkspaceTmuxDiscoveryTests {
                 windows: []
             ),
         ]
-        snapshot.hosts[0].remoteDiagnostics = [.missingKwtCapability]
+        let remote = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
-            remoteTmuxPathProvider: { _, _ in successfulTmuxResolution("/usr/bin/tmux") }
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
+            kwtRemoteProvisioner: { _ in
+                throw KwtRemoteInstallError.bundleIncomplete
+            },
+            tmuxSessionDiscovery: { host in
+                .success(host.isRemote ? [
+                    DiscoveredTmuxSession(
+                        name: sessionName,
+                        windowCount: 1,
+                        createdAt: "1721552400",
+                        managed: true
+                    ),
+                ] : [])
+            },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            configuredSSHHostsPublisher:
+            configuredHosts.eraseToAnyPublisher(),
+            startServices: true
         )
         let selection = WorkspaceTmuxSessionSelection(
             hostID: environment.host.id,
@@ -906,6 +932,9 @@ extension WorkspaceTmuxDiscoveryTests {
             tmuxAttachMode: .direct
         )
 
+        await waitUntilMainActor {
+            model.isWorkspaceInventoryRefreshComplete
+        }
         model.openBorrowedTmuxSession(selection)
         await launchActiveTmuxSurface(model, store: surfaceStore)
 
@@ -913,6 +942,73 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(command.contains("'attach-session'"))
         #expect(!command.contains("'open'"))
         #expect(!command.contains("managed kwt is unavailable"))
+        #expect(model.snapshot.host(id: environment.host.id)?.primaryDiagnostic == nil)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("repairing managed kwt restores workspace-aware attach")
+    func repairedHelperRestoresWorkspaceOpen() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let remote = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([remote])
+        let provisioningShouldFail = LockedValue(true)
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtInventoryLoader: { _ in KwtHostInventory(projects: []) },
+            kwtRemoteProvisioner: { _ in
+                if provisioningShouldFail.load() {
+                    throw KwtRemoteInstallError.bundleIncomplete
+                }
+            },
+            kwtBranchLister: { _, _ in [] },
+            configuredSSHHostsProvider: { configuredHosts.value },
+            configuredSSHHostsPublisher:
+            configuredHosts.eraseToAnyPublisher(),
+            startServices: true
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .direct
+        )
+
+        await waitUntilMainActor {
+            model.isWorkspaceInventoryRefreshComplete
+        }
+        provisioningShouldFail.store(false)
+        _ = try await model.branches(for: environment.project.id)
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'open'"))
+        #expect(command.contains(environment.worktree.path))
+        await model.shutdown()
     }
 
     @MainActor

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -1012,6 +1012,106 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("a missing helper during branch listing restores direct attach")
+    func branchStatus127FallsBackToDirectAttach() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let failure = KwtWorktreeError.commandFailed(
+            host: environment.host.name,
+            status: 127
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtBranchLister: { _, _ in throw failure }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .direct
+        )
+
+        await #expect(throws: failure) {
+            try await model.branches(for: environment.project.id)
+        }
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'attach-session'"))
+        #expect(!command.contains("'open'"))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("a missing helper during change status restores direct attach")
+    func changeStatus127FallsBackToDirectAttach() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.worktrees[0].generation =
+            "0123456789abcdef0123456789abcdef"
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let failure = KwtWorktreeError.changeStatusFailed(
+            host: environment.host.name,
+            status: 127
+        )
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtWorktreeChangeReader: { _, _, _ in throw failure }
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .direct
+        )
+
+        await #expect(throws: failure) {
+            try await model.prepareWorktreeRemoval(environment.worktree.id)
+        }
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'attach-session'"))
+        #expect(!command.contains("'open'"))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("cached worktree session uses kwt when the helper is available")
     func cachedWorktreeSessionUsesKwt() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -211,7 +211,7 @@ extension WorkspaceTmuxDiscoveryTests {
             configKey: "new-builder",
             name: "New Builder",
             platform: .linux,
-            sshDestination: " \nwesm@builder.example.com:2222\t"
+            sshDestination: " \noperator@builder.example.com:2222\t"
         )
         let capturedTarget = LockedValue<CommandHost?>(nil)
         let provisionedHost = LockedValue<SSHHost?>(nil)
@@ -242,10 +242,15 @@ extension WorkspaceTmuxDiscoveryTests {
         )
 
         #expect(result == .success("ghosthub"))
-        #expect(provisionedHost.load() == draft)
+        #expect(provisionedHost.load() == SSHHost(
+            configKey: draft.configKey,
+            name: draft.name,
+            platform: draft.platform,
+            sshDestination: "operator@builder.example.com:2222"
+        ))
         #expect(events.load() == ["provision", "register"])
         #expect(capturedTarget.load() == .ssh(SSHHostInfo(
-            user: "wesm",
+            user: "operator",
             hostname: "builder.example.com",
             port: 2222,
             platform: .posix

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -81,12 +81,19 @@ extension WorkspaceTmuxDiscoveryTests {
             sshDestination: " \nwesm@builder.example.com:2222\t"
         )
         let capturedTarget = LockedValue<CommandHost?>(nil)
+        let provisionedHost = LockedValue<SSHHost?>(nil)
+        let events = LockedValue<[String]>([])
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { host in
+                provisionedHost.store(host)
+                events.withLock { $0.append("provision") }
+            },
             kwtProjectRegistration: { path, target in
                 capturedTarget.store(target)
+                events.withLock { $0.append("register") }
                 return KwtProjectRecord(
                     repository: "github.com/kenn-io/ghosthub",
                     name: "ghosthub",
@@ -102,12 +109,45 @@ extension WorkspaceTmuxDiscoveryTests {
         )
 
         #expect(result == .success("ghosthub"))
+        #expect(provisionedHost.load() == draft)
+        #expect(events.load() == ["provision", "register"])
         #expect(capturedTarget.load() == .ssh(SSHHostInfo(
             user: "wesm",
             hostname: "builder.example.com",
             port: 2222,
             platform: .posix
         )))
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("Host Settings install uses managed kwt provisioning")
+    func hostSettingsInstallUsesManagedProvisioning() async throws {
+        let environment = try setupHostEnvironment()
+        let draft = SSHHost(
+            configKey: "new-builder",
+            name: "New Builder",
+            platform: .linux,
+            sshDestination: ""
+        )
+        let provisionedHost = LockedValue<SSHHost?>(nil)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { host in
+                provisionedHost.store(host)
+            }
+        )
+
+        let result = await model.installRemoteKwt(on: draft)
+
+        guard case .success = result else {
+            Issue.record("Expected managed kwt provisioning to succeed")
+            await model.shutdown()
+            return
+        }
+        #expect(provisionedHost.load() == draft)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -134,6 +134,66 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("Host Settings Add Project rejects an endpoint changed during kwt provisioning")
+    func hostSettingsAddProjectRejectsEndpointChangedDuringProvisioning() async throws {
+        let environment = try setupRemoteEnvironment()
+        let initialHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            initialHost,
+        ])
+        let provisioningGate = AsyncGate()
+        let registrationCalls = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { _ in
+                await provisioningGate.wait()
+            },
+            kwtProjectRegistration: { _, _ in
+                _ = registrationCalls.increment()
+                return KwtProjectRecord(
+                    repository: environment.project.scopedKey,
+                    name: environment.project.name,
+                    path: environment.project.rootPath,
+                    lastTouched: nil
+                )
+            },
+            configuredSSHHostsProvider: { configuredHosts.value }
+        )
+
+        let registration = Task { @MainActor in
+            await model.registerRemoteProject(
+                environment.project.rootPath,
+                on: initialHost
+            )
+        }
+        await provisioningGate.waitUntilWaiting()
+        configuredHosts.send([
+            SSHHost(
+                configKey: initialHost.configKey,
+                name: initialHost.name,
+                platform: initialHost.platform,
+                sshDestination: "user-a@host-b.example.com"
+            ),
+        ])
+        model.refreshHosts()
+        provisioningGate.open()
+
+        #expect(await registration.value == .failure(.message(
+            "The host connection changed. "
+                + "Close Add Project and try again."
+        )))
+        #expect(registrationCalls.count == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("Remove Project stops when provisioning changes the endpoint")
     func removeProjectStopsAfterProvisioningEndpointChange() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -254,8 +254,8 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
-    @Test("Host Settings install uses managed kwt provisioning")
-    func hostSettingsInstallUsesManagedProvisioning() async throws {
+    @Test("Host Settings reinstall bypasses passive kwt provisioning")
+    func hostSettingsReinstallBypassesPassiveProvisioning() async throws {
         let environment = try setupHostEnvironment()
         let draft = SSHHost(
             configKey: "new-builder",
@@ -263,13 +263,17 @@ extension WorkspaceTmuxDiscoveryTests {
             platform: .linux,
             sshDestination: ""
         )
-        let provisionedHost = LockedValue<SSHHost?>(nil)
+        let passiveProvisioningCalls = Counter()
+        let installedHost = LockedValue<SSHHost?>(nil)
         let model = try makeModel(
             database: environment.database,
             localHostID: environment.host.id,
             snapshot: environment.snapshot,
-            kwtRemoteProvisioner: { host in
-                provisionedHost.store(host)
+            kwtRemoteProvisioner: { _ in
+                _ = passiveProvisioningCalls.increment()
+            },
+            kwtRemoteInstaller: { host in
+                installedHost.store(host)
             }
         )
 
@@ -280,7 +284,8 @@ extension WorkspaceTmuxDiscoveryTests {
             await model.shutdown()
             return
         }
-        #expect(provisionedHost.load() == draft)
+        #expect(passiveProvisioningCalls.count == 0)
+        #expect(installedHost.load() == draft)
         await model.shutdown()
     }
 

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -71,6 +71,139 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("Add Project rejects an endpoint changed during kwt provisioning")
+    func addProjectRejectsEndpointChangedDuringProvisioning() async throws {
+        let environment = try setupRemoteEnvironment()
+        let initialHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            initialHost,
+        ])
+        let provisioningGate = AsyncGate()
+        let registrationCalls = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { _ in
+                await provisioningGate.wait()
+            },
+            kwtProjectRegistration: { _, _ in
+                _ = registrationCalls.increment()
+                return KwtProjectRecord(
+                    repository: environment.project.scopedKey,
+                    name: environment.project.name,
+                    path: environment.project.rootPath,
+                    lastTouched: nil
+                )
+            },
+            configuredSSHHostsProvider: { configuredHosts.value }
+        )
+        let capturedHost = try #require(
+            model.snapshot.host(id: environment.host.id)
+        )
+
+        let registration = Task { @MainActor in
+            await model.registerProject(
+                environment.project.rootPath,
+                on: capturedHost
+            )
+        }
+        await provisioningGate.waitUntilWaiting()
+        configuredHosts.send([
+            SSHHost(
+                configKey: initialHost.configKey,
+                name: initialHost.name,
+                platform: initialHost.platform,
+                sshDestination: "user-a@host-b.example.com"
+            ),
+        ])
+        model.refreshHosts()
+        provisioningGate.open()
+
+        #expect(await registration.value == .failure(.message(
+            "The host connection changed. "
+                + "Close Add Project and try again."
+        )))
+        #expect(registrationCalls.count == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
+    @Test("Remove Project stops when provisioning changes the endpoint")
+    func removeProjectStopsAfterProvisioningEndpointChange() async throws {
+        let environment = try setupRemoteEnvironment()
+        let project = try #require(environment.snapshot.projects.first)
+        let confirmedHost = try #require(environment.snapshot.hosts.first)
+        let initialHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            initialHost,
+        ])
+        let provisioningGate = AsyncGate()
+        let inventoryLoads = Counter()
+        let removalCalls = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: environment.snapshot,
+            kwtInventoryLoader: { _ in
+                _ = inventoryLoads.increment()
+                return WorkspaceTmuxTestSupport.inventory(
+                    project: project,
+                    worktrees: environment.snapshot.worktrees
+                )
+            },
+            kwtRemoteProvisioner: { _ in
+                await provisioningGate.wait()
+            },
+            kwtProjectRemoval: { path, _, _, _, _ in
+                _ = removalCalls.increment()
+                return KwtProjectRecord(
+                    repository: project.scopedKey,
+                    name: project.name,
+                    path: path,
+                    lastTouched: nil
+                )
+            },
+            configuredSSHHostsProvider: { configuredHosts.value }
+        )
+
+        let removal = Task { @MainActor in
+            await model.unregisterProject(
+                project,
+                confirmedHost: confirmedHost
+            )
+        }
+        await provisioningGate.waitUntilWaiting()
+        configuredHosts.send([
+            SSHHost(
+                configKey: initialHost.configKey,
+                name: initialHost.name,
+                platform: initialHost.platform,
+                sshDestination: "user-a@host-b.example.com"
+            ),
+        ])
+        model.refreshHosts()
+        provisioningGate.open()
+
+        #expect(await removal.value == .failure(.message(
+            "The project or host connection changed. Try removing it again."
+        )))
+        #expect(inventoryLoads.count == 0)
+        #expect(removalCalls.count == 0)
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("Host Settings registers a project on an unsaved host draft")
     func hostSettingsRegistersProjectOnUnsavedDraft() async throws {
         let environment = try setupHostEnvironment()

--- a/Tests/App/WorkspaceTmuxRecoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxRecoveryTests.swift
@@ -1258,6 +1258,104 @@ extension WorkspaceTmuxDiscoveryTests {
     }
 
     @MainActor
+    @Test("missing kwt during workspace open falls back to direct attach")
+    func missingKwtDuringWorkspaceOpenFallsBackToDirectAttach() async throws {
+        let environment = try setupRemoteEnvironment()
+        var snapshot = environment.snapshot
+        let sessionName = "kwt-ghosthub-main"
+        let otherSessionName = "kwt-ghosthub-other"
+        snapshot.worktrees[0].tmuxSessionName = sessionName
+        snapshot.hosts[0].tmuxSessions = [
+            TmuxSessionSummary(
+                name: sessionName,
+                managed: true,
+                windows: []
+            ),
+            TmuxSessionSummary(
+                name: otherSessionName,
+                managed: true,
+                windows: []
+            ),
+        ]
+        let surfaceStore = SceneTmuxSurfaceStoreStub()
+        let provisioningCalls = Counter()
+        let discoveryCalls = Counter()
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: snapshot,
+            nativeTmuxSurfaceStore: surfaceStore,
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/bin/tmux")
+            },
+            kwtRemoteProvisioner: { _ in
+                _ = provisioningCalls.increment()
+            },
+            tmuxSessionDiscovery: { _ in
+                _ = discoveryCalls.increment()
+                return .success([
+                    DiscoveredTmuxSession(
+                        name: sessionName,
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: true
+                    ),
+                    DiscoveredTmuxSession(
+                        name: otherSessionName,
+                        windowCount: 1,
+                        createdAt: nil,
+                        managed: true
+                    ),
+                ])
+            },
+            tmuxReconnectIntervals: [.milliseconds(1)]
+        )
+        let selection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: sessionName,
+            worktreeID: environment.worktree.id,
+            worktreePath: environment.worktree.path,
+            tmuxAttachMode: .direct
+        )
+        model.openBorrowedTmuxSession(selection)
+        await launchActiveTmuxSurface(model, store: surfaceStore)
+        #expect(
+            surfaceStore.lastConfiguration?.command?.contains("'open'")
+                == true
+        )
+        await waitUntilMainActor { discoveryCalls.count >= 1 }
+
+        surfaceStore.surface.closeObservers.values.first?(false, 127)
+        await waitUntilMainActor {
+            surfaceStore.requestCount == 2
+                && model.activeBorrowedTmuxSessionIsConnected
+        }
+
+        let command = try #require(surfaceStore.lastConfiguration?.command)
+        #expect(command.contains("'attach-session'"))
+        #expect(!command.contains("'open'"))
+        #expect(provisioningCalls.count == 0)
+
+        let otherSelection = WorkspaceTmuxSessionSelection(
+            hostID: environment.host.id,
+            name: otherSessionName,
+            worktreePath: "/srv/ghosthub-other",
+            tmuxAttachMode: .direct
+        )
+        model.openBorrowedTmuxSession(otherSelection)
+        await waitUntilMainActor {
+            model.prepareActiveBorrowedTmuxSurface()
+            return surfaceStore.requestCount == 3
+        }
+        let otherCommand = try #require(
+            surfaceStore.lastConfiguration?.command
+        )
+        #expect(otherCommand.contains("'attach-session'"))
+        #expect(!otherCommand.contains("'open'"))
+        await model.shutdown()
+    }
+
+    @MainActor
     @Test("retryable surface failure relaunches an absent workspace")
     func retryableSurfaceFailureRelaunchesAbsentWorkspace() async throws {
         let environment = try setupRemoteEnvironment()

--- a/Tests/App/WorkspaceWorktreeCreationTests.swift
+++ b/Tests/App/WorkspaceWorktreeCreationTests.swift
@@ -1,4 +1,7 @@
+import Combine
 import Foundation
+import GhosthubSettings
+import GhosthubTransport
 import GhosthubUI
 import GhosthubWorkspace
 import Testing
@@ -57,6 +60,63 @@ private enum WorktreeMutationProbeError: Error, Equatable {
 
 @Suite("Workspace worktree creation", .serialized)
 struct WorkspaceWorktreeCreationTests {
+    @Test("creation rejects an endpoint changed during kwt provisioning")
+    @MainActor
+    func creationRejectsEndpointChangedDuringProvisioning() async throws {
+        let environment = try setupRemoteEnvironment()
+        let initialHost = SSHHost(
+            configKey: environment.host.configKey,
+            name: environment.host.name,
+            platform: environment.host.platform,
+            sshDestination: try #require(environment.host.sshDestination)
+        )
+        let configuredHosts = CurrentValueSubject<[SSHHost], Never>([
+            initialHost,
+        ])
+        let provisioningGate = AsyncGate()
+        let creationCalls = LockedValue(0)
+        let model = try makeModel(
+            database: environment.database,
+            localHostID: UUID(),
+            snapshot: environment.snapshot,
+            kwtRemoteProvisioner: { _ in
+                await provisioningGate.wait()
+            },
+            kwtWorktreeCreator: { _, _, _ in
+                creationCalls.withLock { $0 += 1 }
+            },
+            configuredSSHHostsProvider: { configuredHosts.value }
+        )
+
+        let creation = Task { @MainActor in
+            do {
+                try await model.createWorktree(WorktreeCreateRequest(
+                    projectID: environment.project.id,
+                    branchName: "feature/endpoint-change",
+                    createsBranch: true
+                ))
+                return nil as KwtWorktreeError?
+            } catch {
+                return error as? KwtWorktreeError
+            }
+        }
+        await provisioningGate.waitUntilWaiting()
+        configuredHosts.send([
+            SSHHost(
+                configKey: initialHost.configKey,
+                name: initialHost.name,
+                platform: initialHost.platform,
+                sshDestination: "user-a@host-b.example.com"
+            ),
+        ])
+        model.refreshHosts()
+        provisioningGate.open()
+
+        #expect(await creation.value == .projectUnavailable)
+        #expect(creationCalls.load() == 0)
+        await model.shutdown()
+    }
+
     @Test("separate scene models serialize mutations by host and project")
     @MainActor
     func separateModelsShareMutationGate() async throws {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -594,8 +594,9 @@ under the host's POSIX `/bin/sh`; non-POSIX account shells such as fish are not
 asked to interpret those commands. Windows commands execute through encoded
 noninteractive PowerShell.
 Direct tmux discovery provides every otherwise-unbound session. A remote host
-without kwt remains a valid tmux-only host; remote inventory failures stay
-attached to that host and never replace usable local or cached inventory with a
+without kwt remains a valid tmux-only host. Passive remote kwt maintenance and
+inventory failures stay private, retain the current scene's cached project
+inventory, and never replace usable terminal inventory with a host or
 workspace-wide error. Ghosthub has no Middleman runtime or API dependency.
 
 An enabled exe.dev account is a host-inventory provider, not a terminal
@@ -673,12 +674,14 @@ through kwt on its selected endpoint; unbound sessions continue to attach
 directly to the host's normal tmux server.
 
 Adding a remote macOS or Linux host authorizes Ghosthub to maintain its
-per-user managed kwt helper as part of inventory refresh. Provisioning failure
-disables that host's worktree actions and reports the error without blocking
-ordinary tmux discovery or attachment. The helper never replaces or resolves
-a host's system kwt. Versioned directories retain older pinned helpers, so an
-older Ghosthub build can select and restore its own revision; reinstalling one
-revision also retains `kwt.previous`.
+per-user managed kwt helper. Inventory refresh maintains it quietly. Before an
+explicit project or worktree operation, Ghosthub revalidates and repairs the
+helper; a repair failure stops that operation and appears in its action error,
+without degrading the host or terminal discovery, attachment, and reconnect.
+The helper never replaces or resolves a host's system kwt. Versioned
+directories retain older pinned helpers, so an older Ghosthub build can select
+and restore its own revision; reinstalling one revision also retains
+`kwt.previous`.
 
 In the Rust port's WSL host, a managed-helper path cache is never execution
 authority. The host revalidates the pinned digest and revision before every

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,8 +170,10 @@ or updates its pinned architecture-matched helper in the remote user's
 Linux host. On a fresh host, enter each existing checkout's absolute path under
 **Add Project**. The managed helper records it through kwt's supported registry
 command and Ghosthub refreshes project/worktree inventory. Tmux discovery and
-attachment continue to work if helper provisioning fails. Windows provisioning
-remains explicit until its kwt executables are Authenticode-signed.
+attachment continue to work if passive helper provisioning fails. Ghosthub
+retries managed-helper repair before an explicit project or worktree operation
+and reports a failure on that operation. Windows provisioning remains explicit
+until its kwt executables are Authenticode-signed.
 
 Ghosthub uses the host's OpenSSH configuration directly and invokes an
 ordinary tmux client on the target host. Tmux owns windows, panes, layouts,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,10 +95,12 @@ Use **Test Connection** to verify authentication and that `tmux` is on the
 remote login-shell `PATH`.
 Kwt does not need a system installation: Ghosthub automatically installs or
 updates its managed helper when it loads inventory for a configured remote
-macOS or Linux host. If provisioning fails, use the host warning to retry or
-open Host Settings. If the host has never used kwt, enter an existing
-checkout's absolute path with the **+** beside the **Projects** group for that
-host; repeat for each repository Ghosthub should display.
+macOS or Linux host. Passive maintenance failures do not affect terminal
+sessions or show a host warning. Ghosthub retries the repair when you request a
+project or worktree operation and reports an error there if it still cannot
+prepare the helper. If the host has never used kwt, enter an existing checkout's
+absolute path with the **+** beside the **Projects** group for that host; repeat
+for each repository Ghosthub should display.
 
 **Test Connection** follows your OpenSSH host-key policy. If the exact full
 destination has an unseen key, Ghosthub presents OpenSSH's fingerprint for

--- a/tools/tests/test_demo_scripts.py
+++ b/tools/tests/test_demo_scripts.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
 import plistlib
 import pwd
+import selectors
 import shutil
 import signal
 import socket
 import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -318,22 +321,55 @@ def run_zellij_until_render(
     arguments: list[str],
     *,
     env: dict[str, str],
+    expected_output: str,
 ) -> tuple[str, str]:
     process = subprocess.Popen(
         [str(fixture), *arguments],
         cwd=ROOT,
         env=env,
-        text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,
     )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    stdout = bytearray()
+    stderr = bytearray()
+    expected = expected_output.encode()
+    deadline = time.monotonic() + 5
+
     try:
-        stdout, stderr = process.communicate(timeout=0.2)
-    except subprocess.TimeoutExpired:
-        os.killpg(process.pid, signal.SIGTERM)
-        stdout, stderr = process.communicate(timeout=1)
-    return stdout, stderr
+        with selectors.DefaultSelector() as selector:
+            selector.register(process.stdout, selectors.EVENT_READ, stdout)
+            selector.register(process.stderr, selectors.EVENT_READ, stderr)
+            while expected not in stdout and process.poll() is None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                events = selector.select(timeout=remaining)
+                if not events:
+                    break
+                for key, _ in events:
+                    chunk = os.read(key.fd, 4096)
+                    if chunk:
+                        key.data.extend(chunk)
+                    else:
+                        selector.unregister(key.fileobj)
+                if not selector.get_map():
+                    break
+    finally:
+        if process.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGTERM)
+        try:
+            remaining_stdout, remaining_stderr = process.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            remaining_stdout, remaining_stderr = process.communicate(timeout=1)
+        stdout.extend(remaining_stdout)
+        stderr.extend(remaining_stderr)
+    return stdout.decode(errors="replace"), stderr.decode(errors="replace")
 
 
 @pytest.mark.parametrize(
@@ -365,16 +401,20 @@ def test_demo_zellij_accepts_hardened_session_arguments(
     (scratch / ".ghosthub-demo-scratch").touch()
     fixture = DEMO / fixture_name
     env = {**os.environ, scratch_variable: str(scratch)}
+    attached_expected = f"{render_prefix}: -release"
+    created_expected = f"{render_prefix}: -new-release"
 
     attached, attach_error = run_zellij_until_render(
         fixture,
         ["attach", "--", "-release"],
         env=env,
+        expected_output=attached_expected,
     )
     created, create_error = run_zellij_until_render(
         fixture,
         ["--session=-new-release"],
         env=env,
+        expected_output=created_expected,
     )
     killed = subprocess.run(
         [str(fixture), "kill-session", "--", kill_name],
@@ -385,8 +425,8 @@ def test_demo_zellij_accepts_hardened_session_arguments(
         check=False,
     )
 
-    assert f"{render_prefix}: -release" in attached, attach_error
-    assert f"{render_prefix}: -new-release" in created, create_error
+    assert attached_expected in attached, attach_error
+    assert created_expected in created, create_error
     assert killed.returncode == 0, killed.stderr
     assert (scratch / f"zellij-killed-{kill_name}").is_file()
 

--- a/website/docs/content/projects-worktrees.md
+++ b/website/docs/content/projects-worktrees.md
@@ -26,8 +26,10 @@ not scan the machine or edit kwt configuration itself.
 
 Ghosthub automatically maintains the
 [managed kwt helper](remote-hosts.md#managed-kwt-helper) on configured remote
-macOS and Linux hosts. Project registration is not yet available for native
-Windows hosts.
+macOS and Linux hosts. Before a project or worktree operation, Ghosthub repairs
+the helper if needed; if repair fails, that operation shows the error without
+affecting ordinary terminal sessions. Project registration is not yet available
+for native Windows hosts.
 
 If the SSH destination changes while the Add Project sheet is open, close the
 sheet and start again so the confirmation applies to the current host.

--- a/website/docs/content/remote-hosts.md
+++ b/website/docs/content/remote-hosts.md
@@ -119,8 +119,10 @@ Tmux-only hosts do not need kwt. To show projects and worktrees on a remote
 macOS or Linux host, configure the host normally. Ghosthub automatically copies
 or updates its matching revision-pinned helper during project inventory. It
 verifies the helper, stores it under `~/.ghosthub/`, and does not install or
-replace a system-wide kwt. If provisioning fails, tmux sessions remain usable
-and the host warning offers a retry and a shortcut to Host Settings.
+replace a system-wide kwt. Passive maintenance failures stay out of the way of
+tmux, Herdr, and Zellij sessions. When you request a project or worktree
+operation, Ghosthub repairs the helper first and shows an error on that action
+only if repair still fails.
 
 Register individual repositories with the explicit **Add Project** action.
 Ghosthub never scans a remote filesystem. See

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -30,8 +30,9 @@ tmux list-sessions
 ```
 
 An expanded host with no discovered tmux, Herdr, or Zellij sessions or projects reports
-that it is empty. Project inventory is separate from SSH reachability, so a
-reachable host can also show a separate kwt diagnostic.
+that it is empty. Project inventory is separate from SSH reachability. A
+managed kwt maintenance failure stays silent until you request a project or
+worktree operation that needs the helper.
 
 ## Herdr Sessions does not appear
 
@@ -103,11 +104,10 @@ potentially stale or misidentified frame.
 ## A project does not appear
 
 For a remote macOS or Linux host, Ghosthub installs its managed kwt helper
-automatically. If the host shows a provisioning warning, retry it or open Host
-Settings. Then select the **+** beside that host's **Projects** group and
-provide the absolute path to an existing checkout on that host. Ghosthub does
-not discover
-repositories by scanning.
+automatically. Select the **+** beside that host's **Projects** group and provide
+the absolute path to an existing checkout on that host. Ghosthub repairs the
+helper before registration and reports an error on that action if repair fails.
+It does not discover repositories by scanning.
 
 Project registration is not yet supported for native Windows hosts.
 


### PR DESCRIPTION
Remote macOS and Linux `kwt` maintenance no longer makes a working terminal host appear broken or prevents Ghosthub from reconnecting to ordinary tmux sessions.

- Keeps passive helper and project-inventory failures out of host diagnostics while retaining the current scene's cached project data.
- Revalidates and repairs Ghosthub's pinned helper before explicit project and worktree operations; if repair still fails, the requested action reports the error without running its `kwt` command.
- Attaches an already-discovered worktree session through ordinary tmux when the helper is known to be unavailable, then restores workspace-aware attachment after a successful repair.
- Routes Host Settings installation through the same provisioning coordinator, so background and user-requested maintenance share one authority.
- Leaves system-installed `kwt` untouched, preserves explicit Windows installation, and updates the architecture, troubleshooting docs, and website Guide to match.
- Waits for observable Zellij demo output in CI instead of assuming the fixture starts within 200 milliseconds, while keeping bounded process-group cleanup.
- Waits for observable Herdr recovery state under concurrent Swift Testing instead of assuming MainActor work starts within one second.
