### PR TITLE
Paste Mac clipboard images into remote tmux sessions

### DIFF
--- a/Sources/App/NativeSessionAttachmentSupport.swift
+++ b/Sources/App/NativeSessionAttachmentSupport.swift
@@ -6,6 +6,9 @@ import GhosthubWorkspace
 @MainActor
 protocol NativeSessionPaneSurfacing: AnyObject {
     var blocksClipboardReads: Bool { get set }
+    var remoteImagePasteHandler: ((TerminalClipboardImage) -> Void)? {
+        get set
+    }
     var paneSplitShortcutHandler: ((TerminalPaneSplitShortcut) -> Void)? {
         get set
     }
@@ -19,6 +22,8 @@ protocol NativeSessionPaneSurfacing: AnyObject {
     var childExitCode: UInt32? { get }
     func requestKeyboardFocus()
     @discardableResult
+    func pasteProgrammaticInput(_ string: String) -> Bool
+    @discardableResult
     func sizeForPreviewGrid(columns: Int, rows: Int) -> Bool
     func clearPreviewGridSize()
     func registerSurfaceCloseObserver(
@@ -28,6 +33,11 @@ protocol NativeSessionPaneSurfacing: AnyObject {
 }
 
 extension NativeSessionPaneSurfacing {
+    var remoteImagePasteHandler: ((TerminalClipboardImage) -> Void)? {
+        get { nil }
+        set {}
+    }
+
     var paneSplitShortcutHandler: ((TerminalPaneSplitShortcut) -> Void)? {
         get { nil }
         set {}
@@ -48,6 +58,11 @@ extension NativeSessionPaneSurfacing {
     var launchFailureIsRetryable: Bool { false }
 
     func requestKeyboardFocus() {}
+
+    @discardableResult
+    func pasteProgrammaticInput(_: String) -> Bool {
+        false
+    }
 
     @discardableResult
     func sizeForPreviewGrid(columns _: Int, rows _: Int) -> Bool {

--- a/Sources/App/NativeTmuxSessionCoordinator.swift
+++ b/Sources/App/NativeTmuxSessionCoordinator.swift
@@ -167,6 +167,11 @@ final class NativeTmuxSessionCoordinator {
         var task: Task<Void, Never>
     }
 
+    private struct ImagePasteTask {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
+
     private struct AttachmentCleanupTail {
         var id: UUID
         var task: Task<Void, Never>
@@ -192,6 +197,7 @@ final class NativeTmuxSessionCoordinator {
         () -> Bool
     private let paneSplitter: TmuxPaneSplitter
     private let paneFinder: TmuxPaneFinder
+    private let imagePaster: TmuxImagePaster
     private let terminalOperationErrorDuration: Duration
     private let clientIdentityRetryDelays: [Duration]
     private let sleep: @Sendable (Duration) async throws -> Void
@@ -214,6 +220,7 @@ final class NativeTmuxSessionCoordinator {
     private var paneSplitClientBindings: [UUID: PaneSplitClientBinding] = [:]
     private var paneSplitClients: [UUID: TmuxAttachedClientIdentity] = [:]
     private var terminalOperationErrorDismissals: [UUID: TerminalOperationErrorDismissal] = [:]
+    private var imagePasteTasks: [UUID: ImagePasteTask] = [:]
     private var previewIdentityRetryHandles: Set<UUID> = []
     private var unavailablePreviewIdentityHandles: Set<UUID> = []
     private var deferredPresentationStyleHandles: Set<UUID> = []
@@ -269,6 +276,7 @@ final class NativeTmuxSessionCoordinator {
             },
         paneSplitter: TmuxPaneSplitter = TmuxPaneSplitter(),
         paneFinder: TmuxPaneFinder = TmuxPaneFinder(),
+        imagePaster: TmuxImagePaster = TmuxImagePaster(),
         terminalOperationErrorDuration: Duration = .seconds(4),
         clientIdentityRetryDelays: [Duration] = [
             .milliseconds(250), .seconds(1), .seconds(2),
@@ -296,6 +304,7 @@ final class NativeTmuxSessionCoordinator {
         self.remoteConnectionProvider = remoteConnectionProvider
         self.paneSplitter = paneSplitter
         self.paneFinder = paneFinder
+        self.imagePaster = imagePaster
         self.terminalOperationErrorDuration = terminalOperationErrorDuration
         self.clientIdentityRetryDelays = clientIdentityRetryDelays
         self.sleep = sleep
@@ -1053,6 +1062,11 @@ final class NativeTmuxSessionCoordinator {
             deferredPresentationStyleHandles.insert(handle.id)
         }
         surface.blocksClipboardReads = attachment.host.isRemote
+        installImagePasteHandler(
+            on: surface,
+            handle: handle,
+            attachment: attachment
+        )
         if didCreateSurface,
            attachment.ignoresClientSize,
            let previewGridSize = attachment.previewGridSize {
@@ -1164,6 +1178,83 @@ final class NativeTmuxSessionCoordinator {
             id: workerID,
             task: task
         )
+    }
+
+    private func installImagePasteHandler(
+        on surface: any NativeSessionPaneSurfacing,
+        handle: BorrowedTmuxSessionHandle,
+        attachment: NativeTmuxAttachment
+    ) {
+        surface.remoteImagePasteHandler = nil
+        guard case let .ssh(host) = attachment.host,
+              host.platform == .posix
+        else { return }
+        let connectionArguments = attachment.sshConnectionSnapshot.arguments
+        let attachmentID = attachment.id
+        surface.remoteImagePasteHandler = { [weak self, weak surface] image in
+            guard let self, let surface else { return }
+            startImagePaste(
+                image,
+                host: host,
+                connectionArguments: connectionArguments,
+                surface: surface,
+                handle: handle,
+                attachmentID: attachmentID
+            )
+        }
+    }
+
+    private func startImagePaste(
+        _ image: TerminalClipboardImage,
+        host: SSHHostInfo,
+        connectionArguments: [String],
+        surface: any NativeSessionPaneSurfacing,
+        handle: BorrowedTmuxSessionHandle,
+        attachmentID: UUID
+    ) {
+        imagePasteTasks.removeValue(forKey: handle.id)?.task.cancel()
+        let taskID = UUID()
+        let task = Task { [weak self, weak surface] in
+            guard let self, let surface else { return }
+            let result = await imagePaster.paste(
+                image,
+                on: host,
+                connectionArguments: connectionArguments
+            )
+            guard !Task.isCancelled,
+                  imagePasteTasks[handle.id]?.id == taskID,
+                  attachments[handle.id]?.id == attachmentID,
+                  launchedAttachmentIDs[handle.id] == attachmentID
+            else { return }
+            imagePasteTasks.removeValue(forKey: handle.id)
+            switch result {
+            case let .success(path):
+                guard surface.pasteProgrammaticInput(path) else {
+                    presentTerminalOperationError(
+                        "Ghosthub could not deliver the uploaded image path to the terminal.",
+                        on: surface,
+                        handle: handle,
+                        attachmentID: attachmentID
+                    )
+                    return
+                }
+                clearTerminalOperationError(on: surface, handleID: handle.id)
+            case let .failure(failure):
+                if SSHConnectionFailure.indicatesUnusableConnection(
+                    status: failure.status,
+                    output: failure.diagnostic
+                ), let connection = attachments[handle.id]?.sshConnection {
+                    Task { await connection.invalidate() }
+                }
+                presentTerminalOperationError(
+                    failure.localizedDescription,
+                    on: surface,
+                    handle: handle,
+                    attachmentID: attachmentID
+                )
+            }
+        }
+        imagePasteTasks[handle.id] = ImagePasteTask(id: taskID, task: task)
     }
 
     private func paneSplitTarget(
@@ -1575,6 +1666,7 @@ final class NativeTmuxSessionCoordinator {
     }
 
     private func cancelPaneSplits(handleID: UUID) {
+        imagePasteTasks.removeValue(forKey: handleID)?.task.cancel()
         paneSplitClientBindings.removeValue(forKey: handleID)?.task.cancel()
         paneSplitWorkers.removeValue(forKey: handleID)?.task.cancel()
         terminalOperationErrorDismissals.removeValue(forKey: handleID)?.task.cancel()
@@ -1908,10 +2000,12 @@ final class NativeTmuxSessionCoordinator {
         provisioningTasks.values.forEach { $0.cancel() }
         paneSplitClientBindings.values.forEach { $0.task.cancel() }
         paneSplitWorkers.values.forEach { $0.task.cancel() }
+        imagePasteTasks.values.forEach { $0.task.cancel() }
         terminalOperationErrorDismissals.values.forEach { $0.task.cancel() }
         provisioningTasks.removeAll()
         paneSplitClientBindings.removeAll()
         paneSplitWorkers.removeAll()
+        imagePasteTasks.removeAll()
         terminalOperationErrorDismissals.removeAll()
         paneSplitRequests.removeAll()
         paneSplitClients.removeAll()

--- a/Sources/App/TmuxImagePaster.swift
+++ b/Sources/App/TmuxImagePaster.swift
@@ -21,7 +21,8 @@ struct TmuxImagePaster: Sendable {
         _ host: SSHHostInfo,
         _ connectionArguments: [String],
         _ remoteCommand: String,
-        _ image: Data
+        _ image: Data,
+        _ timeout: TimeInterval
     ) async -> AccountCommandOutput
 
     private static let resultMarker = "GHOSTHUB_IMAGE_PASTE"
@@ -54,7 +55,8 @@ struct TmuxImagePaster: Sendable {
             host,
             connectionArguments,
             Self.uploadCommand(fileName: fileName),
-            image.pngData
+            image.pngData,
+            Self.uploadTimeout(byteCount: image.pngData.count)
         )
         guard output.status == 0 else {
             return .failure(.init(
@@ -120,6 +122,12 @@ struct TmuxImagePaster: Sendable {
         return path
     }
 
+    static func uploadTimeout(byteCount: Int) -> TimeInterval {
+        let baseTimeout: TimeInterval = 30
+        let transferAllowance = TimeInterval(max(0, byteCount)) / 65_536
+        return min(600, baseTimeout + transferAllowance)
+    }
+
     private static func normalizedDiagnostic(_ diagnostic: String) -> String {
         String(
             diagnostic
@@ -133,7 +141,8 @@ struct TmuxImagePaster: Sendable {
         host: SSHHostInfo,
         connectionArguments: [String],
         remoteCommand: String,
-        image: Data
+        image: Data,
+        timeout: TimeInterval
     ) async -> AccountCommandOutput {
         await BlockingTask.run(priority: .userInitiated) {
             let directory = FileManager.default.temporaryDirectory
@@ -181,7 +190,7 @@ struct TmuxImagePaster: Sendable {
                     + " < " + shellQuotedCommandArgument(localImage.path)
                 return AccountCommandRunner().runLocalLoginShell(
                     command: invocation,
-                    timeout: 30
+                    timeout: timeout
                 )
             } catch {
                 try? FileManager.default.removeItem(at: directory)

--- a/Sources/App/TmuxImagePaster.swift
+++ b/Sources/App/TmuxImagePaster.swift
@@ -1,0 +1,196 @@
+import Foundation
+import GhosthubTerminal
+import GhosthubTransport
+import GhosthubWorkspace
+
+struct TmuxImagePasteFailure: Error, Equatable, LocalizedError, Sendable {
+    let status: Int32
+    let diagnostic: String
+
+    var errorDescription: String? {
+        var message = "Ghosthub could not paste the clipboard image into the remote session."
+        if !diagnostic.isEmpty {
+            message += " \(diagnostic)"
+        }
+        return message
+    }
+}
+
+struct TmuxImagePaster: Sendable {
+    typealias Runner = @Sendable (
+        _ host: SSHHostInfo,
+        _ connectionArguments: [String],
+        _ remoteCommand: String,
+        _ image: Data
+    ) async -> AccountCommandOutput
+
+    private static let resultMarker = "GHOSTHUB_IMAGE_PASTE"
+    private let runner: Runner
+    private let fileNameProvider: @Sendable () -> String
+
+    init(
+        runner: @escaping Runner = Self.run,
+        fileNameProvider: @escaping @Sendable () -> String = {
+            "paste-\(UUID().uuidString.lowercased()).png"
+        }
+    ) {
+        self.runner = runner
+        self.fileNameProvider = fileNameProvider
+    }
+
+    func paste(
+        _ image: TerminalClipboardImage,
+        on host: SSHHostInfo,
+        connectionArguments: [String]
+    ) async -> Result<String, TmuxImagePasteFailure> {
+        guard host.platform == .posix else {
+            return .failure(.init(
+                status: 64,
+                diagnostic: "Image paste is unavailable on this host platform."
+            ))
+        }
+        let fileName = fileNameProvider()
+        let output = await runner(
+            host,
+            connectionArguments,
+            Self.uploadCommand(fileName: fileName),
+            image.pngData
+        )
+        guard output.status == 0 else {
+            return .failure(.init(
+                status: output.status,
+                diagnostic: Self.normalizedDiagnostic(
+                    output.stderr.isEmpty ? output.stdout : output.stderr
+                )
+            ))
+        }
+        guard let path = Self.uploadedPath(
+            from: output.stdout,
+            fileName: fileName
+        ) else {
+            return .failure(.init(
+                status: 65,
+                diagnostic: "The remote host did not confirm the uploaded image path."
+            ))
+        }
+        return .success(path)
+    }
+
+    static func uploadCommand(
+        fileName: String,
+        imageDirectory: String? = nil
+    ) -> String {
+        let quotedName = shellQuotedCommandArgument(fileName)
+        let quotedDirectory = imageDirectory.map(shellQuotedCommandArgument)
+            ?? #""$HOME/.ghosthub/paste-images""#
+        return """
+        umask 077
+        ghosthub_image_dir=\(quotedDirectory)
+        mkdir -p -- "$ghosthub_image_dir" || exit $?
+        chmod 700 "$ghosthub_image_dir" || exit $?
+        find "$ghosthub_image_dir" -type f -name 'paste-*.png' -mtime +7 -delete >/dev/null 2>&1 || :
+        ghosthub_image_path="$ghosthub_image_dir"/\(quotedName)
+        if cat > "$ghosthub_image_path"; then
+          chmod 600 "$ghosthub_image_path" || exit $?
+          printf '\n%s\t%s\n' \(shellQuotedCommandArgument(resultMarker)) "$ghosthub_image_path"
+        else
+          ghosthub_status=$?
+          rm -f -- "$ghosthub_image_path"
+          exit "$ghosthub_status"
+        fi
+        """
+    }
+
+    static func uploadedPath(
+        from output: String,
+        fileName: String
+    ) -> String? {
+        let prefix = resultMarker + "\t"
+        guard let line = output.split(whereSeparator: \Character.isNewline)
+            .map(String.init)
+            .last(where: { $0.hasPrefix(prefix) })
+        else { return nil }
+        let path = String(line.dropFirst(prefix.count))
+        guard path.first == "/",
+              path.hasSuffix("/\(fileName)"),
+              !path.unicodeScalars.contains(where: {
+                  CharacterSet.controlCharacters.contains($0)
+              })
+        else { return nil }
+        return path
+    }
+
+    private static func normalizedDiagnostic(_ diagnostic: String) -> String {
+        String(
+            diagnostic
+                .split(whereSeparator: \Character.isWhitespace)
+                .joined(separator: " ")
+                .prefix(400)
+        )
+    }
+
+    private static func run(
+        host: SSHHostInfo,
+        connectionArguments: [String],
+        remoteCommand: String,
+        image: Data
+    ) async -> AccountCommandOutput {
+        await BlockingTask.run(priority: .userInitiated) {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "ghosthub-image-paste-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+            let localImage = directory.appendingPathComponent(
+                "clipboard.png",
+                isDirectory: false
+            )
+            do {
+                try FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: false,
+                    attributes: [.posixPermissions: 0o700]
+                )
+                defer { try? FileManager.default.removeItem(at: directory) }
+                try image.write(to: localImage, options: .atomic)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o600],
+                    ofItemAtPath: localImage.path
+                )
+
+                var arguments = [
+                    "-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+                ]
+                arguments += connectionArguments
+                if let port = host.port {
+                    arguments += ["-p", String(port)]
+                }
+                let destination = host.user.map { "\($0)@\(host.hostname)" }
+                    ?? host.hostname
+                arguments += [
+                    "--",
+                    destination,
+                    AccountCommandRunner.remoteLoginCommand(
+                        host: host,
+                        command: remoteCommand
+                    ),
+                ]
+                let invocation = (["/usr/bin/ssh"] + arguments)
+                    .map(shellQuotedCommandArgument)
+                    .joined(separator: " ")
+                    + " < " + shellQuotedCommandArgument(localImage.path)
+                return AccountCommandRunner().runLocalLoginShell(
+                    command: invocation,
+                    timeout: 30
+                )
+            } catch {
+                try? FileManager.default.removeItem(at: directory)
+                return AccountCommandOutput(
+                    status: 74,
+                    stdout: "",
+                    stderr: error.localizedDescription
+                )
+            }
+        }
+    }
+}

--- a/Sources/Terminal/LibghosttyRuntime.swift
+++ b/Sources/Terminal/LibghosttyRuntime.swift
@@ -1105,13 +1105,7 @@ public final class LibghosttyRuntime: ObservableObject,
             // libghostty's semantic request is the authorization boundary.
             // User-configured paste bindings may read the clipboard, while
             // OSC 52 reads remain empty regardless of `clipboard-read`.
-            let contents = clipboardReadContents(
-                blocked: surfaceView.blocksClipboardReads,
-                request: request,
-                contents: TerminalPasteboardAccess.current.string(
-                    forType: .string
-                )
-            )
+            let contents = surfaceView.clipboardContents(for: request)
             contents.withCString { ptr in
                 ghostty_surface_complete_clipboard_request(
                     surfaceHandle, ptr, requestState, false

--- a/Sources/Terminal/TerminalClipboardImage.swift
+++ b/Sources/Terminal/TerminalClipboardImage.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Foundation
+
+public struct TerminalClipboardImage: Equatable, Sendable {
+    public let pngData: Data
+
+    public init(pngData: Data) {
+        self.pngData = pngData
+    }
+
+    @MainActor
+    static func read(from pasteboard: any TerminalPasteboard) -> Self? {
+        if let png = pasteboard.data(forType: .png), !png.isEmpty {
+            return Self(pngData: png)
+        }
+        guard let tiff = pasteboard.data(forType: .tiff),
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:]),
+              !png.isEmpty
+        else { return nil }
+        return Self(pngData: png)
+    }
+}

--- a/Sources/Terminal/TerminalPasteboard.swift
+++ b/Sources/Terminal/TerminalPasteboard.swift
@@ -3,6 +3,7 @@ import AppKit
 @MainActor
 protocol TerminalPasteboard: AnyObject {
     func string(forType dataType: NSPasteboard.PasteboardType) -> String?
+    func data(forType dataType: NSPasteboard.PasteboardType) -> Data?
 
     @discardableResult
     func clearContents() -> Int

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -157,6 +157,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     private nonisolated(unsafe) var eventMonitor: Any?
     var lastPerformKeyEvent: TimeInterval?
     private var consumedCommandKeyCodes: Set<UInt16> = []
+    private var consumedImagePasteKeyCodes: Set<UInt16> = []
     private var consumedPaneSplitKeyCodes: Set<UInt16> = []
     private var surfaceResizeState = SurfaceResizeState()
     private var previewGridSize: (columns: Int, rows: Int)?
@@ -199,12 +200,18 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     /// Routes clipboard paste through tmux's paste buffer so tmux can honor
     /// the pane application's bracketed-paste mode.
     public var tmuxPanePasteSink: ((Data) -> Void)?
+    /// Installed by remote session coordinators that can copy a Mac clipboard
+    /// image to the session host. The uploaded image is returned to the
+    /// terminal as an ordinary path paste, preserving the application's
+    /// bracketed-paste and image-path handling.
+    public var remoteImagePasteHandler: ((TerminalClipboardImage) -> Void)?
     /// Remote tmux surfaces must not read from or write to the local Mac
     /// clipboard through terminal escape sequences. Explicit user paste
     /// remains available because libghostty labels semantic paste requests
     /// before the runtime reads the pasteboard.
     public var blocksClipboardReads = false
     private var isClipboardConfirmationPending = false
+    private var programmaticPasteContents: String?
     private var tmuxTerminalModeTracker = AttachedTmuxTerminalModeTracker()
     /// The surface's grid dimensions (columns, rows) changed. Task-8 addition:
     /// control mode uses this to feed pane resizes back to tmux (per-pane
@@ -801,6 +808,22 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         chars.withCString { ptr in
             ghostty_surface_text(surface, ptr, UInt(len - 1))
         }
+    }
+
+    /// Pastes generated text through libghostty's normal paste path rather
+    /// than injecting raw terminal bytes. This preserves bracketed paste and
+    /// lets terminal applications distinguish a pasted image path from typing.
+    @discardableResult
+    public func pasteProgrammaticInput(_ string: String) -> Bool {
+        guard !string.isEmpty, programmaticPasteContents == nil else {
+            return false
+        }
+        programmaticPasteContents = string
+        guard performBindingAction("paste_from_clipboard") else {
+            programmaticPasteContents = nil
+            return false
+        }
+        return true
     }
 
     public func sendProgrammaticReturn() {
@@ -1580,6 +1603,10 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
     ) -> Bool {
         guard let surface else { return false }
 
+        if handleRemoteImagePaste(action: action, event: event) {
+            return true
+        }
+
         // Diverges from fantastty: fantastty's keyAction builds the C key
         // event first and threads pane routing through the `withCString`
         // closure that supplies `key_ev.text` (its dual with-text/without-text
@@ -1801,6 +1828,52 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
             && !flags.contains(.option)
             && !flags.contains(.control)
             && event.charactersIgnoringModifiers?.lowercased() == "v"
+    }
+
+    private func handleRemoteImagePaste(
+        action: ghostty_input_action_e,
+        event: NSEvent
+    ) -> Bool {
+        if action == GHOSTTY_ACTION_RELEASE {
+            return consumedImagePasteKeyCodes.remove(event.keyCode) != nil
+        }
+        if consumedImagePasteKeyCodes.contains(event.keyCode) {
+            return true
+        }
+        guard action == GHOSTTY_ACTION_PRESS,
+              let handler = remoteImagePasteHandler,
+              isImagePasteShortcut(event),
+              let image = TerminalClipboardImage.read(
+                  from: TerminalPasteboardAccess.current
+              )
+        else { return false }
+        consumedImagePasteKeyCodes.insert(event.keyCode)
+        handler(image)
+        return true
+    }
+
+    private func isImagePasteShortcut(_ event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return flags.contains(.control)
+            && !flags.contains(.shift)
+            && !flags.contains(.option)
+            && !flags.contains(.command)
+            && event.charactersIgnoringModifiers?.lowercased() == "v"
+    }
+
+    func clipboardContents(
+        for request: ghostty_clipboard_request_e?
+    ) -> String {
+        if request == GHOSTTY_CLIPBOARD_REQUEST_PASTE,
+           let contents = programmaticPasteContents {
+            programmaticPasteContents = nil
+            return contents
+        }
+        return LibghosttyRuntime.clipboardReadContents(
+            blocked: blocksClipboardReads,
+            request: request,
+            contents: TerminalPasteboardAccess.current.string(forType: .string)
+        )
     }
 
     func requestClipboardConfirmation(

--- a/Sources/Terminal/TerminalSurfaceView.swift
+++ b/Sources/Terminal/TerminalSurfaceView.swift
@@ -490,6 +490,7 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         hasSyncedFocusState = true
         if !newFocused {
             consumedCommandKeyCodes.removeAll()
+            consumedImagePasteKeyCodes.removeAll()
         }
         if stateChanged {
             onFocusChange?(newFocused)
@@ -1840,25 +1841,18 @@ public final class TerminalSurfaceView: NSView, ObservableObject {
         if consumedImagePasteKeyCodes.contains(event.keyCode) {
             return true
         }
+        let pasteboard = TerminalPasteboardAccess.current
         guard action == GHOSTTY_ACTION_PRESS,
               let handler = remoteImagePasteHandler,
-              isImagePasteShortcut(event),
+              isPasteShortcut(event),
+              pasteboard.string(forType: .string)?.isEmpty != false,
               let image = TerminalClipboardImage.read(
-                  from: TerminalPasteboardAccess.current
+                  from: pasteboard
               )
         else { return false }
         consumedImagePasteKeyCodes.insert(event.keyCode)
         handler(image)
         return true
-    }
-
-    private func isImagePasteShortcut(_ event: NSEvent) -> Bool {
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        return flags.contains(.control)
-            && !flags.contains(.shift)
-            && !flags.contains(.option)
-            && !flags.contains(.command)
-            && event.charactersIgnoringModifiers?.lowercased() == "v"
     }
 
     func clipboardContents(

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -67,7 +67,7 @@ struct NativeTmuxSessionCoordinatorTests {
                 return (0, "")
             },
             imagePaster: TmuxImagePaster(
-                runner: { receivedHost, arguments, _, image in
+                runner: { receivedHost, arguments, _, image, _ in
                     uploaded.withLock {
                         $0 = (receivedHost, arguments, image)
                     }

--- a/Tests/App/NativeTmuxSessionCoordinatorTests.swift
+++ b/Tests/App/NativeTmuxSessionCoordinatorTests.swift
@@ -41,6 +41,71 @@ private func splitMismatchMarker(in command: String) -> String? {
 @Suite("Native tmux connection identity", .serialized)
 @MainActor
 struct NativeTmuxSessionCoordinatorTests {
+    @Test("remote image paste uploads through the attachment route and pastes its path")
+    func remoteImagePasteUsesAttachmentRoute() async throws {
+        let uploaded = LockedValue<(SSHHostInfo, [String], Data)?>(nil)
+        let store = RecordingNativeSessionSurfaceStore()
+        let host = SSHHostInfo(
+            user: "dev",
+            hostname: "builder.example.test",
+            port: nil
+        )
+        let connectionArguments = ["-F", "/tmp/ghosthub ssh/config"]
+        let coordinator = NativeTmuxSessionCoordinator(
+            terminalCoordinator: store,
+            tmuxPathProvider: { successfulTmuxResolution("/usr/bin/tmux") },
+            remoteTmuxPathProvider: { _, _ in
+                successfulTmuxResolution("/usr/local/bin/tmux")
+            },
+            remoteConnectionProvider: { _, _ in
+                testKwtSSHAttachment(arguments: connectionArguments)
+            },
+            paneSplitter: supportedPaneSplitter { _, _, command in
+                if command.contains("GHOSTHUB_TMUX_SPLIT_CLIENT_IDENTITY") {
+                    return (0, coordinatorSplitClientOutput)
+                }
+                return (0, "")
+            },
+            imagePaster: TmuxImagePaster(
+                runner: { receivedHost, arguments, _, image in
+                    uploaded.withLock {
+                        $0 = (receivedHost, arguments, image)
+                    }
+                    return AccountCommandOutput(
+                        status: 0,
+                        stdout: "GHOSTHUB_IMAGE_PASTE\t/home/dev/.ghosthub/paste-images/paste-test.png\n",
+                        stderr: ""
+                    )
+                },
+                fileNameProvider: { "paste-test.png" }
+            )
+        )
+        var ready = false
+        coordinator.onSurfaceReady = { _ in ready = true }
+        let handle = coordinator.attach(
+            hostID: UUID(),
+            name: "agent",
+            host: .ssh(host),
+            sessionIdentity: coordinatorSplitIdentity
+        )
+        await waitUntilMainActor { ready }
+        _ = coordinator.surface(handle: handle)
+        let handler = try #require(store.surface.remoteImagePasteHandler)
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+
+        handler(TerminalClipboardImage(pngData: png))
+
+        await waitUntilMainActor { !store.surface.programmaticPastes.isEmpty }
+        #expect(uploaded.load()?.0 == host)
+        #expect(uploaded.load()?.1 == connectionArguments)
+        #expect(uploaded.load()?.2 == png)
+        #expect(
+            store.surface.programmaticPastes
+                == ["/home/dev/.ghosthub/paste-images/paste-test.png"]
+        )
+        await coordinator.shutdown()
+    }
+
     @Test("dead remote tmux resolution invalidates before lease release")
     func deadResolutionInvalidatesConnection() async {
         let events = LockedValue<[String]>([])

--- a/Tests/App/SceneModelTestSupport.swift
+++ b/Tests/App/SceneModelTestSupport.swift
@@ -712,6 +712,7 @@ final class RecordingNativeSessionSurfaceStore: NativeSessionSurfaceStoring {
 @MainActor
 final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     var blocksClipboardReads = false
+    var remoteImagePasteHandler: ((TerminalClipboardImage) -> Void)?
     var terminalOperationErrorMessage: String?
     var terminalFindController = TerminalFindController.unavailable
     var hasEffectiveKeyboardFocus = false
@@ -727,6 +728,7 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     private(set) var clearPreviewGridCount = 0
     var onPreviewGridSize: ((TmuxGridSize) -> Void)?
     var onClearPreviewGrid: (() -> Void)?
+    private(set) var programmaticPastes: [String] = []
 
     init(
         launchError: Error? = nil,
@@ -749,6 +751,12 @@ final class RecordingNativeSessionPaneSurface: NativeSessionPaneSurfacing {
     func clearPreviewGridSize() {
         clearPreviewGridCount += 1
         onClearPreviewGrid?()
+    }
+
+    @discardableResult
+    func pasteProgrammaticInput(_ string: String) -> Bool {
+        programmaticPastes.append(string)
+        return true
     }
 
     func registerSurfaceCloseObserver(

--- a/Tests/App/TmuxImagePasterLiveIntegrationTests.swift
+++ b/Tests/App/TmuxImagePasterLiveIntegrationTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import GhosthubTerminal
+import GhosthubTransport
+import Testing
+@testable import GhosthubApp
+
+@Suite("Remote image paste SSH integration", .serialized)
+struct TmuxImagePasterLiveIntegrationTests {
+    @Test("uploads exact image bytes through the fixture SSH route")
+    func uploadsImageThroughFixture() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["GHOSTHUB_RUN_LIVE_INTEGRATION_TESTS"] == "1",
+              environment["GHOSTHUB_REQUIRE_SSH_INTERACTION_FIXTURE"] == "1"
+        else { return }
+        let destination = try #require(
+            environment["GHOSTHUB_SSH_INTEGRATION_DESTINATION"]
+        )
+        let sshConfig = try #require(
+            environment["GHOSTHUB_TEST_SSH_CONFIG"]
+        )
+        let host = try #require(
+            CommandHostResolver.parseSSHDestination(destination)
+        )
+        let fileName = "paste-live-\(UUID().uuidString.lowercased()).png"
+        let image = TerminalClipboardImage(pngData: Data([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0xFF, 0x7F,
+        ]))
+        let result = await TmuxImagePaster(
+            fileNameProvider: { fileName }
+        ).paste(
+            image,
+            on: host,
+            connectionArguments: ["-F", sshConfig]
+        )
+        let remotePath = try result.get()
+        let expectedPath = "/home/ghosthub/.ghosthub/paste-images/\(fileName)"
+        #expect(remotePath == expectedPath)
+        defer {
+            _ = AccountCommandRunner().runRemoteLoginShell(
+                host: host,
+                connectionArguments: ["-F", sshConfig],
+                command: "rm -f -- \(shellQuotedCommandArgument(remotePath))",
+                timeout: 15
+            )
+        }
+
+        let imageDirectory = (remotePath as NSString).deletingLastPathComponent
+        let inspection = AccountCommandRunner().runRemoteLoginShell(
+            host: host,
+            connectionArguments: ["-F", sshConfig],
+            command: """
+            stat -c '%a' -- \(shellQuotedCommandArgument(imageDirectory))
+            stat -c '%a' -- \(shellQuotedCommandArgument(remotePath))
+            od -An -v -t x1 -- \(shellQuotedCommandArgument(remotePath)) | tr -d ' \n'
+            printf '\n'
+            """,
+            timeout: 15
+        )
+
+        #expect(inspection.status == 0, Comment(rawValue: inspection.stderr))
+        #expect(inspection.stdout == "700\n600\n89504e470d0a1a0a00ff7f\n")
+    }
+}

--- a/Tests/App/TmuxImagePasterTests.swift
+++ b/Tests/App/TmuxImagePasterTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import GhosthubTerminal
+import GhosthubTestSupport
+import GhosthubTransport
+import GhosthubWorkspace
+import Testing
+@testable import GhosthubApp
+
+@Suite("Remote tmux image paste")
+struct TmuxImagePasterTests {
+    @Test("stages image bytes and reports the remote cache path")
+    func uploadCommandStagesImage() throws {
+        let fixture = try TempDirectoryFixture()
+        let input = fixture.childURL("clipboard source.png")
+        let imageDirectory = fixture.childURL("paste images")
+        let target = imageDirectory.appendingPathComponent("paste-test.png")
+        let image = Data([0x89, 0x50, 0x4E, 0x47, 0x01, 0x02])
+        try image.write(to: input)
+        let command = TmuxImagePaster.uploadCommand(
+            fileName: target.lastPathComponent,
+            imageDirectory: imageDirectory.path
+        )
+        let output = AccountCommandRunner().runLocalLoginShell(
+            command: """
+            (
+            \(command)
+            ) < \(shellQuotedCommandArgument(input.path))
+            """,
+            timeout: 10
+        )
+
+        #expect(output.status == 0, Comment(rawValue: output.stderr))
+        #expect(try Data(contentsOf: target) == image)
+        #expect(
+            TmuxImagePaster.uploadedPath(
+                from: output.stdout,
+                fileName: target.lastPathComponent
+            ) == target.path
+        )
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: imageDirectory.path
+        )
+        let fileAttributes = try FileManager.default.attributesOfItem(
+            atPath: target.path
+        )
+        #expect(
+            (directoryAttributes[.posixPermissions] as? NSNumber)?.intValue
+                == 0o700
+        )
+        #expect(
+            (fileAttributes[.posixPermissions] as? NSNumber)?.intValue
+                == 0o600
+        )
+    }
+
+    @Test("uploads PNG bytes through the frozen SSH route and accepts its path")
+    func uploadsImageAndReturnsRemotePath() async throws {
+        struct Invocation: Sendable {
+            let host: SSHHostInfo
+            let connectionArguments: [String]
+            let image: Data
+        }
+        let invocation = LockedValue<Invocation?>(nil)
+        let host = SSHHostInfo(
+            user: "dev",
+            hostname: "builder.example.test",
+            port: 2222
+        )
+        let image = TerminalClipboardImage(pngData: Data([0x89, 0x50, 0x4E, 0x47]))
+        let paster = TmuxImagePaster(
+            runner: { host, arguments, _, image in
+                invocation.withLock {
+                    $0 = Invocation(
+                        host: host,
+                        connectionArguments: arguments,
+                        image: image
+                    )
+                }
+                return AccountCommandOutput(
+                    status: 0,
+                    stdout: "shell banner\nGHOSTHUB_IMAGE_PASTE\t/home/dev/.ghosthub/paste-images/paste-test.png\n",
+                    stderr: ""
+                )
+            },
+            fileNameProvider: { "paste-test.png" }
+        )
+
+        let path = try await paster.paste(
+            image,
+            on: host,
+            connectionArguments: ["-F", "/tmp/ghosthub-ssh-config"]
+        ).get()
+
+        #expect(path == "/home/dev/.ghosthub/paste-images/paste-test.png")
+        #expect(invocation.load()?.host == host)
+        #expect(
+            invocation.load()?.connectionArguments
+                == ["-F", "/tmp/ghosthub-ssh-config"]
+        )
+        #expect(invocation.load()?.image == image.pngData)
+    }
+
+    @Test("rejects an upload response that does not name the staged image")
+    func rejectsUnexpectedRemotePath() async {
+        let paster = TmuxImagePaster(
+            runner: { _, _, _, _ in
+                AccountCommandOutput(
+                    status: 0,
+                    stdout: "GHOSTHUB_IMAGE_PASTE\t/tmp/different.png\n",
+                    stderr: ""
+                )
+            },
+            fileNameProvider: { "paste-test.png" }
+        )
+
+        let result = await paster.paste(
+            TerminalClipboardImage(pngData: Data([1])),
+            on: SSHHostInfo(
+                user: nil,
+                hostname: "builder.example.test",
+                port: nil
+            ),
+            connectionArguments: []
+        )
+
+        guard case let .failure(failure) = result else {
+            Issue.record("Expected an invalid upload response")
+            return
+        }
+        #expect(failure.status == 65)
+    }
+}

--- a/Tests/App/TmuxImagePasterTests.swift
+++ b/Tests/App/TmuxImagePasterTests.swift
@@ -8,6 +8,16 @@ import Testing
 
 @Suite("Remote tmux image paste")
 struct TmuxImagePasterTests {
+    @Test("allows larger clipboard images more upload time within a cap")
+    func uploadTimeoutScalesWithImageSize() {
+        #expect(TmuxImagePaster.uploadTimeout(byteCount: 0) == 30)
+        #expect(
+            TmuxImagePaster.uploadTimeout(byteCount: 10 * 1_024 * 1_024)
+                == 190
+        )
+        #expect(TmuxImagePaster.uploadTimeout(byteCount: .max) == 600)
+    }
+
     @Test("stages image bytes and reports the remote cache path")
     func uploadCommandStagesImage() throws {
         let fixture = try TempDirectoryFixture()
@@ -59,6 +69,7 @@ struct TmuxImagePasterTests {
             let host: SSHHostInfo
             let connectionArguments: [String]
             let image: Data
+            let timeout: TimeInterval
         }
         let invocation = LockedValue<Invocation?>(nil)
         let host = SSHHostInfo(
@@ -68,12 +79,13 @@ struct TmuxImagePasterTests {
         )
         let image = TerminalClipboardImage(pngData: Data([0x89, 0x50, 0x4E, 0x47]))
         let paster = TmuxImagePaster(
-            runner: { host, arguments, _, image in
+            runner: { host, arguments, _, image, timeout in
                 invocation.withLock {
                     $0 = Invocation(
                         host: host,
                         connectionArguments: arguments,
-                        image: image
+                        image: image,
+                        timeout: timeout
                     )
                 }
                 return AccountCommandOutput(
@@ -98,12 +110,18 @@ struct TmuxImagePasterTests {
                 == ["-F", "/tmp/ghosthub-ssh-config"]
         )
         #expect(invocation.load()?.image == image.pngData)
+        #expect(
+            invocation.load()?.timeout
+                == TmuxImagePaster.uploadTimeout(
+                    byteCount: image.pngData.count
+                )
+        )
     }
 
     @Test("rejects an upload response that does not name the staged image")
     func rejectsUnexpectedRemotePath() async {
         let paster = TmuxImagePaster(
-            runner: { _, _, _, _ in
+            runner: { _, _, _, _, _ in
                 AccountCommandOutput(
                     status: 0,
                     stdout: "GHOSTHUB_IMAGE_PASTE\t/tmp/different.png\n",

--- a/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
+++ b/Tests/TerminalSmoke/TerminalSmokeFixtures.swift
@@ -10,15 +10,21 @@ import XCTest
 @MainActor
 final class InMemoryTerminalPasteboard: TerminalPasteboard {
     private var contents: [NSPasteboard.PasteboardType: String] = [:]
+    private var dataContents: [NSPasteboard.PasteboardType: Data] = [:]
     var acceptsWrites = true
 
     func string(forType dataType: NSPasteboard.PasteboardType) -> String? {
         contents[dataType]
     }
 
+    func data(forType dataType: NSPasteboard.PasteboardType) -> Data? {
+        dataContents[dataType]
+    }
+
     @discardableResult
     func clearContents() -> Int {
         contents.removeAll()
+        dataContents.removeAll()
         return 1
     }
 
@@ -28,6 +34,7 @@ final class InMemoryTerminalPasteboard: TerminalPasteboard {
         owner newOwner: Any?
     ) -> Int {
         contents.removeAll()
+        dataContents.removeAll()
         return newTypes.count
     }
 
@@ -39,6 +46,10 @@ final class InMemoryTerminalPasteboard: TerminalPasteboard {
         guard acceptsWrites else { return false }
         contents[dataType] = string
         return true
+    }
+
+    func setData(_ data: Data, forType dataType: NSPasteboard.PasteboardType) {
+        dataContents[dataType] = data
     }
 }
 

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -2529,7 +2529,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         XCTAssertTrue(sunkData.isEmpty, "Paste must not use raw send-keys input.")
     }
 
-    func testRemoteImagePasteConsumesCtrlVBeforeItReachesThePTY() throws {
+    func testRemoteImagePasteConsumesCmdVBeforeItReachesThePTY() throws {
         let appHandle = try requireAppHandle()
         let scriptURL = makeRawInputProbeScript(readBytes: 1)
         let view = makeSurface(
@@ -2548,22 +2548,23 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
 
         dispatch(
             makeKeyEvent(
-                characters: "\u{16}",
+                characters: "v",
                 charactersIgnoringModifiers: "v",
-                modifiers: [.control],
+                modifiers: [.command],
                 keyCode: 9,
                 windowNumber: window.windowNumber
             ),
             to: window,
-            route: .window
+            route: .application
         )
         typeText("x", into: view, window: window)
 
         waitForViewportText("<RAW:78>", in: view)
+        XCTAssertTrue(readViewportText(from: view).contains("<RAW:78>"))
         XCTAssertEqual(receivedImage?.pngData, png)
     }
 
-    func testRemoteCtrlVWithoutImageReachesThePTY() throws {
+    func testRemoteCtrlVWithImageReachesThePTY() throws {
         let appHandle = try requireAppHandle()
         let scriptURL = makeRawInputProbeScript(readBytes: 1)
         let view = makeSurface(
@@ -2577,8 +2578,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let window = hostInWindow(view)
         waitUntil(timeout: 5.0) { view.error == nil }
         waitForProbeReady(in: view)
-        pasteboard.clearContents()
-        pasteboard.setString("ordinary text", forType: .string)
+        pasteboard.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
 
         dispatch(
             makeKeyEvent(
@@ -2593,6 +2593,96 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         )
 
         waitForViewportText("<RAW:16>", in: view)
+        XCTAssertTrue(readViewportText(from: view).contains("<RAW:16>"))
+        XCTAssertNil(receivedImage)
+    }
+
+    func testRemoteImagePasteLatchCannotConsumeLaterCtrlV() throws {
+        let appHandle = try requireAppHandle()
+        let scriptURL = makeRawInputProbeScript(readBytes: 1)
+        let view = makeSurface(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        view.remoteImagePasteHandler = { _ in }
+        let window = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForProbeReady(in: view)
+        pasteboard.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
+
+        dispatch(
+            makeKeyEvent(
+                characters: "v",
+                charactersIgnoringModifiers: "v",
+                modifiers: [.command],
+                keyCode: 9,
+                windowNumber: window.windowNumber
+            ),
+            to: window,
+            route: .window
+        )
+        view.focusDidChange(false)
+        view.focusDidChange(true)
+        dispatch(
+            makeKeyEvent(
+                characters: "\u{16}",
+                charactersIgnoringModifiers: "v",
+                modifiers: [.control],
+                keyCode: 9,
+                windowNumber: window.windowNumber
+            ),
+            to: window,
+            route: .window
+        )
+        typeText("x", into: view, window: window)
+
+        waitForViewportText("<RAW:16>", in: view)
+        XCTAssertTrue(readViewportText(from: view).contains("<RAW:16>"))
+    }
+
+    func testRemoteCmdVPrefersTextWhenClipboardAlsoHasImage() throws {
+        let appHandle = try requireAppHandle()
+        let pastedText = "ordinary text"
+        let expectedData = Data("\u{1b}[200~\(pastedText)\u{1b}[201~".utf8)
+        let expectedRaw = expectedData
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let scriptURL = makeBracketedPasteProbeScript(
+            readBytes: expectedData.count
+        )
+        let view = makeSurface(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        var receivedImage: TerminalClipboardImage?
+        view.remoteImagePasteHandler = { receivedImage = $0 }
+        let window = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForProbeReady(in: view)
+        pasteboard.declareTypes([.string, .png], owner: nil)
+        pasteboard.setString(pastedText, forType: .string)
+        pasteboard.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
+
+        dispatch(
+            makeKeyEvent(
+                characters: "v",
+                charactersIgnoringModifiers: "v",
+                modifiers: [.command],
+                keyCode: 9,
+                windowNumber: window.windowNumber
+            ),
+            to: window,
+            route: .window
+        )
+
+        waitForViewportText("<RAW:\(expectedRaw)>", in: view)
+        XCTAssertTrue(
+            readViewportText(from: view).contains("<RAW:\(expectedRaw)>")
+        )
         XCTAssertNil(receivedImage)
     }
 

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -2529,6 +2529,99 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         XCTAssertTrue(sunkData.isEmpty, "Paste must not use raw send-keys input.")
     }
 
+    func testRemoteImagePasteConsumesCtrlVBeforeItReachesThePTY() throws {
+        let appHandle = try requireAppHandle()
+        let scriptURL = makeRawInputProbeScript(readBytes: 1)
+        let view = makeSurface(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+        var receivedImage: TerminalClipboardImage?
+        view.remoteImagePasteHandler = { receivedImage = $0 }
+        let window = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForProbeReady(in: view)
+        pasteboard.setData(png, forType: .png)
+
+        dispatch(
+            makeKeyEvent(
+                characters: "\u{16}",
+                charactersIgnoringModifiers: "v",
+                modifiers: [.control],
+                keyCode: 9,
+                windowNumber: window.windowNumber
+            ),
+            to: window,
+            route: .window
+        )
+        typeText("x", into: view, window: window)
+
+        waitForViewportText("<RAW:78>", in: view)
+        XCTAssertEqual(receivedImage?.pngData, png)
+    }
+
+    func testRemoteCtrlVWithoutImageReachesThePTY() throws {
+        let appHandle = try requireAppHandle()
+        let scriptURL = makeRawInputProbeScript(readBytes: 1)
+        let view = makeSurface(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        var receivedImage: TerminalClipboardImage?
+        view.remoteImagePasteHandler = { receivedImage = $0 }
+        let window = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForProbeReady(in: view)
+        pasteboard.clearContents()
+        pasteboard.setString("ordinary text", forType: .string)
+
+        dispatch(
+            makeKeyEvent(
+                characters: "\u{16}",
+                charactersIgnoringModifiers: "v",
+                modifiers: [.control],
+                keyCode: 9,
+                windowNumber: window.windowNumber
+            ),
+            to: window,
+            route: .window
+        )
+
+        waitForViewportText("<RAW:16>", in: view)
+        XCTAssertNil(receivedImage)
+    }
+
+    func testProgrammaticImagePathUsesBracketedPaste() throws {
+        let appHandle = try requireAppHandle()
+        let path = "/home/dev/.ghosthub/paste-images/paste-test.png"
+        let expectedData = Data("\u{1b}[200~\(path)\u{1b}[201~".utf8)
+        let expectedRaw = expectedData
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let scriptURL = makeBracketedPasteProbeScript(
+            readBytes: expectedData.count
+        )
+        let view = makeSurface(
+            app: appHandle,
+            configuration: TerminalSurfaceConfiguration(
+                command: "python3 '\(scriptURL.path)'"
+            )
+        )
+        view.blocksClipboardReads = true
+        _ = hostInWindow(view)
+        waitUntil(timeout: 5.0) { view.error == nil }
+        waitForProbeReady(in: view)
+
+        XCTAssertTrue(view.pasteProgrammaticInput(path))
+
+        waitForViewportText("<RAW:\(expectedRaw)>", in: view)
+    }
+
     /// Regression coverage for roborev finding 1332: `isPasteShortcut`
     /// previously required device-independent flags to equal exactly
     /// `.command`, so Caps Lock being active (which contributes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,14 +484,18 @@ continue borrowing connections until their route-identity and grouped-command
 contracts move behind the same higher-level boundary. Every remaining borrower
 is async: the pool is awaited, and only the blocking OpenSSH invocation itself
 runs off the cooperative thread pool.
-An explicit Ctrl-V image paste on a remote POSIX tmux surface reuses that
-presentation's frozen connection arguments while its lease remains owned.
+An explicit Cmd-V paste from an image-only clipboard on a remote POSIX tmux
+surface reuses that presentation's frozen connection arguments while its lease
+remains owned.
 Ghosthub converts the Mac pasteboard image to PNG, streams it to the remote
 account's `~/.ghosthub/paste-images/` directory, and routes the returned
 absolute path through libghostty's normal paste action. Image bytes never
 travel through tmux input, and the remote process never receives authority to
-read the Mac clipboard. The upload result is attachment-generation checked,
-so a late transfer cannot paste into a replacement presentation.
+read the Mac clipboard. Upload deadlines scale with the image size up to a
+bounded maximum. The upload result is attachment-generation checked, so a late
+transfer cannot paste into a replacement presentation. Ctrl-V remains remote
+program input, and Cmd-V follows the ordinary text-paste path whenever text is
+also present on the clipboard.
 Confirmation requests retain only the selected host and reviewed route key;
 they release the preparation lease, then reacquire and require the same route
 before the confirmed mutation begins.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,14 @@ continue borrowing connections until their route-identity and grouped-command
 contracts move behind the same higher-level boundary. Every remaining borrower
 is async: the pool is awaited, and only the blocking OpenSSH invocation itself
 runs off the cooperative thread pool.
+An explicit Ctrl-V image paste on a remote POSIX tmux surface reuses that
+presentation's frozen connection arguments while its lease remains owned.
+Ghosthub converts the Mac pasteboard image to PNG, streams it to the remote
+account's `~/.ghosthub/paste-images/` directory, and routes the returned
+absolute path through libghostty's normal paste action. Image bytes never
+travel through tmux input, and the remote process never receives authority to
+read the Mac clipboard. The upload result is attachment-generation checked,
+so a late transfer cannot paste into a replacement presentation.
 Confirmation requests retain only the selected host and reviewed route key;
 they release the preparation lease, then reacquire and require the same route
 before the confirmed mutation begins.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -732,15 +732,15 @@ of every clipboard request: Ghosthub supplies clipboard contents only for a
 configured `paste_from_clipboard` action, independent of which key triggers
 it. libghostty retains bracketed-paste framing and requires confirmation before
 unsafe unbracketed text can reach the PTY. On a remote POSIX tmux surface,
-Ctrl-V with an image on the Mac clipboard is a separate explicit image-paste
+Cmd-V with an image-only Mac clipboard is a separate explicit image-paste
 action. Ghosthub encodes TIFF clipboard images as PNG, streams the PNG through
 the attachment's frozen SSH route into `~/.ghosthub/paste-images/`, and asks
 libghostty to paste the resulting
 absolute remote path. Tmux therefore retains its normal bracketed-paste
 behavior, and applications such as Codex and Claude can ingest the path on the
 machine where they run. Cached paste images older than seven days are removed
-when the next image is uploaded. Text paste and non-image Ctrl-V input retain
-their ordinary terminal paths.
+when the next image is uploaded. Cmd-V prefers ordinary text paste when the
+clipboard also contains text, and Ctrl-V always retains its terminal meaning.
 
 ## Inventory and Startup
 

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -731,7 +731,16 @@ OSC 52, regardless of `clipboard-read`. libghostty exposes the semantic type
 of every clipboard request: Ghosthub supplies clipboard contents only for a
 configured `paste_from_clipboard` action, independent of which key triggers
 it. libghostty retains bracketed-paste framing and requires confirmation before
-unsafe unbracketed text can reach the PTY.
+unsafe unbracketed text can reach the PTY. On a remote POSIX tmux surface,
+Ctrl-V with an image on the Mac clipboard is a separate explicit image-paste
+action. Ghosthub encodes TIFF clipboard images as PNG, streams the PNG through
+the attachment's frozen SSH route into `~/.ghosthub/paste-images/`, and asks
+libghostty to paste the resulting
+absolute remote path. Tmux therefore retains its normal bracketed-paste
+behavior, and applications such as Codex and Claude can ingest the path on the
+machine where they run. Cached paste images older than seven days are removed
+when the next image is uploaded. Text paste and non-image Ctrl-V input retain
+their ordinary terminal paths.
 
 ## Inventory and Startup
 

--- a/tools/run_kwt_ssh_fixture.sh
+++ b/tools/run_kwt_ssh_fixture.sh
@@ -257,14 +257,19 @@ ssh -F "$fixture/ssh_config" ghosthub-direct printf fixture-ready \
 ssh -F "$fixture/ssh_config" ghosthub-jumped printf fixture-ready \
     | grep -qx fixture-ready
 
-GHOSTHUB_RUN_LIVE_INTEGRATION_TESTS=1 \
-GHOSTHUB_REQUIRE_SSH_INTERACTION_FIXTURE=1 \
-GHOSTHUB_SSH_INTEGRATION_DESTINATION=ghosthub-direct \
-GHOSTHUB_SSH_PROXYJUMP_INTEGRATION_DESTINATION=ghosthub-jumped \
-GHOSTHUB_SSH_INTERACTIVE_INTEGRATION_DESTINATION=ghosthub-interactive-jumped \
-GHOSTHUB_SSH_UNATTENDED_INTEGRATION_DESTINATION=ghosthub-unattended \
-GHOSTHUB_SSH_UNATTENDED_KNOWN_HOSTS="$fixture/unattended_known_hosts" \
-GHOSTHUB_SSH_INTEGRATION_KWT_HOME="$kwt_home" \
-GHOSTHUB_KWT_CONTRACT_BINARY="$kwt_binary" \
-    sh "$repo_root/tools/run_swift_tests.sh" \
-        swift test --filter KwtSSHLiveIntegrationTests
+for test_filter in \
+    KwtSSHLiveIntegrationTests \
+    TmuxImagePasterLiveIntegrationTests
+do
+    GHOSTHUB_RUN_LIVE_INTEGRATION_TESTS=1 \
+    GHOSTHUB_REQUIRE_SSH_INTERACTION_FIXTURE=1 \
+    GHOSTHUB_SSH_INTEGRATION_DESTINATION=ghosthub-direct \
+    GHOSTHUB_SSH_PROXYJUMP_INTEGRATION_DESTINATION=ghosthub-jumped \
+    GHOSTHUB_SSH_INTERACTIVE_INTEGRATION_DESTINATION=ghosthub-interactive-jumped \
+    GHOSTHUB_SSH_UNATTENDED_INTEGRATION_DESTINATION=ghosthub-unattended \
+    GHOSTHUB_SSH_UNATTENDED_KNOWN_HOSTS="$fixture/unattended_known_hosts" \
+    GHOSTHUB_SSH_INTEGRATION_KWT_HOME="$kwt_home" \
+    GHOSTHUB_KWT_CONTRACT_BINARY="$kwt_binary" \
+        sh "$repo_root/tools/run_swift_tests.sh" \
+            swift test --filter "$test_filter"
+done

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -51,6 +51,12 @@ uses tmux's vanilla configuration. Mouse mode is a shared session option, so
 other attached clients see it too; tmux's own mouse bindings remain in charge.
 Native Windows/psmux keeps its existing mouse-reporting limitation.
 
+When Codex, Claude, or another terminal tool is running in a remote macOS or
+Linux tmux session, press ++ctrl+v++ to paste an image from the Mac clipboard.
+Ghosthub copies the image into the remote account's Ghosthub cache and
+pastes its remote file path into the active pane, so the tool can attach it as
+if its clipboard were local. Ordinary ++cmd+v++ text paste is unchanged.
+
 Hold ++cmd++ while pointing at a highlighted terminal link, then click to open
 it in the default macOS application.
 

--- a/website/docs/content/sessions.md
+++ b/website/docs/content/sessions.md
@@ -52,10 +52,12 @@ other attached clients see it too; tmux's own mouse bindings remain in charge.
 Native Windows/psmux keeps its existing mouse-reporting limitation.
 
 When Codex, Claude, or another terminal tool is running in a remote macOS or
-Linux tmux session, press ++ctrl+v++ to paste an image from the Mac clipboard.
-Ghosthub copies the image into the remote account's Ghosthub cache and
+Linux tmux session, press ++cmd+v++ with an image-only Mac clipboard to paste
+the image. Ghosthub copies it into the remote account's Ghosthub cache and
 pastes its remote file path into the active pane, so the tool can attach it as
-if its clipboard were local. Ordinary ++cmd+v++ text paste is unchanged.
+if its clipboard were local. When the clipboard also contains text,
+++cmd+v++ pastes the text normally. ++ctrl+v++ is always passed through to the
+remote program.
 
 Hold ++cmd++ while pointing at a highlighted terminal link, then click to open
 it in the default macOS application.


### PR DESCRIPTION
Remote Codex, Claude, and other terminal tools cannot read the Mac pasteboard when they run over SSH, so attempting to paste an image falls back to an unavailable remote clipboard. On remote POSIX tmux surfaces, Ghosthub now turns an image-only `Cmd-V` into a private remote PNG path and pastes that path through libghostty's normal bracketed-paste flow.

- Streams PNG bytes through the attachment's frozen SSH route into `~/.ghosthub/paste-images/`, removes cached images older than seven days during later uploads, and scales the upload deadline from 30 seconds to a 600-second cap.
- Checks the attachment generation before delivering a completed upload, preventing a slow transfer from landing in a replacement session.
- Leaves `Ctrl-V` available to Vim, readline, zsh, and other remote programs. A clipboard containing both text and an image follows ordinary text-paste behavior.
- Keeps the initial scope to remote POSIX tmux. Herdr and Zellij need equivalent backend-specific handoffs.

Automated coverage exercises the AppKit key route, image-only and mixed clipboard behavior, Ctrl-V passthrough, bracketed path paste, and stale-attachment fencing. The Docker SSH fixture also runs the production uploader against a disposable SSH server and verifies the returned path, exact binary contents, and private directory/file modes. A real remote Codex or Claude acceptance run remains manual because those authenticated interactive tools are outside Ghosthub's test boundary.

For manual acceptance, copy an image on the Mac, open Codex or Claude in a remote tmux session, and press `Cmd-V`. The tool should receive the remote image path without an X11 clipboard error; `Ctrl-V` should retain its normal application behavior.

The required builds and focused workflows pass. The full Swift run completes 2,031 tests with one unrelated existing failure in `WorkspaceApplicationShortcutTests.presentedLogViewerTakesFindPriority`.
