### PR TITLE
Stop terminal smoke tests from leaking shell processes

### DIFF
--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -343,7 +343,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         let monitor = eventMonitor
         let surfaceHandle = surface
         let queue = keyInputQueue
-        let token = callbackToken
+        let token = callbackToken!
         let onSurfaceDestroyed = onSurfaceDestroyed
         NotificationCenter.default.removeObserver(self)
 
@@ -360,15 +360,47 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             // the free (via `withExtendedLifetime` below) guarantees no
             // in-flight callback can resolve a dangling token afterward.
             Task.detached { @MainActor in
-                queue.sync {}
-                Self.viewsBySurfaceIdentity.removeValue(
-                    forKey: surfaceIdentity
+                Self.freeSurface(
+                    surfaceHandle,
+                    identity: surfaceIdentity,
+                    keyInputQueue: queue,
+                    callbackToken: token,
+                    onSurfaceDestroyed: onSurfaceDestroyed
                 )
-                onSurfaceDestroyed?(surfaceIdentity)
-                ghostty_surface_free(surfaceHandle)
-                withExtendedLifetime(token) {}
             }
         }
+    }
+
+    /// Stops this surface and its child process before the view is released.
+    ///
+    /// Normal AppKit view disposal still uses the deferred `deinit` path. A
+    /// caller with a shorter process lifetime, such as an isolated XCTest
+    /// worker, can use this method to finish libghostty cleanup before exit.
+    package func shutdown() {
+        guard let surfaceHandle = surface else { return }
+        surface = nil
+        Self.freeSurface(
+            surfaceHandle,
+            identity: UInt(bitPattern: surfaceHandle),
+            keyInputQueue: keyInputQueue,
+            callbackToken: callbackToken,
+            onSurfaceDestroyed: onSurfaceDestroyed
+        )
+    }
+
+    private static func freeSurface(
+        _ surfaceHandle: ghostty_surface_t,
+        identity: UInt,
+        keyInputQueue: DispatchQueue,
+        callbackToken: SurfaceCallbackToken,
+        onSurfaceDestroyed: ((UInt) -> Void)?
+    ) {
+        keyInputQueue.sync {}
+        viewsBySurfaceIdentity.removeValue(forKey: identity)
+        onSurfaceDestroyed?(identity)
+        callbackToken.view = nil
+        ghostty_surface_free(surfaceHandle)
+        withExtendedLifetime(callbackToken) {}
     }
 
     // MARK: - Public API

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -359,8 +359,8 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             // callbacks before returning, so keeping `token` alive across
             // the free (via `withExtendedLifetime` below) guarantees no
             // in-flight callback can resolve a dangling token afterward.
-            Task.detached { @MainActor in
-                Self.freeSurface(
+            Task { @MainActor in
+                await Self.freeSurface(
                     surfaceHandle,
                     identity: surfaceIdentity,
                     keyInputQueue: queue,
@@ -376,10 +376,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// Normal AppKit view disposal still uses the deferred `deinit` path. A
     /// caller with a shorter process lifetime, such as an isolated XCTest
     /// worker, can use this method to finish libghostty cleanup before exit.
-    package func shutdown() {
+    package func shutdown() async {
         guard let surfaceHandle = surface else { return }
         surface = nil
-        Self.freeSurface(
+        await Self.freeSurface(
             surfaceHandle,
             identity: UInt(bitPattern: surfaceHandle),
             keyInputQueue: keyInputQueue,
@@ -394,8 +394,14 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         keyInputQueue: DispatchQueue,
         callbackToken: SurfaceCallbackToken,
         onSurfaceDestroyed: ((UInt) -> Void)?
-    ) {
-        keyInputQueue.sync {}
+    ) async {
+        // Suspend instead of blocking the main actor. A queued key send can
+        // wait for main-thread libghostty work when its message queue is full.
+        await withCheckedContinuation { continuation in
+            keyInputQueue.async {
+                continuation.resume()
+            }
+        }
         viewsBySurfaceIdentity.removeValue(forKey: identity)
         onSurfaceDestroyed?(identity)
         callbackToken.view = nil

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -24,23 +24,27 @@ final class TerminalSurfacePreviewTests: XCTestCase {
 
     override func tearDown() async throws {
         for surface in surfaces {
-            surface.shutdown()
+            await surface.shutdown()
         }
         surfaces.removeAll()
         try await super.tearDown()
     }
 
-    func testSurfaceShutdownStopsChildProcessGroup() throws {
+    func testSurfaceShutdownStopsChildProcessGroup() async throws {
         let view = try makeSurface()
+        let launchDeadline = Date().addingTimeInterval(5)
+        while view.childProcessID == nil, Date() < launchDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
         let childPID = try XCTUnwrap(view.childProcessID)
         let processGroup = getpgid(childPID)
         XCTAssertGreaterThan(processGroup, 0)
 
-        view.shutdown()
+        await view.shutdown()
 
         let deadline = Date().addingTimeInterval(2)
         while kill(-processGroup, 0) == 0, Date() < deadline {
-            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            try await Task.sleep(for: .milliseconds(20))
         }
         XCTAssertEqual(kill(-processGroup, 0), -1)
         XCTAssertEqual(errno, ESRCH)

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CoreVideo
+import Darwin
 import GhosttyKit
 import GhosthubTmux
 import GhosthubTransport
@@ -14,10 +15,35 @@ import XCTest
 @MainActor
 final class TerminalSurfacePreviewTests: XCTestCase {
     private static var retainedRuntime: LibghosttyRuntime?
+    private var surfaces: [TerminalSurfaceView] = []
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         try skipUnlessLibghosttyReady()
+    }
+
+    override func tearDown() async throws {
+        for surface in surfaces {
+            surface.shutdown()
+        }
+        surfaces.removeAll()
+        try await super.tearDown()
+    }
+
+    func testSurfaceShutdownStopsChildProcessGroup() throws {
+        let view = try makeSurface()
+        let childPID = try XCTUnwrap(view.childProcessID)
+        let processGroup = getpgid(childPID)
+        XCTAssertGreaterThan(processGroup, 0)
+
+        view.shutdown()
+
+        let deadline = Date().addingTimeInterval(2)
+        while kill(-processGroup, 0) == 0, Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertEqual(kill(-processGroup, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
     }
 
     func testSnapshotProducesGPUFrameWithoutMutatingSurface() async throws {
@@ -1398,6 +1424,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             view.error?.localizedDescription
                 ?? "libghostty surface creation failed"
         )
+        surfaces.append(view)
         return view
     }
 


### PR DESCRIPTION
Parallel terminal preview tests now close every real libghostty surface before their isolated XCTest worker exits, so successful tests cannot leave login-shell processes running on a persistent runner.

- Adds an explicit, idempotent surface shutdown path that awaits queued key input without blocking the main actor, while preserving deferred AppKit disposal for normal views.
- Makes the preview-test fixture retain and shut down every surface before teardown returns.
- Requires shutdown to remove the launched child process group after observing that the shell has started. This process-level regression runs in hosted CI because it intentionally starts the account's login shell.
- The app build, formatter, commit hooks, test-target compilation, and libghostty bootstrap suite pass locally. The broader Python suite has 427 passes and its existing pinned-kwt Go toolchain mismatch.
