### PR TITLE
Backport remaining libghostty memory fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -whitespace

--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,8 @@ debug-app: ensure-kwt ensure-kwt-variants bootstrap-libghostty
 	cp -f "$(APP_ENTITLEMENTS_PATH)" "$$debug_entitlements"; \
 	plutil -insert 'com\.apple\.security\.cs\.disable-library-validation' \
 		-bool true "$$debug_entitlements"; \
+	plutil -insert 'com\.apple\.security\.get-task-allow' \
+		-bool true "$$debug_entitlements"; \
 	codesign --force --deep --options runtime \
 		--entitlements "$$debug_entitlements" \
 		--sign - "$(DEBUG_APP_PATH)" >/dev/null; \

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let libghosttyBuildRoot = packageRoot.appendingPathComponent(".build/libghostty"
 let vendorMetadataPath = packageRoot.appendingPathComponent("Vendor/ghostty.version.json")
 let libghosttyManifestPath = libghosttyBuildRoot.appendingPathComponent("manifest.json")
 /// Increment whenever Ghosthub's libghostty patch surface changes.
-let requiredLibghosttyBootstrapVersion = 24
+let requiredLibghosttyBootstrapVersion = 25
 
 func loadJSONDictionary(at url: URL) -> [String: Any]? {
     guard let data = try? Data(contentsOf: url),

--- a/Vendor/ghostty-patches/0001-renderer-release-GPU-resources-for-hidden-surfaces-m.patch
+++ b/Vendor/ghostty-patches/0001-renderer-release-GPU-resources-for-hidden-surfaces-m.patch
@@ -1,0 +1,322 @@
+From e7075e965f98c96e0da3328ab82c37fadec45728 Mon Sep 17 00:00:00 2001
+From: Mitchell Hashimoto <m@mitchellh.com>
+Date: Tue, 25 Aug 2026 10:40:06 -0700
+Subject: [PATCH 1/4] renderer: release GPU resources for hidden surfaces
+ (macOS)
+
+Ref #12034
+
+This commit releases many GPU resources when a surface becomes invisible and
+rebuilds it on the next draw. I don't say "all" because there are still
+some things we can improve on (Kitty images).
+
+We previously held onto all GPU resources for the lifetime of the surface
+regardless of its visibility state. This is 3x (for triple-buffering):
+screen render targets, uniform/cell/custom shader buffers, font textures,
+and more.
+
+Measured on macOS (Metal):
+
+| Measurement (1 visible + 20 hidden tabs)    | Before    | After   |
+|---------------------------------------------|-----------|---------|
+| Tracked GPU allocations (steady state)      | 384.6 MiB | 18.3 MiB |
+| `MTLDevice.currentAllocatedSize`            | 393.3 MiB | 19.7 MiB |
+| `footprint` IOSurface (dirty)               | 309 MB    | 15 MB   |
+| Swap chain rebuild on unhide (42 switches)  | n/a       | avg 0.43 ms, max 0.55 ms |
+
+As you can see, importantly, swap chain rebuild is fast: 0.43ms average.
+That means that the rebuild is imperceptible and happens well within
+a frame draw time.
+
+This is macOS only, but most of the work was in the generic renderer.
+GTK only needs to call `releaseGpuResources` when it becomes invisible
+to get the same benefits. I didn't have my VM handy to test this yet so
+I didn't include it.
+---
+ src/apprt.zig            |   9 ++++
+ src/renderer/OpenGL.zig  |   6 +++
+ src/renderer/Thread.zig  |  10 +---
+ src/renderer/generic.zig | 111 +++++++++++++++++++++++++++------------
+ 4 files changed, 93 insertions(+), 43 deletions(-)
+
+diff --git a/src/apprt.zig b/src/apprt.zig
+index c467f1801..ffc3af287 100644
+--- a/src/apprt.zig
++++ b/src/apprt.zig
+@@ -51,6 +51,15 @@ pub const runtime = switch (build_config.artifact) {
+ pub const App = runtime.App;
+ pub const Surface = runtime.Surface;
+ 
++/// True if all GPU operations (drawing, resource creation and
++/// destruction) must happen on the app thread. This is the case
++/// when the graphics context is owned by the app thread (GTK's
++/// GLArea). When false, the render thread performs GPU operations
++/// itself.
++pub const must_draw_from_app_thread =
++    @hasDecl(App, "must_draw_from_app_thread") and
++    App.must_draw_from_app_thread;
++
+ test {
+     _ = Runtime;
+     _ = runtime;
+diff --git a/src/renderer/OpenGL.zig b/src/renderer/OpenGL.zig
+index 4b01da0c5..40c11f606 100644
+--- a/src/renderer/OpenGL.zig
++++ b/src/renderer/OpenGL.zig
+@@ -335,6 +335,12 @@ pub fn presentLastTarget(self: *OpenGL) !void {
+     if (self.last_target) |target| try self.present(target);
+ }
+ 
++/// Called when the renderer released its GPU resources; the last
++/// presented target is deinited with them so we must drop our copy.
++pub fn gpuResourcesReleased(self: *OpenGL) void {
++    self.last_target = null;
++}
++
+ /// Returns the options to use when constructing buffers.
+ pub inline fn bufferOptions(self: OpenGL) bufferpkg.Options {
+     _ = self;
+diff --git a/src/renderer/Thread.zig b/src/renderer/Thread.zig
+index 508721379..995a70d0a 100644
+--- a/src/renderer/Thread.zig
++++ b/src/renderer/Thread.zig
+@@ -21,14 +21,6 @@ const CURSOR_BLINK_INTERVAL = 600;
+ 
+ /// Whether calls to `drawFrame` must be done from the app thread.
+ ///
+-/// If this is `true` then we send a `redraw_surface` message to the apprt
+-/// whenever we need to draw instead of calling `drawFrame` directly.
+-const must_draw_from_app_thread =
+-    if (@hasDecl(apprt.App, "must_draw_from_app_thread"))
+-        apprt.App.must_draw_from_app_thread
+-    else
+-        false;
+-
+ /// The type used for sending messages to the IO thread. For now this is
+ /// hardcoded with a capacity. We can make this a comptime parameter in
+ /// the future if we want it configurable.
+@@ -499,7 +491,7 @@ fn drawFrame(self: *Thread, now: bool) void {
+     // when we're forced to via `now`.
+     if (!now and self.renderer.hasVsync()) return;
+ 
+-    if (must_draw_from_app_thread) {
++    if (apprt.must_draw_from_app_thread) {
+         _ = self.app_mailbox.push(
+             .{ .redraw_surface = self.surface },
+             .{ .instant = {} },
+diff --git a/src/renderer/generic.zig b/src/renderer/generic.zig
+index ff632f64a..a17e24aa5 100644
+--- a/src/renderer/generic.zig
++++ b/src/renderer/generic.zig
+@@ -202,8 +202,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+         /// Health of the most recently completed frame.
+         health: std.atomic.Value(Health) = .{ .raw = .healthy },
+ 
+-        /// Our swap chain (multiple buffering)
+-        swap_chain: SwapChain,
++        /// True when we have a graphics context that can create GPU
++        /// resources. Creating any GPU resource while this is false is invalid.
++        display_realized: bool = true,
++
++        /// Our swap chain (multiple buffering). Null when it has
++        /// been released, either because the surface is hidden
++        /// (`releaseGpuResources`) or because the display is
++        /// unrealized. Rebuilt on the next `drawFrame`.
++        swap_chain: ?SwapChain,
+ 
+         /// This value is used to force-update swap chain targets in the
+         /// event of a config change that requires it (such as blending mode).
+@@ -254,14 +261,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             /// frame state struct so we can start working on a new frame.
+             frame_sema: std.Thread.Semaphore = .{ .permits = buf_count },
+ 
+-            /// Set to true when deinited, if you try to deinit a defunct
+-            /// swap chain it will just be ignored, to prevent double-free.
+-            ///
+-            /// This is required because of `displayUnrealized`, since it
+-            /// `deinits` the swapchain, which leads to a double-free if
+-            /// the renderer is deinited after that.
+-            defunct: bool = false,
+-
+             pub fn init(api: GraphicsAPI, custom_shaders: bool) !SwapChain {
+                 var result: SwapChain = .{ .frames = undefined };
+ 
+@@ -274,9 +273,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             }
+ 
+             pub fn deinit(self: *SwapChain) void {
+-                if (self.defunct) return;
+-                self.defunct = true;
+-
+                 // Wait for all of our inflight draws to complete
+                 // so that we can cleanly deinit our GPU state.
+                 for (0..buf_count) |_| self.frame_sema.wait();
+@@ -286,11 +282,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             /// Get the next frame state to draw to. This will wait on the
+             /// semaphore to ensure that the frame is available. This must
+             /// always be paired with a call to releaseFrame.
+-            pub fn nextFrame(self: *SwapChain) error{Defunct}!*FrameState {
+-                if (self.defunct) return error.Defunct;
+-
++            pub fn nextFrame(self: *SwapChain) *FrameState {
+                 self.frame_sema.wait();
+-                errdefer self.frame_sema.post();
+                 self.frame_index = (self.frame_index + 1) % buf_count;
+                 return &self.frames[self.frame_index];
+             }
+@@ -802,7 +795,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             self.terminal_state.deinit(self.alloc);
+             if (self.search_selected_match) |*m| m.arena.deinit();
+             if (self.search_matches) |*m| m.arena.deinit();
+-            self.swap_chain.deinit();
++            if (self.swap_chain) |*sc| sc.deinit();
+ 
+             if (DisplayLink != void) {
+                 if (self.display_link) |display_link| {
+@@ -947,9 +940,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             defer self.draw_mutex.unlock();
+ 
+             // We assume that the swap chain was deinited in
+-            // `displayUnrealized`, in which case it should be
+-            // marked defunct. If not, we have a problem.
+-            assert(self.swap_chain.defunct);
++            // `displayUnrealized`. If not, we have a problem.
++            assert(self.swap_chain == null);
++            assert(!self.display_realized);
+ 
+             // We reinitialize our shaders and our swap chain.
+             try self.initShaders();
+@@ -957,6 +950,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+                 self.api,
+                 self.has_custom_shaders,
+             );
++            self.display_realized = true;
+             self.reinitialize_shaders = false;
+             self.target_config_modified = 1;
+         }
+@@ -975,11 +969,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             self.draw_mutex.lock();
+             defer self.draw_mutex.unlock();
+ 
+-            // We deinit our swap chain and shaders.
+-            //
+-            // This will mark them as defunct so that they
+-            // can't be double-freed or used in draw calls.
+-            self.swap_chain.deinit();
++            // We deinit our swap chain and shaders. Clearing
++            // `display_realized` ensures drawFrame doesn't attempt
++            // to rebuild the swap chain (we have no GPU context);
++            // displayRealized will.
++            if (self.swap_chain) |*sc| sc.deinit();
++            self.swap_chain = null;
++            self.display_realized = false;
+             self.shaders.deinit(self.alloc);
+         }
+ 
+@@ -1062,6 +1058,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+                     display_link.stop() catch {};
+                 }
+             }
++
++            // When hidden, release GPU resources on runtimes whose renderer
++            // thread owns the graphics context. The swap chain is rebuilt on
++            // the next draw after the surface becomes visible again.
++            if (comptime !apprt.must_draw_from_app_thread) {
++                if (!visible) self.releaseGpuResources();
++            }
++        }
++
++        /// Release the GPU resources held by a hidden surface. This is safe to
++        /// call repeatedly; a released swap chain is rebuilt by drawFrame.
++        pub fn releaseGpuResources(self: *Self) void {
++            self.draw_mutex.lock();
++            defer self.draw_mutex.unlock();
++
++            if (self.swap_chain) |*sc| {
++                sc.deinit();
++                self.swap_chain = null;
++
++                if (comptime @hasDecl(GraphicsAPI, "gpuResourcesReleased")) {
++                    self.api.gpuResourcesReleased();
++                }
++            }
+         }
+ 
+         /// Set the new font grid.
+@@ -1076,11 +1095,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+ 
+             // Update all our textures so that they sync on the next frame.
+             // We can modify this without a lock because the GPU does not
+-            // touch this data.
+-            for (&self.swap_chain.frames) |*frame| {
++            // touch this data. A released swap chain is rebuilt with
++            // fresh frames that sync all textures on first use.
++            if (self.swap_chain) |*sc| for (&sc.frames) |*frame| {
+                 frame.grayscale_modified = 0;
+                 frame.color_modified = 0;
+-            }
++            };
+ 
+             // Get our metrics from the grid. This doesn't require a lock because
+             // the metrics are never recalculated.
+@@ -1468,6 +1488,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             // then drawing is absurd, so we just return.
+             if (surface_size.width == 0 or surface_size.height == 0) return;
+ 
++            // If we have no graphics context we can't draw. This is
++            // only the case while unrealized (GTK); displayRealized
++            // rebuilds the swap chain.
++            if (!self.display_realized) return;
++
++            // Get our swap chain, rebuilding it if it was released
++            // while we were hidden. Rebuilding is deferred to draw
++            // time because resource creation must happen somewhere
++            // our graphics API allows it (OpenGL requires a current
++            // context, which drawFrame guarantees).
++            const swap_chain: *SwapChain, const swap_chain_rebuilt: bool =
++                if (self.swap_chain) |*sc| .{ sc, false } else rebuild: {
++                    self.swap_chain = try SwapChain.init(
++                        self.api,
++                        self.has_custom_shaders,
++                    );
++                    break :rebuild .{ &self.swap_chain.?, true };
++                };
++
+             const size_changed =
+                 self.size.screen.width != surface_size.width or
+                 self.size.screen.height != surface_size.height;
+@@ -1476,6 +1515,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             // don't need to since the previous frame should be identical.
+             const needs_redraw =
+                 size_changed or
++                swap_chain_rebuilt or
+                 self.cells_rebuilt or
+                 self.hasAnimations() or
+                 sync;
+@@ -1490,9 +1530,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+             self.cells_rebuilt = false;
+ 
+             // Wait for a frame to be available.
+-            const frame = try self.swap_chain.nextFrame();
+-            errdefer self.swap_chain.releaseFrame();
+-            // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
++            const frame = swap_chain.nextFrame();
++            errdefer swap_chain.releaseFrame();
++            // log.debug("drawing frame index={}", .{swap_chain.frame_index});
+ 
+             // If we need to reinitialize our shaders, do so.
+             if (self.reinitialize_shaders) {
+@@ -1737,8 +1777,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
+                 }, .{ .forever = {} });
+             }
+ 
+-            // Always release our semaphore
+-            self.swap_chain.releaseFrame();
++            // Always release our semaphore. The swap chain is
++            // guaranteed to exist here: it is only torn down after
++            // waiting for all in-flight frames to complete, and this
++            // callback is what signals that completion.
++            self.swap_chain.?.releaseFrame();
+         }
+ 
+         /// Call this any time the background image path changes.

--- a/Vendor/ghostty-patches/0003-terminal-track-page-ownership-explicitly-on-pagelist.patch
+++ b/Vendor/ghostty-patches/0003-terminal-track-page-ownership-explicitly-on-pagelist.patch
@@ -1,0 +1,518 @@
+From 15d61f17d55e2476690ffe4b4da02daee03d1aaa Mon Sep 17 00:00:00 2001
+From: Mitchell Hashimoto <m@mitchellh.com>
+Date: Tue, 7 Jul 2026 13:47:38 -0700
+Subject: [PATCH 3/4] terminal: track page ownership explicitly on pagelist
+ nodes
+
+PageList decided whether a page's backing memory belongs to the memory
+pool or the heap by comparing its length against std_size. This was super
+error-prone and the source of many bugs historically. We locked it down
+but its bothered me and has gotten in the way of another feature I've
+wanted to do: memory compaction.
+
+First, this commit records the ownership explicitly on each node and uses it
+everywhere ownership was previously inferred from size.
+
+Second, createPage gains an exact_size option that forces an exact-size
+heap allocation even when the layout would fit a pool item.
+
+Third, compact() now uses it to shrink any page to its minimum size,
+including standard pages. Nothing calls compact [YET!] but this is going
+to be the key to compressing scrollback history.
+
+This is groundwork for a ton of memory savings. Coming soon.
+---
+ src/terminal/PageList.zig | 281 ++++++++++++++++++++++++++++----------
+ 1 file changed, 209 insertions(+), 72 deletions(-)
+
+diff --git a/src/terminal/PageList.zig b/src/terminal/PageList.zig
+index 6e39428db..95669ab40 100644
+--- a/src/terminal/PageList.zig
++++ b/src/terminal/PageList.zig
+@@ -46,6 +46,22 @@ const Node = struct {
+     next: ?*Node = null,
+     data: Page,
+     serial: u64,
++
++    /// How the backing memory of `data` was allocated. Pool-owned
++    /// memory is always a full standard-size item from the memory
++    /// pool, regardless of the page layout size. Heap-owned memory
++    /// is allocated directly with the page allocator and is exactly
++    /// `data.memory.len` bytes.
++    ///
++    /// This must never be inferred from the memory length: heap-owned
++    /// pages can be smaller than the standard size (e.g. compacted
++    /// pages), and returning one to the pool would corrupt it.
++    ///
++    /// This has no default on purpose so that every construction site
++    /// is forced to make an explicit decision.
++    owned: Owned,
++
++    const Owned = enum { pool, heap };
+ };
+ 
+ /// The memory pool we get page nodes from.
+@@ -444,13 +460,14 @@ fn initPages(
+     // redundant here for safety.
+     assert(layout.total_size <= size.max_page_size);
+ 
+-    // If we have an error, we need to clean up our non-standard pages
++    // If we have an error, we need to clean up our heap-owned pages
+     // since they're not in the pool.
+     errdefer {
+         var it = page_list.first;
+         while (it) |node| : (it = node.next) {
+-            if (node.data.memory.len > std_size) {
+-                page_alloc.free(node.data.memory);
++            switch (node.owned) {
++                .pool => {},
++                .heap => page_alloc.free(node.data.memory),
+             }
+         }
+     }
+@@ -487,6 +504,7 @@ fn initPages(
+         node.* = .{
+             .data = .initBuf(.init(page_buf), layout),
+             .serial = serial.*,
++            .owned = if (pooled) .pool else .heap,
+         };
+         node.data.size.rows = @min(rem, node.data.capacity.rows);
+         rem -= node.data.size.rows;
+@@ -631,12 +649,13 @@ pub fn deinit(self: *PageList) void {
+     self.tracked_pins.deinit(self.pool.alloc);
+ 
+     // Go through our linked list and deallocate all pages that are
+-    // not standard size.
++    // heap-owned (not in the pool).
+     const page_alloc = self.pool.pages.arena.child_allocator;
+     var it = self.pages.first;
+     while (it) |node| : (it = node.next) {
+-        if (node.data.memory.len > std_size) {
+-            page_alloc.free(node.data.memory);
++        switch (node.owned) {
++            .pool => {},
++            .heap => page_alloc.free(node.data.memory),
+         }
+     }
+ 
+@@ -670,14 +689,14 @@ pub fn reset(self: *PageList) void {
+     ) catch unreachable;
+ 
+     // Before resetting our pools we need to free any pages that
+-    // are non-standard size since those were allocated outside
+-    // the pool.
++    // are heap-owned since those were allocated outside the pool.
+     {
+         const page_alloc = self.pool.pages.arena.child_allocator;
+         var it = self.pages.first;
+         while (it) |node| : (it = node.next) {
+-            if (node.data.memory.len > std_size) {
+-                page_alloc.free(node.data.memory);
++            switch (node.owned) {
++                .pool => {},
++                .heap => page_alloc.free(node.data.memory),
+             }
+         }
+     }
+@@ -817,8 +836,9 @@ pub fn clone(
+         const page_alloc = pool.pages.arena.child_allocator;
+         var page_it = page_list.first;
+         while (page_it) |node| : (page_it = node.next) {
+-            if (node.data.memory.len > std_size) {
+-                page_alloc.free(node.data.memory);
++            switch (node.owned) {
++                .pool => {},
++                .heap => page_alloc.free(node.data.memory),
+             }
+         }
+     }
+@@ -832,7 +852,7 @@ pub fn clone(
+         // we don't know if the source page has a standard size.
+         const node = try createPageExt(
+             &pool,
+-            chunk.node.data.capacity,
++            .{ .cap = chunk.node.data.capacity },
+             &page_serial,
+             &page_size,
+         );
+@@ -1074,7 +1094,7 @@ fn resizeCols(
+             break :err cap;
+         };
+ 
+-        const node = try self.createPage(cap);
++        const node = try self.createPage(.{ .cap = cap });
+         node.data.size.rows = 1;
+         break :node node;
+     };
+@@ -1910,7 +1930,7 @@ const ReflowCursor = struct {
+         // after reinitializing our cursor on the new page.
+         const new_rows = self.new_rows;
+ 
+-        const node = try list.createPage(cap);
++        const node = try list.createPage(.{ .cap = cap });
+         errdefer comptime unreachable;
+         node.data.size.rows = 1;
+         list.pages.insertAfter(self.node, node);
+@@ -2289,7 +2309,7 @@ fn resizeWithoutReflowGrowCols(
+     // We need to loop because our col growth may force us
+     // to split pages.
+     while (copied < page.size.rows) {
+-        const new_node = try self.createPage(cap);
++        const new_node = try self.createPage(.{ .cap = cap });
+         defer new_node.data.assertIntegrity();
+ 
+         // The length we can copy into the new page is at most the number
+@@ -2760,13 +2780,15 @@ pub fn scrollClear(self: *PageList) Allocator.Error!void {
+ 
+ /// Compact a page to use the minimum required memory for the contents
+ /// it stores. Returns the new node pointer if compaction occurred, or null
+-/// if the page was already compact or compaction would not provide meaningful
++/// if the page was already compact or compaction would not provide any
+ /// savings.
+ ///
+-/// The current design of PageList at the time of writing this doesn't
+-/// allow for smaller than `std_size` nodes so if the current node's backing
+-/// page is standard size or smaller, no compaction will occur. In the
+-/// future we should fix this up.
++/// The compacted page is always an exact-size heap allocation, never
++/// a pool item, since a pool item always retains a full std_size
++/// buffer regardless of the page layout. Note that this means that
++/// when compacting a pool-owned node, the freed pool item is returned
++/// to the pool free list, so the memory savings are only fully
++/// realized once the pool itself is reset or freed.
+ ///
+ /// If this returns OOM, the PageList is left unchanged and no dangling
+ /// memory references exist. It is safe to ignore the error and continue using
+@@ -2778,18 +2800,23 @@ pub fn compact(self: *PageList, node: *List.Node) Allocator.Error!?*List.Node {
+     // We should never have empty rows in our pagelist anyways...
+     assert(page.size.rows > 0);
+ 
+-    // We never compact standard size or smaller pages because changing
+-    // the capacity to something smaller won't save memory.
+-    if (page.memory.len <= std_size) return null;
+-
+     // Compute the minimum capacity required for this page's content
+     const req_cap = page.exactRowCapacity(0, page.size.rows);
+     const new_size = Page.layout(req_cap).total_size;
+-    const old_size = page.memory.len;
++
++    // The memory this node currently retains. A pool-owned node always
++    // retains a full pool item no matter its layout size.
++    const old_size: usize = switch (node.owned) {
++        .pool => PagePool.item_size,
++        .heap => page.memory.len,
++    };
+     if (new_size >= old_size) return null;
+ 
+     // Create the new smaller page
+-    const new_node = try self.createPage(req_cap);
++    const new_node = try self.createPage(.{
++        .cap = req_cap,
++        .exact_size = true,
++    });
+     errdefer self.destroyNode(new_node);
+     const new_page: *Page = &new_node.data;
+     new_page.size = page.size;
+@@ -2868,7 +2895,7 @@ pub fn split(
+     defer self.assertIntegrity();
+ 
+     // Create a new node with the same capacity of managed memory.
+-    const target = try self.createPage(page.capacity);
++    const target = try self.createPage(.{ .cap = page.capacity });
+     errdefer self.destroyNode(target);
+ 
+     // Determine how many rows we're copying
+@@ -3164,10 +3191,17 @@ pub fn grow(self: *PageList) Allocator.Error!?*List.Node {
+         }
+         self.viewport_pin.garbage = false;
+ 
+-        // Non-standard pages can't be reused, just destroy them.
+-        if (first.data.memory.len > std_size) {
+-            self.destroyNode(first);
+-            break :prune;
++        switch (first.owned) {
++            // Pool-owned pages are reused below.
++            .pool => {},
++
++            // Heap-owned pages can't be reused because they may be
++            // any size (larger or smaller than a standard page), so
++            // just destroy them.
++            .heap => {
++                self.destroyNode(first);
++                break :prune;
++            },
+         }
+ 
+         // Reset our memory
+@@ -3197,7 +3231,7 @@ pub fn grow(self: *PageList) Allocator.Error!?*List.Node {
+     }
+ 
+     // We need to allocate a new memory buffer.
+-    const next_node = try self.createPage(cap);
++    const next_node = try self.createPage(.{ .cap = cap });
+     // we don't errdefer this because we've added it to the linked
+     // list and its fine to have dangling unused pages.
+     self.pages.append(next_node);
+@@ -3293,7 +3327,7 @@ pub fn increaseCapacity(
+     log.info("adjusting page capacity={}", .{cap});
+ 
+     // Create our new page and clone the old page into it.
+-    const new_node = try self.createPage(cap);
++    const new_node = try self.createPage(.{ .cap = cap });
+     errdefer self.destroyNode(new_node);
+     const new_page: *Page = &new_node.data;
+     assert(new_page.capacity.rows >= page.capacity.rows);
+@@ -3336,16 +3370,29 @@ pub fn increaseCapacity(
+     return new_node;
+ }
+ 
++/// Options for createPage and createPageExt.
++const CreatePage = struct {
++    /// The capacity to allocate the page with.
++    cap: Capacity,
++
++    /// Force the page backing memory to be an exact-size heap
++    /// allocation even if it would fit within a standard-size pool
++    /// item. This is used when compacting pages to their minimum
++    /// size, since a pool item always retains a full std_size buffer
++    /// regardless of the page layout.
++    exact_size: bool = false,
++};
++
+ /// Create a new page node. This does not add it to the list and this
+ /// does not do any memory size accounting with max_size/page_size.
+ inline fn createPage(
+     self: *PageList,
+-    cap: Capacity,
++    opts: CreatePage,
+ ) Allocator.Error!*List.Node {
+-    // log.debug("create page cap={}", .{cap});
++    // log.debug("create page cap={}", .{opts.cap});
+     return try createPageExt(
+         &self.pool,
+-        cap,
++        opts,
+         &self.page_serial,
+         &self.page_size,
+     );
+@@ -3353,15 +3400,15 @@ inline fn createPage(
+ 
+ inline fn createPageExt(
+     pool: *MemoryPool,
+-    cap: Capacity,
++    opts: CreatePage,
+     serial: *u64,
+     total_size: ?*usize,
+ ) Allocator.Error!*List.Node {
+     var page = try pool.nodes.create();
+     errdefer pool.nodes.destroy(page);
+ 
+-    const layout = Page.layout(cap);
+-    const pooled = layout.total_size <= std_size;
++    const layout = Page.layout(opts.cap);
++    const pooled = !opts.exact_size and layout.total_size <= std_size;
+     const page_alloc = pool.pages.arena.child_allocator;
+ 
+     // It would be better to encode this into the Zig error handling
+@@ -3392,6 +3439,7 @@ inline fn createPageExt(
+     page.* = .{
+         .data = .initBuf(.init(page_buf), layout),
+         .serial = serial.*,
++        .owned = if (pooled) .pool else .heap,
+     };
+     page.data.size.rows = 0;
+     serial.* += 1;
+@@ -3424,16 +3472,28 @@ fn destroyNodeExt(
+ ) void {
+     const page: *Page = &node.data;
+ 
+-    // Update our accounting for page size
+-    if (total_size) |v| v.* -= page.memory.len;
++    // Update our accounting for page size. This must mirror what was
++    // added at creation time: a pool-owned page always accounts for a
++    // full pool item even if its layout is smaller, while a heap-owned
++    // page accounts for its exact memory length.
++    if (total_size) |v| v.* -= switch (node.owned) {
++        .pool => PagePool.item_size,
++        .heap => page.memory.len,
++    };
+ 
+-    if (page.memory.len <= std_size) {
+-        // Reset the memory to zero so it can be reused
+-        @memset(page.memory, 0);
+-        pool.pages.destroy(@ptrCast(page.memory.ptr));
+-    } else {
+-        const page_alloc = pool.pages.arena.child_allocator;
+-        page_alloc.free(page.memory);
++    switch (node.owned) {
++        .pool => {
++            assert(page.memory.len <= std_size);
++
++            // Reset the memory to zero so it can be reused
++            @memset(page.memory, 0);
++            pool.pages.destroy(@ptrCast(page.memory.ptr));
++        },
++
++        .heap => {
++            const page_alloc = pool.pages.arena.child_allocator;
++            page_alloc.free(page.memory);
++        },
+     }
+ 
+     pool.nodes.destroy(node);
+@@ -13879,23 +13939,108 @@ test "PageList resize (no reflow) more cols remaps pins in backfill path" {
+     try testing.expectEqual(marker, cell.content.codepoint);
+ }
+ 
+-test "PageList compact std_size page returns null" {
++test "PageList compact pool page produces exact-size heap page" {
+     const testing = std.testing;
+     const alloc = testing.allocator;
+ 
+     var s = try init(alloc, 80, 24, 0);
+     defer s.deinit();
+ 
+-    // A freshly created page should be at std_size
++    // A freshly created page is pool-owned at std_size.
+     const node = s.pages.first.?;
++    try testing.expectEqual(.pool, node.owned);
+     try testing.expect(node.data.memory.len <= std_size);
++    const original_size = node.data.size;
++
++    // Compacting it should produce a much smaller exact-size heap page.
++    const new_node = (try s.compact(node)).?;
++    try testing.expectEqual(.heap, new_node.owned);
++    try testing.expect(new_node.data.memory.len < std_size);
++    try testing.expectEqual(original_size.rows, new_node.data.size.rows);
++    try testing.expectEqual(original_size.cols, new_node.data.size.cols);
++    try testing.expectEqual(new_node, s.pages.first.?);
+ 
+-    // compact should return null since there's nothing to compact
+-    const result = try s.compact(node);
+-    try testing.expectEqual(null, result);
++    // Our page size accounting should exactly match the compacted
++    // page since it is the only page in the list.
++    try testing.expectEqual(new_node.data.memory.len, s.page_size);
++
++    // Compacting again should be a no-op since it is already exact.
++    try testing.expectEqual(null, try s.compact(new_node));
++}
+ 
+-    // Page should still be the same
+-    try testing.expectEqual(node, s.pages.first.?);
++test "PageList compact then grow allocates new page" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    var s = try init(alloc, 80, 24, null);
++    defer s.deinit();
++
++    // Compact the only page. It now has no spare row capacity.
++    const node = (try s.compact(s.pages.first.?)).?;
++    try testing.expectEqual(node.data.size.rows, node.data.capacity.rows);
++
++    // Growing must allocate a fresh standard page from the pool,
++    // exercising that a compacted page remains a valid live page.
++    _ = try s.grow();
++    try testing.expect(s.pages.first != s.pages.last);
++    try testing.expectEqual(.pool, s.pages.last.?.owned);
++    try testing.expectEqual(@as(usize, 25), s.totalRows());
++}
++
++test "PageList compact then reset frees heap pages" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    var s = try init(alloc, 80, 24, 0);
++    defer s.deinit();
++
++    // Compact the only page so the list contains a sub-std_size
++    // heap-owned page.
++    const node = (try s.compact(s.pages.first.?)).?;
++    try testing.expectEqual(.heap, node.owned);
++    try testing.expect(node.data.memory.len < std_size);
++
++    // Reset must free the heap page (testing allocator catches leaks
++    // and invalid frees) and rebuild from the pool.
++    s.reset();
++    try testing.expectEqual(.pool, s.pages.first.?.owned);
++    try testing.expectEqual(@as(usize, s.rows), s.totalRows());
++}
++
++test "PageList compact then clone" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    var s = try init(alloc, 80, 24, null);
++    defer s.deinit();
++
++    // Write a marker so we can verify contents survive.
++    {
++        const node = s.pages.first.?;
++        const rac = node.data.getRowAndCell(1, 2);
++        rac.cell.* = .{
++            .content_tag = .codepoint,
++            .content = .{ .codepoint = 'X' },
++        };
++    }
++
++    // Compact so the source list contains a sub-std_size heap page.
++    const node = (try s.compact(s.pages.first.?)).?;
++    try testing.expectEqual(.heap, node.owned);
++    try testing.expect(node.data.memory.len < std_size);
++
++    var s2 = try s.clone(alloc, .{
++        .top = .{ .screen = .{} },
++    });
++    defer s2.deinit();
++    try testing.expectEqual(@as(usize, s.rows), s2.totalRows());
++
++    // Verify the marker survived the clone.
++    {
++        const node2 = s2.pages.first.?;
++        const rac = node2.data.getRowAndCell(1, 2);
++        try testing.expectEqual(@as(u21, 'X'), rac.cell.content.codepoint);
++    }
+ }
+ 
+ test "PageList compact oversized page" {
+@@ -13985,7 +14130,7 @@ test "PageList compact oversized page" {
+     }
+ }
+ 
+-test "PageList compact insufficient savings returns null" {
++test "PageList compact after increaseCapacity" {
+     const testing = std.testing;
+     const alloc = testing.allocator;
+ 
+@@ -13994,23 +14139,15 @@ test "PageList compact insufficient savings returns null" {
+ 
+     var node = s.pages.first.?;
+ 
+-    // Make the page slightly oversized (just one increase)
+-    // This might not provide enough savings to justify compaction
++    // Grow the page capacity. The content is unchanged, so compaction
++    // should always shrink it back down to an exact-size heap page.
+     node = try s.increaseCapacity(node, .grapheme_bytes);
++    const grown_len = node.data.memory.len;
+ 
+-    // If the page is still at or below std_size, compact returns null
+-    if (node.data.memory.len <= std_size) {
+-        const result = try s.compact(node);
+-        try testing.expectEqual(null, result);
+-    } else {
+-        // If it did grow beyond std_size, verify that compaction
+-        // works or returns null based on savings calculation
+-        const result = try s.compact(node);
+-        // Either it compacted or determined insufficient savings
+-        if (result) |new_node| {
+-            try testing.expect(new_node.data.memory.len < node.data.memory.len);
+-        }
+-    }
++    const new_node = (try s.compact(node)).?;
++    try testing.expectEqual(.heap, new_node.owned);
++    try testing.expect(new_node.data.memory.len < grown_len);
++    try testing.expect(new_node.data.memory.len < std_size);
+ }
+ 
+ test "PageList split at middle row" {

--- a/Vendor/ghostty-patches/0004-terminal-return-free-listed-page-memory-to-the-OS.patch
+++ b/Vendor/ghostty-patches/0004-terminal-return-free-listed-page-memory-to-the-OS.patch
@@ -1,0 +1,269 @@
+From 53eead5fa1e5501f038a8e9bc799e170930d1aaa Mon Sep 17 00:00:00 2001
+From: Mitchell Hashimoto <m@mitchellh.com>
+Date: Tue, 7 Jul 2026 20:25:54 -0700
+Subject: [PATCH] terminal: return free-listed page memory to the OS
+
+The PageList page pool never returns memory to the OS: destroyed pages
+are zeroed and free-listed until the surface exits. Any operation that
+shrinks the page count (clearing scrollback, pruning churn, resets,
+reflow) therefore retains its high-water RSS forever.
+
+Clearing a full scrollback keeps all of it resident, which at the default 10MB
+scrollback-limit is 10MB per terminal of memory that can never be
+used again for anything else.
+
+Lots of memes on the internet about this, and it turns out operating
+systems give us an answer for this (both Linux and macOS at least),
+so let's do it kids.
+
+Pool items can't be individually freed since they live inside arena
+chunks, but they are page-aligned and page-multiple sized, so we can
+decommit them while they sit in the free list. Our page-aligned
+allocation pays off, again!
+
+On Linux, madvise(MADV_DONTNEED) reclaims the pages immediately and
+guarantees zero-fill on the next touch, which also lets us skip the
+zeroing memset entirely, making destroy cheaper.
+
+On macOS, we zero in place and mark the item MADV_FREE_REUSABLE, which
+removes it from the process footprint immediately. Reuse is paired
+with MADV_FREE_REUSE when the pool hands a buffer back out so that
+footprint accounting stays correct. The zero invariant required by
+page reuse holds either way: reusable page contents are either
+preserved (our zeroes) or reclaimed and zero-filled by the kernel.
+
+Other platforms and test builds keep the existing memset behavior.
+
+Fable 5 found the retention behavior while re-analyzing scrollback
+memory, wrote the change and tests, and verified the madvise semantics
+empirically with memory probes on macOS and a real Linux kernel, plus
+before/after throughput benchmarks on both. I reviewed the analysis,
+the diff, rewrote the code to be more idiomatic Zig, and wrote this
+commit message you're reading.
+---
+ src/terminal/PageList.zig | 184 +++++++++++++++++++++++++++++++++++---
+ 1 file changed, 172 insertions(+), 12 deletions(-)
+
+diff --git a/src/terminal/PageList.zig b/src/terminal/PageList.zig
+index 95669ab40..fcfc11c40 100644
+--- a/src/terminal/PageList.zig
++++ b/src/terminal/PageList.zig
+@@ -480,7 +480,9 @@ fn initPages(
+ 
+         const page_buf = if (pooled) buf: {
+             try tw.check(.page_buf_std);
+-            break :buf try pool.pages.create();
++            const buf = try pool.pages.create();
++            recommitPoolItem(buf);
++            break :buf buf;
+         } else buf: {
+             try tw.check(.page_buf_non_std);
+             break :buf try page_alloc.alignedAlloc(
+@@ -3419,14 +3421,15 @@ inline fn createPageExt(
+     // Our page buffer comes from our standard memory pool if it
+     // is within our standard size since this is what the pool
+     // dispenses. Otherwise, we use the heap allocator to allocate.
+-    const page_buf = if (pooled)
+-        try pool.pages.create()
+-    else
+-        try page_alloc.alignedAlloc(
+-            u8,
+-            .fromByteUnits(std.heap.page_size_min),
+-            layout.total_size,
+-        );
++    const page_buf = if (pooled) buf: {
++        const buf = try pool.pages.create();
++        recommitPoolItem(buf);
++        break :buf buf;
++    } else try page_alloc.alignedAlloc(
++        u8,
++        .fromByteUnits(std.heap.page_size_min),
++        layout.total_size,
++    );
+     errdefer if (pooled)
+         pool.pages.destroy(page_buf)
+     else
+@@ -3485,9 +3488,12 @@ fn destroyNodeExt(
+         .pool => {
+             assert(page.memory.len <= std_size);
+ 
+-            // Reset the memory to zero so it can be reused
+-            @memset(page.memory, 0);
+-            pool.pages.destroy(@ptrCast(page.memory.ptr));
++            // Reset the memory to zero (and decommit it, where
++            // supported) so it can be reused.
++            const item: *align(std.heap.page_size_min) [std_size]u8 =
++                @ptrCast(@alignCast(page.memory.ptr));
++            decommitPoolItem(item, page.memory.len);
++            pool.pages.destroy(item);
+         },
+ 
+         .heap => {
+@@ -3499,6 +3505,100 @@ fn destroyNodeExt(
+     pool.nodes.destroy(node);
+ }
+ 
++/// Zero a pool item buffer that is about to be returned to the pool
++/// free list and, where supported, tell the OS it can reclaim the
++/// backing memory while the buffer sits unused. Without the decommit,
++/// a pool that shrinks (scrollback clears, pruning churn, resets)
++/// retains its high-water RSS forever, since MemoryPool free lists
++/// never return memory to the OS.
++///
++/// dirty_len is the length of the page that lived in this item, which
++/// may be smaller than the item; bytes beyond it are already zero.
++///
++/// The invariant required for page reuse (see createPageExt): after
++/// this call the entire item reads back as zeroes. The pool writes its
++/// free list node into the first pointer-size bytes afterwards, which
++/// is safe because page initialization always overwrites them (see the
++/// comptime assert in Page).
++fn decommitPoolItem(
++    item: *align(std.heap.page_size_min) [std_size]u8,
++    dirty_len: usize,
++) void {
++    // In test builds the buffer comes from std.testing.allocator, not
++    // the OS page allocator, so madvise is neither safe nor meaningful.
++    if (comptime builtin.is_test) {
++        @memset(item[0..dirty_len], 0);
++        return;
++    }
++
++    // MADV_DONTNEED on a private anonymous mapping immediately
++    // reclaims the pages and guarantees they read back zero-filled
++    // on the next access, so we can skip the memset entirely.
++    //
++    // We use MADV_DONTNEED rather than MADV_FREE deliberately:
++    // MADV_FREE doesn't reduce RSS until memory pressure (invisible
++    // to users watching memory usage) and doesn't guarantee zeroes
++    // on the next read. MADV_DONTNEED's synchronous TLB-shootdown
++    // cost only matters at allocator-level call frequency; page
++    // destroys here are rare (clears, reflow, capacity changes), and
++    // the hottest reuse path (grow's prune-reuse) doesn't go through
++    // this function at all.
++    if (comptime builtin.os.tag == .linux) {
++        if (std.posix.madvise(
++            item,
++            std_size,
++            std.posix.MADV.DONTNEED,
++        )) |_| return else |err| {
++            log.warn("madvise(DONTNEED) failed err={}", .{err});
++            // Fall through to the memset below.
++        }
++    }
++
++    // On Darwin we zero in place and then mark the memory as
++    // reusable, which removes it from the process footprint until
++    // it is touched again. Contents of reusable memory are either
++    // preserved (our zeroes) or reclaimed and zero-filled on the
++    // next access, so the invariant holds either way. The reuse
++    // side calls MADV_FREE_REUSE to fix up footprint accounting
++    // (see recommitPoolItem).
++    if (comptime builtin.os.tag.isDarwin()) {
++        @memset(item[0..dirty_len], 0);
++        std.posix.madvise(
++            item,
++            std_size,
++            std.posix.MADV.FREE_REUSABLE,
++        ) catch {
++            // Best-effort: plain MADV_FREE reclaims under memory
++            // pressure only and needs no reuse pairing.
++            std.posix.madvise(
++                item,
++                std_size,
++                std.posix.MADV.FREE,
++            ) catch {};
++        };
++        return;
++    }
++
++    @memset(item[0..dirty_len], 0);
++}
++
++/// The counterpart to decommitPoolItem for buffers handed back out by
++/// the pool. Only Darwin requires this: MADV_FREE_REUSE re-accounts
++/// previously reusable memory to the process footprint. Without it the
++/// memory still works (touching reusable pages revives them) but
++/// footprint reporting can undercount. Harmless on buffers that were
++/// never marked reusable (fresh or preheated items).
++fn recommitPoolItem(item: *align(std.heap.page_size_min) [std_size]u8) void {
++    if (comptime builtin.is_test) return;
++    if (comptime builtin.os.tag.isDarwin()) {
++        std.posix.madvise(
++            item,
++            std_size,
++            std.posix.MADV.FREE_REUSE,
++        ) catch {};
++    }
++}
++
+ /// Fast-path function to erase exactly 1 row. Erasing means that the row
+ /// is completely REMOVED, not just cleared. All rows following the removed
+ /// row will be shifted up by 1 to fill the empty space.
+@@ -14130,6 +14230,66 @@ test "PageList compact oversized page" {
+     }
+ }
+ 
++test "PageList decommitPoolItem zeroes the dirty region" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    // Note: in test builds decommitPoolItem always takes the memset
++    // path; the madvise-based paths rely on kernel zero-fill semantics
++    // that unit tests cannot exercise (see decommitPoolItem).
++    const buf = try alloc.alignedAlloc(
++        u8,
++        .fromByteUnits(std.heap.page_size_min),
++        std_size,
++    );
++    defer alloc.free(buf);
++    const item: *align(std.heap.page_size_min) [std_size]u8 = @ptrCast(buf.ptr);
++
++    // Fully dirty item.
++    @memset(item, 0xAA);
++    decommitPoolItem(item, std_size);
++    try testing.expect(std.mem.allEqual(u8, item, 0));
++
++    // Partially dirty item: an item that hosted a page smaller than
++    // the item is only dirty up to the page length; the rest is zero
++    // by invariant and must remain zero.
++    @memset(item[0..1024], 0xAA);
++    decommitPoolItem(item, 1024);
++    try testing.expect(std.mem.allEqual(u8, item, 0));
++}
++
++test "PageList destroyed pool page reuse is zeroed" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    var s = try init(alloc, 80, 24, null);
++    defer s.deinit();
++
++    // Create a page and scribble over its entire backing memory,
++    // then destroy it so the buffer returns to the pool free list.
++    const node = try s.createPage(.{ .cap = initialCapacity(80) });
++    node.data.size.rows = 1;
++    const mem_ptr = node.data.memory.ptr;
++    @memset(node.data.memory, 0xAA);
++    s.destroyNode(node);
++
++    // Reusing the buffer must produce a fully valid, zeroed page.
++    const node2 = try s.createPage(.{ .cap = initialCapacity(80) });
++    try testing.expectEqual(mem_ptr, node2.data.memory.ptr);
++    node2.data.size.rows = node2.data.capacity.rows;
++
++    const cells_len = @as(usize, node2.data.capacity.cols) *
++        @as(usize, node2.data.capacity.rows);
++    const cells = node2.data.cells.ptr(node2.data.memory)[0..cells_len];
++    try testing.expect(std.mem.allEqual(
++        u64,
++        @as([]const u64, @ptrCast(cells)),
++        0,
++    ));
++    node2.data.assertIntegrity();
++    s.destroyNode(node2);
++}
++
+ test "PageList compact after increaseCapacity" {
+     const testing = std.testing;
+     const alloc = testing.allocator;

--- a/Vendor/ghostty-patches/README.md
+++ b/Vendor/ghostty-patches/README.md
@@ -1,0 +1,19 @@
+# Ghostty Memory Backports
+
+Ghosthub applies these patches in the order declared by `GHOSTTY_BACKPORTS` to
+its clean, pinned Ghostty `v1.3.1` checkout. PR #220 separately backports ten
+upstream lifetime fixes through `apply_upstream_lifetime_backports`; the patches
+here are the additional long-lived terminal-memory fixes not included there.
+
+| Patch | Upstream commit | Upstream PR | Purpose |
+| --- | --- | --- | --- |
+| `0001` | `c4e16970a803b170e352432424f44192cb59f3ac` | [#14017](https://github.com/ghostty-org/ghostty/pull/14017) | Release Metal and IOSurface resources while a terminal surface is hidden. |
+| `0003` | `16e4b5e98f10f255bdda934a61ff41e9b3a849c7` | [#13241](https://github.com/ghostty-org/ghostty/pull/13241) | Track terminal page ownership explicitly so pooled and heap-backed pages are reclaimed safely. |
+| `0004` | `896aca499001f42e132f456ebc9cdfed616cf1fb` | [#13245](https://github.com/ghostty-org/ghostty/pull/13245) | Return free-listed terminal page memory to macOS or Linux instead of retaining the high-water footprint. |
+
+The first patch is adapted to the semaphore and display-link APIs in `v1.3.1`.
+The page-list source changes match their upstream commits; the fourth patch omits
+unrelated test context that landed between the pinned release and that commit.
+
+When the pinned Ghostty release contains these fixes, remove the corresponding
+patches, update `GHOSTTY_BACKPORTS`, and bump `GHOSTHUB_BOOTSTRAP_VERSION`.

--- a/tools/libghostty_bootstrap.py
+++ b/tools/libghostty_bootstrap.py
@@ -15,11 +15,27 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-GHOSTHUB_BOOTSTRAP_VERSION = 24
+GHOSTHUB_BOOTSTRAP_VERSION = 25
 GHOSTHUB_GHOSTTY_BUNDLE_ID = "com.ghosthub"
 GHOSTHUB_TERM_PROGRAM = "ghosthub"
 SOURCE_FETCH_ATTEMPTS = 3
 SOURCE_FETCH_RETRY_DELAY_SECONDS = 5.0
+
+GHOSTTY_BACKPORTS = (
+    (
+        "c4e16970a803b170e352432424f44192cb59f3ac",
+        "0001-renderer-release-GPU-resources-for-hidden-surfaces-m.patch",
+    ),
+    (
+        "16e4b5e98f10f255bdda934a61ff41e9b3a849c7",
+        "0003-terminal-track-page-ownership-explicitly-on-pagelist.patch",
+    ),
+    (
+        "896aca499001f42e132f456ebc9cdfed616cf1fb",
+        "0004-terminal-return-free-listed-page-memory-to-the-OS.patch",
+    ),
+)
+GHOSTTY_BACKPORT_COMMITS = [commit for commit, _ in GHOSTTY_BACKPORTS]
 
 
 class BootstrapError(RuntimeError):
@@ -807,6 +823,55 @@ def patch_termio_discarded_message_cleanup(
         description="upstream drained mailbox message cleanup",
     )
 
+
+def apply_ghostty_backports(paths: BootstrapPaths, *, git: str) -> None:
+    """Apply Ghostty memory fixes that landed after the pinned release."""
+    git_path = resolve_tool(git)
+    patch_root = paths.repo_root / "Vendor" / "ghostty-patches"
+
+    for commit, filename in GHOSTTY_BACKPORTS:
+        patch_path = patch_root / filename
+        if not patch_path.is_file():
+            raise BootstrapError(
+                f"Ghostty backport {commit} is missing its patch file: {patch_path}"
+            )
+
+        command = [
+            git_path,
+            "-C",
+            str(paths.source_checkout_root),
+            "apply",
+            "--whitespace=error-all",
+            str(patch_path),
+        ]
+        check = subprocess.run(
+            [*command[:4], "--check", *command[4:]],
+            capture_output=True,
+            text=True,
+        )
+        if check.returncode == 0:
+            try:
+                subprocess.run(command, check=True, capture_output=True, text=True)
+            except subprocess.CalledProcessError as error:
+                raise BootstrapError(
+                    f"Failed to apply Ghostty memory backport {commit} from "
+                    f"{patch_path}.\n{describe_command_failure(error)}"
+                ) from error
+            continue
+
+        reverse = subprocess.run(
+            [*command[:4], "--reverse", "--check", *command[4:]],
+            capture_output=True,
+            text=True,
+        )
+        if reverse.returncode == 0:
+            continue
+
+        detail = check.stderr.strip() or check.stdout.strip() or "git apply failed"
+        raise BootstrapError(
+            f"Ghostty memory backport {commit} no longer applies to the pinned "
+            f"source checkout: {patch_path}\n{detail}"
+        )
 
 def patch_build_config_bundle_id(path: Path) -> None:
     original = 'pub const bundle_id = "com.mitchellh.ghostty";'
@@ -1865,6 +1930,11 @@ def artifact_state_message(
             "libghostty artifacts were built against a different Ghostty revision. "
             "Re-run `python3 tools/bootstrap_libghostty.py`."
         )
+    if manifest.get("ghosttyBackports") != GHOSTTY_BACKPORT_COMMITS:
+        return (
+            "libghostty artifacts were built without the current Ghostty memory backports. "
+            "Re-run `python3 tools/bootstrap_libghostty.py`."
+        )
     if manifest.get("ghosthubBootstrapVersion") != GHOSTHUB_BOOTSTRAP_VERSION:
         return (
             "libghostty artifacts were built against an older Ghosthub bootstrap schema. "
@@ -2147,6 +2217,7 @@ def write_manifest(
         "ghosttySource": metadata.source,
         "ghosttyTag": metadata.tag,
         "ghosttyCommit": metadata.commit,
+        "ghosttyBackports": GHOSTTY_BACKPORT_COMMITS,
         "ghosthubBootstrapVersion": GHOSTHUB_BOOTSTRAP_VERSION,
         "ghosttyBundleID": GHOSTHUB_GHOSTTY_BUNDLE_ID,
         "ghosttyConfigLoadExport": True,
@@ -2187,6 +2258,7 @@ def bootstrap(
     rebuilt_variant = False
     if artifact_state_message(paths.cached_artifacts, metadata, xcframework_target, optimize) is not None:
         ensure_source_checkout(paths, metadata, git=git)
+        apply_ghostty_backports(paths, git=git)
         apply_ghosthub_source_patches(paths)
         apply_upstream_lifetime_backports(paths.source_checkout_root)
 

--- a/tools/tests/test_libghostty_bootstrap.py
+++ b/tools/tests/test_libghostty_bootstrap.py
@@ -151,6 +151,37 @@ void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
     )
 
 
+def test_apply_ghostty_backports_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _paths(tmp_path)
+    source = paths.source_checkout_root
+    source.mkdir(parents=True)
+    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    target = source / "memory.txt"
+    target.write_text("retained\n")
+
+    patch_root = tmp_path / "Vendor" / "ghostty-patches"
+    patch_root.mkdir(parents=True)
+    patch_name = "memory.patch"
+    patch_root.joinpath(patch_name).write_text(
+        """diff --git a/memory.txt b/memory.txt
+--- a/memory.txt
++++ b/memory.txt
+@@ -1 +1 @@
+-retained
++released
+"""
+    )
+    monkeypatch.setattr(bootstrap, "GHOSTTY_BACKPORTS", (("memory-fix", patch_name),))
+
+    bootstrap.apply_ghostty_backports(paths, git="git")
+    bootstrap.apply_ghostty_backports(paths, git="git")
+
+    assert target.read_text() == "released\n"
+
+
 def _make_archive(
     workdir: Path,
     name: str,
@@ -274,6 +305,7 @@ def test_artifact_state_flags_archive_missing_ghostty_api(tmp_path: Path) -> Non
         json.dumps(
             {
                 "ghosttyCommit": "abc123",
+                "ghosttyBackports": bootstrap.GHOSTTY_BACKPORT_COMMITS,
                 "ghosthubBootstrapVersion": bootstrap.GHOSTHUB_BOOTSTRAP_VERSION,
                 "xcframeworkTarget": "native",
                 "optimize": "Debug",
@@ -1343,6 +1375,7 @@ def test_universal_build_requires_both_sdk_targets(
 def test_bootstrap_wraps_build_failures_with_setup_guidance(repo: Repo) -> None:
     with (
         mock.patch.object(bootstrap, "ensure_source_checkout"),
+        mock.patch.object(bootstrap, "apply_ghostty_backports"),
         mock.patch.object(bootstrap, "apply_ghosthub_source_patches"),
         mock.patch.object(bootstrap, "apply_upstream_lifetime_backports"),
         mock.patch.object(
@@ -1513,6 +1546,11 @@ def test_artifact_state_reports_missing_bootstrap_outputs(repo: Repo) -> None:
             {"ghosttyCommit": "different"},
             "against a different Ghostty revision",
             id="commit",
+        ),
+        pytest.param(
+            {"ghosttyBackports": []},
+            "without the current Ghostty memory backports",
+            id="memory-backports",
         ),
         pytest.param(
             {"ghosthubBootstrapVersion": bootstrap.GHOSTHUB_BOOTSTRAP_VERSION - 1},
@@ -2082,6 +2120,7 @@ def _write_artifacts(
     manifest: dict[str, object] = {
         "ghosthubBootstrapVersion": bootstrap.GHOSTHUB_BOOTSTRAP_VERSION,
         "ghosttyBundleID": bootstrap.GHOSTHUB_GHOSTTY_BUNDLE_ID,
+        "ghosttyBackports": bootstrap.GHOSTTY_BACKPORT_COMMITS,
         "embeddedEnvIsolation": True,
         "macosLoginQuiet": True,
         "ghosttyConfigLoadExport": True,


### PR DESCRIPTION
- Reduce long-lived Ghosthub memory retention while pinned to libghostty 1.3.1.
- Release Metal and IOSurface resources while terminal surfaces are hidden, without detaching tmux or SSH clients ([Ghostty #14017](https://github.com/ghostty-org/ghostty/pull/14017)).
- Track terminal page ownership explicitly and return free-listed page memory to the OS instead of retaining the process high-water footprint ([Ghostty #13241](https://github.com/ghostty-org/ghostty/pull/13241), [Ghostty #13245](https://github.com/ghostty-org/ghostty/pull/13245)).
- Build on the ten upstream lifetime fixes already merged in #220; record the exact upstream commits and bump the bootstrap schema so stale artifacts rebuild.
- Keep the v1.3.1 adaptation limited to hidden-surface semaphore and display-link APIs; the page-list source changes match upstream.
- Allow local debug builds to be inspected with macOS memory tools; packaged release entitlements remain unchanged.
- The patched libghostty passes its focused PageList tests, Ghosthub’s full Swift and Python suites, formatting checks, and the app build.