### PR TITLE
Rust Port: Add remote clipboard controls

### DIFF
--- a/docs/rust-port.md
+++ b/docs/rust-port.md
@@ -339,8 +339,10 @@ bytes.
 
 Clipboard behavior follows the shipped Swift contract. Local and remote tmux
 surfaces may write the system clipboard through OSC 52 when `clipboard-write`
-allows it, so tmux copy-mode yanks reach Windows as they do on macOS. Remote
-OSC 52 reads always receive an empty response regardless of `clipboard-read`;
+allows it, so tmux copy-mode yanks reach Windows as they do on macOS. The
+Terminal settings pane changes this policy immediately for open and retained
+presentations as well as future attachments. Remote OSC 52 reads always
+receive an empty response regardless of `clipboard-read`;
 local OSC 52 reads follow the configured local policy. Only a genuine user
 paste action may acquire clipboard contents for PTY input, and the terminal
 worker applies bracketed-paste framing and unsafe-paste confirmation before
@@ -1147,9 +1149,11 @@ workspace. Terminal palettes never recolor Ghosthub's application chrome;
 interface appearance remains a separate settings concern. Existing terminal
 clients keep the palette they negotiated until reopened; new clients use the
 current defaults. Terminal persists the cursor shape, whether shell integration
-may replace that shape, and whether keyboard input hides the pointer until it
-moves again. Cursor changes apply to existing surfaces immediately, including
-dynamic DECSCUSR application requests when shell control is enabled. Hosts owns only
+may replace that shape, whether keyboard input hides the pointer until it moves
+again, and whether remote terminal applications may write to the clipboard
+through OSC 52. Cursor and clipboard-policy changes apply to existing surfaces
+immediately, including dynamic DECSCUSR application requests when shell control
+is enabled. Hosts owns only
 `[[ssh-host]]` records. The shell's stable navigation, page header, list, and
 detail regions are the permanent container for the remaining Swift settings
 domains.
@@ -1159,11 +1163,11 @@ The parity inventory is:
 | --- | --- |
 | Hosts | Native add, edit, remove, explicit connect, and SSH prompt UI |
 | Appearance | Built-in themes, Custom colors, installed-font and size pickers, live preview, and atomic persistence |
-| Terminal | Cursor shape, shell-controlled cursor permission, mouse hiding while typing, and atomic persistence |
+| Terminal | Cursor shape, shell-controlled cursor permission, mouse hiding while typing, remote clipboard writes, and atomic persistence |
 | Keyboard | Runtime shortcuts exist; pane not yet implemented |
 | Worktrees | Project/worktree workflows exist; preferences pane not yet implemented |
 | Agents | Not yet implemented |
-| Privacy | Clipboard policy exists in configuration; pane not yet implemented |
+| Privacy | Anonymous usage-reporting preference not yet implemented |
 | Integrations | Not yet implemented |
 
 Adding the remaining panes extends the existing shell rather than replacing

--- a/rust/terminal/src/lib.rs
+++ b/rust/terminal/src/lib.rs
@@ -87,6 +87,11 @@ impl ClipboardPolicy {
             allow_osc52_write,
         }
     }
