### PR TITLE
Keep sidebar expansion independent and reduce redraws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,11 +321,10 @@ test-kwt-contract: ensure-kwt ensure-tmux
 		sh tools/run_with_timeout.sh 600 sh tools/run_swift_tests.sh \
 			$(SWIFT) test --filter PinnedKwtContractTests
 
-# Bounds the render work a key-window switch may trigger; catches
-# focus-driven view invalidation regressions in seconds.
+# Bounds window redraws and checks activation-triggered settings and preview work.
 test-activation-gate:
 	@sh tools/run_swift_tests.sh $(SWIFT) test \
-		--disable-xctest --filter ActivationWorkGateTests
+		--filter 'ActivationWorkGateTests|SettingsStoreTests/testRefreshingAnonymousUsageDataPublishesOnlyChanges|TerminalSurfacePreviewTests/testApplicationReactivationDefersParkedRenderingUntilKeySceneResume'
 
 # Essential workflow smoke for kwt inventory and ordinary tmux attachment.
 test-essential-workflows: test-kwt-contract

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ test-kwt-contract: ensure-kwt ensure-tmux
 # Bounds window redraws and checks activation-triggered settings and preview work.
 test-activation-gate:
 	@sh tools/run_swift_tests.sh $(SWIFT) test \
-		--filter 'ActivationWorkGateTests|SettingsStoreTests/testRefreshingAnonymousUsageDataPublishesOnlyChanges|TerminalSurfacePreviewTests/testApplicationReactivationDefersParkedRenderingUntilKeySceneResume'
+		--filter 'ActivationWorkGateTests|SettingsStoreTests/testRefreshingAnonymousUsageDataPublishesOnlyChanges|TerminalSurfacePreviewTests/testApplicationReactivationDefersParkedRenderingUntilKeySceneResume|TerminalSurfacePreviewTests/testReacquisitionWaitsForAvailableParkingWithoutPolling'
 
 # Essential workflow smoke for kwt inventory and ordinary tmux attachment.
 test-essential-workflows: test-kwt-contract

