### PR TITLE
Remove the unused required CI result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,19 +273,3 @@ jobs:
           case "${GHOSTHUB_CI_STATE_ROOT:-}" in
             /tmp/ghosthub-ci.*) rm -rf -- "$GHOSTHUB_CI_STATE_ROOT" ;;
           esac
-
-  # kenn-ops requires this main-pinned check as "run / Required CI".
-  required:
-    name: Required CI
-    if: ${{ always() }}
-    needs: [macos-arm64]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Require authoritative macOS validation
-        env:
-          RESULT: ${{ needs.macos-arm64.result }}
-        run: |
-          if [[ "$RESULT" != success ]]; then
-            echo "Authoritative macOS validation ended with: $RESULT" >&2
-            exit 1
-          fi


### PR DESCRIPTION
Removes the unused `Required CI` aggregation job. CI continues to report the hosted and self-hosted lane outcomes without adding a separate policy-oriented check.

Runner selection, advisory behavior, fork routing, and the live repository rules remain unchanged.
