### PR TITLE
Respect configured titlebar opacity

### DIFF
--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -85,13 +85,10 @@ enum WorkspaceWindowChrome {
               let titlebar = closeButton.superview
         else { return }
         titlebar.wantsLayer = true
-        if transparent {
-            titlebar.layer?.backgroundColor = NSColor.clear.cgColor
-        } else {
-            titlebar.effectiveAppearance.performAsCurrentDrawingAppearance {
-                titlebar.layer?.backgroundColor =
-                    WorkspaceSurfaceColor.nsColor.cgColor
-            }
+        titlebar.effectiveAppearance.performAsCurrentDrawingAppearance {
+            titlebar.layer?.backgroundColor = WorkspaceSurfaceColor.nsColor(
+                opacity: transparent ? appearance.opacity : 1.0
+            ).cgColor
         }
     }
 }

--- a/Tests/App/WorkspaceWindowChromeTests.swift
+++ b/Tests/App/WorkspaceWindowChromeTests.swift
@@ -36,6 +36,29 @@ struct WorkspaceWindowChromeTests {
         #expect(blurredWindows.count == 1)
     }
 
+    @Test("transparent appearance uses configured titlebar opacity")
+    func transparentTitlebar() throws {
+        let window = makeWindow()
+        WorkspaceWindowChrome.apply(
+            to: window,
+            appearance: TerminalBackgroundAppearance(
+                opacity: 0.8, blurCValue: 0, increasedContrast: false
+            ),
+            applyBlur: { _ in }
+        )
+
+        let titlebar = try #require(
+            window.standardWindowButton(.closeButton)?.superview
+        )
+        let layerColor = try #require(titlebar.layer?.backgroundColor)
+        let alpha = try #require(
+            NSColor(cgColor: layerColor)?
+                .usingColorSpace(.sRGB)?
+                .alphaComponent
+        )
+        #expect(abs(alpha - 0.8) < 0.001)
+    }
+
     @Test("opaque appearance restores current chrome")
     func opaqueWindow() {
         let window = makeWindow()


### PR DESCRIPTION
Fixes transparent terminal configurations painting the compact titlebar fully clear and allowing active terminal colors to bleed into window chrome.

- Tints the titlebar with the canonical workspace color at the effective `background-opacity`, matching the sidebar.
- Keeps the window non-opaque for terminal transparency while preserving opaque fullscreen and increased-contrast chrome.
- Covers the real AppKit titlebar layer so a clear background cannot satisfy the regression test again.
- Confirmed locally at `background-opacity = 0.95`.
