### PR TITLE
Refresh queued updates and restore window positions after relaunch

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -219,9 +219,13 @@ struct GhosthubApp: App {
             #if canImport(AppKit)
             CommandGroup(replacing: .appInfo) {
                 Button("About Ghosthub") {
-                    let options = ApplicationVersion.aboutPanelVersion().map {
+                    var options = ApplicationVersion.aboutPanelVersion().map {
                         [NSApplication.AboutPanelOptionKey.version: $0]
                     } ?? [:]
+                    options[NSApplication.AboutPanelOptionKey(rawValue: "Copyright")] = (Bundle.main
+                        .object(
+                            forInfoDictionaryKey: "NSHumanReadableCopyright"
+                        ) as? String)?.replacingOccurrences(of: "LLC. ", with: "LLC.\n")
                     NSApplication.shared.orderFrontStandardAboutPanel(
                         options: options
                     )

--- a/Sources/App/ManualUpdateRefresh.swift
+++ b/Sources/App/ManualUpdateRefresh.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Sparkle
+
+/// Keeps a resumable offer until a fresh feed check has found its replacement.
+@MainActor
+final class ManualUpdateRefresh {
+    private struct Offer {
+        let version: String
+        let show: () -> Void
+        let skip: () -> Void
+    }
+
+    private let latestVersion: () async throws -> String?
+    private let checkAgain: () -> Void
+    private let showChecking: (@escaping () -> Void) -> Void
+    private let showError: (any Error, @escaping () -> Void) -> Void
+    private var offer: Offer?
+    private var offeredVersion: String?
+    private var requested = false
+    private var awaitingCycleFinish = false
+    private(set) var task: Task<Void, Never>?
+
+    init(
+        latestVersion: @escaping () async throws -> String?,
+        checkAgain: @escaping () -> Void,
+        showChecking: @escaping (@escaping () -> Void) -> Void,
+        showError: @escaping (any Error, @escaping () -> Void) -> Void
+    ) {
+        self.latestVersion = latestVersion
+        self.checkAgain = checkAgain
+        self.showChecking = showChecking
+        self.showError = showError
+    }
+
+    func checkForUpdates() {
+        guard task == nil, !awaitingCycleFinish else { return }
+        requested = true
+        if let offer {
+            refresh(offer)
+        } else {
+            checkAgain()
+        }
+    }
+
+    func receiveOffer(
+        version: String,
+        resuming: Bool,
+        show: @escaping () -> Void,
+        skip: @escaping () -> Void
+    ) {
+        let offer = Offer(version: version, show: show, skip: skip)
+        offeredVersion = version
+        self.offer = offer
+        if requested, resuming {
+            refresh(offer)
+        } else {
+            requested = false
+            show()
+        }
+    }
+
+    func userDidChoose() {
+        offer = nil
+    }
+
+    func receiveReadyOffer(show: @escaping () -> Void, skip: @escaping () -> Void) {
+        guard let offeredVersion else {
+            show()
+            return
+        }
+        receiveOffer(version: offeredVersion, resuming: true, show: show, skip: skip)
+    }
+
+    func updateCycleDidFinish() {
+        offer = nil
+        offeredVersion = nil
+        requested = false
+        guard awaitingCycleFinish else { return }
+        awaitingCycleFinish = false
+        checkAgain()
+    }
+
+    private func refresh(_ offer: Offer) {
+        requested = false
+        showChecking { [weak self] in
+            self?.task?.cancel()
+        }
+        task = Task { [weak self] in
+            guard let self else { return }
+            defer { task = nil }
+            do {
+                let version = try await latestVersion()
+                try Task.checkCancellation()
+                if let version,
+                   SUStandardVersionComparator.default.compareVersion(
+                       version, toVersion: offer.version
+                   ) == .orderedDescending {
+                    awaitingCycleFinish = true
+                    self.offer = nil
+                    offer.skip()
+                } else {
+                    offer.show()
+                }
+            } catch {
+                if Task.isCancelled {
+                    offer.show()
+                } else {
+                    showError(error, offer.show)
+                }
+            }
+        }
+    }
+}

--- a/Sources/App/NightlyUpdateVersionDisplay.swift
+++ b/Sources/App/NightlyUpdateVersionDisplay.swift
@@ -1,0 +1,57 @@
+#if canImport(AppKit)
+import Foundation
+import Sparkle
+
+final class NightlyUpdateVersionDisplay: NSObject, SUVersionDisplay, SPUStandardUserDriverDelegate {
+    private let installedDate: String?
+
+    init(infoDictionary: [String: Any]) {
+        let developmentVersion = infoDictionary["GhosthubDevelopmentVersion"] as? String
+        installedDate = developmentVersion?.components(separatedBy: " · ").dropFirst().first
+        super.init()
+    }
+
+    func standardUserDriverRequestsVersionDisplayer() -> (any SUVersionDisplay)? {
+        self
+    }
+
+    func formatUpdateVersion(
+        fromUpdate update: SUAppcastItem,
+        andBundleDisplayVersion inOutBundleDisplayVersion: AutoreleasingUnsafeMutablePointer<
+            NSString
+        >,
+        withBundleVersion bundleVersion: String
+    ) -> String {
+        inOutBundleDisplayVersion.pointee = installedVersion(build: bundleVersion) as NSString
+        return updateVersion(date: update.date, build: update.versionString)
+    }
+
+    func formatBundleDisplayVersion(
+        _ bundleDisplayVersion: String,
+        withBundleVersion bundleVersion: String,
+        matchingUpdate: SUAppcastItem?
+    ) -> String {
+        installedVersion(build: bundleVersion)
+    }
+
+    func installedVersion(build: String) -> String {
+        Self.label(date: installedDate, build: build)
+    }
+
+    func updateVersion(date: Date?, build: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return Self.label(date: date.map(formatter.string(from:)), build: build)
+    }
+
+    private static func label(date: String?, build: String) -> String {
+        if let date {
+            return "Nightly · \(date) · build \(build)"
+        }
+        return "Nightly · build \(build)"
+    }
+}
+#endif

--- a/Sources/App/UpdateController.swift
+++ b/Sources/App/UpdateController.swift
@@ -57,6 +57,7 @@ struct UpdateConfiguration: Equatable {
 
 @MainActor
 final class UpdateInstallationDelegate: NSObject, SPUUpdaterDelegate {
+    var updateCycleFinished: () -> Void = {}
     private var prepareRelaunch: () -> Void
     private var cancelRelaunch: () -> Void
     private var authorizeTermination: () -> Void
@@ -133,37 +134,59 @@ final class UpdateInstallationDelegate: NSObject, SPUUpdaterDelegate {
         error: (any Error)?
     ) {
         updateSessionDidFinish(error: error != nil)
+        updateCycleFinished()
     }
 }
 
 @MainActor
 final class UpdateController {
     private let installationDelegate: UpdateInstallationDelegate?
-    private let controller: SPUStandardUpdaterController?
+    private let updater: SPUUpdater?
+    private let userDriver: UpdateUserDriver?
+    private let versionDisplay: NightlyUpdateVersionDisplay?
     private var didStart = false
 
     init(
         infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:]
     ) {
-        guard UpdateConfiguration(
+        let configuration = UpdateConfiguration(
             infoDictionary: infoDictionary
-        ).isReady else {
+        )
+        guard configuration.isReady else {
             installationDelegate = nil
-            controller = nil
+            updater = nil
+            userDriver = nil
+            versionDisplay = nil
             return
         }
 
         let installationDelegate = UpdateInstallationDelegate()
         self.installationDelegate = installationDelegate
-        controller = SPUStandardUpdaterController(
-            startingUpdater: false,
-            updaterDelegate: installationDelegate,
-            userDriverDelegate: nil
+        let versionDisplay = infoDictionary["GhosthubReleaseChannel"] as? String == "nightly"
+            ? NightlyUpdateVersionDisplay(infoDictionary: infoDictionary) : nil
+        self.versionDisplay = versionDisplay
+        let feed = UpdateFeed(configuration: configuration)
+        let userDriver = UpdateUserDriver(
+            hostBundle: .main,
+            delegate: versionDisplay,
+            latestVersion: { try await feed.latestVersion() }
         )
+        self.userDriver = userDriver
+        let updater = SPUUpdater(
+            hostBundle: .main,
+            applicationBundle: .main,
+            userDriver: userDriver,
+            delegate: installationDelegate
+        )
+        self.updater = updater
+        userDriver.updater = updater
+        installationDelegate.updateCycleFinished = { [weak userDriver] in
+            userDriver?.updateCycleDidFinish()
+        }
     }
 
     var isAvailable: Bool {
-        controller != nil
+        updater != nil
     }
 
     func configureRelaunch(
@@ -181,14 +204,19 @@ final class UpdateController {
     }
 
     func start() {
-        guard !didStart, let controller else { return }
-        didStart = true
-        controller.startUpdater()
+        guard !didStart, let updater else { return }
+        do {
+            try updater.start()
+            didStart = true
+        } catch {
+            userDriver?.showUpdaterError(error, acknowledgement: {})
+        }
     }
 
     func checkForUpdates() {
         start()
-        controller?.checkForUpdates(nil)
+        guard didStart else { return }
+        userDriver?.checkForUpdates()
     }
 }
 #endif

--- a/Sources/App/UpdateFeed.swift
+++ b/Sources/App/UpdateFeed.swift
@@ -1,0 +1,152 @@
+#if canImport(AppKit)
+import CryptoKit
+import Darwin
+import Foundation
+import Sparkle
+
+/// Probes Ghosthub's single-release feed without disturbing Sparkle's queued installer.
+struct UpdateFeed {
+    private let configuration: UpdateConfiguration
+
+    init(configuration: UpdateConfiguration) {
+        self.configuration = configuration
+    }
+
+    func latestVersion() async throws -> String? {
+        guard configuration.isReady,
+              let feedURL = configuration.feedURL,
+              let publicKey = configuration.publicKey,
+              let installedVersion = Bundle.main
+              .object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        else {
+            throw FeedError.invalidConfiguration
+        }
+
+        let request = URLRequest(
+            url: feedURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 20
+        )
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let response = response as? HTTPURLResponse,
+              (200 ..< 300).contains(response.statusCode)
+        else {
+            throw FeedError.invalidResponse
+        }
+
+        let system = ProcessInfo.processInfo.operatingSystemVersion
+        var arm64: Int32 = 0
+        var size = MemoryLayout.size(ofValue: arm64)
+        let isAppleSilicon = sysctlbyname("hw.optional.arm64", &arm64, &size, nil, 0) == 0
+            && arm64 == 1
+        return try Self.latestVersion(
+            in: data,
+            publicKey: publicKey,
+            installedVersion: installedVersion,
+            systemVersion: "\(system.majorVersion).\(system.minorVersion).\(system.patchVersion)",
+            isAppleSilicon: isAppleSilicon
+        )
+    }
+
+    static func latestVersion(
+        in data: Data,
+        publicKey: Data,
+        installedVersion: String,
+        systemVersion: String,
+        isAppleSilicon: Bool
+    ) throws -> String? {
+        // Sparkle signs exactly the bytes preceding this trailing comment.
+        let marker = Data("<!-- sparkle-signatures:\n".utf8)
+        guard let markerRange = data.range(of: marker, options: .backwards),
+              let trailer = String(data: data[markerRange.upperBound...], encoding: .utf8)
+        else {
+            throw FeedError.invalidSignature
+        }
+        let lines = trailer.split(whereSeparator: \.isNewline)
+        let content = data[..<markerRange.lowerBound]
+        guard lines.count == 3,
+              lines[0].hasPrefix("edSignature: "),
+              lines[1].hasPrefix("length: "),
+              lines[2] == "-->",
+              let signature =
+              Data(base64Encoded: String(lines[0].dropFirst("edSignature: ".count))),
+              Int(lines[1].dropFirst("length: ".count)) == content.count,
+              try Curve25519.Signing.PublicKey(rawRepresentation: publicKey)
+              .isValidSignature(signature, for: content)
+        else {
+            throw FeedError.invalidSignature
+        }
+
+        // Our release tooling publishes one full enclosure and an item-level build version.
+        // Leave Sparkle's existing queue alone if that feed contract changes.
+        let document = try XMLDocument(data: content, options: .nodeLoadExternalEntitiesNever)
+        let enclosures = try document.nodes(forXPath: "/rss/channel/item/enclosure")
+        let namespace = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+        guard enclosures.count == 1,
+              let enclosure = enclosures[0] as? XMLElement,
+              let item = enclosure.parent as? XMLElement,
+              let rawURL = enclosure.attribute(forName: "url")?.stringValue,
+              let archiveURL = URL(string: rawURL),
+              archiveURL.scheme == "https", archiveURL.host != nil,
+              let rawSignature = enclosure.attribute(forLocalName: "edSignature", uri: namespace)?
+              .stringValue,
+              let archiveSignature = Data(base64Encoded: rawSignature),
+              archiveSignature.count == 64
+        else {
+            throw FeedError.unsupportedFeed
+        }
+        func value(_ name: String) -> String? {
+            guard let raw = item.elements(forLocalName: name, uri: namespace).first?.stringValue
+            else {
+                return nil
+            }
+            let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? nil : text
+        }
+        guard let version = value("version") else {
+            throw FeedError.unsupportedFeed
+        }
+
+        let comparator = SUStandardVersionComparator.default
+        if let minimum = value("minimumSystemVersion"),
+           comparator.compareVersion(systemVersion, toVersion: minimum) == .orderedAscending {
+            return nil
+        }
+        if let maximum = value("maximumSystemVersion"),
+           comparator.compareVersion(systemVersion, toVersion: maximum) == .orderedDescending {
+            return nil
+        }
+        if let minimum = value("minimumUpdateVersion"),
+           comparator.compareVersion(installedVersion, toVersion: minimum) == .orderedAscending {
+            return nil
+        }
+        let hardware = value("hardwareRequirements")?.lowercased()
+            .components(separatedBy: CharacterSet.whitespacesAndNewlines
+                .union(CharacterSet(charactersIn: ",")))
+        if hardware?.contains("arm64") == true, !isAppleSilicon {
+            return nil
+        }
+        return version
+    }
+
+    private enum FeedError: LocalizedError {
+        case invalidConfiguration
+        case invalidResponse
+        case invalidSignature
+        case unsupportedFeed
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidConfiguration:
+                "The update feed isn’t configured."
+            case .invalidResponse:
+                "The update server didn’t return a release feed."
+            case .invalidSignature:
+                "The update feed could not be verified."
+            case .unsupportedFeed:
+                "The update feed doesn’t describe a usable release."
+            }
+        }
+    }
+}
+#endif

--- a/Sources/App/UpdateRelaunchWindowPlacement.swift
+++ b/Sources/App/UpdateRelaunchWindowPlacement.swift
@@ -1,0 +1,64 @@
+#if canImport(AppKit)
+import AppKit
+
+/// The update manifest follows logical window identity, including when a
+/// missing native window must be replayed with a fresh SwiftUI scene token.
+@MainActor
+final class UpdateRelaunchWindowPlacement {
+    private weak var window: NSWindow?
+    private var pendingFrame: WorkspaceWindowFrame?
+
+    static func capture(
+        _ state: WorkspaceWindowState,
+        window: NSWindow?
+    ) -> WorkspaceWindowState {
+        var state = state
+        state.frame = nil
+        // AppKit owns full-screen restoration and its separate desktop.
+        if let window, !window.styleMask.contains(.fullScreen) {
+            let frame = window.frame
+            state.frame = WorkspaceWindowFrame(
+                x: frame.minX,
+                y: frame.minY,
+                width: frame.width,
+                height: frame.height
+            )
+        }
+        return state
+    }
+
+    func bind(_ window: NSWindow?) {
+        self.window = window
+        applyPendingFrame()
+    }
+
+    func restore(_ state: WorkspaceWindowState) {
+        pendingFrame = state.frame
+        applyPendingFrame()
+    }
+
+    private func applyPendingFrame() {
+        guard let saved = pendingFrame, let window else { return }
+        pendingFrame = nil
+        guard !window.styleMask.contains(.fullScreen) else { return }
+        var frame = NSRect(
+            x: saved.x,
+            y: saved.y,
+            width: saved.width,
+            height: saved.height
+        )
+        // Keep exact coordinates while that display is available. AppKit's
+        // constraint adjusts only the vertical position and height, so also
+        // bring the horizontal extent onto an available display if necessary.
+        if !NSScreen.screens.contains(where: {
+            $0.visibleFrame.intersects(frame)
+        }), let screen = window.screen ?? NSScreen.main {
+            frame.origin.x = screen.visibleFrame.minX
+            frame.size.width = min(frame.width, screen.visibleFrame.width)
+            frame = window.constrainFrameRect(frame, to: screen)
+        }
+        // Setting the frame does not order the window or activate its Space.
+        window.setFrame(frame, display: false)
+    }
+}
+#endif

--- a/Sources/App/UpdateUserDriver.swift
+++ b/Sources/App/UpdateUserDriver.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Sparkle
+
+/// Uses Sparkle's native UI and installer, refreshing resumable offers on demand.
+@MainActor
+final class UpdateUserDriver: SPUStandardUserDriver {
+    weak var updater: SPUUpdater?
+    private let latestVersion: () async throws -> String?
+
+    private lazy var refresh = ManualUpdateRefresh(
+        latestVersion: latestVersion,
+        checkAgain: { [weak self] in self?.updater?.checkForUpdates() },
+        showChecking: { [weak self] cancel in
+            self?.presentChecking(cancel: cancel)
+        },
+        showError: { [weak self] error, acknowledge in
+            self?.presentRefreshError(error, acknowledge: acknowledge)
+        }
+    )
+
+    init(
+        hostBundle: Bundle,
+        delegate: (any SPUStandardUserDriverDelegate)?,
+        latestVersion: @escaping () async throws -> String?
+    ) {
+        self.latestVersion = latestVersion
+        super.init(hostBundle: hostBundle, delegate: delegate)
+    }
+
+    func checkForUpdates() {
+        refresh.checkForUpdates()
+    }
+
+    func updateCycleDidFinish() {
+        refresh.updateCycleDidFinish()
+    }
+
+    override func showUpdateFound(
+        with appcastItem: SUAppcastItem,
+        state: SPUUserUpdateState,
+        reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        refresh.receiveOffer(
+            version: appcastItem.versionString,
+            resuming: state.stage != .notDownloaded,
+            show: { [weak self] in
+                self?.presentOffer(appcastItem, state: state, reply: reply)
+            },
+            skip: { [weak self] in
+                self?.dismissUpdateInstallation()
+                reply(.skip)
+            }
+        )
+    }
+
+    override func showReady(
+        toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        refresh.receiveReadyOffer(
+            show: { [weak self] in self?.presentReadyOffer(reply: reply) },
+            skip: { [weak self] in
+                self?.dismissUpdateInstallation()
+                reply(.skip)
+            }
+        )
+    }
+
+    private func presentReadyOffer(reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        super.dismissUpdateInstallation()
+        super.showReady(toInstallAndRelaunch: { [weak self] choice in
+            self?.refresh.userDidChoose()
+            reply(choice)
+        })
+    }
+
+    private func presentOffer(
+        _ item: SUAppcastItem,
+        state: SPUUserUpdateState,
+        reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        super.dismissUpdateInstallation()
+        super.showUpdateFound(with: item, state: state) { [weak self] choice in
+            self?.refresh.userDidChoose()
+            reply(choice)
+        }
+    }
+
+    private func presentChecking(cancel: @escaping () -> Void) {
+        super.dismissUpdateInstallation()
+        super.showUserInitiatedUpdateCheck(cancellation: cancel)
+    }
+
+    private func presentRefreshError(
+        _ error: any Error,
+        acknowledge: @escaping () -> Void
+    ) {
+        super.dismissUpdateInstallation()
+        let notice = NSError(
+            domain: "com.ghosthub.updates",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Couldn’t check for a newer update.",
+                NSLocalizedRecoverySuggestionErrorKey:
+                    "The previously found update is still available. "
+                    + error.localizedDescription,
+            ]
+        )
+        super.showUpdaterError(notice, acknowledgement: acknowledge)
+    }
+}

--- a/Sources/App/WorkspaceWindow.swift
+++ b/Sources/App/WorkspaceWindow.swift
@@ -722,6 +722,7 @@ struct WorkspaceWindow: View {
     @Binding var windowState: WorkspaceWindowState?
     let updateRelaunchRestorer: UpdateRelaunchRestorer
     let openRelaunchWindow: (WorkspaceWindowState) -> Void
+    @State private var updateRelaunchPlacement = UpdateRelaunchWindowPlacement()
     #endif
     @State private var windowStateBuffer = WorkspaceWindowStateBuffer()
     @State private var updateRelaunchSceneID = UUID()
@@ -1337,6 +1338,7 @@ struct WorkspaceWindow: View {
                 onRenameWindow: requestWindowTitleRename,
                 onWindowChanged: { window in
                     sceneModel.workspaceWindow = window
+                    updateRelaunchPlacement.bind(window)
                 }
             )
         )
@@ -1474,7 +1476,7 @@ struct WorkspaceWindow: View {
             #endif
             registry.register(
                 sceneModel,
-                captureRestorationState: captureWindowState
+                captureRestorationState: captureUpdateRelaunchState
             )
             if terminalRuntime.configReloadNotice?.kind == .error {
                 visibleConfigReloadNotice =
@@ -1537,6 +1539,7 @@ struct WorkspaceWindow: View {
         _ state: WorkspaceWindowState
     ) {
         updateRelaunchWindowID = state.windowID
+        updateRelaunchPlacement.restore(state)
         _ = windowStateBuffer.beginAppearance(with: state)
         if windowState != state {
             windowStateBuffer.prepareToPresent(state)
@@ -1549,6 +1552,17 @@ struct WorkspaceWindow: View {
         refreshWindowState()
     }
     #endif
+
+    private func captureUpdateRelaunchState() -> WorkspaceWindowState {
+        let state = captureWindowState()
+        #if canImport(AppKit)
+        return UpdateRelaunchWindowPlacement.capture(
+            state, window: sceneModel.workspaceWindow
+        )
+        #else
+        return state
+        #endif
+    }
 
     private func captureWindowState() -> WorkspaceWindowState {
         let state = sceneModel.restorationState(

--- a/Sources/App/WorkspaceWindowState.swift
+++ b/Sources/App/WorkspaceWindowState.swift
@@ -140,6 +140,13 @@ enum WorkspaceWindowTitle {
     }
 }
 
+struct WorkspaceWindowFrame: Codable, Hashable, Sendable {
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+}
+
 struct WorkspaceWindowState: Codable, Hashable, Sendable {
     var windowID: UUID
     var navigation: WorkspaceNavigationDescriptor?
@@ -147,6 +154,8 @@ struct WorkspaceWindowState: Codable, Hashable, Sendable {
     var herdr: WorkspaceHerdrDescriptor? = nil
     var zellij: WorkspaceZellijDescriptor? = nil
     var customTitle: String? = nil
+    /// Captured immediately before an update, independently of native Resume.
+    var frame: WorkspaceWindowFrame? = nil
 
     static func fresh(windowID: UUID = UUID()) -> Self {
         Self(windowID: windowID, navigation: nil, tmux: nil)

--- a/Tests/App/ManualUpdateRefreshTests.swift
+++ b/Tests/App/ManualUpdateRefreshTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+@Suite("Manual update refresh")
+struct ManualUpdateRefreshTests {
+    @Test("a newer release discards the queued offer before starting a new cycle")
+    func replacesQueuedUpdate() async {
+        var events: [String] = []
+        let refresh = ManualUpdateRefresh(
+            latestVersion: { "197" },
+            checkAgain: { events.append("check") },
+            showChecking: { _ in events.append("checking") },
+            showError: { _, _ in Issue.record("Unexpected error") }
+        )
+        refresh.receiveOffer(
+            version: "196", resuming: true,
+            show: { events.append("offer") },
+            skip: { events.append("skip") }
+        )
+        refresh.checkForUpdates()
+        await refresh.task?.value
+        #expect(events == ["offer", "checking", "skip"])
+        refresh.updateCycleDidFinish()
+        #expect(events == ["offer", "checking", "skip", "check"])
+        refresh.updateCycleDidFinish()
+        #expect(events.filter { $0 == "check" }.count == 1)
+    }
+
+    @Test(
+        "a current or incompatible feed keeps the queued download",
+        arguments: ["196", "195", nil]
+    )
+    func keepsQueuedUpdate(latest: String?) async {
+        var shown = 0
+        let refresh = ManualUpdateRefresh(
+            latestVersion: { latest }, checkAgain: {}, showChecking: { _ in },
+            showError: { _, _ in Issue.record("Unexpected error") }
+        )
+        refresh.checkForUpdates()
+        refresh.receiveOffer(
+            version: "196", resuming: true,
+            show: { shown += 1 },
+            skip: { Issue.record("Discarded a usable update") }
+        )
+        await refresh.task?.value
+        #expect(shown == 1)
+    }
+
+    @Test("a failed check explains the failure and preserves the old offer")
+    func failedCheck() async {
+        var events: [String] = []
+        let refresh = ManualUpdateRefresh(
+            latestVersion: { throw URLError(.notConnectedToInternet) },
+            checkAgain: {}, showChecking: { _ in },
+            showError: { _, acknowledge in
+                events.append("error")
+                acknowledge()
+            }
+        )
+        refresh.checkForUpdates()
+        refresh.receiveOffer(
+            version: "196", resuming: true,
+            show: { events.append("offer") },
+            skip: { Issue.record("Discarded a usable update") }
+        )
+        await refresh.task?.value
+        #expect(events == ["error", "offer"])
+    }
+
+    @Test("a fresh Sparkle result does not trigger a second feed request")
+    func freshResult() {
+        var shown = false
+        let refresh = ManualUpdateRefresh(
+            latestVersion: { Issue.record("Redundant request")
+                return nil
+            },
+            checkAgain: {}, showChecking: { _ in },
+            showError: { _, _ in Issue.record("Unexpected error") }
+        )
+        refresh.checkForUpdates()
+        refresh.receiveOffer(
+            version: "197", resuming: false,
+            show: { shown = true }, skip: {}
+        )
+        #expect(shown)
+        #expect(refresh.task == nil)
+    }
+
+    @Test("cancelling a network check restores the offer without an error alert")
+    func cancelledNetworkCheck() async {
+        var cancel: (() -> Void)?
+        var response: CheckedContinuation<String?, any Error>?
+        var shown = 0
+        let refresh = ManualUpdateRefresh(
+            latestVersion: {
+                try await withCheckedThrowingContinuation { response = $0 }
+            },
+            checkAgain: {}, showChecking: { cancel = $0 },
+            showError: { _, acknowledge in
+                Issue.record("Cancellation displayed an error")
+                acknowledge()
+            }
+        )
+        refresh.checkForUpdates()
+        refresh.receiveOffer(version: "196", resuming: true, show: {
+            shown += 1
+        }, skip: { Issue.record("Cancellation discarded the update") })
+        while response == nil {
+            await Task.yield()
+        }
+        cancel?()
+        response?.resume(throwing: URLError(.cancelled))
+        await refresh.task?.value
+        #expect(shown == 1)
+    }
+
+    @Test("a manually downloaded update can be replaced at the ready prompt")
+    func refreshesReadyUpdate() async {
+        var events: [String] = []
+        let refresh = ManualUpdateRefresh(
+            latestVersion: { "197" },
+            checkAgain: { events.append("check") },
+            showChecking: { _ in events.append("checking") },
+            showError: { _, _ in Issue.record("Unexpected error") }
+        )
+        refresh.receiveOffer(version: "196", resuming: false, show: {}, skip: {
+            Issue.record("Used obsolete pre-download reply")
+        })
+        refresh.userDidChoose()
+        refresh.receiveReadyOffer(show: { events.append("ready") }, skip: {
+            events.append("cancel installation")
+        })
+        refresh.checkForUpdates()
+        await refresh.task?.value
+        #expect(events == ["ready", "checking", "cancel installation"])
+        refresh.updateCycleDidFinish()
+        #expect(events.last == "check")
+    }
+}

--- a/Tests/App/NightlyUpdateVersionDisplayTests.swift
+++ b/Tests/App/NightlyUpdateVersionDisplayTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import GhosthubApp
+
+@Suite("Nightly update versions")
+struct NightlyUpdateVersionDisplayTests {
+    @Test("nightly builds on the same day have distinct update labels")
+    func sameDayBuilds() {
+        let display = NightlyUpdateVersionDisplay(infoDictionary: [
+            "GhosthubDevelopmentVersion": "Nightly · 2026-08-13 · abcdef12",
+        ])
+        let updateDate = ISO8601DateFormatter().date(from: "2026-08-13T00:30:00Z")!
+
+        #expect(display.installedVersion(build: "123") == "Nightly · 2026-08-13 · build 123")
+        #expect(display
+            .updateVersion(date: updateDate, build: "124") == "Nightly · 2026-08-13 · build 124")
+    }
+
+    @Test("nightly labels keep the build when dates are absent")
+    func missingDates() {
+        let display = NightlyUpdateVersionDisplay(infoDictionary: [:])
+
+        #expect(display.installedVersion(build: "123") == "Nightly · build 123")
+        #expect(display.updateVersion(date: nil, build: "124") == "Nightly · build 124")
+    }
+}

--- a/Tests/App/UpdateFeedTests.swift
+++ b/Tests/App/UpdateFeedTests.swift
@@ -1,0 +1,136 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import GhosthubApp
+
+@Suite("Fresh update feed")
+struct UpdateFeedTests {
+    @Test("reads the build version from a verified release feed")
+    func latestRelease() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key)
+
+        #expect(try latestVersion(feed, key: key) == "200")
+    }
+
+    @Test("rejects changed content and signatures from another key")
+    func rejectsUnverifiedFeed() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key)
+        let tampered = Data(String(decoding: feed, as: UTF8.self)
+            .replacingOccurrences(of: ">200<", with: ">300<").utf8)
+
+        #expect(throws: (any Error).self) {
+            try latestVersion(tampered, key: key)
+        }
+        #expect(throws: (any Error).self) {
+            try latestVersion(feed, key: Curve25519.Signing.PrivateKey())
+        }
+    }
+
+    @Test("requires the signed length to cover the release XML")
+    func rejectsWrongLength() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key, length: 0)
+
+        #expect(throws: (any Error).self) {
+            try latestVersion(feed, key: key)
+        }
+    }
+
+    @Test("preserves a queued update when the sole release is incompatible", arguments: [
+        "<sparkle:minimumSystemVersion>16</sparkle:minimumSystemVersion>",
+        "<sparkle:maximumSystemVersion>14</sparkle:maximumSystemVersion>",
+        "<sparkle:minimumUpdateVersion>101</sparkle:minimumUpdateVersion>",
+        "<sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>",
+    ])
+    func incompatibleRelease(requirement: String) throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key, requirements: requirement)
+
+        #expect(try latestVersion(feed, key: key) == nil)
+    }
+
+    @Test("accepts satisfied requirements at their inclusive boundaries")
+    func compatibleRelease() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key, requirements: """
+        <sparkle:minimumSystemVersion>15</sparkle:minimumSystemVersion>
+        <sparkle:maximumSystemVersion>15</sparkle:maximumSystemVersion>
+        <sparkle:minimumUpdateVersion>100</sparkle:minimumUpdateVersion>
+        <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+        """)
+
+        #expect(try UpdateFeed.latestVersion(
+            in: feed, publicKey: key.publicKey.rawRepresentation,
+            installedVersion: "100", systemVersion: "15", isAppleSilicon: true
+        ) == "200")
+    }
+
+    @Test("does not guess between multiple update enclosures")
+    func rejectsMultipleEnclosures() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(
+            key: key,
+            requirements: "<enclosure url=\"https://example.com/other.dmg\" />"
+        )
+
+        #expect(throws: (any Error).self) {
+            try latestVersion(feed, key: key)
+        }
+    }
+
+    @Test("requires an archive URL and signature even in a signed feed", arguments: [
+        "<enclosure sparkle:edSignature=\"\(Data(repeating: 0, count: 64).base64EncodedString())\" />",
+        "<enclosure url=\"https://example.com/release.dmg\" />",
+    ])
+    func rejectsIncompleteEnclosure(enclosure: String) throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let feed = try signedFeed(key: key, enclosure: enclosure)
+
+        #expect(throws: (any Error).self) {
+            try latestVersion(feed, key: key)
+        }
+    }
+
+    private func latestVersion(_ feed: Data, key: Curve25519.Signing.PrivateKey) throws -> String? {
+        try UpdateFeed.latestVersion(
+            in: feed, publicKey: key.publicKey.rawRepresentation,
+            installedVersion: "100", systemVersion: "15", isAppleSilicon: false
+        )
+    }
+
+    private func signedFeed(
+        key: Curve25519.Signing.PrivateKey,
+        requirements: String = "",
+        length: Int? = nil,
+        enclosure: String? = nil
+    ) throws -> Data {
+        let archiveSignature = try key.signature(for: Data("release archive fixture".utf8))
+            .base64EncodedString()
+        let releaseEnclosure = enclosure ?? """
+        <enclosure url="https://example.com/release.dmg" length="123" type="application/octet-stream" sparkle:edSignature="\(
+            archiveSignature
+        )" />
+        """
+        let content = Data("""
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+          <channel><item>
+            <sparkle:version>200</sparkle:version>
+            <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
+            \(requirements)
+            \(releaseEnclosure)
+          </item></channel>
+        </rss>
+
+        """.utf8)
+        let signature = try key.signature(for: content).base64EncodedString()
+        return content + Data("""
+        <!-- sparkle-signatures:
+        edSignature: \(signature)
+        length: \(length ?? content.count)
+        -->
+        """.utf8)
+    }
+}

