### PR TITLE
Retry transient kwt inventory failures

### DIFF
--- a/Sources/App/KwtInventoryClient.swift
+++ b/Sources/App/KwtInventoryClient.swift
@@ -250,6 +250,7 @@ struct KwtInventoryClient: Sendable {
     private let loginShellProvider: @Sendable () -> String
     private let localBinaryPath: String?
     private let remoteBinaryRevision: String?
+    private let retryDelays: [Duration]
 
     init(
         localRunner: LocalRunner? = nil,
@@ -258,6 +259,9 @@ struct KwtInventoryClient: Sendable {
         localBinaryPath: String? = KwtBinaryLocator.bundledPath(),
         remoteBinaryRevision: String? =
             KwtBinaryLocator.bundledRemoteRevision(),
+        retryDelays: [Duration] = [
+            .seconds(1), .seconds(4), .seconds(15),
+        ],
         loginShellProvider: @escaping @Sendable () -> String =
             AccountCommandRunner.loginShell
     ) {
@@ -280,6 +284,7 @@ struct KwtInventoryClient: Sendable {
         self.loginShellProvider = loginShellProvider
         self.localBinaryPath = localBinaryPath
         self.remoteBinaryRevision = remoteBinaryRevision
+        self.retryDelays = retryDelays
     }
 
     func load(from host: CommandHost) async throws -> KwtHostInventory {
@@ -336,7 +341,7 @@ struct KwtInventoryClient: Sendable {
             )
         let hostPlatform = platform(for: host)
         let prelude = binaryPrelude(for: host)
-        let projectsResult = run(
+        let projectsResult = try await run(
             host: host,
             sshConnectionArguments: sshConnectionArguments,
             command: Self.projectsCommand(
@@ -348,7 +353,7 @@ struct KwtInventoryClient: Sendable {
         if case .ssh = host {
             try Task.checkCancellation()
         }
-        let directoriesResult = run(
+        let directoriesResult = try await run(
             host: host,
             sshConnectionArguments: sshConnectionArguments,
             command: Self.directoryWorkspacesCommand(
@@ -400,13 +405,13 @@ struct KwtInventoryClient: Sendable {
         let indexed: [(Int, KwtProjectInventory, Bool)]
         switch host {
         case .local:
-            indexed = await withTaskGroup(
+            indexed = try await withThrowingTaskGroup(
                 of: (Int, KwtProjectInventory, Bool).self,
                 returning: [(Int, KwtProjectInventory, Bool)].self
             ) { group in
                 for (index, project) in projects.enumerated() {
                     group.addTask {
-                        loadProject(
+                        try await loadProject(
                             index: index,
                             project: project,
                             host: host,
@@ -417,7 +422,7 @@ struct KwtInventoryClient: Sendable {
                     }
                 }
                 var values: [(Int, KwtProjectInventory, Bool)] = []
-                for await value in group {
+                for try await value in group {
                     values.append(value)
                 }
                 return values
@@ -426,7 +431,7 @@ struct KwtInventoryClient: Sendable {
             var values: [(Int, KwtProjectInventory, Bool)] = []
             for (index, project) in projects.enumerated() {
                 try Task.checkCancellation()
-                let value = loadProject(
+                let value = try await loadProject(
                     index: index,
                     project: project,
                     host: host,
@@ -465,8 +470,8 @@ struct KwtInventoryClient: Sendable {
         sshConnectionArguments: [String]?,
         hostLabel: String,
         windowsKwtRelativePath: String?
-    ) -> (Int, KwtProjectInventory, Bool) {
-        let result = run(
+    ) async throws -> (Int, KwtProjectInventory, Bool) {
+        let result = try await run(
             host: host,
             sshConnectionArguments: sshConnectionArguments,
             command: Self.worktreesCommand(
@@ -527,6 +532,29 @@ struct KwtInventoryClient: Sendable {
         host: CommandHost,
         sshConnectionArguments: [String]?,
         command: String
+    ) async throws -> AccountCommandOutput {
+        var result = runOnce(
+            host: host,
+            sshConnectionArguments: sshConnectionArguments,
+            command: command
+        )
+        for delay in retryDelays {
+            guard Self.isRetryableFailure(result) else { break }
+            try await Task.sleep(for: delay)
+            try Task.checkCancellation()
+            result = runOnce(
+                host: host,
+                sshConnectionArguments: sshConnectionArguments,
+                command: command
+            )
+        }
+        return result
+    }
+
+    private func runOnce(
+        host: CommandHost,
+        sshConnectionArguments: [String]?,
+        command: String
     ) -> AccountCommandOutput {
         switch host {
         case .local:
@@ -554,17 +582,9 @@ struct KwtInventoryClient: Sendable {
                 status: result.status
             )
         }
-        let normalizedOutput = result.stdout.replacingOccurrences(
-            of: "\r\n",
-            with: "\n"
-        )
-        guard let markerRange = normalizedOutput.range(
-            of: Self.jsonMarker,
-            options: .backwards
-        ) else {
+        guard let json = Self.markedJSON(in: result.stdout) else {
             throw KwtInventoryError.malformedOutput(host: hostLabel)
         }
-        let json = normalizedOutput[markerRange.upperBound...]
         do {
             return try JSONDecoder().decode(
                 Value.self,
@@ -573,6 +593,28 @@ struct KwtInventoryClient: Sendable {
         } catch {
             throw KwtInventoryError.malformedOutput(host: hostLabel)
         }
+    }
+
+    private static func isRetryableFailure(
+        _ result: AccountCommandOutput
+    ) -> Bool {
+        guard result.status != 0,
+              let json = markedJSON(in: result.stdout),
+              let envelope = try? JSONDecoder().decode(
+                  KwtCommandErrorEnvelope.self,
+                  from: Data(json.utf8)
+              )
+        else { return false }
+        return envelope.error.retryable
+    }
+
+    private static func markedJSON(in output: String) -> Substring? {
+        let normalized = output.replacingOccurrences(of: "\r\n", with: "\n")
+        guard let markerRange = normalized.range(
+            of: jsonMarker,
+            options: .backwards
+        ) else { return nil }
+        return normalized[markerRange.upperBound...]
     }
 
     private static func indicatesUnusableConnection(
@@ -637,6 +679,14 @@ struct KwtInventoryClient: Sendable {
             + "printf 'GHOSTHUB_KWT_JSON\\n'; "
             + "exec \"$ghosthub_kwt_path\" workspace list --json"
     }
+}
+
+private struct KwtCommandErrorEnvelope: Decodable {
+    struct CommandError: Decodable {
+        let retryable: Bool
+    }
+
+    let error: CommandError
 }
 
 enum KwtSnapshotMerger {

--- a/Tests/App/KwtInventoryClientTests.swift
+++ b/Tests/App/KwtInventoryClientTests.swift
@@ -237,6 +237,67 @@ struct KwtInventoryClientTests {
         #expect(inventory.directoryWorkspaceWarning != nil)
     }
 
+    @Test("retryable directory inventory failure recovers")
+    func retryableDirectoryFailureRecovers() async throws {
+        let directoryRuns = LockedValue(0)
+        let client = KwtInventoryClient(
+            localRunner: { _, command in
+                guard command.contains("workspace list --json") else {
+                    return (0, "GHOSTHUB_KWT_JSON\n[]")
+                }
+                var run = 0
+                directoryRuns.withLock { runs in
+                    runs += 1
+                    run = runs
+                }
+                if run == 1 {
+                    return (
+                        1,
+                        "GHOSTHUB_KWT_JSON\n" +
+                            #"{"error":{"code":"inventory_timeout","message":"inventory refresh timed out","retryable":true}}"#
+                    )
+                }
+                return (
+                    0,
+                    "GHOSTHUB_KWT_JSON\n" +
+                        #"[{"name":"hub","path":"/workspaces/hub","session_name":"kwt-workspace-dir-hub-abc","session_live":true,"tmux_socket_name":"kwt","tmux_attach_mode":"direct"}]"#
+                )
+            },
+            retryDelays: [.zero]
+        )
+
+        let inventory = try await client.load(from: .local)
+
+        #expect(inventory.directoryWorkspaces.map(\.path) == ["/workspaces/hub"])
+        #expect(inventory.directoryWorkspaceWarning == nil)
+        #expect(directoryRuns.load() == 2)
+    }
+
+    @Test("nonretryable directory inventory failure is not repeated")
+    func nonretryableDirectoryFailureIsNotRepeated() async throws {
+        let directoryRuns = LockedValue(0)
+        let client = KwtInventoryClient(
+            localRunner: { _, command in
+                guard command.contains("workspace list --json") else {
+                    return (0, "GHOSTHUB_KWT_JSON\n[]")
+                }
+                directoryRuns.withLock { $0 += 1 }
+                return (
+                    1,
+                    "GHOSTHUB_KWT_JSON\n" +
+                        #"{"error":{"code":"invalid_request","message":"invalid inventory request","retryable":false}}"#
+                )
+            },
+            retryDelays: [.zero]
+        )
+
+        let inventory = try await client.load(from: .local)
+
+        #expect(inventory.directoryWorkspaces.isEmpty)
+        #expect(inventory.directoryWorkspaceWarning != nil)
+        #expect(directoryRuns.load() == 1)
+    }
+
     @Test("project inventory failure does not hide registered directories")
     func projectFailureIsPartial() async throws {
         let client = KwtInventoryClient(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -555,7 +555,10 @@ remove their unique staged file. Neither local nor remote operations select an
 unrelated kwt from `PATH`. Ghosthub integrates only through kwt's CLI and does
 not manage its daemon directly. Kwt may auto-start or reuse its same-account
 daemon behind that boundary. Kwt's machine-readable CLI provides project
-identity, worktree metadata, and exact tmux session names.
+identity, worktree metadata, and exact tmux session names. Read failures that
+kwt marks retryable use cancellation-aware 1-, 4-, and 15-second backoff before
+Ghosthub publishes a warning. Non-retryable failures remain single-attempt,
+and each retry repeats only the failed idempotent read.
 On a macOS or Linux host with no existing kwt registry, the user adds one
 absolute repository path at a time through **Add Project**. Ghosthub delegates
 registration to `kwt projects add --json`, then refreshes ordinary kwt

--- a/website/docs/content/troubleshooting.md
+++ b/website/docs/content/troubleshooting.md
@@ -103,6 +103,11 @@ potentially stale or misidentified frame.
 
 ## A project does not appear
 
+Ghosthub automatically retries a project or directory inventory read when kwt
+reports that the failure is retryable. The retries wait progressively longer
+and keep successful inventory from the other reads. A warning that remains
+after those retries needs manual attention.
+
 For a remote macOS or Linux host, Ghosthub installs its managed kwt helper
 automatically. Select the **+** beside that host's **Projects** group and provide
 the absolute path to an existing checkout on that host. Ghosthub repairs the


### PR DESCRIPTION
Cold-start kwt inventory now recovers from daemon timeouts instead of leaving the sidebar on a persistent status-1 warning.

- Retries only errors that kwt marks retryable, with cancellation-aware 1-, 4-, and 15-second delays.
- Repeats only the failed project, directory, or worktree read, so successful sibling inventory remains intact.
- Leaves permanent errors as single-attempt warnings.
- Adds focused coverage for retryable recovery and non-retryable failures, and documents the behavior.

Closes #225.
