### PR TITLE
Prevent remote kwt inventory from exhausting SSH sessions

### DIFF
--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -230,76 +230,6 @@ enum KwtInventoryError: Error, Equatable, LocalizedError {
     }
 }
 
-private actor KwtInventoryLoadCoordinator {
-    static let shared = KwtInventoryLoadCoordinator()
-
-    private struct Waiter {
-        let id: UUID
-        let continuation: CheckedContinuation<Void, Error>
-    }
-
-    private var activeRoutes: Set<String> = []
-    private var waitersByRoute: [String: [Waiter]] = [:]
-
-    func withExclusiveLoad<Value: Sendable>(
-        routeIdentity: String,
-        operation: @escaping @Sendable () async throws -> Value
-    ) async throws -> Value {
-        try await acquire(routeIdentity: routeIdentity)
-        defer { release(routeIdentity: routeIdentity) }
-        try Task.checkCancellation()
-        return try await operation()
-    }
-
-    private func acquire(routeIdentity: String) async throws {
-        try Task.checkCancellation()
-        if activeRoutes.insert(routeIdentity).inserted {
-            return
-        }
-
-        let waiterID = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                waitersByRoute[routeIdentity, default: []].append(Waiter(
-                    id: waiterID,
-                    continuation: continuation
-                ))
-            }
-        } onCancel: {
-            Task {
-                await self.cancelWaiter(
-                    waiterID,
-                    routeIdentity: routeIdentity
-                )
-            }
-        }
-    }
-
-    private func cancelWaiter(
-        _ waiterID: UUID,
-        routeIdentity: String
-    ) {
-        guard var waiters = waitersByRoute[routeIdentity],
-              let index = waiters.firstIndex(where: { $0.id == waiterID })
-        else { return }
-        let waiter = waiters.remove(at: index)
-        waitersByRoute[routeIdentity] = waiters.isEmpty ? nil : waiters
-        waiter.continuation.resume(throwing: CancellationError())
-    }
-
-    private func release(routeIdentity: String) {
-        guard var waiters = waitersByRoute[routeIdentity],
-              !waiters.isEmpty
-        else {
-            activeRoutes.remove(routeIdentity)
-            return
-        }
-        let waiter = waiters.removeFirst()
-        waitersByRoute[routeIdentity] = waiters.isEmpty ? nil : waiters
-        waiter.continuation.resume()
-    }
-}
-
 /// Reads kwt's supported machine-readable surfaces without interpreting its
 /// configuration files. Directory workspaces are independent of project
 /// inventory. Project order follows `kwt projects --json`; each project is
@@ -381,15 +311,11 @@ struct KwtInventoryClient: Sendable {
         from host: CommandHost,
         sshConnection: KwtSSHConnection
     ) async throws -> KwtHostInventory {
-        try await KwtInventoryLoadCoordinator.shared.withExclusiveLoad(
-            routeIdentity: sshConnection.routeIdentity
-        ) {
-            try await load(
-                from: host,
-                sshConnectionArguments: sshConnection.arguments,
-                sshConnection: sshConnection
-            )
-        }
+        try await load(
+            from: host,
+            sshConnectionArguments: sshConnection.arguments,
+            sshConnection: sshConnection
+        )
     }
 
     private func load(

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -230,6 +230,76 @@ enum KwtInventoryError: Error, Equatable, LocalizedError {
     }
 }
 
