### PR TITLE
Use shared deadline for workspace tmux CI waits

### DIFF
--- a/Tests/App/WorkspaceTmuxDiscoveryTests.swift
+++ b/Tests/App/WorkspaceTmuxDiscoveryTests.swift
@@ -525,7 +525,7 @@ struct WorkspaceTmuxDiscoveryTests {
                 .tmuxSessions.first?.sessionID == "$2"
         }
         model.tmuxAttachedSessionIdentityBecameUnavailable(initialHandle)
-        await waitUntilMainActor(timeout: .seconds(5)) {
+        await waitUntilMainActor {
             surfaceStore.requestCount == 2
                 && model.retainedBorrowedTmuxHandle(for: selection)
                 != initialHandle

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -478,7 +478,7 @@ extension WorkspaceTmuxDiscoveryTests {
         #expect(command.contains("/test/kwt"))
         #expect(command.contains("'open'"))
         #expect(!command.contains("ignore-size"))
-        await waitUntilMainActor(timeout: .seconds(1)) {
+        await waitUntilMainActor {
             hiddenSizingMutations.load() == 1
         }
 
@@ -611,7 +611,7 @@ extension WorkspaceTmuxDiscoveryTests {
         }
         releaseResolution.signal()
 
-        await waitUntilMainActor(timeout: .seconds(5)) {
+        await waitUntilMainActor {
             model.retainedBorrowedTmuxHandle(for: selection) == nil
         }
         #expect(model.activeBorrowedTmuxSelection == nil)


### PR DESCRIPTION
- Uses `waitUntilMainActor`'s documented 30-second scheduling allowance for the three asynchronous workspace and tmux checks seen timing out under hosted Swift Testing load.
- Keeps the kwt establishment, hidden sizing, detach, pending-client replacement, and surface-removal assertions unchanged. The unavailable-identity path still exercises its 250 ms, 1 s, and 2 s retries.
- The affected tests pass locally in serialized mode, and one exact full serialized lane passed all 2,025 tests. Repeat lanes also exposed a separate intermittent real-tmux identity assertion in `TmuxPaneSplitterTests`; this pull request does not change that test.

<sup>generated by a clanker</sup>
