### PR TITLE
Keep titlebar drags from opening rename

### DIFF
--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -269,7 +269,29 @@ private struct WindowFocusTracker: NSViewRepresentable {
 @MainActor
 private final class DraggableTitlebarHostingView:
     NSHostingView<AnyView> {
+    var onClick: () -> Void = {}
+
+    private lazy var clickRecognizer = NSClickGestureRecognizer(
+        target: self,
+        action: #selector(handleClick(_:))
+    )
+
+    required init(rootView: AnyView) {
+        super.init(rootView: rootView)
+        addGestureRecognizer(clickRecognizer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
     override var mouseDownCanMoveWindow: Bool { true }
+
+    @objc private func handleClick(_ recognizer: NSClickGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        onClick()
+    }
 }
 
 @MainActor
@@ -521,6 +543,7 @@ final class CompactWorkspaceTitlebarController {
         self.onSettings = onSettings
         self.onNewWorktree = onNewWorktree
         self.onRenameWindow = onRenameWindow
+        titleHost.onClick = { [weak self] in self?.onRenameWindow() }
         guard renderedPresentation != presentation else { return false }
 
         renderedPresentation = presentation
@@ -614,21 +637,21 @@ private struct EditableWindowTitleView: View {
     @State private var isHovered = false
 
     var body: some View {
-        Button(action: onRename) {
-            HStack(spacing: 5) {
-                title
-                if isHovered {
-                    Image(systemName: "pencil")
-                        .font(.system(size: 10, weight: .medium))
-                        .frame(width: 16, height: 16)
-                        .transition(.opacity)
-                }
+        HStack(spacing: 5) {
+            title
+            if isHovered {
+                Image(systemName: "pencil")
+                    .font(.system(size: 10, weight: .medium))
+                    .frame(width: 16, height: 16)
+                    .transition(.opacity)
             }
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .contentShape(Rectangle())
         .help("Rename Window")
+        .accessibilityElement(children: .combine)
         .accessibilityLabel("Rename Window")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onRename() }
         .onHover { isHovered = $0 }
     }
 

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -53,8 +53,9 @@ To give one workspace window or tab its own label, choose
 and returns after restoration or an update relaunch. Save an empty title to
 return to the automatic session and host title. Renaming Ghosthub chrome never
 renames a tmux session or window, a Herdr or Zellij session, or a worktree.
-You can also hover the compact title and select either the title or its pencil
-to open the same editor.
+You can also hover the compact title and click either the title or its pencil
+to open the same editor. Dragging from that area moves the window without
+opening the editor.
 
 ![Ghosthub's editor for a workspace window or tab title](assets/guide-window-title.png)
 


### PR DESCRIPTION
Dragging a workspace window by its compact title could also open the rename sheet because the title was an interactive button inside the draggable region.

- Activates rename through a native single-click recognizer, so pointer movement cancels rename while the same title area remains available for window dragging.
- Preserves the title and pencil hover affordance plus the explicit accessibility action.
- Documents the click-versus-drag behavior in the Guide.
- The full Swift suite passes with 1,992 tests and five expected headless skips; the app and documentation builds also pass. The headless runner cannot exercise a real window drag, so the native pointer path still needs a manual drag-and-click check.