--- a/Sources/App/TmuxSessionPreviewCoordinator.swift
+++ b/Sources/App/TmuxSessionPreviewCoordinator.swift
@@ -153,6 +153,7 @@ final class TmuxSessionPreviewCoordinator {
     private var liveTask: Task<Void, Never>?
     private var activationTask: Task<Void, Never>?
     private var activationGeneration: UInt64 = 0
+    private var needsParkingReacquisition = false
     private var isInvokingActivation = false
     private var navigationGeneration: UInt64 = 0
     private var budgetCancellable: AnyCancellable?
@@ -445,6 +446,7 @@ final class TmuxSessionPreviewCoordinator {
     func applicationDidBecomeActive() {
         guard !isApplicationActive else { return }
         isApplicationActive = true
+        needsParkingReacquisition = true
         retryDeferredEfficientCaptures()
         retryDeferredNavigationCaptures()
         presentations.keys.forEach(publish)
@@ -467,6 +469,7 @@ final class TmuxSessionPreviewCoordinator {
             presentations.keys.forEach(publish)
             return
         }
+        needsParkingReacquisition = true
         presentations.keys.forEach(publish)
         scheduleParkingReacquisition()
         restartLiveTaskIfNeeded()
@@ -522,9 +525,11 @@ final class TmuxSessionPreviewCoordinator {
     }
 
     private func scheduleParkingReacquisition() {
-        guard mode.usesLiveRefresh,
+        guard !isShutDown,
+              mode.usesLiveRefresh,
               isApplicationActive,
               isSidebarVisible,
+              sceneIsKeyWindow(),
               activationTask == nil
         else { return }
         invalidateActivationDelay()
@@ -547,7 +552,10 @@ final class TmuxSessionPreviewCoordinator {
                   isSidebarVisible,
                   mode.usesLiveRefresh,
                   sceneIsKeyWindow() {
-                guard reacquireNextParkingSurface() else { return }
+                guard reacquireNextParkingSurface() else {
+                    needsParkingReacquisition = false
+                    return
+                }
                 do {
                     try await sleep(parkingInterval)
                 } catch {
@@ -715,7 +723,7 @@ final class TmuxSessionPreviewCoordinator {
             isParkingHostChanging = false
         }
         parkingHost = host
-        host.setRenderingSuspended(!isApplicationActive)
+        host.setRenderingSuspended(!isApplicationActive || needsParkingReacquisition)
         reconcileEligibility()
     }
 
@@ -910,9 +918,11 @@ final class TmuxSessionPreviewCoordinator {
             return
         }
 
-        // App activation owns incremental reacquisition while its task is
-        // alive. Other presentation updates may still invalidate parking, but
-        // must not mount the remaining fleet in the same main-thread turn.
+        // Preview changes can cancel the timer without completing reacquisition.
+        // Keep the gate closed and reschedule before allowing ordinary parking.
+        if needsParkingReacquisition {
+            scheduleParkingReacquisition()
+        }
         guard activationTask == nil else {
             restartLiveTaskIfNeeded()
             return
@@ -1056,6 +1066,9 @@ final class TmuxSessionPreviewCoordinator {
     }
 
     private func restartLiveTaskIfNeeded() {
+        if needsParkingReacquisition {
+            scheduleParkingReacquisition()
+        }
         let shouldRun = !isShutDown
             && mode.usesLiveRefresh
             && isApplicationActive

--- a/Sources/App/TmuxSessionPreviewCoordinator.swift
+++ b/Sources/App/TmuxSessionPreviewCoordinator.swift
@@ -445,7 +445,6 @@ final class TmuxSessionPreviewCoordinator {
     func applicationDidBecomeActive() {
         guard !isApplicationActive else { return }
         isApplicationActive = true
-        parkingHost?.setRenderingSuspended(false)
         retryDeferredEfficientCaptures()
         retryDeferredNavigationCaptures()
         presentations.keys.forEach(publish)
@@ -963,6 +962,9 @@ final class TmuxSessionPreviewCoordinator {
     /// synchronously resize libghostty, so activation deliberately performs
     /// only one of these operations per main-thread turn.
     private func parkEligiblePresentations(limit: Int?) -> Bool {
+        // Retained previews resume through the same eligibility checks and
+        // activation delay as new parking, after the interactive window returns.
+        parkingHost?.setRenderingSuspended(false)
         var parkedCount = 0
         var hasRemaining = false
         for key in presentations.keys {

--- a/Sources/App/TmuxSessionPreviewCoordinator.swift
+++ b/Sources/App/TmuxSessionPreviewCoordinator.swift
@@ -552,10 +552,11 @@ final class TmuxSessionPreviewCoordinator {
                   isSidebarVisible,
                   mode.usesLiveRefresh,
                   sceneIsKeyWindow() {
-                guard reacquireNextParkingSurface() else {
-                    needsParkingReacquisition = false
-                    return
-                }
+                guard prepareParkingEligibility() else { return }
+                let result = parkEligiblePresentations(limit: 1)
+                needsParkingReacquisition = result.pending
+                // Wait for a host or presentation event when nothing can mount.
+                guard result.pending, result.parked > 0 else { return }
                 do {
                     try await sleep(parkingInterval)
                 } catch {
@@ -690,6 +691,9 @@ final class TmuxSessionPreviewCoordinator {
             parkingBlockedKeys.remove(key)
             publish(key)
         }
+        if needsParkingReacquisition {
+            scheduleParkingReacquisition()
+        }
         restartLiveTaskIfNeeded()
     }
 
@@ -743,7 +747,10 @@ final class TmuxSessionPreviewCoordinator {
               !isParkingHostChanging
         else { return }
         presentations.keys.forEach(requestIdentityIfNeeded)
-        reconcileEligibility()
+        // Missing views resume parking from readiness events, not capture ticks.
+        if !needsParkingReacquisition {
+            reconcileEligibility()
+        }
         for key in presentations.keys where isExpanded(key) {
             guard let presentation = presentations[key],
                   isConnected(presentation),
@@ -922,19 +929,12 @@ final class TmuxSessionPreviewCoordinator {
         // Keep the gate closed and reschedule before allowing ordinary parking.
         if needsParkingReacquisition {
             scheduleParkingReacquisition()
-        }
-        guard activationTask == nil else {
             restartLiveTaskIfNeeded()
             return
         }
 
         _ = parkEligiblePresentations(limit: nil)
         restartLiveTaskIfNeeded()
-    }
-
-    private func reacquireNextParkingSurface() -> Bool {
-        guard prepareParkingEligibility() else { return false }
-        return parkEligiblePresentations(limit: 1)
     }
 
     private func prepareParkingEligibility() -> Bool {
@@ -967,11 +967,10 @@ final class TmuxSessionPreviewCoordinator {
         return true
     }
 
-    /// Parks at most `limit` new surfaces and reports whether another eligible
-    /// surface remains. Parking reparents an AppKit terminal view and can
-    /// synchronously resize libghostty, so activation deliberately performs
-    /// only one of these operations per main-thread turn.
-    private func parkEligiblePresentations(limit: Int?) -> Bool {
+    /// Reports actual mounts and any remaining eligible surfaces. Reparenting
+    /// can synchronously resize libghostty, so activation deliberately mounts
+    /// only one surface per main-thread turn.
+    private func parkEligiblePresentations(limit: Int?) -> (parked: Int, pending: Bool) {
         // Retained previews resume through the same eligibility checks and
         // activation delay as new parking, after the interactive window returns.
         parkingHost?.setRenderingSuspended(false)
@@ -987,8 +986,11 @@ final class TmuxSessionPreviewCoordinator {
                         hasRemaining = true
                     } else {
                         do {
-                            try park(key, presentation: presentation)
-                            parkedCount += 1
+                            if try park(key, presentation: presentation) {
+                                parkedCount += 1
+                            } else {
+                                hasRemaining = true
+                            }
                         } catch {
                             parkingBlockedKeys.insert(key)
                             budget.release(requestID(for: key))
@@ -1001,7 +1003,7 @@ final class TmuxSessionPreviewCoordinator {
             )
             publish(key)
         }
-        return hasRemaining
+        return (parkedCount, hasRemaining)
     }
 
     private func canPark(
@@ -1031,19 +1033,20 @@ final class TmuxSessionPreviewCoordinator {
     private func park(
         _ key: TmuxPreviewKey,
         presentation: Presentation
-    ) throws {
-        guard !parkedKeys.contains(key) else { return }
+    ) throws -> Bool {
+        guard !parkedKeys.contains(key) else { return false }
         if let injectedPark {
             try injectedPark(presentation)
         } else {
             guard let host = parkingHost,
                   let surface = presentation.surface()
-            else { return }
+            else { return false }
             try host.park(surface)
             parkedSurfaces[key] = surface
         }
         parkedKeys.insert(key)
         publish(key)
+        return true
     }
 
     private func unparkAndRelease(_ key: TmuxPreviewKey) {
@@ -1066,16 +1069,18 @@ final class TmuxSessionPreviewCoordinator {
     }
 
     private func restartLiveTaskIfNeeded() {
-        if needsParkingReacquisition {
-            scheduleParkingReacquisition()
-        }
         let shouldRun = !isShutDown
             && mode.usesLiveRefresh
             && isApplicationActive
             && isSidebarVisible
             && sceneIsKeyWindow()
             && activationTask == nil
-            && presentations.keys.contains(where: isExpanded)
+            && presentations.keys.contains { key in
+                isExpanded(key)
+                    && (!needsParkingReacquisition
+                        || presentations[key]?.isActive() == true
+                        || parkedKeys.contains(key))
+            }
         guard shouldRun else {
             liveTask?.cancel()
             liveTask = nil

--- a/Sources/App/WorkspaceSceneModel.swift
+++ b/Sources/App/WorkspaceSceneModel.swift
@@ -217,6 +217,7 @@ final class WorkspaceSceneModel: ObservableObject {
     @Published private(set) var workspaceInventoryWarning: String?
     @Published private(set) var workspaceInventoryWarningsByHost:
         [UUID: String] = [:]
+    private var publishedInventoryRefreshComplete = false
     private var kwtInventoryEnabled = false
     private var kwtInventoriesByHost: [UUID: KwtHostInventory] = [:]
     private var kwtAvailabilityByHost: [UUID: Bool] = [:]
@@ -4280,6 +4281,8 @@ final class WorkspaceSceneModel: ObservableObject {
         defer { isConsumingSharedInventory = false }
         var successfulKwtHosts: [(UUID, CommandHost, KwtHostInventory)] = []
         var successfulTmuxHostIDs: Set<UUID> = []
+        var updatedKwtHostIDs: Set<UUID> = []
+        var updatedHostIDs: Set<UUID> = []
 
         for (hostID, commandHost) in inventoryHosts {
             let applicationKey = SharedInventoryApplicationKey(
@@ -4310,6 +4313,8 @@ final class WorkspaceSceneModel: ObservableObject {
                         publishToStore: false,
                         recordsSuccessfulLoad: recordsSuccessfulLoad
                     )
+                    updatedKwtHostIDs.insert(hostID)
+                    updatedHostIDs.insert(hostID)
                     if recordsSuccessfulLoad {
                         successfulKwtHosts.append((
                             hostID,
@@ -4329,12 +4334,14 @@ final class WorkspaceSceneModel: ObservableObject {
                     case .idle, .loading, .loaded:
                         break
                     case .provisioningFailed:
+                        updatedHostIDs.insert(hostID)
                         kwtAvailabilityByHost[hostID] = false
                         kwtInventoryFailuresByHost.removeValue(
                             forKey: hostID
                         )
                     case let .failed(error):
                         if isRemoteKwtUnavailable(error, hostID: hostID) {
+                            updatedHostIDs.insert(hostID)
                             kwtAvailabilityByHost[hostID] = false
                             kwtInventoryFailuresByHost.removeValue(
                                 forKey: hostID
@@ -4363,6 +4370,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         publish: false
                     )
                     successfulTmuxHostIDs.insert(hostID)
+                    updatedHostIDs.insert(hostID)
                 }
                 if entry.observationRevision
                     > appliedTmuxObservationRevisions[
@@ -4373,6 +4381,7 @@ final class WorkspaceSceneModel: ObservableObject {
                         entry.observationRevision
                     _ = beginTmuxDiscoveryObservation(hostID: hostID)
                     if case let .failed(error) = entry.state {
+                        updatedHostIDs.insert(hostID)
                         applyTmuxDiscoveryResult(
                             .failure(error),
                             hostID: hostID,
@@ -4384,7 +4393,18 @@ final class WorkspaceSceneModel: ObservableObject {
         }
 
         applySharedInventoryProgress(shared)
-        applyInventoryOverlayIfNeeded()
+        // Loading/progress publications carry no new rows. Reapply only the
+        // hosts that changed, leaving successful-observation callbacks below
+        // intact even when the returned inventory is equal to the cache.
+        for hostID in updatedHostIDs {
+            applyHostInventoryOverlayIfNeeded(
+                hostID: hostID,
+                includeKwtInventory: updatedKwtHostIDs.contains(hostID)
+            )
+        }
+        if updatedHostIDs.isEmpty {
+            attemptPendingRestoration()
+        }
         for (hostID, commandHost, inventory) in successfulKwtHosts {
             reconcileRetainedTmuxPresentations(
                 afterAuthoritativeInventoryFor: hostID
@@ -6086,6 +6106,13 @@ final class WorkspaceSceneModel: ObservableObject {
     }
 
     private func updateWorkspaceInventoryState() {
+        // Completion is derived from private discovery state. Notify the UI
+        // when it changes even if the rows, warnings, and load state are equal.
+        let refreshComplete = isWorkspaceInventoryRefreshComplete
+        if publishedInventoryRefreshComplete != refreshComplete {
+            objectWillChange.send()
+            publishedInventoryRefreshComplete = refreshComplete
+        }
         let projectWarnings = kwtInventoriesByHost.values
             .flatMap(\.projects)
             .compactMap { item in
@@ -6110,7 +6137,7 @@ final class WorkspaceSceneModel: ObservableObject {
             .union(directoryWarningsByHost.keys)
             .union(herdrDiscoveryFailuresByHost.keys)
             .union(zellijDiscoveryFailuresByHost.keys)
-        workspaceInventoryWarningsByHost = Dictionary(
+        let warningsByHost = [UUID: String](
             uniqueKeysWithValues: hostIDs.compactMap { hostID in
                 let warnings = [
                     kwtInventoryFailuresByHost[hostID],
@@ -6125,9 +6152,15 @@ final class WorkspaceSceneModel: ObservableObject {
                 return (hostID, unique.joined(separator: "\n"))
             }
         )
-        workspaceInventoryWarning = uniqueProjectWarnings.isEmpty
+        if workspaceInventoryWarningsByHost != warningsByHost {
+            workspaceInventoryWarningsByHost = warningsByHost
+        }
+        let warning = uniqueProjectWarnings.isEmpty
             ? nil
             : uniqueProjectWarnings.joined(separator: "\n")
+        if workspaceInventoryWarning != warning {
+            workspaceInventoryWarning = warning
+        }
         let hasVisibleInventory = !snapshot.projects.isEmpty
             || !snapshot.directoryWorkspaces.isEmpty
             || snapshot.hosts.contains { !$0.tmuxSessions.isEmpty }
@@ -6142,25 +6175,27 @@ final class WorkspaceSceneModel: ObservableObject {
             || isTmuxDiscoveryLoading
             || isHerdrDiscoveryLoading
             || isZellijDiscoveryLoading
-        if hasPendingSources, !hasVisibleInventory {
-            workspaceInventoryState = .loading
-            return
-        }
         let localWarnings = [
             kwtInventoryFailuresByHost[localHostID],
             tmuxDiscoveryFailuresByHost[localHostID],
         ].compactMap { $0 }
-        if !hasPendingSources,
-           !hasCachedInventory,
-           !localWarnings.isEmpty {
-            workspaceInventoryState = .failed(
+        let state: WorkspaceInventoryState
+        if hasPendingSources, !hasVisibleInventory {
+            state = .loading
+        } else if !hasPendingSources,
+                  !hasCachedInventory,
+                  !localWarnings.isEmpty {
+            state = .failed(
                 Array(Set(localWarnings)).sorted().joined(separator: "\n")
             )
-            return
+        } else {
+            // Remote discovery is additive. Its failure belongs to that host
+            // and must never replace the workspace with a blocking error.
+            state = .loaded
         }
-        // Remote discovery is additive. Its failure belongs to that host and
-        // must never replace the workspace with a blocking error.
-        workspaceInventoryState = .loaded
+        if workspaceInventoryState != state {
+            workspaceInventoryState = state
+        }
     }
 
     func logViewerTerminalView() -> AnyView? {

--- a/Sources/Settings/SettingsStore.swift
+++ b/Sources/Settings/SettingsStore.swift
@@ -307,7 +307,9 @@ public final class SettingsStore: ObservableObject {
         let enabled = Self.loadShareAnonymousUsageData(
             using: userDefaults
         )
-        shareAnonymousUsageData = enabled
+        if shareAnonymousUsageData != enabled {
+            shareAnonymousUsageData = enabled
+        }
         return enabled
     }
 

--- a/Sources/UI/WorkspaceSidebarDisclosureState.swift
+++ b/Sources/UI/WorkspaceSidebarDisclosureState.swift
@@ -1,45 +1,12 @@
 import Foundation
 
-/// Persisted disclosure overrides for the sidebar hierarchy. Hosts and tmux
+/// Window-local disclosure overrides for the sidebar hierarchy. Hosts and tmux
 /// sessions are visible by default, while project groups and individual
 /// projects begin collapsed so a large worktree inventory does not hide the
 /// rest of the fleet.
 struct WorkspaceSidebarDisclosureState: Equatable {
-    private(set) var collapsedKeys: Set<String>
-    private(set) var expandedKeys: Set<String>
-
-    init(rawValue: String = "") {
-        let values = rawValue.split(separator: "\n").map(String.init)
-        collapsedKeys = Set(values.compactMap { value in
-            if value.hasPrefix("-") {
-                return String(value.dropFirst())
-            }
-            // Preserve compatibility if this state is initialized with the
-            // original collapsed-key-only representation.
-            return value.hasPrefix("+") ? nil : value
-        })
-        expandedKeys = Set(values.compactMap { value in
-            value.hasPrefix("+") ? String(value.dropFirst()) : nil
-        })
-    }
-
-    var rawValue: String {
-        (expandedKeys.map { "+\($0)" } + collapsedKeys.map { "-\($0)" })
-            .sorted()
-            .joined(separator: "\n")
-    }
-
-    static func migratedRawValue(
-        current: String,
-        legacyCollapsedKeys: String
-    ) -> String {
-        guard current.isEmpty, !legacyCollapsedKeys.isEmpty else {
-            return current
-        }
-        return WorkspaceSidebarDisclosureState(
-            rawValue: legacyCollapsedKeys
-        ).rawValue
-    }
+    private(set) var collapsedKeys: Set<String> = []
+    private(set) var expandedKeys: Set<String> = []
 
     func isExpanded(_ key: String) -> Bool {
         if expandedKeys.contains(key) {

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -231,10 +231,7 @@ struct WorkspaceSidebarView: View {
     @State private var tmuxPreviewExpansion =
         TmuxSessionPreviewExpansionState()
     @State private var tmuxPreviewMountState = TmuxSessionPreviewMountState()
-    @AppStorage("workspaceSidebarDisclosureStateV2")
-    private var disclosureState = ""
-    @AppStorage("workspaceSidebarCollapsedItems")
-    private var legacyCollapsedItems = ""
+    @State private var disclosureState = WorkspaceSidebarDisclosureState()
     @Binding private var worktreeOrderRawValue: String
     @Binding private var tmuxSessionOrderRawValue: String
     @Binding private var herdrSessionOrderRawValue: String
@@ -446,9 +443,6 @@ struct WorkspaceSidebarView: View {
                     .padding(.horizontal, 8)
                 }
             }
-        }
-        .onAppear {
-            migrateDisclosureStateIfNeeded()
         }
         .onChange(of: inventoryRefreshComplete) { _, isComplete in
             if isComplete {
@@ -2203,30 +2197,11 @@ struct WorkspaceSidebarView: View {
     }
 
     private func isExpanded(_ key: String) -> Bool {
-        WorkspaceSidebarDisclosureState(rawValue: resolvedDisclosureState)
-            .isExpanded(key)
+        disclosureState.isExpanded(key)
     }
 
     private func toggle(_ key: String) {
-        var state = WorkspaceSidebarDisclosureState(
-            rawValue: resolvedDisclosureState
-        )
-        state.toggle(key)
-        disclosureState = state.rawValue
-    }
-
-    private var resolvedDisclosureState: String {
-        WorkspaceSidebarDisclosureState.migratedRawValue(
-            current: disclosureState,
-            legacyCollapsedKeys: legacyCollapsedItems
-        )
-    }
-
-    private func migrateDisclosureStateIfNeeded() {
-        let migrated = resolvedDisclosureState
-        guard migrated != disclosureState else { return }
-        disclosureState = migrated
-        legacyCollapsedItems = ""
+        disclosureState.toggle(key)
     }
 
     private func pruneSidebarOrders() {

--- a/Tests/App/TmuxSessionPreviewCoordinatorTests.swift
+++ b/Tests/App/TmuxSessionPreviewCoordinatorTests.swift
@@ -1275,7 +1275,50 @@ struct TmuxSessionPreviewCoordinatorTests {
         }
 
         #expect(harness.parks.count == 1)
+        let added = harness.presentation(index: 3, isActive: false)
+        harness.coordinator.register(added)
+        harness.coordinator.setExpanded(true, for: added.key)
+        #expect(harness.parks.count == 1)
+        await waitUntilMainActor { harness.parks.count == 2 }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        #expect(harness.parks.count == 2)
         harness.coordinator.applicationDidResignActive()
+    }
+
+    @Test(
+        "preview changes preserve delayed reacquisition",
+        arguments: [SessionPreviewMode.live, .alwaysLive]
+    )
+    func previewChangesPreserveDelayedReacquisition(mode: SessionPreviewMode) async {
+        let harness = PreviewCoordinatorHarness(mode: mode)
+        defer { harness.coordinator.shutdown() }
+        let first = harness.presentation(index: 0, isActive: false)
+        let second = harness.presentation(index: 1, isActive: false)
+        harness.coordinator.applicationDidResignActive()
+        harness.coordinator.register(first)
+        harness.coordinator.register(second)
+        harness.coordinator.setExpanded(true, for: first.key)
+        harness.coordinator.applicationDidBecomeActive()
+
+        harness.coordinator.setExpanded(true, for: second.key)
+        #expect(harness.parks.isEmpty)
+        harness.coordinator.setMode(mode == .live ? .alwaysLive : .live)
+        #expect(harness.parks.isEmpty)
+        harness.coordinator.prepareToActivate(second.key) {
+            harness.setActive(true, for: second.key)
+        }
+        #expect(harness.parks.isEmpty)
+        harness.coordinator.remove(second.key, reason: .close)
+        harness.coordinator.presentationDidChange(first.key)
+        #expect(harness.parks.isEmpty)
+        harness.coordinator.setSidebarVisible(false)
+        harness.coordinator.setSidebarVisible(true)
+        #expect(harness.parks.isEmpty)
+
+        await waitUntilMainActor { harness.parks.contains(first.key) }
+        #expect(harness.parks == [first.key])
     }
 
     @Test("invalidating a suspended capture prevents stale publication")
@@ -1593,6 +1636,7 @@ struct TmuxSessionPreviewCoordinatorTests {
         let presentation = harness.presentation(index: 0, isActive: false)
         harness.coordinator.register(presentation)
         harness.coordinator.setExpanded(true, for: presentation.key)
+        await waitUntilMainActor { harness.parks == [presentation.key] }
         #expect(harness.parks == [presentation.key])
 
         NotificationCenter.default.post(

--- a/Tests/App/WorkspaceSharedInventoryTests.swift
+++ b/Tests/App/WorkspaceSharedInventoryTests.swift
@@ -10,6 +10,83 @@ import Testing
 @Suite("Shared workspace inventory", .serialized)
 @MainActor
 struct WorkspaceSharedInventoryTests {
+    @Test("refresh progress does not republish unchanged sidebar warnings or state")
+    func refreshDoesNotRepublishUnchangedSidebarState() async throws {
+        let environment = try setupStandardEnvironment()
+        let inventory = WorkspaceTmuxTestSupport.inventory(
+            project: environment.snapshot.projects[0],
+            worktrees: environment.snapshot.worktrees
+        )
+        let refresh = AsyncGate()
+        defer { refresh.open() }
+        let store = WorkspaceInventoryStore(
+            kwtLoader: { _ in
+                await refresh.wait()
+                return inventory
+            },
+            kwtProvisioner: { _ in },
+            tmuxLoader: { _ in .success([]) },
+            mutationCoordinator: WorktreeMutationCoordinator()
+        )
+        store.publishKwtInventory(inventory, on: .local, mutation: nil)
+        let first = try makeModel(
+            database: environment.database,
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            workspaceInventoryStore: store
+        )
+        let second = try makeModel(
+            database: WorkspaceDatabase.inMemory(),
+            localHostID: environment.host.id,
+            snapshot: environment.snapshot,
+            workspaceInventoryStore: store
+        )
+        first.startKwtInventory()
+        second.startKwtInventory()
+        first.startTmuxSessionDiscovery()
+        second.startTmuxSessionDiscovery()
+        await waitUntilMainActor {
+            first.isWorkspaceInventoryRefreshComplete
+                && second.isWorkspaceInventoryRefreshComplete
+        }
+        var unchangedPublications = 0
+        var sceneChanges = 0
+        var subscriptions: Set<AnyCancellable> = []
+        for model in [first, second] {
+            model.objectWillChange.sink {
+                sceneChanges += 1
+            }.store(in: &subscriptions)
+            model.$workspaceInventoryWarning.dropFirst().sink { _ in
+                unchangedPublications += 1
+            }.store(in: &subscriptions)
+            model.$workspaceInventoryWarningsByHost.dropFirst().sink { _ in
+                unchangedPublications += 1
+            }.store(in: &subscriptions)
+            model.$workspaceInventoryState.dropFirst().sink { _ in
+                unchangedPublications += 1
+            }.store(in: &subscriptions)
+        }
+        first.refreshKwtInventory()
+        #expect(unchangedPublications == 0)
+        #expect(sceneChanges == 2)
+        #expect(!first.isWorkspaceInventoryRefreshComplete)
+        #expect(!second.isWorkspaceInventoryRefreshComplete)
+        await waitUntilMainActor {
+            first.inventoryRefreshProgress.tmuxCompleted
+                && second.inventoryRefreshProgress.tmuxCompleted
+        }
+        sceneChanges = 0
+        refresh.open()
+        await waitUntilMainActor {
+            first.isWorkspaceInventoryRefreshComplete
+                && second.isWorkspaceInventoryRefreshComplete
+        }
+        #expect(sceneChanges >= 2)
+        #expect(unchangedPublications == 0)
+        await first.shutdown()
+        await second.shutdown()
+    }
+
     @Test("endpoint aliases each receive the shared cached result")
     func endpointAliasesReceiveSharedResult() async throws {
         let localID = UUID()

--- a/Tests/Settings/SettingsStoreTests.swift
+++ b/Tests/Settings/SettingsStoreTests.swift
@@ -483,6 +483,35 @@ final class SettingsStoreTests {
     }
 
     @Test
+    func testRefreshingAnonymousUsageDataPublishesOnlyChanges() {
+        let store = makeSUT()
+        let otherStore = makeSUT()
+        var invalidations = 0
+        var values: [Bool] = []
+        let objectObservation = store.objectWillChange.sink {
+            invalidations += 1
+        }
+        let valueObservation = store.$shareAnonymousUsageData
+            .dropFirst()
+            .sink { values.append($0) }
+        defer {
+            objectObservation.cancel()
+            valueObservation.cancel()
+        }
+
+        #expect(store.refreshShareAnonymousUsageData())
+        #expect(invalidations == 0)
+        #expect(values.isEmpty)
+
+        otherStore.setShareAnonymousUsageData(false)
+        #expect(!store.refreshShareAnonymousUsageData())
+        #expect(!store.shareAnonymousUsageData)
+        #expect(!store.refreshShareAnonymousUsageData())
+        #expect(invalidations == 1)
+        #expect(values == [false])
+    }
+
+    @Test
     func testUpdatingTerminalPreferencesWritesManagedConfigBlock() throws {
         let store = makeSUT()
 

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -1088,10 +1088,13 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             override var occlusionState: NSWindow.OcclusionState { .visible }
         }
         let surface = try makeSurface()
+        let secondSurface = try makeSurface()
         let originalOcclusionSetter = TerminalSurfaceView.occlusionSetter
         var occlusionStates: [(visible: Bool, mounted: Bool)] = []
         TerminalSurfaceView.occlusionSetter = { handle, visible in
-            occlusionStates.append((visible, surface.superview != nil))
+            if handle == surface.surfaceHandle {
+                occlusionStates.append((visible, surface.superview != nil))
+            }
             originalOcclusionSetter(handle, visible)
         }
         defer {
@@ -1119,7 +1122,7 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         var sceneIsKey = true
         let coordinator = TmuxSessionPreviewCoordinator(
             mode: .live,
-            budget: LivePreviewBudget(limit: 1),
+            budget: LivePreviewBudget(limit: 2),
             capture: { _, _ in nil },
             isKeyWindow: { sceneIsKey }
         )
@@ -1143,6 +1146,27 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         ))
         coordinator.setExpanded(true, for: key)
         XCTAssertTrue(parkingHost.contains(surface))
+        let secondKey = TmuxPreviewKey(
+            hostID: key.hostID,
+            name: "second-parked-activity",
+            socketName: nil
+        )
+        coordinator.register(.init(
+            key: secondKey,
+            surface: { secondSurface },
+            handleID: { UUID() },
+            generation: { nil },
+            identity: {
+                TmuxSessionIdentity(
+                    serverPID: "101",
+                    sessionID: "$2",
+                    createdAt: "1000"
+                )
+            },
+            connectionState: { .connected },
+            isActive: { false },
+            activate: {}
+        ))
         occlusionStates.removeAll()
 
         coordinator.applicationDidResignActive()
@@ -1155,6 +1179,9 @@ final class TerminalSurfacePreviewTests: XCTestCase {
 
         XCTAssertTrue(parkingHost.contains(surface))
         XCTAssertEqual(occlusionStates.count, resignationEventCount)
+        coordinator.setExpanded(true, for: secondKey)
+        XCTAssertEqual(occlusionStates.count, resignationEventCount)
+        XCTAssertFalse(parkingHost.contains(secondSurface))
         let resumeDeadline = Date().addingTimeInterval(2)
         while !occlusionStates.contains(where: \.visible),
               Date() < resumeDeadline {

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -1201,6 +1201,104 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertFalse(parkingHost.contains(surface))
     }
 
+    func testReacquisitionWaitsForAvailableParkingWithoutPolling() async throws {
+        for missingHost in [true, false] {
+            let surface = try makeSurface()
+            let activeSurface = try makeSurface()
+            let root = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 400))
+            let window = NSWindow(
+                contentRect: root.frame,
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = root
+            window.orderFront(nil)
+            defer { window.orderOut(nil) }
+            let host = LivePreviewParkingHost(frame: root.bounds)
+            root.addSubview(host)
+            let sleeps = OSAllocatedUnfairLock(initialState: [Duration]())
+            var capturedKeys: [TmuxPreviewKey] = []
+            let coordinator = TmuxSessionPreviewCoordinator(
+                mode: .alwaysLive,
+                capture: { presentation, _ in
+                    capturedKeys.append(presentation.key)
+                    return nil
+                },
+                isKeyWindow: { true },
+                sleep: { duration in
+                    sleeps.withLock { $0.append(duration) }
+                    try await Task.sleep(for: duration)
+                },
+                activationDelay: .milliseconds(20)
+            )
+            defer { coordinator.shutdown() }
+            coordinator.applicationDidResignActive()
+            if !missingHost {
+                coordinator.installParkingHost(host)
+            }
+            let key = TmuxPreviewKey(hostID: UUID(), name: "waiting-preview", socketName: nil)
+            let activeKey = TmuxPreviewKey(
+                hostID: key.hostID,
+                name: "active-preview",
+                socketName: nil
+            )
+            let handleID = UUID()
+            let activeHandleID = UUID()
+            var surfaceAvailable = missingHost
+            coordinator.register(.init(
+                key: key,
+                surface: { surfaceAvailable ? surface : nil },
+                handleID: { handleID },
+                generation: { nil },
+                identity: {
+                    TmuxSessionIdentity(serverPID: "101", sessionID: "$1", createdAt: "1000")
+                },
+                connectionState: { .connected },
+                isActive: { false },
+                activate: {}
+            ))
+            coordinator.register(.init(
+                key: activeKey,
+                surface: { activeSurface },
+                handleID: { activeHandleID },
+                generation: { nil },
+                identity: {
+                    TmuxSessionIdentity(serverPID: "101", sessionID: "$2", createdAt: "1000")
+                },
+                connectionState: { .connected },
+                isActive: { true },
+                activate: {}
+            ))
+            coordinator.setExpanded(true, for: key)
+            coordinator.setExpanded(true, for: activeKey)
+            coordinator.applicationDidBecomeActive()
+            let captureDeadline = Date().addingTimeInterval(2)
+            while capturedKeys.count < 2, Date() < captureDeadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            XCTAssertGreaterThanOrEqual(capturedKeys.filter { $0 == activeKey }.count, 2)
+            let parkingSleeps = sleeps.withLock {
+                $0.filter { $0 == .milliseconds(20) || $0 == .milliseconds(10) }
+            }
+            XCTAssertEqual(parkingSleeps, [.milliseconds(20)])
+            XCTAssertFalse(host.contains(surface))
+            surfaceAvailable = true
+            if missingHost {
+                coordinator.installParkingHost(host)
+            } else {
+                coordinator.presentationDidChange(key)
+            }
+            XCTAssertFalse(host.contains(surface))
+            let deadline = Date().addingTimeInterval(2)
+            while !host.contains(surface), Date() < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            XCTAssertTrue(host.contains(surface))
+        }
+    }
+
     func testParkingAppliesTheRequestedTmuxGridAndRestoresGeometry() throws {
         let view = try makeSurface()
         let originalFrame = view.frame

--- a/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfacePreviewTests.swift
@@ -1081,22 +1081,26 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         XCTAssertNil(view.superview)
     }
 
-    func testApplicationActivitySuspendsAndRestoresParkedSurfaceRendering()
-        throws {
+    func testApplicationReactivationDefersParkedRenderingUntilKeySceneResume()
+        async throws {
+        // Exercise a visible window even when WindowServer occludes test windows.
+        final class VisibleWindow: NSWindow {
+            override var occlusionState: NSWindow.OcclusionState { .visible }
+        }
+        let surface = try makeSurface()
         let originalOcclusionSetter = TerminalSurfaceView.occlusionSetter
-        var occlusionStates: [Bool] = []
-        TerminalSurfaceView.occlusionSetter = { surface, visible in
-            occlusionStates.append(visible)
-            originalOcclusionSetter(surface, visible)
+        var occlusionStates: [(visible: Bool, mounted: Bool)] = []
+        TerminalSurfaceView.occlusionSetter = { handle, visible in
+            occlusionStates.append((visible, surface.superview != nil))
+            originalOcclusionSetter(handle, visible)
         }
         defer {
             TerminalSurfaceView.occlusionSetter = originalOcclusionSetter
         }
 
-        let surface = try makeSurface()
         surface.frame = NSRect(x: 0, y: 0, width: 640, height: 400)
         let root = NSView(frame: surface.frame)
-        let window = NSWindow(
+        let window = VisibleWindow(
             contentRect: root.frame,
             styleMask: [.titled],
             backing: .buffered,
@@ -1112,11 +1116,12 @@ final class TerminalSurfacePreviewTests: XCTestCase {
             name: "parked-activity",
             socketName: nil
         )
+        var sceneIsKey = true
         let coordinator = TmuxSessionPreviewCoordinator(
             mode: .live,
             budget: LivePreviewBudget(limit: 1),
             capture: { _, _ in nil },
-            isKeyWindow: { true }
+            isKeyWindow: { sceneIsKey }
         )
         defer { coordinator.shutdown() }
         coordinator.installParkingHost(parkingHost)
@@ -1143,17 +1148,30 @@ final class TerminalSurfacePreviewTests: XCTestCase {
         coordinator.applicationDidResignActive()
 
         XCTAssertTrue(parkingHost.contains(surface))
-        XCTAssertEqual(occlusionStates.last, false)
+        XCTAssertEqual(occlusionStates.last?.visible, false)
         let resignationEventCount = occlusionStates.count
 
         coordinator.applicationDidBecomeActive()
 
         XCTAssertTrue(parkingHost.contains(surface))
-        XCTAssertGreaterThan(occlusionStates.count, resignationEventCount)
-        XCTAssertEqual(
-            occlusionStates.last,
-            TerminalSurfaceView.resolvedOcclusionVisibility(for: window)
-        )
+        XCTAssertEqual(occlusionStates.count, resignationEventCount)
+        let resumeDeadline = Date().addingTimeInterval(2)
+        while !occlusionStates.contains(where: \.visible),
+              Date() < resumeDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(occlusionStates.contains(where: \.visible))
+
+        coordinator.applicationDidResignActive()
+        sceneIsKey = false
+        occlusionStates.removeAll()
+
+        coordinator.applicationDidBecomeActive()
+
+        // Unmounting may report occlusion, but a non-key scene must never
+        // resume its still-mounted fleet, even in a headless WindowServer.
+        XCTAssertTrue(occlusionStates.allSatisfy { !$0.mounted && !$0.visible })
+        XCTAssertFalse(parkingHost.contains(surface))
     }
 
     func testParkingAppliesTheRequestedTmuxGridAndRestoresGeometry() throws {

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -20,6 +20,44 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ActivationWorkGateTests {
+    @Test("collapsing a sidebar group affects only its window")
+    func sidebarDisclosureIsWindowLocal() throws {
+        let app = NSApplication.shared
+        let wasEnhanced = app.value(forKey: "accessibilityEnhancedUserInterface")
+        app.setValue(true, forKey: "accessibilityEnhancedUserInterface")
+        defer { app.setValue(wasEnhanced, forKey: "accessibilityEnhancedUserInterface") }
+        let gate = GateEnvironment()
+        defer { gate.close() }
+        let identifier = "sidebar-section-disclosure-sessions:\(gate.snapshot.hosts[0].id.uuidString)"
+        /// SwiftUI nodes expose these accessors without adopting the full
+        /// NSAccessibilityProtocol, so traverse them through Cocoa's KVC API.
+        func disclosure(in element: NSObject) -> NSObject? {
+            let id = element.responds(to: NSSelectorFromString("accessibilityIdentifier"))
+                ? element.value(forKey: "accessibilityIdentifier") as? String : nil
+            if id == identifier {
+                return element
+            }
+            let children = element.responds(to: NSSelectorFromString("accessibilityChildren"))
+                ? element.value(forKey: "accessibilityChildren") as? [NSObject] : nil
+            for child in children ?? [] {
+                if let match = disclosure(in: child) {
+                    return match
+                }
+            }
+            return nil
+        }
+        let first = try #require(disclosure(in: gate.hostingViews[0]))
+        let second = try #require(disclosure(in: gate.hostingViews[1]))
+        #expect(first.value(forKey: "accessibilityValue") as? String == "Expanded")
+        #expect(second.value(forKey: "accessibilityValue") as? String == "Expanded")
+
+        _ = first.perform(NSSelectorFromString("accessibilityPerformPress"))
+        gate.activateWindow(1)
+
+        #expect(first.value(forKey: "accessibilityValue") as? String == "Collapsed")
+        #expect(second.value(forKey: "accessibilityValue") as? String == "Expanded")
+    }
+
     /// Budgets are a ratchet at the measured baseline plus 30%: 10 switches
     /// cost exactly 20 root body evaluations (one per window per switch)
     /// and no sidebar section recomputation. The headroom absorbs a stray
@@ -79,7 +117,7 @@ private final class GateEnvironment {
 
     private let windowModels: [GateWindowModel]
     private let windows: [NSWindow]
-    private let hostingViews: [NSHostingView<GateHarness>]
+    let hostingViews: [NSHostingView<GateHarness>]
     private let settingsStore: SettingsStore
     private let tempRoot: URL
     private let defaults: UserDefaults

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -20,6 +20,22 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ActivationWorkGateTests {
+    @Test("activation preference refresh does not redraw unchanged windows", arguments: [100, 500])
+    func activationPreferenceRefreshDoesNotRedrawWindows(sessionCount: Int) {
+        let gate = GateEnvironment(sessionCount: sessionCount)
+        defer { gate.close() }
+
+        RenderWorkCounters.beginRecording()
+        for _ in 0 ..< Budget.switches {
+            // Telemetry reloads this shared preference on application activation.
+            gate.settingsStore.refreshShareAnonymousUsageData()
+            gate.settle()
+        }
+        let counts = RenderWorkCounters.endRecording()
+        #expect(counts.rootBodyEvaluations == 0)
+        #expect(counts.sidebarSectionComputations == 0)
+    }
+
     @Test("collapsing a sidebar group affects only its window")
     func sidebarDisclosureIsWindowLocal() throws {
         let app = NSApplication.shared
@@ -118,21 +134,24 @@ private final class GateEnvironment {
     private let windowModels: [GateWindowModel]
     private let windows: [NSWindow]
     let hostingViews: [NSHostingView<GateHarness>]
-    private let settingsStore: SettingsStore
+    let settingsStore: SettingsStore
     private let tempRoot: URL
     private let defaults: UserDefaults
     private let defaultsSuiteName: String
     private let sidebarToggleTarget = NSObject()
 
-    init() {
-        let sessionNames = ["alpha", "beta", "gamma", "delta"]
+    init(sessionCount: Int = 4) {
+        let sessionNames = (0 ..< sessionCount).map { "session-\($0)" }
         let environment = makeWorkspaceEnvironment(
             hostConfig: { host in
-                host.tmuxSessions = sessionNames.map {
+                host.tmuxSessions = sessionNames.enumerated().map { index, name in
                     TmuxSessionSummary(
-                        name: $0,
+                        name: name,
                         managed: false,
-                        windows: []
+                        windows: [],
+                        serverPID: "101",
+                        sessionID: "$\(index)",
+                        createdAt: "1000"
                     )
                 }
             },
@@ -222,7 +241,7 @@ private final class GateEnvironment {
         try? FileManager.default.removeItem(at: tempRoot)
     }
 
-    private func settle(for duration: TimeInterval = 0.05) {
+    func settle(for duration: TimeInterval = 0.05) {
         for hostingView in hostingViews {
             hostingView.layoutSubtreeIfNeeded()
         }

--- a/Tests/UI/WorkspaceSidebarModelTests.swift
+++ b/Tests/UI/WorkspaceSidebarModelTests.swift
@@ -455,7 +455,7 @@ struct WorkspaceSidebarModelTests {
     }
 
     @Test("sidebar disclosure defaults expose fleet before project contents")
-    func sidebarDisclosureStateRoundTrips() {
+    func sidebarDisclosureDefaultsAndToggles() {
         let hostID = UUID()
         let projectID = UUID()
         let hostKey = WorkspaceSidebarDisclosureState.host(hostID)
@@ -474,19 +474,15 @@ struct WorkspaceSidebarModelTests {
 
         state.toggle(projectsKey)
         state.toggle(projectKey)
-        let restored = WorkspaceSidebarDisclosureState(
-            rawValue: state.rawValue
-        )
-        #expect(restored.isExpanded(hostKey))
-        #expect(restored.isExpanded(projectsKey))
-        #expect(restored.isExpanded(projectKey))
+        #expect(state.isExpanded(hostKey))
+        #expect(state.isExpanded(projectsKey))
+        #expect(state.isExpanded(projectKey))
 
-        var reopened = restored
-        reopened.toggle(projectKey)
-        #expect(!reopened.isExpanded(projectKey))
-        reopened.toggle(projectsKey)
-        #expect(!reopened.isExpanded(projectsKey))
-        #expect(reopened.rawValue.isEmpty)
+        state.toggle(projectKey)
+        #expect(!state.isExpanded(projectKey))
+        state.toggle(projectsKey)
+        #expect(!state.isExpanded(projectsKey))
+        #expect(state == WorkspaceSidebarDisclosureState())
     }
 
     @Test("Herdr ordering has its own persisted storage key")
@@ -523,29 +519,6 @@ struct WorkspaceSidebarModelTests {
         #expect(stopped?.herdrSessionState == .stopped)
         #expect(stopped?.herdrSessionIsDefault == false)
         #expect(stopped?.subtitle == "Stopped")
-    }
-
-    @Test("legacy collapsed sidebar items migrate into disclosure overrides")
-    func sidebarDisclosureStateMigratesLegacyKey() {
-        let hostKey = WorkspaceSidebarDisclosureState.host(UUID())
-        let sessionKey = WorkspaceSidebarDisclosureState.sessions(UUID())
-        let legacy = [hostKey, sessionKey].joined(separator: "\n")
-
-        let migrated = WorkspaceSidebarDisclosureState.migratedRawValue(
-            current: "",
-            legacyCollapsedKeys: legacy
-        )
-        let state = WorkspaceSidebarDisclosureState(rawValue: migrated)
-
-        #expect(!state.isExpanded(hostKey))
-        #expect(!state.isExpanded(sessionKey))
-        #expect(migrated.contains("-\(hostKey)"))
-        #expect(
-            WorkspaceSidebarDisclosureState.migratedRawValue(
-                current: "+\(hostKey)",
-                legacyCollapsedKeys: legacy
-            ) == "+\(hostKey)"
-        )
     }
 
     @Test("selected kwt worktree resolves directly to its native tmux session")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,13 @@ window's native tab group. AppKit owns the tab bar, tab movement, and window
 merging; Ghosthub does not render a custom tab strip or project tmux windows
 into native UI.
 
+Sidebar hierarchy expansion belongs to each open scene. Expanding or collapsing
+a host, session group, Projects group, or project never changes another window.
+New scenes start with hosts and session groups expanded and projects collapsed.
+The parsed disclosure sets remain in view state across sidebar hiding and focus
+changes; they are not app-wide preferences or part of restored scene descriptors.
+Saved row ordering and explicit Settings preferences remain app-wide.
+
 The workspace `WindowGroup` is data-backed. Each scene continuously captures a
 small logical descriptor containing stable host and project keys, the durable
 kwt worktree generation or registered directory path, and an exact tmux

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -990,6 +990,8 @@ Off and Efficient modes schedule no preview work when a window becomes key,
 and Off does not mount the hidden parking host. Live and Always Live coalesce
 delayed parking reconciliation for newly available surfaces in the key scene;
 already parked surfaces remain mounted across application deactivation.
+Their rendering resumes after the same activation delay and eligibility checks;
+non-key scenes release retained parking while rendering remains suspended.
 Selecting an ordinary parked
 preview unparks and activates its retained surface synchronously. Selecting an
 Always Live client promotes its verified retained attachment to normal sizing

--- a/docs/sidebar-performance.md
+++ b/docs/sidebar-performance.md
@@ -51,12 +51,15 @@ existing delayed parking path after checking application activity, sidebar
 visibility, preview mode, and scene focus. Efficient capture retries retain their
 existing behavior. Preview changes that cancel the timer preserve pending
 reacquisition and reschedule the delay; cancellation does not permit immediate
-rendering or mounting the remaining fleet at once. The terminal regression
-exercises a real libghostty surface
-with controlled window visibility: no synchronous resume, eventual key-scene
-resume, and no mounted-surface resume in a non-key scene.
+rendering or mounting the remaining fleet at once. Only successful mounts consume
+a parking slot. If the parking host or a surface is unavailable, reacquisition
+stays pending and pauses until a host or presentation event reschedules the delay.
+Healthy previews continue their regular captures without polling for missing
+views. The terminal regressions use real libghostty surfaces to check delayed
+key-scene resume, no mounted-surface resume in a non-key scene, and deferred
+mounting when a missing host or surface becomes available.
 
-`make test-activation-gate` now includes both regressions. These are deterministic
+`make test-activation-gate` includes these regressions. These are deterministic
 work checks, not end-to-end Command-Tab latency measurements. The broader
 first-responder and latency benchmark remains tracked by `360m`; row construction
 and hover measurements remain `s921`. Resource sampling already defers its first

--- a/docs/sidebar-performance.md
+++ b/docs/sidebar-performance.md
@@ -49,7 +49,10 @@ reactivation, before checking whether their scene was key. A non-key scene then
 suspended and unparked those same surfaces. Rendering now resumes through the
 existing delayed parking path after checking application activity, sidebar
 visibility, preview mode, and scene focus. Efficient capture retries retain their
-existing behavior. The terminal regression exercises a real libghostty surface
+existing behavior. Preview changes that cancel the timer preserve pending
+reacquisition and reschedule the delay; cancellation does not permit immediate
+rendering or mounting the remaining fleet at once. The terminal regression
+exercises a real libghostty surface
 with controlled window visibility: no synchronous resume, eventual key-scene
 resume, and no mounted-surface resume in a non-key scene.
 

--- a/docs/sidebar-performance.md
+++ b/docs/sidebar-performance.md
@@ -1,0 +1,93 @@
+# Sidebar performance review
+
+Reviewed September 10, 2026, against `dedc40b2`, including the inventory
+sharing change in `4c8bd7ed`.
+
+## Measured refresh work
+
+A deterministic test opens two scene models with the same populated inventory
+store and holds the next inventory load. It calls `refreshKwtInventory` and counts work
+before any new result returns. Temporary instrumentation in
+`HostInventoryOverlay.apply` counts cached-host merges; Combine subscriptions
+count warning and load-state publications. The test does not connect to real
+hosts or open terminal clients.
+
+| Work before a loader returns | Before | After |
+| --- | ---: | ---: |
+| Cached-host merges | 8 | 0 |
+| Unchanged sidebar warning/state publications | 24 | 0 |
+
+The retained regression test is
+`WorkspaceSharedInventoryTests.refreshDoesNotRepublishUnchangedSidebarState`.
+The merge instrumentation was temporary; snapshot equality alone cannot count
+unnecessary merges. These are work counts, not elapsed-time or frame-rate
+measurements. They do not establish that every source of perceived lag is gone.
+
+The disclosure regression separately hosts two real `RootView` windows sharing
+the same preferences. Pressing a session group's disclosure in one previously
+collapsed both; it now changes only the targeted window. Disclosure state is
+stored as parsed sets, eliminating the old per-check string parsing. The
+app-wide disclosure preference predates `4c8bd7ed`.
+
+## Inventory updates
+
+`WorkspaceInventoryStore` publishes on each loading transition and each result.
+Previously, `WorkspaceSceneModel.consumeSharedInventory` reapplied every cached
+host on every publication, even when its revision checks found no new inventory.
+This regressed the host-scoped application used before `4c8bd7ed`. With H hosts
+and W windows, an ordinary successful KWT/tmux refresh cycle could perform
+4 × W × H² cached-host merges. Explicit refresh adds invalidation publications.
+
+Consumption now applies only hosts with new inventory or availability state.
+Loading-only transitions still update progress and attempt restoration.
+Successful observations still reconcile retained presentations and quarantined
+removals, including when inventory content is unchanged. Warning and load-state
+properties publish only when their values change.
+Actual refresh-completion transitions still notify each scene, including a
+refresh that returns identical data, so sidebar cleanup sees completion.
+
+A worktree selection also records its last-viewed time in persistence and
+replaces the scene snapshot. The unchanged-host branch then refreshes its
+subscription and reapplies cached inventory. Removing the unconditional merge
+from consumption eliminates one of the two full overlays formerly reached by
+that path. Identical subscriber registration still recomputes subscriber host
+sets; avoiding that work is a smaller remaining opportunity.
+
+## Remaining rendering costs
+
+These costs are established by source inspection, not timing measurements.
+They mostly predate `4c8bd7ed` and deserve a separate rendering benchmark.
+
+1. **Reorder metadata grows quadratically within a group.**
+   `WorkspaceSidebarView.hostContents` maps all worktree IDs inside each row's
+   construction, and `worktreeButton` maps them again into drag items. The
+   session-row builders similarly reconstruct all siblings for every row.
+   Build one drag-item array per group and pass it to its rows.
+2. **Rows repeat linear inventory lookups.** `sidebarButton` computes tmux
+   killability, calls the general action builder, and then discards that
+   builder's tmux/Zellij actions. The second call repeats the tmux session scan.
+   Worktree and preview builders also resolve the same worktree repeatedly.
+   Reuse known row data and invoke the Herdr action builder only for Herdr rows.
+3. **Hover invalidates the whole sidebar.** Hover state and dismissal tasks
+   belong to `WorkspaceSidebarView`; nested ordinary `VStack` containers eagerly
+   construct expanded groups. Row views can own hover state, following the
+   existing `ProjectRemovalButton` pattern. Measure row construction and layout
+   before changing virtualization; an outer `LazyVStack` alone leaves eager
+   descendants.
+4. **Section-cache misses scan the fleet repeatedly.**
+   `WorkspaceSidebarModel.sections` filters all worktrees per project and all
+   terminal sessions per worktree. `WorkspaceSidebarOrder.ordered` rebuilds
+   its full position index per group, even for empty saved ordering. Group
+   inputs once per computation and reuse order indexes before adding caches.
+5. **Changed-file updates observe at sidebar scope.** `WorktreeChangesStore`
+   publishes its entry dictionary to the sidebar. A changed panel can invalidate
+   unrelated rows. Unchanged successful polls already suppress publication;
+   blaming every five-second poll would be incorrect.
+
+`make test-activation-gate` covers root-body evaluations and section-cache
+computations for two small windows. It does not measure row construction,
+hover, layout, scrolling, or inventory merging. The next useful benchmark is
+100 versus 500 synthetic rows, with projects expanded and previews off,
+measuring selection, pointer movement, disclosure, and one changed-file result
+separately. Session fixtures need stable tmux identities so action controls
+participate in the measurement.

--- a/docs/sidebar-performance.md
+++ b/docs/sidebar-performance.md
@@ -29,6 +29,37 @@ collapsed both; it now changes only the targeted window. Disclosure state is
 stored as parsed sets, eliminating the old per-check string parsing. The
 app-wide disclosure preference predates `4c8bd7ed`.
 
+## Application reactivation
+
+Packaged builds check the persisted telemetry preference on each application
+activation. `SettingsStore.refreshShareAnonymousUsageData` previously assigned
+its published property even when the value was unchanged. Both `WorkspaceWindow`
+and `RootView` observe this shared store, so the assignment invalidated every
+window. The refresh now publishes only a changed preference; changes made by
+another process still take effect.
+
+The activation gate hosts two `RootView` windows with 100 or 500 synthetic tmux
+sessions per window, using stable session identities and expanded session groups.
+Ten unchanged preference refreshes caused 20 root-body evaluations at both sizes
+before the fix and zero afterward. Section computations remained zero. This
+measures the refresh invoked by telemetry, without sending telemetry events.
+
+Retained live previews also resumed rendering synchronously on application
+reactivation, before checking whether their scene was key. A non-key scene then
+suspended and unparked those same surfaces. Rendering now resumes through the
+existing delayed parking path after checking application activity, sidebar
+visibility, preview mode, and scene focus. Efficient capture retries retain their
+existing behavior. The terminal regression exercises a real libghostty surface
+with controlled window visibility: no synchronous resume, eventual key-scene
+resume, and no mounted-surface resume in a non-key scene.
+
+`make test-activation-gate` now includes both regressions. These are deterministic
+work checks, not end-to-end Command-Tab latency measurements. The broader
+first-responder and latency benchmark remains tracked by `360m`; row construction
+and hover measurements remain `s921`. Resource sampling already defers its first
+sample on reactivation. Inventory still refreshes on return to the app, preserving
+the existing freshness and stale-load replacement contracts.
+
 ## Inventory updates
 
 `WorkspaceInventoryStore` publishes on each loading transition and each result.

--- a/website/docs/content/windows-navigation.md
+++ b/website/docs/content/windows-navigation.md
@@ -21,6 +21,12 @@ moving away from Herdr or Zellij detaches only its presentation and leaves its s
 running. Stopped Herdr rows are dimmed and labeled **Stopped**. Expand a host
 to see its current inventory and connection diagnostics.
 
+Each open window or tab keeps its own expanded and collapsed groups. Expanding
+a host or project in one window leaves other windows as you arranged them.
+New windows start with hosts and session groups expanded and projects collapsed.
+
+![Ghosthub sidebar with host and session groups](assets/guide-sessions.png)
+
 Press ++cmd+b++ to hide or show the sidebar. Hiding it gives the terminal
 the full window while preserving its session attachment.
 


### PR DESCRIPTION
- Keep expanded and collapsed sidebar groups independent in each window or tab. New windows use the default expansion; saved row ordering and Settings remain shared.
- Skip cached-host merges for refresh progress updates while preserving completion notifications and fresh inventory. The two-window regression reduces merges before a loader returns from eight to zero.
- Avoid redrawing every window when activation reloads an unchanged telemetry preference. Ten reloads across two windows with 100 or 500 sessions now cause zero extra root-view evaluations, down from 20.
- Resume retained live-preview rendering after the existing activation delay and key-scene checks. Non-key scenes release their previews while rendering stays suspended.
- Extend the activation gate and document the [performance review](https://github.com/kenn-io/ghosthub/blob/0b8031be/docs/sidebar-performance.md). End-to-end Command-Tab latency and broader row/hover work remain follow-ups.
- Focused checks, activation/workflow gates, and the build pass. The full Swift run was stopped after terminal smoke failures involving the login-shell `python3` shim; it is not reported as passing.