+private actor KwtInventoryLoadCoordinator {
+    static let shared = KwtInventoryLoadCoordinator()
+
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var activeRoutes: Set<String> = []
+    private var waitersByRoute: [String: [Waiter]] = [:]
+
+    func withExclusiveLoad<Value: Sendable>(
+        routeIdentity: String,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try await acquire(routeIdentity: routeIdentity)
+        defer { release(routeIdentity: routeIdentity) }
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    private func acquire(routeIdentity: String) async throws {
+        try Task.checkCancellation()
+        if activeRoutes.insert(routeIdentity).inserted {
+            return
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waitersByRoute[routeIdentity, default: []].append(Waiter(
+                    id: waiterID,
+                    continuation: continuation
+                ))
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(
+                    waiterID,
+                    routeIdentity: routeIdentity
+                )
+            }
+        }
+    }
+
+    private func cancelWaiter(
+        _ waiterID: UUID,
+        routeIdentity: String
+    ) {
+        guard var waiters = waitersByRoute[routeIdentity],
+              let index = waiters.firstIndex(where: { $0.id == waiterID })
+        else { return }
+        let waiter = waiters.remove(at: index)
+        waitersByRoute[routeIdentity] = waiters.isEmpty ? nil : waiters
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func release(routeIdentity: String) {
+        guard var waiters = waitersByRoute[routeIdentity],
+              !waiters.isEmpty
+        else {
+            activeRoutes.remove(routeIdentity)
+            return
+        }
+        let waiter = waiters.removeFirst()
+        waitersByRoute[routeIdentity] = waiters.isEmpty ? nil : waiters
+        waiter.continuation.resume()
+    }
+}
+
 /// Reads kwt's supported machine-readable surfaces without interpreting its
 /// configuration files. Directory workspaces are independent of project
 /// inventory. Project order follows `kwt projects --json`; each project is
@@ -311,11 +381,15 @@ struct KwtInventoryClient: Sendable {
         from host: CommandHost,
         sshConnection: KwtSSHConnection
     ) async throws -> KwtHostInventory {
-        try await load(
-            from: host,
-            sshConnectionArguments: sshConnection.arguments,
-            sshConnection: sshConnection
-        )
+        try await KwtInventoryLoadCoordinator.shared.withExclusiveLoad(
+            routeIdentity: sshConnection.routeIdentity
+        ) {
+            try await load(
+                from: host,
+                sshConnectionArguments: sshConnection.arguments,
+                sshConnection: sshConnection
+            )
+        }
     }
 
     private func load(

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -388,54 +388,42 @@ struct KwtInventoryClient: Sendable {
             throw projectsError
         }
 
-        let indexed = await withTaskGroup(
-            of: (Int, KwtProjectInventory, Bool).self,
-            returning: [(Int, KwtProjectInventory, Bool)].self
-        ) { group in
-            for (index, project) in projects.enumerated() {
-                group.addTask {
-                    let result = run(
-                        host: host,
-                        sshConnectionArguments: sshConnectionArguments,
-                        command: Self.worktreesCommand(
-                            projectPath: project.path,
-                            platform: platform(for: host),
-                            binaryPrelude: binaryPrelude(for: host),
+        let indexed: [(Int, KwtProjectInventory, Bool)]
+        switch host {
+        case .local:
+            indexed = await withTaskGroup(
+                of: (Int, KwtProjectInventory, Bool).self,
+                returning: [(Int, KwtProjectInventory, Bool)].self
+            ) { group in
+                for (index, project) in projects.enumerated() {
+                    group.addTask {
+                        loadProject(
+                            index: index,
+                            project: project,
+                            host: host,
+                            sshConnectionArguments: sshConnectionArguments,
+                            hostLabel: hostLabel,
                             windowsKwtRelativePath: windowsKwtRelativePath
-                        )
-                    )
-                    do {
-                        let worktrees: [KwtWorktreeRecord] = try decode(
-                            result,
-                            hostLabel: hostLabel
-                        )
-                        return (
-                            index,
-                            KwtProjectInventory(
-                                project: project,
-                                worktrees: worktrees,
-                                warning: nil
-                            ),
-                            Self.indicatesUnusableConnection(result)
-                        )
-                    } catch {
-                        return (
-                            index,
-                            KwtProjectInventory(
-                                project: project,
-                                worktrees: [],
-                                warning: error.localizedDescription
-                            ),
-                            Self.indicatesUnusableConnection(result)
                         )
                     }
                 }
+                var values: [(Int, KwtProjectInventory, Bool)] = []
+                for await value in group {
+                    values.append(value)
+                }
+                return values
             }
-            var values: [(Int, KwtProjectInventory, Bool)] = []
-            for await value in group {
-                values.append(value)
+        case .ssh:
+            indexed = projects.enumerated().map { index, project in
+                loadProject(
+                    index: index,
+                    project: project,
+                    host: host,
+                    sshConnectionArguments: sshConnectionArguments,
+                    hostLabel: hostLabel,
+                    windowsKwtRelativePath: windowsKwtRelativePath
+                )
             }
-            return values
         }
         if topConnectionUnusable || indexed.contains(where: { $0.2 }) {
             await sshConnection?.invalidate()
@@ -446,6 +434,51 @@ struct KwtInventoryClient: Sendable {
             directoryWorkspaces: directoryWorkspaces,
             directoryWorkspaceWarning: directoryWorkspaceWarning
         )
+    }
+
+    private func loadProject(
+        index: Int,
+        project: KwtProjectRecord,
+        host: CommandHost,
+        sshConnectionArguments: [String]?,
+        hostLabel: String,
+        windowsKwtRelativePath: String?
+    ) -> (Int, KwtProjectInventory, Bool) {
+        let result = run(
+            host: host,
+            sshConnectionArguments: sshConnectionArguments,
+            command: Self.worktreesCommand(
+                projectPath: project.path,
+                platform: platform(for: host),
+                binaryPrelude: binaryPrelude(for: host),
+                windowsKwtRelativePath: windowsKwtRelativePath
+            )
+        )
+        do {
+            let worktrees: [KwtWorktreeRecord] = try decode(
+                result,
+                hostLabel: hostLabel
+            )
+            return (
+                index,
+                KwtProjectInventory(
+                    project: project,
+                    worktrees: worktrees,
+                    warning: nil
+                ),
+                Self.indicatesUnusableConnection(result)
+            )
+        } catch {
+            return (
+                index,
+                KwtProjectInventory(
+                    project: project,
+                    worktrees: [],
+                    warning: error.localizedDescription
+                ),
+                Self.indicatesUnusableConnection(result)
+            )
+        }
     }
 
     private func binaryPrelude(for host: CommandHost) -> String {

--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -323,6 +323,9 @@ struct KwtInventoryClient: Sendable {
         sshConnectionArguments: [String]?,
         sshConnection: KwtSSHConnection? = nil
     ) async throws -> KwtHostInventory {
+        if case .ssh = host {
+            try Task.checkCancellation()
+        }
         let hostLabel = switch host {
         case .local: "this Mac"
         case let .ssh(info): info.displayName
@@ -342,6 +345,9 @@ struct KwtInventoryClient: Sendable {
                 windowsKwtRelativePath: windowsKwtRelativePath
             )
         )
+        if case .ssh = host {
+            try Task.checkCancellation()
+        }
         let directoriesResult = run(
             host: host,
             sshConnectionArguments: sshConnectionArguments,
@@ -351,6 +357,9 @@ struct KwtInventoryClient: Sendable {
                 windowsKwtRelativePath: windowsKwtRelativePath
             )
         )
+        if case .ssh = host {
+            try Task.checkCancellation()
+        }
         let topConnectionUnusable = [projectsResult, directoriesResult]
             .contains(where: Self.indicatesUnusableConnection)
         let projects: [KwtProjectRecord]
@@ -414,8 +423,10 @@ struct KwtInventoryClient: Sendable {
                 return values
             }
         case .ssh:
-            indexed = projects.enumerated().map { index, project in
-                loadProject(
+            var values: [(Int, KwtProjectInventory, Bool)] = []
+            for (index, project) in projects.enumerated() {
+                try Task.checkCancellation()
+                let value = loadProject(
                     index: index,
                     project: project,
                     host: host,
@@ -423,7 +434,18 @@ struct KwtInventoryClient: Sendable {
                     hostLabel: hostLabel,
                     windowsKwtRelativePath: windowsKwtRelativePath
                 )
+                if value.2 {
+                    await sshConnection?.invalidate()
+                    try Task.checkCancellation()
+                    throw KwtInventoryError.commandFailed(
+                        host: hostLabel,
+                        status: 255
+                    )
+                }
+                try Task.checkCancellation()
+                values.append(value)
             }
+            indexed = values
         }
         if topConnectionUnusable || indexed.contains(where: { $0.2 }) {
             await sshConnection?.invalidate()

--- a/Sources/App/KwtInventoryService.swift
+++ b/Sources/App/KwtInventoryService.swift
@@ -1,0 +1,129 @@
+import Foundation
+import GhosthubTransport
+
+private actor KwtInventoryLoadCoordinator {
+    static let shared = KwtInventoryLoadCoordinator()
+
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var activeHosts: Set<SSHHostInfo> = []
+    private var waitersByHost: [SSHHostInfo: [Waiter]] = [:]
+
+    func withExclusiveLoad<Value: Sendable>(
+        host: SSHHostInfo,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try await acquire(host: host)
+        defer { release(host: host) }
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    private func acquire(host: SSHHostInfo) async throws {
+        try Task.checkCancellation()
+        if activeHosts.insert(host).inserted {
+            return
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waitersByHost[host, default: []].append(Waiter(
+                    id: waiterID,
+                    continuation: continuation
+                ))
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(waiterID, host: host)
+            }
+        }
+    }
+
+    private func cancelWaiter(_ waiterID: UUID, host: SSHHostInfo) {
+        guard var waiters = waitersByHost[host],
+              let index = waiters.firstIndex(where: { $0.id == waiterID })
+        else { return }
+        let waiter = waiters.remove(at: index)
+        waitersByHost[host] = waiters.isEmpty ? nil : waiters
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func release(host: SSHHostInfo) {
+        guard var waiters = waitersByHost[host], !waiters.isEmpty else {
+            activeHosts.remove(host)
+            return
+        }
+        let waiter = waiters.removeFirst()
+        waitersByHost[host] = waiters.isEmpty ? nil : waiters
+        waiter.continuation.resume()
+    }
+}
+
+struct KwtInventoryService: Sendable {
+    private enum RouteExpectation: Sendable {
+        case any
+        case exact(String?)
+    }
+
+    private let client: KwtInventoryClient
+    private let lease: KwtSSHCommandLease
+
+    init(
+        client: KwtInventoryClient = KwtInventoryClient(),
+        lease: KwtSSHCommandLease = KwtSSHCommandLease()
+    ) {
+        self.client = client
+        self.lease = lease
+    }
+
+    func load(from host: CommandHost) async throws -> KwtHostInventory {
+        try await load(from: host, routeExpectation: .any)
+    }
+
+    func load(
+        from host: CommandHost,
+        expectedRouteIdentity: String?
+    ) async throws -> KwtHostInventory {
+        try await load(
+            from: host,
+            routeExpectation: .exact(expectedRouteIdentity)
+        )
+    }
+
+    private func load(
+        from host: CommandHost,
+        routeExpectation: RouteExpectation
+    ) async throws -> KwtHostInventory {
+        guard case let .ssh(info) = host else {
+            if case let .exact(expected) = routeExpectation,
+               expected != nil {
+                throw KwtSSHLeaseError.routeChanged
+            }
+            return try await client.load(from: host)
+        }
+
+        return try await KwtInventoryLoadCoordinator.shared.withExclusiveLoad(
+            host: info
+        ) {
+            try await lease.withConnection(on: host) { connection in
+                guard let connection else {
+                    throw KwtInventoryError.sshLeaseRequired(
+                        host: info.displayName
+                    )
+                }
+                if case let .exact(expected) = routeExpectation,
+                   connection.routeIdentity != expected {
+                    throw KwtSSHLeaseError.routeChanged
+                }
+                return try await client.load(
+                    from: host,
+                    sshConnection: connection
+                )
+            }
+        }
+    }
+}

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -1035,32 +1035,15 @@ final class WorkspaceSceneModel: ObservableObject {
             DisplayAvailability.activeCount()
         },
         kwtInventoryLoader: @escaping KwtInventoryLoader = { host in
-            try await KwtSSHCommandLease().withConnection(on: host) {
-                connection in
-                if let connection {
-                    return try await KwtInventoryClient().load(
-                        from: host,
-                        sshConnection: connection
-                    )
-                }
-                return try await KwtInventoryClient().load(from: host)
-            }
+            try await KwtInventoryService().load(from: host)
         },
         kwtConditionalInventoryLoader:
         @escaping KwtConditionalInventoryLoader = {
             host, expectedRouteIdentity in
-            try await KwtSSHCommandLease().withConnection(on: host) {
-                connection in
-                guard connection?.routeIdentity == expectedRouteIdentity
-                else { throw KwtSSHLeaseError.routeChanged }
-                if let connection {
-                    return try await KwtInventoryClient().load(
-                        from: host,
-                        sshConnection: connection
-                    )
-                }
-                return try await KwtInventoryClient().load(from: host)
-            }
+            try await KwtInventoryService().load(
+                from: host,
+                expectedRouteIdentity: expectedRouteIdentity
+            )
         },
         kwtRemoteProvisioner: @escaping KwtRemoteProvisioner = { host in
             try await KwtRemoteProvisioningCoordinator.shared

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -432,6 +432,82 @@ struct KwtInventoryClientTests {
         #expect(projectRuns.load() == 1)
     }
 
+    @Test("remote inventory loads sharing a route do not overlap")
+    func sharedRouteRemoteInventoryIsSerialized() async throws {
+        let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)
+        let commandRuns = LockedValue(0)
+        let activeCommands = LockedValue((active: 0, maximum: 0))
+        let firstCommandStarted = DispatchSemaphore(value: 0)
+        let firstCommandMayFinish = DispatchSemaphore(value: 0)
+        let laterCommandStarted = DispatchSemaphore(value: 0)
+        let client = KwtInventoryClient(
+            remoteRunner: { _, _, _ in
+                var run = 0
+                commandRuns.withLock { count in
+                    count += 1
+                    run = count
+                }
+                activeCommands.withLock { state in
+                    state.active += 1
+                    state.maximum = max(state.maximum, state.active)
+                }
+                if run == 1 {
+                    firstCommandStarted.signal()
+                    _ = firstCommandMayFinish.wait(timeout: .now() + 1)
+                } else {
+                    laterCommandStarted.signal()
+                }
+                activeCommands.withLock { $0.active -= 1 }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "GHOSTHUB_KWT_JSON\n[]",
+                    stderr: ""
+                )
+            }
+        )
+        let firstConnection = KwtSSHConnection(
+            arguments: ["-S", "/tmp/kwt.sock"],
+            routeIdentity: "serialized-route",
+            generation: 1
+        )
+        let secondConnection = KwtSSHConnection(
+            arguments: ["-S", "/tmp/kwt.sock"],
+            routeIdentity: "serialized-route",
+            generation: 1
+        )
+        let firstLoad = Task<KwtHostInventory, Error> {
+            try await client.load(
+                from: .ssh(ssh),
+                sshConnection: firstConnection
+            )
+        }
+
+        let didStartFirst = await BlockingTask.run {
+            firstCommandStarted.wait(timeout: .now() + 1) == .success
+        }
+        #expect(didStartFirst)
+        firstLoad.cancel()
+        let secondLoad = Task<KwtHostInventory, Error> {
+            try await client.load(
+                from: .ssh(ssh),
+                sshConnection: secondConnection
+            )
+        }
+        let secondStartedBeforeFirstFinished = await BlockingTask.run {
+            laterCommandStarted.wait(timeout: .now() + 0.2) == .success
+        }
+        #expect(!secondStartedBeforeFirstFinished)
+
+        firstCommandMayFinish.signal()
+        await #expect(throws: CancellationError.self) {
+            try await firstLoad.value
+        }
+        let inventory = try await secondLoad.value
+
+        #expect(inventory.projects.isEmpty)
+        #expect(activeCommands.load().maximum == 1)
+    }
+
     @Test("unusable remote connection stops remaining projects")
     func unusableRemoteConnectionStopsRemainingProjects() async {
         let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -465,21 +465,16 @@ struct KwtInventoryClientTests {
                 )
             }
         )
-        let firstConnection = KwtSSHConnection(
-            arguments: ["-S", "/tmp/kwt.sock"],
-            routeIdentity: "serialized-route",
-            generation: 1
-        )
-        let secondConnection = KwtSSHConnection(
-            arguments: ["-S", "/tmp/kwt.sock"],
-            routeIdentity: "serialized-route",
-            generation: 1
-        )
-        let firstLoad = Task<KwtHostInventory, Error> {
-            try await client.load(
-                from: .ssh(ssh),
-                sshConnection: firstConnection
+        let lease = KwtSSHCommandLease { _ in
+            KwtSSHConnection(
+                arguments: ["-S", "/tmp/kwt.sock"],
+                routeIdentity: "serialized-route",
+                generation: 1
             )
+        }
+        let service = KwtInventoryService(client: client, lease: lease)
+        let firstLoad = Task<KwtHostInventory, Error> {
+            try await service.load(from: .ssh(ssh))
         }
 
         let didStartFirst = await BlockingTask.run {
@@ -488,10 +483,7 @@ struct KwtInventoryClientTests {
         #expect(didStartFirst)
         firstLoad.cancel()
         let secondLoad = Task<KwtHostInventory, Error> {
-            try await client.load(
-                from: .ssh(ssh),
-                sshConnection: secondConnection
-            )
+            try await service.load(from: .ssh(ssh))
         }
         let secondStartedBeforeFirstFinished = await BlockingTask.run {
             laterCommandStarted.wait(timeout: .now() + 0.2) == .success
@@ -506,6 +498,94 @@ struct KwtInventoryClientTests {
 
         #expect(inventory.projects.isEmpty)
         #expect(activeCommands.load().maximum == 1)
+    }
+
+    @Test("queued remote inventory reacquires after invalidation")
+    func queuedRemoteInventoryReacquiresAfterInvalidation() async throws {
+        let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)
+        let route = KwtSSHRouteSnapshot.fixture(
+            routeIdentity: "serialized-route"
+        )
+        let leaseGenerations = LockedValue(0)
+        let leaseBorrows = LockedValue(0)
+        let firstGenerationRuns = LockedValue(0)
+        let firstCommandStarted = DispatchSemaphore(value: 0)
+        let firstCommandMayFinish = DispatchSemaphore(value: 0)
+        let laterBorrowStarted = DispatchSemaphore(value: 0)
+        let pool = KwtSSHConnectionPool { route, _ in
+            var generation = 0
+            leaseGenerations.withLock {
+                $0 += 1
+                generation = $0
+            }
+            return KwtSSHTestLease(
+                routeIdentity: route.routeIdentity,
+                generation: UInt64(generation),
+                arguments: ["generation=\(generation)"]
+            )
+        }
+        let lease = KwtSSHCommandLease { _ in
+            var borrow = 0
+            leaseBorrows.withLock {
+                $0 += 1
+                borrow = $0
+            }
+            if borrow > 1 {
+                laterBorrowStarted.signal()
+            }
+            return try await pool.acquire(route: route, prompt: { _ in "" })
+        }
+        let client = KwtInventoryClient(
+            remoteRunner: { _, arguments, _ in
+                if arguments == ["generation=1"] {
+                    var run = 0
+                    firstGenerationRuns.withLock {
+                        $0 += 1
+                        run = $0
+                    }
+                    if run == 1 {
+                        firstCommandStarted.signal()
+                        _ = firstCommandMayFinish.wait(timeout: .now() + 1)
+                    }
+                    return AccountCommandOutput(
+                        status: 255,
+                        stdout: "",
+                        stderr: "Control socket connect: Connection refused"
+                    )
+                }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "GHOSTHUB_KWT_JSON\n[]",
+                    stderr: ""
+                )
+            }
+        )
+        let service = KwtInventoryService(client: client, lease: lease)
+        let firstLoad = Task<KwtHostInventory, Error> {
+            try await service.load(from: .ssh(ssh))
+        }
+
+        let didStartFirst = await BlockingTask.run {
+            firstCommandStarted.wait(timeout: .now() + 1) == .success
+        }
+        #expect(didStartFirst)
+        let secondLoad = Task<KwtHostInventory, Error> {
+            try await service.load(from: .ssh(ssh))
+        }
+        let borrowedBeforeInvalidation = await BlockingTask.run {
+            laterBorrowStarted.wait(timeout: .now() + 0.2) == .success
+        }
+        #expect(!borrowedBeforeInvalidation)
+        firstCommandMayFinish.signal()
+
+        await #expect(throws: KwtInventoryError.self) {
+            try await firstLoad.value
+        }
+        let inventory = try await secondLoad.value
+
+        #expect(inventory.projects.isEmpty)
+        #expect(leaseBorrows.load() == 2)
+        #expect(leaseGenerations.load() == 2)
     }
 
     @Test("unusable remote connection stops remaining projects")

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -319,6 +319,59 @@ struct KwtInventoryClientTests {
         #expect(inventory.directoryWorkspaces.map(\.path) == ["/srv/hub"])
     }
 
+    @Test("remote project inventory is serialized")
+    func remoteProjectInventoryIsSerialized() async throws {
+        let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)
+        let concurrency = LockedValue((active: 0, maximum: 0))
+        let overlap = DispatchSemaphore(value: 0)
+        let client = KwtInventoryClient(
+            remoteRunner: { _, _, command in
+                if command.contains("projects --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n" +
+                            #"[{"repository":"one","name":"one","path":"/one","registration_fingerprint":"one-fingerprint"},{"repository":"two","name":"two","path":"/two","registration_fingerprint":"two-fingerprint"}]"#,
+                        stderr: ""
+                    )
+                }
+                if command.contains("workspace list --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n[]",
+                        stderr: ""
+                    )
+                }
+
+                var active = 0
+                concurrency.withLock { state in
+                    state.active += 1
+                    state.maximum = max(state.maximum, state.active)
+                    active = state.active
+                }
+                if active == 1 {
+                    _ = overlap.wait(timeout: .now() + 0.2)
+                } else {
+                    overlap.signal()
+                }
+                concurrency.withLock { $0.active -= 1 }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "GHOSTHUB_KWT_JSON\n[]",
+                    stderr: ""
+                )
+            }
+        )
+
+        let inventory = try await client.load(
+            from: .ssh(ssh),
+            sshConnectionArguments: ["-S", "/tmp/kwt.sock"]
+        )
+
+        #expect(inventory.projects.count == 2)
+        #expect(inventory.projects.allSatisfy { $0.warning == nil })
+        #expect(concurrency.load().maximum == 1)
+    }
+
     @Test("remote inventory invalidates a lost daemon master")
     func invalidatesLostRemoteMaster() async {
         let invalidations = LockedValue(0)

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -372,6 +372,116 @@ struct KwtInventoryClientTests {
         #expect(concurrency.load().maximum == 1)
     }
 
+    @Test("cancelled remote inventory stops before the next project")
+    func cancelledRemoteInventoryStopsBeforeNextProject() async {
+        let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)
+        let projectRuns = LockedValue(0)
+        let firstProjectStarted = DispatchSemaphore(value: 0)
+        let firstProjectMayFinish = DispatchSemaphore(value: 0)
+        let client = KwtInventoryClient(
+            remoteRunner: { _, _, command in
+                if command.contains("projects --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n" +
+                            #"[{"repository":"one","name":"one","path":"/one","registration_fingerprint":"one-fingerprint"},{"repository":"two","name":"two","path":"/two","registration_fingerprint":"two-fingerprint"},{"repository":"three","name":"three","path":"/three","registration_fingerprint":"three-fingerprint"}]"#,
+                        stderr: ""
+                    )
+                }
+                if command.contains("workspace list --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n[]",
+                        stderr: ""
+                    )
+                }
+
+                var run = 0
+                projectRuns.withLock { count in
+                    count += 1
+                    run = count
+                }
+                if run == 1 {
+                    firstProjectStarted.signal()
+                    _ = firstProjectMayFinish.wait(timeout: .now() + 1)
+                }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "GHOSTHUB_KWT_JSON\n[]",
+                    stderr: ""
+                )
+            }
+        )
+        let load = Task<KwtHostInventory, Error> {
+            try await client.load(
+                from: CommandHost.ssh(ssh),
+                sshConnectionArguments: ["-S", "/tmp/kwt.sock"]
+            )
+        }
+
+        let didStart = await BlockingTask.run {
+            firstProjectStarted.wait(timeout: .now() + 1) == .success
+        }
+        #expect(didStart)
+        load.cancel()
+        firstProjectMayFinish.signal()
+
+        await #expect(throws: CancellationError.self) {
+            try await load.value
+        }
+        #expect(projectRuns.load() == 1)
+    }
+
+    @Test("unusable remote connection stops remaining projects")
+    func unusableRemoteConnectionStopsRemainingProjects() async {
+        let ssh = SSHHostInfo(user: "tester", hostname: "builder", port: nil)
+        let projectRuns = LockedValue(0)
+        let invalidations = LockedValue(0)
+        let connection = KwtSSHConnection(
+            arguments: ["-S", "/tmp/kwt.sock"],
+            routeIdentity: "route-one",
+            generation: 1,
+            invalidate: { invalidations.withLock { $0 += 1 } }
+        )
+        let client = KwtInventoryClient(
+            remoteRunner: { _, _, command in
+                if command.contains("projects --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n" +
+                            #"[{"repository":"one","name":"one","path":"/one","registration_fingerprint":"one-fingerprint"},{"repository":"two","name":"two","path":"/two","registration_fingerprint":"two-fingerprint"}]"#,
+                        stderr: ""
+                    )
+                }
+                if command.contains("workspace list --json") {
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_KWT_JSON\n[]",
+                        stderr: ""
+                    )
+                }
+                projectRuns.withLock { $0 += 1 }
+                return AccountCommandOutput(
+                    status: 255,
+                    stdout: "",
+                    stderr: "Control socket connect(/tmp/kwt.sock): Connection refused"
+                )
+            }
+        )
+
+        await #expect(throws: KwtInventoryError.commandFailed(
+            host: "tester@builder",
+            status: 255
+        )) {
+            try await client.load(
+                from: .ssh(ssh),
+                sshConnection: connection
+            )
+        }
+        #expect(projectRuns.load() == 1)
+        #expect(invalidations.load() == 1)
+    }
+
     @Test("remote inventory invalidates a lost daemon master")
     func invalidatesLostRemoteMaster() async {
         let invalidations = LockedValue(0)

--- a/Tests/App/WorkspaceTmuxCreationTests.swift
+++ b/Tests/App/WorkspaceTmuxCreationTests.swift
@@ -301,6 +301,7 @@ extension WorkspaceTmuxDiscoveryTests {
     func launchedRemoteCreationReconcilesBeforeRemoval() async throws {
         let environment = try setupRemoteEnvironment()
         let attempts = Counter()
+        let retryMayFinish = AsyncGate()
         let surfaceStore = SceneTmuxSurfaceStoreStub()
         let model = try makeModel(
             database: environment.database,
@@ -318,6 +319,7 @@ extension WorkspaceTmuxDiscoveryTests {
                         )
                     ))
                 }
+                await retryMayFinish.wait()
                 return .success([
                     DiscoveredTmuxSession(
                         name: "release-work",
@@ -341,13 +343,14 @@ extension WorkspaceTmuxDiscoveryTests {
         )
         close(false, 1)
 
-        await waitUntilMainActor { attempts.count == 1 }
+        await retryMayFinish.waitUntilWaiting()
         #expect(model.pendingCreatedTmuxSessionCount == 1)
         #expect(
             model.snapshot.host(id: environment.host.id)?
                 .tmuxSessions.map(\.name) == ["release-work"]
         )
 
+        retryMayFinish.open()
         await waitUntilMainActor {
             model.pendingCreatedTmuxSessionCount == 0
         }


### PR DESCRIPTION
- Prevents healthy remote projects from appearing as inventory failures when a host refuses excess multiplexed SSH sessions.
- Serializes complete remote `kwt` inventory per configured SSH host before borrowing the shared connection, while keeping local project discovery parallel.
- Stops superseded refreshes before their next command; replacements wait for an already-running blocking command to exit.
- Invalidates unusable pooled connections and makes queued refreshes borrow the current generation instead of retaining a dead socket.
- Covers project ordering, cross-window overlap, cancellation, connection invalidation, and the self-hosted tmux-creation retry race with focused regressions.
