### PR TITLE
Keep transparent sidebar divider thin

### DIFF
--- a/Sources/UI/RootView.swift
+++ b/Sources/UI/RootView.swift
@@ -544,7 +544,7 @@ public struct RootView: View {
                 HStack(spacing: 0) {
                     Color.clear
                         .frame(
-                            width: (sidebarWidth + Self.dividerHit)
+                            width: sidebarWidth
                                 * sidebarVisibilityProgress
                         )
 
@@ -559,10 +559,11 @@ public struct RootView: View {
                         .frame(width: sidebarWidth)
 
                     columnDivider
+                        .offset(x: -Self.dividerHit / 2)
                         .gesture(sidebarDragGesture)
                 }
                 .offset(
-                    x: -(sidebarWidth + Self.dividerHit)
+                    x: -sidebarWidth
                         * (1 - sidebarVisibilityProgress)
                 )
                 .opacity(sidebarVisibilityProgress)
@@ -612,7 +613,11 @@ public struct RootView: View {
     /// cursor shows reliably regardless of adjacent views.
     private struct ResizeCursorView: NSViewRepresentable {
         func makeNSView(context: Context) -> CursorRectView {
-            CursorRectView()
+            let view = CursorRectView()
+            view.setAccessibilityIdentifier(
+                "workspace-sidebar-resize-handle"
+            )
+            return view
         }
 
         func updateNSView(

--- a/Tests/App/ExeVMInventoryTests.swift
+++ b/Tests/App/ExeVMInventoryTests.swift
@@ -821,8 +821,12 @@ struct ExeVMInventoryTests {
     func inFlightEditsPreserveRetainedResults() async {
         let (workStarted, workStartedContinuation) =
             AsyncStream<Void>.makeStream()
+        let releasePersonal = DispatchSemaphore(value: 0)
         let releaseWork = DispatchSemaphore(value: 0)
         let client = ExeVMClient { host, _, startMarker, endMarker in
+            if host.hostname == "personal.exe.dev" {
+                releasePersonal.wait()
+            }
             if host.hostname == "work.exe.dev" {
                 workStartedContinuation.yield()
                 releaseWork.wait()
@@ -853,6 +857,15 @@ struct ExeVMInventoryTests {
                 sshDestination: "work.exe.dev"
             ),
         ]
+        let personalPublished = Task { @MainActor in
+            for await hosts in store.$hosts.values {
+                if hosts.contains(where: {
+                    $0.metadata.accountConfigKey == "personal"
+                }) {
+                    return
+                }
+            }
+        }
         let published = Task { @MainActor in
             for await hosts in store.$hosts.values {
                 if hosts.contains(where: {
@@ -864,6 +877,8 @@ struct ExeVMInventoryTests {
         }
         let refreshID = store.refresh(accounts: accounts)
         for await _ in workStarted.prefix(1) {}
+        releasePersonal.signal()
+        await personalPublished.value
 
         store.invalidateRefresh(
             refreshID,

--- a/Tests/App/WorkspaceHerdrPresentationTests.swift
+++ b/Tests/App/WorkspaceHerdrPresentationTests.swift
@@ -1820,7 +1820,7 @@ struct WorkspaceHerdrPresentationTests {
 
         displays.withLock { $0 = 1 }
         model.reconnectActiveHerdrSessionNow()
-        await waitUntilMainActor(timeout: .seconds(1)) {
+        await waitUntilMainActor {
             store.requestedConfigurations.count == 1
                 && model.activeBorrowedHerdrConnectionState == .connected
         }

--- a/Tests/UI/SidebarToggleStabilityTests.swift
+++ b/Tests/UI/SidebarToggleStabilityTests.swift
@@ -103,6 +103,51 @@ struct SidebarToggleStabilityTests {
         #expect(transitionWidth < finalWidth)
     }
 
+    @Test("transparent sidebar divider overlaps the terminal seam")
+    func transparentSidebarDividerOverlapsTerminalSeam() throws {
+        let env = StabilityTestEnvironment(
+            backgroundAppearance: TerminalBackgroundAppearance(
+                opacity: 0.82,
+                blurCValue: 0,
+                increasedContrast: false
+            )
+        )
+        defer { env.close() }
+
+        let terminal = try #require(env.findStableContent())
+        let terminalFrame = terminal.convert(
+            terminal.bounds,
+            to: env.hostingView
+        )
+        #expect(
+            abs(
+                terminalFrame.minX
+                    - WorkspaceSidebarWidthPolicy.defaultWidth
+            ) < 1
+        )
+
+        let handle = try #require(viewByAccessibilityID(
+            "workspace-sidebar-resize-handle",
+            in: env.hostingView
+        ))
+        let handleFrame = handle.convert(
+            handle.bounds,
+            to: env.hostingView
+        )
+        #expect(
+            abs(
+                handleFrame.width
+                    - WorkspaceSidebarWidthPolicy.dividerHitWidth
+            ) < 1
+        )
+        #expect(
+            abs(
+                handleFrame.midX
+                    - WorkspaceSidebarWidthPolicy.defaultWidth
+            ) < 1
+        )
+    }
+
     @Test("sidebar command toggles only its targeted window")
     func sidebarCommandTogglesOnlyTargetedWindow() {
         let firstTarget = SidebarToggleTarget()
@@ -275,7 +320,7 @@ private final class StabilityTestEnvironment {
 
     private let model: StabilityTestModel
     private let window: NSWindow?
-    private let hostingView: NSHostingView<StabilityTestHarness>
+    let hostingView: NSHostingView<StabilityTestHarness>
     private let settingsStore: SettingsStore
     private let tempRoot: URL
     private let defaults: UserDefaults
@@ -326,6 +371,7 @@ private final class StabilityTestEnvironment {
     }
 
     init(
+        backgroundAppearance: TerminalBackgroundAppearance = .opaque,
         sidebarToggleTarget: AnyObject = SidebarToggleTarget(),
         presentsWindow: Bool = true
     ) {
@@ -393,6 +439,7 @@ private final class StabilityTestEnvironment {
                 model: model,
                 settingsStore: settingsStore,
                 defaults: defaults,
+                backgroundAppearance: backgroundAppearance,
                 sidebarToggleTarget: sidebarToggleTarget,
                 workspaceWindowProvider: {
                     windowReference.window
@@ -508,6 +555,7 @@ private struct StabilityTestHarness: View {
     @ObservedObject var model: StabilityTestModel
     let settingsStore: SettingsStore
     let defaults: UserDefaults
+    let backgroundAppearance: TerminalBackgroundAppearance
     let sidebarToggleTarget: AnyObject
     let workspaceWindowProvider: () -> NSWindow?
 
@@ -543,6 +591,10 @@ private struct StabilityTestHarness: View {
         )
         .defaultAppStorage(defaults)
         .environment(\.controlActiveState, .key)
+        .environment(
+            \.terminalBackgroundAppearance,
+            backgroundAppearance
+        )
     }
 }
 


### PR DESCRIPTION
Prevents `background-opacity` from exposing the sidebar resize gutter as a transparent strip.

- Places the terminal directly against the thin sidebar separator.
- Keeps the existing 14-point resize target centered over the seam, preserving the resize cursor and drag behavior.
- Covers the transparent seam and hit-target geometry in the existing AppKit-hosted sidebar tests.
- Makes the existing exe.dev inventory and Herdr reconnect coverage deterministic under hosted-runner scheduling; production behavior is unchanged.
