### PR TITLE
Require the main-pinned CI result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,3 +273,19 @@ jobs:
           case "${GHOSTHUB_CI_STATE_ROOT:-}" in
             /tmp/ghosthub-ci.*) rm -rf -- "$GHOSTHUB_CI_STATE_ROOT" ;;
           esac
+
+  # kenn-ops requires this main-pinned check as "run / Required CI".
+  required:
+    name: Required CI
+    if: ${{ always() }}
+    needs: [macos-arm64]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require authoritative macOS validation
+        env:
+          RESULT: ${{ needs.macos-arm64.result }}
+        run: |
+          if [[ "$RESULT" != success ]]; then
+            echo "Authoritative macOS validation ended with: $RESULT" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adds one stable, main-pinned CI result that repository policy can require without depending on a hosted or self-hosted lane name.

- Fails unless the authoritative macOS matrix succeeds.
- Keeps hosted CI authoritative while self-hosted validation remains advisory in parallel mode.
- Leaves enforcement inactive until the dependent infrastructure change lands after this workflow is present on `main`.