+
+    #[must_use]
+    pub const fn allows_osc52_write(self) -> bool {
+        self.allow_osc52_write
+    }
 }
 
 impl Default for ClipboardPolicy {
@@ -303,6 +308,10 @@ impl TerminalEngine {
         self.term.set_options(self.config.clone());
         self.publish_full();
         self.term.reset_damage();
+    }
+
+    pub fn set_clipboard_policy(&mut self, policy: ClipboardPolicy) {
+        self.clipboard_policy = policy;
     }
 
     #[must_use]

--- a/rust/terminal/src/worker.rs
+++ b/rust/terminal/src/worker.rs
@@ -86,6 +86,7 @@ struct IngressState {
     resize: Option<ResizeCommand>,
     mouse_motion: Option<MouseInput>,
     default_cursor_shape: Option<CursorShape>,
+    clipboard_policy: Option<ClipboardPolicy>,
     queued_bytes: usize,
 }
 
@@ -188,6 +189,7 @@ pub struct TerminalWorker {
     surface: Arc<SurfaceStore>,
     confirmed_live: Arc<AtomicBool>,
     clipboard_visibility: Arc<AtomicU64>,
+    clipboard_write_allowed: Arc<AtomicBool>,
     /// Count of paste-cancel actions successfully delivered into this
     /// worker's control channel; shared so a test can keep observing it
     /// after the worker is torn down.
@@ -475,6 +477,9 @@ impl TerminalWorker {
         let worker_confirmed_live = Arc::clone(&confirmed_live);
         let clipboard_visibility = Arc::new(AtomicU64::new(INITIAL_CLIPBOARD_VISIBILITY));
         let worker_clipboard_visibility = Arc::clone(&clipboard_visibility);
+        let clipboard_write_allowed =
+            Arc::new(AtomicBool::new(clipboard_policy.allows_osc52_write()));
+        let worker_clipboard_write_allowed = Arc::clone(&clipboard_write_allowed);
 
         let startup = StartupPty::new(process);
         let writer_thread = match thread::Builder::new()
@@ -508,6 +513,7 @@ impl TerminalWorker {
                     &events_sender,
                     &worker_confirmed_live,
                     &worker_clipboard_visibility,
+                    &worker_clipboard_write_allowed,
                 );
             });
         let worker_thread = match worker_result {
@@ -532,6 +538,7 @@ impl TerminalWorker {
             surface,
             confirmed_live,
             clipboard_visibility,
+            clipboard_write_allowed,
             #[cfg(feature = "test-support")]
             delivered_paste_cancels: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             thread: Some(worker_thread),
@@ -683,6 +690,32 @@ impl TerminalWorker {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .default_cursor_shape = Some(shape);
         let _stopped = wake_coalesced(&self.coalesced_wake, "update terminal cursor shape");
+    }
+
+    /// Update which terminal-originated clipboard operations may reach the UI.
+    pub fn set_clipboard_policy(&self, policy: ClipboardPolicy) {
+        let allowed = policy.allows_osc52_write();
+        let changed = self.clipboard_write_allowed.swap(allowed, Ordering::AcqRel) != allowed;
+        self.ingress
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clipboard_policy = Some(policy);
+        let _stopped = wake_coalesced(&self.coalesced_wake, "update terminal clipboard policy");
+        if !changed {
+            return;
+        }
+        let visibility = self.clipboard_visibility.load(Ordering::Acquire);
+        advance_clipboard_visibility(
+            &self.clipboard_visibility,
+            clipboard_visibility_is_enabled(visibility),
+        );
+        if !allowed {
+            let mut deferred = self
+                .deferred_events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            discard_clipboard_events(&self.events, &mut deferred);
+        }
     }
 
     /// Resize the VT grid and PTY in one ordered worker operation.
@@ -867,6 +900,7 @@ fn run_worker(
     events: &Sender<TerminalEvent>,
     confirmed_live: &AtomicBool,
     clipboard_visibility: &AtomicU64,
+    clipboard_write_allowed: &AtomicBool,
 ) {
     let mut report_exit = false;
     let mut observed_exit = None;
@@ -1035,7 +1069,8 @@ fn run_worker(
                     }
                     for write in output.clipboard_writes {
                         let visibility = clipboard_visibility.load(Ordering::Acquire);
-                        if clipboard_visibility_is_enabled(visibility)
+                        if clipboard_write_allowed.load(Ordering::Acquire)
+                            && clipboard_visibility_is_enabled(visibility)
                             && !emit_event(
                                 events,
                                 shutdown,
@@ -1197,12 +1232,16 @@ fn process_coalesced(
     let CoalescedWork {
         resize,
         default_cursor_shape,
+        clipboard_policy,
         input,
         wake_again,
     } = take_coalesced_work(commands, ingress, accept_mouse_motion);
 
     if let Some(shape) = default_cursor_shape {
         engine.set_default_cursor_shape(shape);
+    }
+    if let Some(policy) = clipboard_policy {
+        engine.set_clipboard_policy(policy);
     }
     if let Some(resize) = resize
         && !process_resize(resize, engine, pty, shutdown, events)
@@ -1252,6 +1291,7 @@ enum CoalescedInput {
 struct CoalescedWork {
     resize: Option<ResizeCommand>,
     default_cursor_shape: Option<CursorShape>,
+    clipboard_policy: Option<ClipboardPolicy>,
     input: CoalescedInput,
     wake_again: bool,
 }
@@ -1268,6 +1308,7 @@ fn take_coalesced_work(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let default_cursor_shape = state.default_cursor_shape.take();
+    let clipboard_policy = state.clipboard_policy.take();
     let (resize, input, wake_again) = if accept_mouse_motion {
         match commands.try_recv() {
             Ok(mut command) => {
@@ -1299,6 +1340,7 @@ fn take_coalesced_work(
     CoalescedWork {
         resize,
         default_cursor_shape,
+        clipboard_policy,
         input,
         wake_again,
     }
@@ -1805,6 +1847,7 @@ mod tests {
                 modifiers: Modifiers::default(),
             }),
             default_cursor_shape: None,
+            clipboard_policy: None,
             queued_bytes: 0,
         });
 
@@ -1828,7 +1871,7 @@ mod tests {
     }
 
     #[test]
-    fn cursor_defaults_coalesce_while_ordered_input_is_blocked() {
+    fn terminal_settings_coalesce_while_ordered_input_is_blocked() {
         let (sender, receiver) = bounded(1);
         sender
             .send(QueuedCommand {
@@ -1839,6 +1882,7 @@ mod tests {
             .expect("fill ordered queue");
         let ingress = Mutex::new(IngressState {
             default_cursor_shape: Some(CursorShape::Underline),
+            clipboard_policy: Some(ClipboardPolicy::remote(false)),
             queued_bytes: 11,
             ..IngressState::default()
         });
@@ -1846,15 +1890,15 @@ mod tests {
         let work = take_coalesced_work(&receiver, &ingress, false);
 
         assert_eq!(work.default_cursor_shape, Some(CursorShape::Underline));
+        assert_eq!(work.clipboard_policy, Some(ClipboardPolicy::remote(false)));
         assert!(matches!(work.input, CoalescedInput::None));
         assert_eq!(receiver.len(), 1, "ordered input remains queued");
+        let state = ingress
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(
-            ingress
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .default_cursor_shape
-                .is_none(),
-            "the latest cursor default is consumed independently"
+            state.default_cursor_shape.is_none() && state.clipboard_policy.is_none(),
+            "the latest terminal defaults are consumed independently"
         );
     }
 
@@ -1970,6 +2014,7 @@ mod tests {
                 modifiers: Modifiers::default(),
             }),
             default_cursor_shape: None,
+            clipboard_policy: None,
             queued_bytes: 0,
         });
 

--- a/rust/terminal/tests/engine.rs
+++ b/rust/terminal/tests/engine.rs
@@ -251,11 +251,17 @@ fn damage_after_scroll_is_relative_to_the_immediately_previous_frame() {
 }
 
 #[test]
-fn denied_remote_osc_52_write_emits_no_clipboard_event() {
+fn remote_osc_52_write_policy_updates_apply_to_later_output() {
     let size = GridSize::new(4, 2).expect("valid grid");
     let mut engine = TerminalEngine::with_clipboard_policy(size, ClipboardPolicy::remote(false));
 
-    let output = engine.process(b"\x1b]52;c;SGVsbG8=\x07");
+    let denied = engine.process(b"\x1b]52;c;SGVsbG8=\x07");
+    engine.set_clipboard_policy(ClipboardPolicy::remote(true));
+    let allowed = engine.process(b"\x1b]52;c;V29ybGQ=\x07");
+    engine.set_clipboard_policy(ClipboardPolicy::remote(false));
+    let denied_again = engine.process(b"\x1b]52;c;R2hvc3RodWI=\x07");
 
-    assert!(output.clipboard_writes().is_empty());
+    assert!(denied.clipboard_writes().is_empty());
+    assert_eq!(allowed.clipboard_writes()[0].text, "World");
+    assert!(denied_again.clipboard_writes().is_empty());
 }

--- a/rust/ui/src/lib.rs
+++ b/rust/ui/src/lib.rs
@@ -520,7 +520,7 @@ impl SettingsPane {
     const fn subtitle(self) -> &'static str {
         match self {
             Self::Appearance => "Choose a terminal theme and installed monospace font.",
-            Self::Terminal => "Control cursor behavior and pointer visibility while typing.",
+            Self::Terminal => "Control cursor, pointer, and remote clipboard behavior.",
             Self::Hosts => "Connect the machines and tmux sessions in your SSH network.",
         }
     }
@@ -540,6 +540,7 @@ enum TerminalField {
     CursorStyle,
     ShellIntegrationCursor,
     HideMouseWhileTyping,
+    RemoteClipboardWrite,
 }
 
 impl TerminalField {
@@ -548,10 +549,13 @@ impl TerminalField {
             (Self::CursorStyle, false) | (Self::HideMouseWhileTyping, true) => {
                 Self::ShellIntegrationCursor
             }
-            (Self::ShellIntegrationCursor, false) | (Self::CursorStyle, true) => {
+            (Self::ShellIntegrationCursor, false) | (Self::RemoteClipboardWrite, true) => {
                 Self::HideMouseWhileTyping
             }
-            (Self::ShellIntegrationCursor, true) | (Self::HideMouseWhileTyping, false) => {
+            (Self::HideMouseWhileTyping, false) | (Self::CursorStyle, true) => {
+                Self::RemoteClipboardWrite
+            }
+            (Self::RemoteClipboardWrite, false) | (Self::ShellIntegrationCursor, true) => {
                 Self::CursorStyle
             }
         }
@@ -717,7 +721,7 @@ fn focus_settings_detail(dialog: &mut SettingsDialog, reverse: bool) -> bool {
         }
         SettingsPane::Terminal => {
             dialog.terminal_editor.field = if reverse {
-                TerminalField::HideMouseWhileTyping
+                TerminalField::RemoteClipboardWrite
             } else {
                 TerminalField::CursorStyle
             };
@@ -784,7 +788,7 @@ fn advance_settings_focus(dialog: &mut SettingsDialog, reverse: bool) {
             let at_edge = if reverse {
                 dialog.terminal_editor.field == TerminalField::CursorStyle
             } else {
-                dialog.terminal_editor.field == TerminalField::HideMouseWhileTyping
+                dialog.terminal_editor.field == TerminalField::RemoteClipboardWrite
             };
             if at_edge {
                 dialog.sidebar_focus = Some(if reverse {
@@ -1370,14 +1374,12 @@ const fn worktree_open_mode(context: WorktreeOpenContext) -> WorktreeOpenMode {
     };
     if matches!(context.authority, WorktreeAuthority::Generation) && kwt_available {
         WorktreeOpenMode::RepairOrOpen
-    } else if matches!(context.attach_mode, KwtTmuxAttachMode::Direct)
+    } else if (matches!(context.attach_mode, KwtTmuxAttachMode::Direct)
         && matches!(context.authority, WorktreeAuthority::Generation)
         && (matches!(context.socket, WorktreeSocket::Custom)
-            || matches!(context.session, WorktreeSessionPresence::Discovered))
-    {
-        WorktreeOpenMode::DirectTmux
-    } else if matches!(context.authority, WorktreeAuthority::Generationless)
-        && matches!(context.session, WorktreeSessionPresence::Discovered)
+            || matches!(context.session, WorktreeSessionPresence::Discovered)))
+        || (matches!(context.authority, WorktreeAuthority::Generationless)
+            && matches!(context.session, WorktreeSessionPresence::Discovered))
     {
         WorktreeOpenMode::DirectTmux
     } else {
@@ -2193,6 +2195,11 @@ impl RootView {
             }
             TerminalField::HideMouseWhileTyping if activate => {
                 editor.draft.hide_mouse_while_typing = !editor.draft.hide_mouse_while_typing;
+                true
+            }
+            TerminalField::RemoteClipboardWrite if activate => {
+                editor.draft.allow_remote_clipboard_write =
+                    !editor.draft.allow_remote_clipboard_write;
                 true
             }
             _ => false,
@@ -5791,6 +5798,10 @@ impl RootView {
                             dialog.terminal_editor.draft.hide_mouse_while_typing =
                                 !dialog.terminal_editor.draft.hide_mouse_while_typing;
                         }
+                        TerminalField::RemoteClipboardWrite => {
+                            dialog.terminal_editor.draft.allow_remote_clipboard_write =
+                                !dialog.terminal_editor.draft.allow_remote_clipboard_write;
+                        }
                         TerminalField::CursorStyle => {}
                     }
                 }
@@ -5803,6 +5814,24 @@ impl RootView {
                     this.persist_terminal_settings(draft, cx);
                 }
             }))
+            .into_any_element()
+    }
+
+    fn terminal_settings_section(
+        title: &'static str,
+        content: gpui::AnyElement,
+    ) -> gpui::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .text_base()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .child(title),
+            )
+            .child(content)
             .into_any_element()
     }
 
@@ -5833,17 +5862,12 @@ impl RootView {
             .flex()
             .flex_col()
             .gap_6()
-            .child(
+            .child(Self::terminal_settings_section(
+                "Cursor",
                 div()
                     .flex()
                     .flex_col()
                     .gap_3()
-                    .child(
-                        div()
-                            .text_base()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .child("Cursor"),
-                    )
                     .child(cursor_options)
                     .child(self.terminal_toggle_row(
                         "terminal-shell-cursor",
@@ -5852,28 +5876,31 @@ impl RootView {
                         TerminalField::ShellIntegrationCursor,
                         editor.draft.allow_shell_integration_cursor,
                         cx,
-                    )),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_3()
-                    .child(
-                        div()
-                            .text_base()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .child("Interaction"),
-                    )
-                    .child(self.terminal_toggle_row(
-                        "terminal-hide-mouse",
-                        "Hide mouse while typing",
-                        "Reveal the pointer again as soon as it moves over the terminal.",
-                        TerminalField::HideMouseWhileTyping,
-                        editor.draft.hide_mouse_while_typing,
-                        cx,
-                    )),
-            );
+                    ))
+                    .into_any_element(),
+            ))
+            .child(Self::terminal_settings_section(
+                "Interaction",
+                self.terminal_toggle_row(
+                    "terminal-hide-mouse",
+                    "Hide mouse while typing",
+                    "Reveal the pointer again as soon as it moves over the terminal.",
+                    TerminalField::HideMouseWhileTyping,
+                    editor.draft.hide_mouse_while_typing,
+                    cx,
+                ),
+            ))
+            .child(Self::terminal_settings_section(
+                "Clipboard",
+                self.terminal_toggle_row(
+                    "terminal-remote-clipboard-write",
+                    "Allow remote clipboard writes",
+                    "Let terminal applications copy text to your clipboard with OSC 52.",
+                    TerminalField::RemoteClipboardWrite,
+                    editor.draft.allow_remote_clipboard_write,
+                    cx,
+                ),
+            ));
         if let Some(error) = &editor.error {
             form = form.child(
                 div()
@@ -9657,6 +9684,7 @@ mod tests {
             cursor_style: CursorStyle::Block,
             allow_shell_integration_cursor: false,
             hide_mouse_while_typing: true,
+            allow_remote_clipboard_write: true,
         };
         let dialog = SettingsDialog::new(
             &[],
@@ -9694,6 +9722,7 @@ mod tests {
             cursor_style: CursorStyle::Bar,
             allow_shell_integration_cursor: false,
             hide_mouse_while_typing: true,
+            allow_remote_clipboard_write: true,
         };
         let mut dialog =
             SettingsDialog::new(&[], appearance, terminal, vec!["Cascadia Mono".to_owned()]);
@@ -9717,13 +9746,14 @@ mod tests {
         advance_settings_focus(&mut dialog, false);
         advance_settings_focus(&mut dialog, false);
         advance_settings_focus(&mut dialog, false);
+        advance_settings_focus(&mut dialog, false);
         assert_eq!(dialog.sidebar_focus, Some(SettingsPane::Appearance));
 
         advance_settings_focus(&mut dialog, true);
         assert_eq!(dialog.sidebar_focus, None);
         assert_eq!(
             dialog.terminal_editor.field,
-            TerminalField::HideMouseWhileTyping
+            TerminalField::RemoteClipboardWrite
         );
     }
 

--- a/rust/workspace/src/lib.rs
+++ b/rust/workspace/src/lib.rs
@@ -74,11 +74,11 @@ use scene::{
     invalidate_pending_kill_with_intent, join_runtime, lock_live_navigation, presentation_is_open,
     publish_discovered_host, publish_herdr_lifecycle_response, publish_pending_kill,
     publish_remote_connection, publish_remote_worker, publish_restored_retained_presentation,
-    publish_terminfo_retry_boundary, reconcile_herdr_lifecycle_inventory,
-    reconcile_presentation_session_names, reconcile_remote_presentations,
-    reinsert_retained_presentation, release_scene, reopen_closed_retained_presentation,
-    request_ssh_prompt, reserve_kwt_project_mutation, reserve_kwt_worktree_operation,
-    restore_attach_fallback, restore_attach_fallback_locked,
+    publish_terminfo_retry_boundary, purge_queued_clipboard_writes,
+    reconcile_herdr_lifecycle_inventory, reconcile_presentation_session_names,
+    reconcile_remote_presentations, reinsert_retained_presentation, release_scene,
+    reopen_closed_retained_presentation, request_ssh_prompt, reserve_kwt_project_mutation,
+    reserve_kwt_worktree_operation, restore_attach_fallback, restore_attach_fallback_locked,
     restore_inventory_after_creation_failure, restore_pending_kwt_removal,
     restore_scene_inventory_state, retire_clipboard_writes, run_attach, run_attach_over_remote,
     run_create, run_herdr_create, run_kwt_project_mutation, run_kwt_worktree_operation,
@@ -135,6 +135,7 @@ pub struct Appearance {
     cursor_style: CursorStyle,
     allow_shell_integration_cursor: bool,
     hide_mouse_while_typing: bool,
+    allow_remote_clipboard_write: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -142,6 +143,7 @@ pub struct TerminalSettingsDraft {
     pub cursor_style: CursorStyle,
     pub allow_shell_integration_cursor: bool,
     pub hide_mouse_while_typing: bool,
+    pub allow_remote_clipboard_write: bool,
 }
 
 impl From<&TerminalAppearance> for TerminalSettingsDraft {
@@ -150,6 +152,7 @@ impl From<&TerminalAppearance> for TerminalSettingsDraft {
             cursor_style: value.cursor_style(),
             allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
             hide_mouse_while_typing: value.hide_mouse_while_typing(),
+            allow_remote_clipboard_write: value.allow_remote_clipboard_write(),
         }
     }
 }
@@ -160,6 +163,7 @@ impl From<&Appearance> for TerminalSettingsDraft {
             cursor_style: value.cursor_style(),
             allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
             hide_mouse_while_typing: value.hide_mouse_while_typing(),
+            allow_remote_clipboard_write: value.allow_remote_clipboard_write(),
         }
     }
 }
@@ -237,6 +241,11 @@ impl Appearance {
     pub const fn hide_mouse_while_typing(&self) -> bool {
         self.hide_mouse_while_typing
     }
+
+    #[must_use]
+    pub const fn allow_remote_clipboard_write(&self) -> bool {
+        self.allow_remote_clipboard_write
+    }
 }
 
 impl From<TerminalAppearance> for Appearance {
@@ -250,6 +259,7 @@ impl From<TerminalAppearance> for Appearance {
             cursor_style: value.cursor_style(),
             allow_shell_integration_cursor: value.allow_shell_integration_cursor(),
             hide_mouse_while_typing: value.hide_mouse_while_typing(),
+            allow_remote_clipboard_write: value.allow_remote_clipboard_write(),
         }
     }
 }
@@ -3900,7 +3910,6 @@ impl Workspace {
                     herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                     session_operations: Mutex::new(()),
                     remote_constructive_in_flight: AtomicBool::new(false),
-                    allow_remote_clipboard_write: true,
                     refresh_generation: AtomicU64::new(0),
                     refresh_finished: AtomicU64::new(0),
                     refresh_publication: Mutex::new(()),
@@ -4043,7 +4052,6 @@ impl Workspace {
         discovery: Arc<dyn WslDiscovery>,
         refresh_runtime: Arc<dyn RefreshRuntime>,
     ) -> (Runtime, Option<String>) {
-        let allow_remote_clipboard_write = appearance.allow_remote_clipboard_write();
         let hosts = wsl
             .as_ref()
             .map(WslHostSpec::host_item)
@@ -4081,7 +4089,6 @@ impl Workspace {
                 herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                 session_operations: Mutex::new(()),
                 remote_constructive_in_flight: AtomicBool::new(false),
-                allow_remote_clipboard_write,
                 refresh_generation: AtomicU64::new(0),
                 refresh_finished: AtomicU64::new(0),
                 refresh_publication: Mutex::new(()),
@@ -4104,7 +4111,6 @@ impl Workspace {
 
     #[must_use]
     pub fn start_wsl(config: WslConfig, appearance: TerminalAppearance) -> Self {
-        let allow_remote_clipboard_write = appearance.allow_remote_clipboard_write();
         let workspace = Self {
             scene: attach_scene(
                 Arc::new(Runtime {
@@ -4141,7 +4147,6 @@ impl Workspace {
                     herdr_lifecycle: Mutex::new(HerdrLifecycleState::default()),
                     session_operations: Mutex::new(()),
                     remote_constructive_in_flight: AtomicBool::new(false),
-                    allow_remote_clipboard_write,
                     refresh_generation: AtomicU64::new(0),
                     refresh_finished: AtomicU64::new(0),
                     refresh_publication: Mutex::new(()),
@@ -4269,8 +4274,7 @@ impl Workspace {
             .hide_mouse_while_typing()
     }
 
-    /// Persist terminal interaction settings and publish them to the
-    /// running workspace, updating the default cursor shape on every live
+    /// Persist terminal interaction settings and publish them to every live
     /// worker.
     ///
     /// # Errors
@@ -4309,7 +4313,8 @@ impl Workspace {
                     draft.cursor_style,
                     draft.allow_shell_integration_cursor,
                     draft.hide_mouse_while_typing,
-                );
+                )
+                .with_remote_clipboard_write(draft.allow_remote_clipboard_write);
             let roots = settings.roots.clone();
             settings
                 .config
@@ -4328,6 +4333,10 @@ impl Workspace {
         update_default_cursor_shapes(
             &self.scene,
             current_default_cursor_shape(&self.scene.runtime),
+        );
+        update_remote_clipboard_policies(
+            &self.scene,
+            current_remote_clipboard_policy(&self.scene.runtime),
         );
         self.scene.runtime.revision.fetch_add(1, Ordering::Release);
         Ok(())
@@ -6146,7 +6155,7 @@ impl Workspace {
         let presentation_id = presentation.presentation_id;
         presentation.worker.set_clipboard_writes_enabled(true);
         let (_, previous_worker) = workers.replace(presentation.worker);
-        reconcile_active_worker_cursor(&self.scene.runtime, &workers);
+        reconcile_active_worker_terminal_settings(&self.scene.runtime, &workers);
         let previous_remote = remote_active.take();
         clear_pending_paste(&self.scene);
         set_terminal_notice(&self.scene, term);
@@ -9540,6 +9549,14 @@ pub(crate) fn current_default_cursor_shape(runtime: &Runtime) -> CursorShape {
     runtime.cursor_default.load()
 }
 
+pub(crate) fn current_remote_clipboard_policy(runtime: &Runtime) -> ClipboardPolicy {
+    let appearance = runtime
+        .appearance
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ClipboardPolicy::remote(appearance.allow_remote_clipboard_write())
+}
+
 /// Push the new default cursor shape to every live worker across every
 /// scene; existing surfaces reflect the setting without a restart.
 fn update_default_cursor_shapes(initiator: &Arc<Scene>, shape: CursorShape) {
@@ -9571,6 +9588,44 @@ fn update_default_cursor_shapes(initiator: &Arc<Scene>, shape: CursorShape) {
     }
 }
 
+fn update_remote_clipboard_policies(initiator: &Arc<Scene>, policy: ClipboardPolicy) {
+    for scene in live_scenes(&initiator.runtime) {
+        if let Some(worker) = scene
+            .worker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active()
+        {
+            worker.set_clipboard_policy(policy);
+        }
+        {
+            let retained = scene
+                .retained_presentations
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for presentation in &retained.entries {
+                presentation.worker.set_clipboard_policy(policy);
+            }
+        }
+        let remote = scene
+            .remote_retained
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for presentation in &remote.entries {
+            presentation.worker.set_clipboard_policy(policy);
+        }
+        drop(remote);
+        if !policy.allows_osc52_write() {
+            purge_queued_clipboard_writes(&scene);
+        }
+    }
+}
+
+pub(crate) fn reconcile_worker_terminal_settings(runtime: &Runtime, worker: &TerminalWorker) {
+    worker.set_default_cursor_shape(current_default_cursor_shape(runtime));
+    worker.set_clipboard_policy(current_remote_clipboard_policy(runtime));
+}
+
 pub(crate) fn insert_retained_presentation(
     runtime: &Runtime,
     retained: &Mutex<crate::RetainedPresentations<TerminalWorker>>,
@@ -9579,9 +9634,7 @@ pub(crate) fn insert_retained_presentation(
     let mut retained = retained
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    presentation
-        .worker
-        .set_default_cursor_shape(current_default_cursor_shape(runtime));
+    reconcile_worker_terminal_settings(runtime, &presentation.worker);
     retained.insert(presentation);
 }
 
@@ -9593,20 +9646,20 @@ pub(crate) fn insert_remote_retained_presentation(
     let mut retained = retained
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    presentation
-        .worker
-        .set_default_cursor_shape(current_default_cursor_shape(runtime));
+    reconcile_worker_terminal_settings(runtime, &presentation.worker);
     retained.insert(presentation);
 }
 
-pub(crate) fn reconcile_active_worker_cursor(
+pub(crate) fn reconcile_active_worker_terminal_settings(
     runtime: &Runtime,
     workers: &WorkerState<TerminalWorker>,
 ) {
-    workers
-        .active()
-        .expect("worker was published before cursor reconciliation")
-        .set_default_cursor_shape(current_default_cursor_shape(runtime));
+    reconcile_worker_terminal_settings(
+        runtime,
+        workers
+            .active()
+            .expect("worker was published before terminal settings reconciliation"),
+    );
 }
 
 fn rgb(color: u32) -> Rgb {

--- a/rust/workspace/src/runtime.rs
+++ b/rust/workspace/src/runtime.rs
@@ -79,7 +79,6 @@ pub(crate) struct Runtime {
     pub(crate) herdr_lifecycle: Mutex<HerdrLifecycleState>,
     pub(crate) session_operations: Mutex<()>,
     pub(crate) remote_constructive_in_flight: AtomicBool,
-    pub(crate) allow_remote_clipboard_write: bool,
     pub(crate) refresh_generation: AtomicU64,
     pub(crate) refresh_finished: AtomicU64,
     pub(crate) refresh_publication: Mutex<()>,

--- a/rust/workspace/src/scene.rs
+++ b/rust/workspace/src/scene.rs
@@ -2,14 +2,14 @@
 
 use crate::{
     Arc, AtomicBool, AtomicU64, AttachFreshError, AttachRequest, AttachTarget, AttachTerm,
-    AttachmentState, CREATE_IDENTITY_TIMEOUT, CancellationToken, ClipboardPolicy,
-    ClosedRetainedPresentation, ConptyAdmissionAttacher, CreateRequest, DiagnosticKind,
-    DirectoryWorkspaceItem, Duration, FallbackAuthority, HERDR_STARTUP_BACKOFF, HerdrCreateRequest,
-    HerdrInventory, HerdrLaunchPrecondition, HerdrLaunchTarget, HerdrLifecycleAction,
-    HerdrSessionName, HerdrSessionState, HostConnectionState, HostContext, HostDiagnostic,
-    HostError, HostItem, HostSnapshot, INVENTORY_REFRESH_INTERVAL, Instant, KWT_REFRESH_BUDGET,
-    KWT_REFRESH_INTERVAL, KillCaptureIntent, KillCaptureRequest, KillTarget, KwtBranchItem,
-    KwtInventory, KwtProjectAction, KwtProjectMutationRequest, KwtProjectMutationTask,
+    AttachmentState, CREATE_IDENTITY_TIMEOUT, CancellationToken, ClosedRetainedPresentation,
+    ConptyAdmissionAttacher, CreateRequest, DiagnosticKind, DirectoryWorkspaceItem, Duration,
+    FallbackAuthority, HERDR_STARTUP_BACKOFF, HerdrCreateRequest, HerdrInventory,
+    HerdrLaunchPrecondition, HerdrLaunchTarget, HerdrLifecycleAction, HerdrSessionName,
+    HerdrSessionState, HostConnectionState, HostContext, HostDiagnostic, HostError, HostItem,
+    HostSnapshot, INVENTORY_REFRESH_INTERVAL, Instant, KWT_REFRESH_BUDGET, KWT_REFRESH_INTERVAL,
+    KillCaptureIntent, KillCaptureRequest, KillTarget, KwtBranchItem, KwtInventory,
+    KwtProjectAction, KwtProjectMutationRequest, KwtProjectMutationTask,
     KwtPullRequestImportRequest, KwtPullRequestItem, KwtRefresh, KwtRemovalCapture,
     KwtRemovalCaptureIntent, KwtState, KwtWorktreeOperation, KwtWorktreeOutcome, KwtWorktreeTarget,
     KwtWorktreeTask, Mutex, Ordering, PendingCreation, PendingHerdrLifecycle, PendingKill,
@@ -32,18 +32,19 @@ use crate::{
     cancel_scene_remote_attachments, cancel_superseded_remote_constructive_navigation,
     capture_kwt_creation_baseline, clear_pending_remote_constructive, created_session,
     creation_launch_geometry, current_default_colors, current_default_cursor_shape,
-    current_inventory_session_name, default_terminal_geometry, discover_fresh_runtime,
-    finish_pending_creation, fmt, for_each_scene, fresh_herdr_session, herdr_launch_result_matches,
-    insert_remote_retained_presentation, insert_retained_presentation, invalidate_kwt_inventory,
-    kwt_attachment_failure, kwt_pull_request_import_failure, live_scenes, lock_session_operations,
-    next_operation_id, next_presentation_id, next_scene_id, normalize_attached_kwt_target,
-    pending_kwt_creation, pending_kwt_creation_target, pending_remote_constructive_snapshot,
-    poll_session_startup, preflight_kwt_worktree_remove, publish_refresh,
-    publish_worker_at_latest_geometry, ready_content, recapture_remote_herdr_attach_request,
-    recapture_remote_herdr_create_request, recapture_remote_tmux_attach_request,
-    recapture_remote_zellij_attach_request, recapture_remote_zellij_create_request,
-    reconcile_active_worker_cursor, reconcile_herdr_lifecycle_fences,
-    reconcile_kwt_session_availability, refresh_budget, refreshed_session_name, register_scene,
+    current_inventory_session_name, current_remote_clipboard_policy, default_terminal_geometry,
+    discover_fresh_runtime, finish_pending_creation, fmt, for_each_scene, fresh_herdr_session,
+    herdr_launch_result_matches, insert_remote_retained_presentation, insert_retained_presentation,
+    invalidate_kwt_inventory, kwt_attachment_failure, kwt_pull_request_import_failure, live_scenes,
+    lock_session_operations, next_operation_id, next_presentation_id, next_scene_id,
+    normalize_attached_kwt_target, pending_kwt_creation, pending_kwt_creation_target,
+    pending_remote_constructive_snapshot, poll_session_startup, preflight_kwt_worktree_remove,
+    publish_refresh, publish_worker_at_latest_geometry, ready_content,
+    recapture_remote_herdr_attach_request, recapture_remote_herdr_create_request,
+    recapture_remote_tmux_attach_request, recapture_remote_zellij_attach_request,
+    recapture_remote_zellij_create_request, reconcile_active_worker_terminal_settings,
+    reconcile_herdr_lifecycle_fences, reconcile_kwt_session_availability,
+    reconcile_worker_terminal_settings, refresh_budget, refreshed_session_name, register_scene,
     remember_pending_kwt_creation, remote_constructive_is_current,
     remote_constructive_target_is_present, remove_cached_kwt_worktree,
     require_current_kwt_selection, require_host_session_actions, require_wsl_host_id,
@@ -1096,7 +1097,7 @@ pub(crate) fn activate_retained_presentation(
     worker.set_clipboard_writes_enabled(false);
     let surface = worker.surface_handle();
     let worker_generation = workers.publish(worker);
-    reconcile_active_worker_cursor(&scene.runtime, &workers);
+    reconcile_active_worker_terminal_settings(&scene.runtime, &workers);
     drop(workers);
 
     clear_pending_paste(scene);
@@ -4575,7 +4576,7 @@ pub(crate) fn prepare_remote_tmux_attachment<'scene>(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -4724,7 +4725,7 @@ pub(crate) fn prepare_remote_herdr_attachment<'scene>(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -4865,7 +4866,7 @@ pub(crate) fn prepare_remote_zellij_attachment<'scene>(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -5209,7 +5210,7 @@ pub(crate) fn create_remote_herdr_fresh(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -5327,7 +5328,7 @@ pub(crate) fn create_remote_zellij_fresh(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -5657,7 +5658,7 @@ pub(crate) fn create_herdr_fresh(
                     geometry.grid,
                     geometry.sequence,
                     geometry.pixels,
-                    ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                    current_remote_clipboard_policy(&scene.runtime),
                     current_default_colors(&scene.runtime),
                     current_default_cursor_shape(&scene.runtime),
                 )
@@ -5775,7 +5776,7 @@ pub(crate) fn create_zellij_fresh(
             geometry.grid,
             geometry.sequence,
             geometry.pixels,
-            ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+            current_remote_clipboard_policy(&scene.runtime),
             current_default_colors(&scene.runtime),
             current_default_cursor_shape(&scene.runtime),
         )
@@ -5881,7 +5882,7 @@ pub(crate) fn publish_created_presentation(
         worker,
         initial_geometry,
         resize_terminal_worker,
-        |worker| worker.set_default_cursor_shape(current_default_cursor_shape(&scene.runtime)),
+        |worker| reconcile_worker_terminal_settings(&scene.runtime, worker),
     ) {
         attachment.clear_if_current(generation);
         finish_pending_creation(&scene.runtime, &pending);
@@ -5968,7 +5969,7 @@ pub(crate) fn create_fresh(
             launch_geometry.grid,
             launch_geometry.sequence,
             launch_geometry.pixels,
-            ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+            current_remote_clipboard_policy(&scene.runtime),
             current_default_colors(&scene.runtime),
             current_default_cursor_shape(&scene.runtime),
         )
@@ -6113,7 +6114,7 @@ pub(crate) fn run_attach(
                 initial_geometry,
                 resize_terminal_worker,
                 |worker| {
-                    worker.set_default_cursor_shape(current_default_cursor_shape(&scene.runtime));
+                    reconcile_worker_terminal_settings(&scene.runtime, worker);
                 },
             ) {
                 let current_request = attachment
@@ -6279,7 +6280,7 @@ pub(crate) fn publish_remote_worker(
         None
     };
     let (worker_generation, previous_worker) = workers.replace(worker);
-    reconcile_active_worker_cursor(&scene.runtime, &workers);
+    reconcile_active_worker_terminal_settings(&scene.runtime, &workers);
     let previous_remote = remote_active.replace(RemoteActive {
         key,
         selection: selection.clone(),
@@ -6457,7 +6458,7 @@ pub(crate) fn run_attach_over_remote(
         return;
     }
     let (_, previous_worker) = workers.replace(worker);
-    reconcile_active_worker_cursor(&scene.runtime, &workers);
+    reconcile_active_worker_terminal_settings(&scene.runtime, &workers);
     let previous_remote = remote_active.take();
     set_terminal_notice(scene, attached_term);
     let presentation_id = next_presentation_id(&scene.runtime);
@@ -6546,7 +6547,7 @@ pub(crate) fn run_retained_retry(scene: &Scene, retry: &RetainedRetry) {
                 return;
             }
             worker.set_clipboard_writes_enabled(false);
-            worker.set_default_cursor_shape(current_default_cursor_shape(&scene.runtime));
+            reconcile_worker_terminal_settings(&scene.runtime, &worker);
             let published = scene
                 .retained_presentations
                 .lock()
@@ -7137,9 +7138,7 @@ pub(crate) fn publish_restored_retained_presentation(
         if scene.closed.load(Ordering::Acquire) {
             Some(presentation)
         } else {
-            presentation
-                .worker
-                .set_default_cursor_shape(current_default_cursor_shape(&scene.runtime));
+            reconcile_worker_terminal_settings(&scene.runtime, &presentation.worker);
             retained.insert(presentation);
             None
         }
@@ -7486,7 +7485,7 @@ pub(crate) fn launch_fresh_tmux(
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
-        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_remote_clipboard_policy(&scene.runtime),
         current_default_colors(&scene.runtime),
         current_default_cursor_shape(&scene.runtime),
     )
@@ -7575,7 +7574,7 @@ fn launch_fresh_named_tmux(
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
-        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_remote_clipboard_policy(&scene.runtime),
         current_default_colors(&scene.runtime),
         current_default_cursor_shape(&scene.runtime),
     )
@@ -7827,7 +7826,7 @@ pub(crate) fn launch_fresh_protected_worktree_once(
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
-        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_remote_clipboard_policy(&scene.runtime),
         current_default_colors(&scene.runtime),
         current_default_cursor_shape(&scene.runtime),
     )
@@ -7978,7 +7977,7 @@ fn launch_fresh_direct_kwt_plan(
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
-        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_remote_clipboard_policy(&scene.runtime),
         current_default_colors(&scene.runtime),
         current_default_cursor_shape(&scene.runtime),
     )
@@ -8112,7 +8111,7 @@ pub(crate) fn launch_fresh_herdr(
                 geometry.grid,
                 geometry.sequence,
                 geometry.pixels,
-                ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+                current_remote_clipboard_policy(&scene.runtime),
                 current_default_colors(&scene.runtime),
                 current_default_cursor_shape(&scene.runtime),
             )
@@ -8145,7 +8144,7 @@ pub(crate) fn launch_fresh_zellij(
         geometry.grid,
         geometry.sequence,
         geometry.pixels,
-        ClipboardPolicy::remote(scene.runtime.allow_remote_clipboard_write),
+        current_remote_clipboard_policy(&scene.runtime),
         current_default_colors(&scene.runtime),
         current_default_cursor_shape(&scene.runtime),
     )

--- a/rust/workspace/src/tests.rs
+++ b/rust/workspace/src/tests.rs
@@ -1999,6 +1999,7 @@ fn appearance_projects_terminal_default_colors() {
         cursor_style: CursorStyle::Block,
         allow_shell_integration_cursor: false,
         hide_mouse_while_typing: true,
+        allow_remote_clipboard_write: true,
     };
 
     let colors = default_colors(&appearance);
@@ -15069,6 +15070,7 @@ fn light_themes_render_every_ansi_color_with_readable_contrast() {
             cursor_style: CursorStyle::Block,
             allow_shell_integration_cursor: false,
             hide_mouse_while_typing: true,
+            allow_remote_clipboard_write: true,
         };
         let colors = default_colors(&appearance);
         let mut engine =

--- a/rust/workspace/tests/view_state.rs
+++ b/rust/workspace/tests/view_state.rs
@@ -249,6 +249,7 @@ fn saved_terminal_settings_are_persisted_and_published_without_rebuilding_hosts(
         cursor_style: workspace::CursorStyle::Underline,
         allow_shell_integration_cursor: true,
         hide_mouse_while_typing: false,
+        allow_remote_clipboard_write: false,
     };
     assert!(workspace.hide_mouse_while_typing());
 
@@ -261,10 +262,12 @@ fn saved_terminal_settings_are_persisted_and_published_without_rebuilding_hosts(
     assert_eq!(snapshot.appearance().cursor_style(), draft.cursor_style);
     assert!(snapshot.appearance().allow_shell_integration_cursor());
     assert!(!snapshot.appearance().hide_mouse_while_typing());
+    assert!(!snapshot.appearance().allow_remote_clipboard_write());
     assert!(snapshot.hosts().is_empty());
     let loaded = ApplicationConfig::load(&roots).expect("reload application config");
     assert_eq!(loaded.terminal().cursor_style(), draft.cursor_style);
     assert!(loaded.terminal().allow_shell_integration_cursor());
     assert!(!loaded.terminal().hide_mouse_while_typing());
+    assert!(!loaded.terminal().allow_remote_clipboard_write());
     fs::remove_dir_all(root).expect("remove temporary config root");
 }


### PR DESCRIPTION
Remote programs use OSC 52, a terminal escape sequence, to copy text to the local clipboard. Rust users could already allow or block this behavior in the configuration file, but they could not change it in the app. Open terminals also kept the value from startup.

- Adds an **Allow remote clipboard writes** switch under **Settings → Terminal**.
- Supports mouse, Tab, Shift-Tab, Enter, and Space interaction.
- Saves changes immediately and applies them to open, retained, and newly opened terminals without a restart.
- Drops clipboard writes that were waiting when the setting was turned off. Remote clipboard reads remain blocked.
- Keeps **Privacy** reserved for the separate anonymous usage-reporting setting from the Swift app.
- Tests the real allow-and-block behavior, saved settings, keyboard navigation, and updates delivered while terminal input is busy.

The full Rust workspace test suite passes. Formatting, compilation, Clippy with warnings denied, and dependency-policy checks also pass.