--- a/Tests/App/UpdateRelaunchWindowPlacementTests.swift
+++ b/Tests/App/UpdateRelaunchWindowPlacementTests.swift
@@ -22,8 +22,9 @@ struct UpdateRelaunchWindowPlacementTests {
         )
         defer { window.orderOut(nil) }
         var state = WorkspaceWindowState.fresh()
+        let rightmostScreenEdge = try #require(NSScreen.screens.map { $0.frame.maxX }.max())
         state.frame = WorkspaceWindowFrame(
-            x: try #require(NSScreen.screens.map { $0.frame.maxX }.max()) + 2000,
+            x: Double(rightmostScreenEdge) + 2000,
             y: screen.visibleFrame.minY + 50,
             width: screen.visibleFrame.width + 200,
             height: 300

--- a/Tests/App/UpdateRelaunchWindowPlacementTests.swift
+++ b/Tests/App/UpdateRelaunchWindowPlacementTests.swift
@@ -1,0 +1,97 @@
+import AppKit
+import Testing
+@testable import GhosthubApp
+
+@MainActor
+@Suite("Update relaunch window placement")
+struct UpdateRelaunchWindowPlacementTests {
+    @Test("a frame on a disconnected display returns to an available screen")
+    func restoresOffscreenFrame() throws {
+        _ = NSApplication.shared
+        let screen = try #require(NSScreen.main)
+        let window = NSWindow(
+            contentRect: NSRect(
+                x: screen.visibleFrame.minX + 50,
+                y: screen.visibleFrame.minY + 50,
+                width: 500,
+                height: 300
+            ),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        var state = WorkspaceWindowState.fresh()
+        state.frame = WorkspaceWindowFrame(
+            x: try #require(NSScreen.screens.map { $0.frame.maxX }.max()) + 2000,
+            y: screen.visibleFrame.minY + 50,
+            width: screen.visibleFrame.width + 200,
+            height: 300
+        )
+        let placement = UpdateRelaunchWindowPlacement()
+        placement.bind(window)
+        placement.restore(state)
+
+        #expect(screen.visibleFrame.contains(window.frame))
+        #expect(!window.isVisible)
+    }
+
+    @Test("replayed windows recover their own frame regardless of binding order")
+    func restoresMatchingFrames() throws {
+        _ = NSApplication.shared
+        let screen = try #require(NSScreen.main)
+        let firstFrame = NSRect(
+            x: screen.visibleFrame.minX + 50,
+            y: screen.visibleFrame.minY + 50,
+            width: 500,
+            height: 300
+        )
+        let secondFrame = firstFrame.offsetBy(dx: 70, dy: 80)
+        let first = NSWindow(
+            contentRect: firstFrame,
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let second = NSWindow(
+            contentRect: secondFrame,
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            first.orderOut(nil)
+            second.orderOut(nil)
+        }
+        first.setFrame(firstFrame, display: false)
+        second.setFrame(secondFrame, display: false)
+        let firstState = UpdateRelaunchWindowPlacement.capture(
+            .fresh(), window: first
+        )
+        let secondState = UpdateRelaunchWindowPlacement.capture(
+            .fresh(), window: second
+        )
+        first.setFrame(secondFrame, display: false)
+        second.setFrame(firstFrame, display: false)
+
+        let firstPlacement = UpdateRelaunchWindowPlacement()
+        let secondPlacement = UpdateRelaunchWindowPlacement()
+        secondPlacement.bind(second)
+        secondPlacement.restore(secondState)
+        firstPlacement.restore(firstState)
+        firstPlacement.bind(first)
+
+        #expect(first.frame == firstFrame)
+        #expect(second.frame == secondFrame)
+        #expect(!first.isVisible && !second.isVisible)
+
+        // SwiftUI can report the same window again after the user moves it.
+        first.setFrame(secondFrame, display: false)
+        firstPlacement.bind(first)
+        #expect(first.frame == secondFrame)
+
+        // A late native identity corrects a provisional scene assignment.
+        secondPlacement.restore(firstState)
+        #expect(second.frame == firstFrame)
+    }
+}

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -101,7 +101,12 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         }
 
         guard case let .match(total, selected) = controller.result else {
-            return XCTFail("expected libghostty to publish a Find match")
+            let visibleMatches = viewportText().components(separatedBy: "needle").count - 1
+            return XCTFail(
+                "expected libghostty to publish a Find match; "
+                    + "result=\(controller.result), working=\(controller.isWorking), "
+                    + "visible matches=\(visibleMatches)"
+            )
         }
         XCTAssertEqual(total, 3)
         XCTAssertNil(selected)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,10 @@ tmux presentation. A directory workspace resolves by its authoritative kwt
 registry path on the same host. SwiftUI and macOS normally
 remain responsible for restoring scene count, native tab groups, and window
 geometry. Before a Sparkle relaunch, Ghosthub also atomically records the
-ordered logical descriptors in a one-shot manifest under `~/.ghosthub/`. The
+ordered logical descriptors and ordinary window frames in a one-shot manifest
+under `~/.ghosthub/`. Frames are captured from live windows immediately before
+update termination and follow the same logical window identity as the session.
+The
 app collects initial and late native scene values until AppKit reports that
 native window restoration has finished and every restored workspace window has
 registered its SwiftUI scene. Ghosthub requires the scenes' optional bindings to
@@ -122,7 +125,11 @@ tokens rather than saved window IDs, preventing SwiftUI from coalescing them wit
 a late native scene; a displaced request is retargeted and issued again with the
 same token. The manifest remains until every saved descriptor has begun
 restoration in exactly one live assigned scene. Native restoration therefore
-still owns geometry and tab grouping without dropping or duplicating a session.
+still owns Spaces, full-screen restoration, and tab grouping. Ghosthub applies
+each saved ordinary window frame when the corresponding NSWindow is available,
+including replayed scenes and late identity corrections, without activating or
+ordering the window. A disconnected display's frame is constrained to an
+available display.
 After assignment, the scene model owns the complete logical descriptor; delayed
 native payloads that share its window UUID but contain stale navigation or
 presentation data are rewritten before they can become persisted scene state.
@@ -343,6 +350,16 @@ without a packaged feed and public key disable the update command instead of
 contacting a release service. The app menu exposes **Check for Updates…**, and
 Sparkle performs automatic background checks using its standard native UI and
 installation flow.
+
+A manual check refreshes an already offered or downloaded update against the
+current channel feed. The probe verifies the feed signature with the bundled
+key and checks the single full release's platform requirements before replacing
+the queued offer. If a newer compatible build exists, Ghosthub replies through
+Sparkle's cancellation interface and waits for that update cycle to finish
+before requesting a fresh Sparkle check. Sparkle still selects, verifies,
+downloads, and installs the update. A failed or cancelled probe retains the
+existing offer. Nightly versions use Sparkle's display formatter to show the
+UTC date and build number without changing bundle version metadata.
 
 When the user accepts Sparkle's **Install and Relaunch**, Ghosthub captures
 every live scene descriptor into the updater relaunch manifest before it

--- a/docs/release.md
+++ b/docs/release.md
@@ -480,6 +480,19 @@ public `kenn-io/ghosthub-nightly` distribution repository. The canonical
 `kenn-io/ghosthub` repository receives no nightly tag or release, and the
 channel is not linked from ghosthub.ai or consumed by Homebrew.
 
+Sparkle's nightly update dialogs display the build date and numeric build
+number, including when multiple builds share the same release version or date.
+This is display formatting only: `CFBundleShortVersionString` still comes from
+`RELEASE_VERSION`, and `CFBundleVersion` remains the commit-count build number.
+Manual checks refresh queued offers against the current signed, single-release
+feed before replacing them. An unavailable or incompatible newer release leaves
+the existing offer available.
+
+Update relaunches capture ordinary window frames with their session descriptors.
+This capture must run in the app being replaced, so the first update from a
+build predating frame capture cannot provide those frames. macOS retains
+ownership of native Spaces, full-screen restoration, and tab groups.
+
 `.github/workflows/nightly.yml` runs at 08:00 UTC and exits before allocating a
 macOS runner when the current `main` source revision is already the completed
 channel revision. A manual `workflow_dispatch` with `force: true` rebuilds that

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -78,10 +78,22 @@ saved presentation only when it can confirm the exact tmux, running Herdr, or
 active Zellij
 session. Offline SSH hosts continue retrying as inventory refreshes.
 
-During an update relaunch, Ghosthub recreates saved windows if macOS does not
-return them. A window that previously had no terminal attached restores its
+During an update relaunch, Ghosthub saves each ordinary window's position and
+size along with its session, and recreates saved windows if macOS does not
+return them. If a display was disconnected, its windows return to an available
+display. macOS manages desktop Spaces, full-screen windows, and native tab
+groups; Ghosthub does not move windows between Spaces. Frame restoration applies
+to updates started from a build that includes this capture behavior.
+
+A window that previously had no terminal attached restores its
 navigation state without creating a worktree session. Select the worktree when
 you are ready to attach.
+
+**Ghosthub → Check for Updates…** checks for a newer compatible release even
+when an earlier update is already waiting to install. If a newer release is
+found, it replaces that queued offer. If the check fails, the earlier update
+remains available. Nightly update dialogs identify releases by date and build
+number so that builds sharing a release version are distinguishable.
 
 ## Rearrange navigation
 


### PR DESCRIPTION
- Make **Check for Updates…** refresh the current signed channel feed before replacing an older queued update. Failed or cancelled checks keep the existing offer available. Verified replacement of a downloaded, ready-to-install update with the real Sparkle installer in a disposable signed app.
- Show dates and build numbers in nightly update dialogs so successive builds are distinguishable.
- Save each ordinary window’s position and size with its session identity and restore them after updating. This starts with updates initiated by the new build; the first update into it cannot recover frames the old build did not save. Original macOS Space placement remains unverified, with Spaces, full-screen windows, and tab groups left to native restoration.
- Put the About panel’s license text on a new line after “Kenn Software LLC.”
