### PR TITLE
Require terminal tests to stop owned surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,9 @@ parent's checklist.
 - Tests that start a real tmux server must use `TestTmuxServer` and run under
   `tools/run_swift_tests.sh`; command-construction-only and Zellij tests do not
   need that fixture.
+- Tests that create a `TerminalSurfaceView`, directly or through a coordinator,
+  must own it through teardown and await `shutdown()` before the test worker
+  exits. Do not rely on view deinitialization or process exit to stop its shell.
 - Run Python tests with `make python-test`.
 
 ## Naming


### PR DESCRIPTION
Terminal test guidance now requires every directly or coordinator-created surface to remain owned through teardown and complete `shutdown()` before its worker exits. This preserves the shell-cleanup contract that the trusted-runner rollout now exercises under parallel XCTest workers.