### PR TITLE
Stabilize session tests and retry helper dependency downloads

### DIFF
--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -949,16 +949,15 @@ extension WorkspaceTmuxDiscoveryTests {
     @MainActor
     @Test("directory ownership rebind restarts an active reconnect")
     func directoryOwnershipRebindRestartsActiveReconnect() async throws {
-        let discoveries = TmuxDiscoveryResultQueue([
+        let session = DiscoveredTmuxSession(
+            name: "release-work",
+            windowCount: 1,
+            createdAt: nil,
+            managed: false
+        )
+        let reconnectProbes = TmuxDiscoveryResultQueue([
             .failure(.probeTimedOut(shell: "build-box")),
-            .success([
-                DiscoveredTmuxSession(
-                    name: "release-work",
-                    windowCount: 1,
-                    createdAt: nil,
-                    managed: false
-                ),
-            ]),
+            .success([session]),
         ])
         let environment = try setupRemoteTmuxEnvironment()
         let directory = DirectoryWorkspaceSummary(
@@ -980,7 +979,11 @@ extension WorkspaceTmuxDiscoveryTests {
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },
-            tmuxSessionDiscovery: { _ in discoveries.removeFirst() },
+            // Initial workspace confirmation must not consume reconnect results.
+            tmuxSessionDiscovery: { _ in .success([session]) },
+            tmuxSessionValidationDiscovery: { _, _ in
+                reconnectProbes.removeFirst()
+            },
             tmuxReconnectIntervals: [.seconds(60)]
         )
         let canonical = WorkspaceSidebarModel.tmuxSessionSelection(
@@ -994,9 +997,12 @@ extension WorkspaceTmuxDiscoveryTests {
 
         model.openBorrowedTmuxSession(canonical)
         await launchActiveTmuxSurface(model, store: surfaceStore)
+        await waitUntilMainActor {
+            model.activeBorrowedTmuxSessionIsConnected
+        }
         surfaceStore.surface.closeObservers.values.first?(false, 255)
         await waitUntilMainActor {
-            discoveries.count == 1
+            reconnectProbes.count == 1
                 && model.activeBorrowedTmuxRecoveryState?.isReconnecting
                 == true
         }
@@ -1005,7 +1011,7 @@ extension WorkspaceTmuxDiscoveryTests {
         model.reconnectActiveTmuxSessionNow()
 
         await waitUntilMainActor {
-            discoveries.count == 2
+            reconnectProbes.count == 2
                 && surfaceStore.requestCount == 2
                 && model.activeBorrowedTmuxSessionIsConnected
         }

--- a/Tests/App/WorkspaceTmuxPresentationTests.swift
+++ b/Tests/App/WorkspaceTmuxPresentationTests.swift
@@ -976,6 +976,11 @@ extension WorkspaceTmuxDiscoveryTests {
             localHostID: environment.localHostID,
             snapshot: snapshot,
             nativeTmuxSurfaceStore: surfaceStore,
+            nativeTmuxPaneSplitter: WorkspaceTmuxTestSupport.previewPaneSplitter(
+                identity: TmuxSessionIdentity(
+                    serverPID: "101", sessionID: "$1", createdAt: "1000"
+                )
+            ),
             remoteTmuxPathProvider: { _, _ in
                 successfulTmuxResolution("/usr/bin/tmux")
             },

--- a/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
+++ b/Tests/App/WorkspaceTmuxProjectRemovalTests.swift
@@ -3244,9 +3244,10 @@ extension WorkspaceTmuxDiscoveryTests {
             capturedEndpointReads.count >= 1
                 && surfaceStore.removedKeys.count == 1
         }
-        try await Task.sleep(for: .milliseconds(20))
 
-        #expect(capturedEndpointReads.count == 1)
+        // Pending client identity can consume an attempt before endpoint reads.
+        // Rejection must follow a read, regardless of how many retries remain.
+        #expect(capturedEndpointReads.count >= 1)
         #expect(model.retainedBorrowedTmuxPresentationCount == 0)
         #expect(model.activeBorrowedTmuxSelection == nil)
         #expect(!model.activeBorrowedTmuxSessionIsConnected)

--- a/Tests/App/WorktreeChangesReadCoordinatorTests.swift
+++ b/Tests/App/WorktreeChangesReadCoordinatorTests.swift
@@ -100,18 +100,26 @@ struct WorktreeChangesReadCoordinatorTests {
         )
         let probe = ConcurrentReadProbe()
         let identity = changesIdentity(hostID: UUID(), index: 1)
+        let secondStarted = AsyncGate()
         let first = Task {
             try await coordinator.load(identity: identity) {
                 try await probe.load(identity)
             }
         }
+        await probe.waitUntilStarted(1)
+
         let second = Task {
-            try await coordinator.load(identity: identity) {
-                try await probe.load(identity)
-            }
+            try await { (coordinator: isolated WorktreeChangesReadCoordinator) in
+                // Stay on this actor from signaling through load registration;
+                // the first read cannot finish on it before the second joins.
+                secondStarted.open()
+                return try await coordinator.load(identity: identity) {
+                    try await probe.load(identity)
+                }
+            }(coordinator)
         }
 
-        await probe.waitUntilStarted(1)
+        await secondStarted.wait()
         #expect(await probe.startedCount == 1)
         await probe.releaseAll()
         _ = try await first.value

--- a/tools/build_pinned_kwt.sh
+++ b/tools/build_pinned_kwt.sh
@@ -180,6 +180,21 @@ else
 fi
 
 mkdir -p "$(dirname "$output")"
+# Fill the shared module cache separately so a transient download failure can
+# retry without repeating compilation or hiding a compiler error.
+(
+  cd "$source_dir"
+  for attempt in 1 2 3; do
+    if go mod download; then
+      exit 0
+    fi
+    if [[ "$attempt" -eq 3 ]]; then
+      exit 1
+    fi
+    printf 'kwt dependency download failed; retrying after %s seconds.\n' "$attempt" >&2
+    sleep "$attempt"
+  done
+)
 kwt_revision_time="$(
   TZ=UTC git -C "$source_dir" show -s \
     --date=format-local:'%Y-%m-%dT%H:%M:%SZ' \

--- a/tools/tests/test_build_pinned_kwt.py
+++ b/tools/tests/test_build_pinned_kwt.py
@@ -11,6 +11,17 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def isolate_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in os.environ:
+        if key.startswith("GIT_"):
+            monkeypatch.delenv(key)
+    config = tmp_path / "gitconfig"
+    config.write_text("")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+
 def bootstrap_fixture(tmp_path: Path) -> tuple[Path, str, str, Path]:
     repository = tmp_path / "repository"
     repository.mkdir()
@@ -56,6 +67,9 @@ def bootstrap_fixture(tmp_path: Path) -> tuple[Path, str, str, Path]:
     fake_go.write_text(
         """#!/bin/sh
 set -eu
+if [ "$*" = "mod download" ]; then
+  exit 0
+fi
 if [ "$#" -eq 2 ] && [ "$1" = "env" ]; then
   case "$2" in
     GOOS) printf 'darwin\\n' ;;
@@ -124,6 +138,65 @@ chmod +x "$output"
     )
     fake_go.chmod(fake_go.stat().st_mode | stat.S_IXUSR)
     return repository, revision, second_revision, fake_bin
+
+
+@pytest.mark.parametrize(
+    "download_failures,build_fails", [(2, False), (3, False), (0, True)]
+)
+def test_dependency_download_retries_are_bounded(
+    tmp_path: Path, download_failures: int, build_fails: bool
+) -> None:
+    repository, revision, _, fake_bin = bootstrap_fixture(tmp_path)
+    fake_go = fake_bin / "go"
+    successful_go = fake_bin / "successful-go"
+    fake_go.rename(successful_go)
+    calls = tmp_path / "go-calls"
+    fake_go.write_text(
+        """#!/bin/sh
+set -eu
+printf '%s\\n' "$1" >> "$GO_CALLS"
+if [ "$*" = "mod download" ]; then
+  attempts=$(grep -c '^mod$' "$GO_CALLS")
+  if [ "$attempts" -le "$DOWNLOAD_FAILURES" ]; then
+    echo 'dependency download: stream error: INTERNAL_ERROR; received from peer' >&2
+    exit 1
+  fi
+elif [ "$1" = "build" ] && [ "$BUILD_FAILS" = 1 ]; then
+  echo 'compiler error' >&2
+  exit 1
+fi
+exec "$(dirname "$0")/successful-go" "$@"
+"""
+    )
+    fake_go.chmod(0o755)
+    output = tmp_path / "output" / "kwt"
+    result = subprocess.run(
+        [
+            "bash",
+            "tools/build_pinned_kwt.sh",
+            str(repository),
+            revision,
+            str(tmp_path / "source"),
+            str(output),
+        ],
+        cwd=Path(__file__).parents[2],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "GO_CALLS": str(calls),
+            "DOWNLOAD_FAILURES": str(download_failures),
+            "BUILD_FAILS": str(int(build_fails)),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    commands = calls.read_text().splitlines()
+    assert commands.count("mod") == min(download_failures + 1, 3)
+    assert commands.count("build") == int(download_failures < 3)
+    succeeds = download_failures < 3 and not build_fails
+    assert (result.returncode == 0) == succeeds, result.stderr
+    assert Path(f"{output}.revision").exists() == succeeds
 
 
 def test_failed_initial_clone_does_not_block_retry(tmp_path: Path) -> None:


### PR DESCRIPTION
- Prevent CI timing failures in directory reconnect, endpoint confirmation, and shared worktree-file inspection tests.
- Give initial workspace confirmation a separate response and a synthetic client identity. Wait for both file readers to enter the coordinator before releasing their shared inspection.
- Require an unconfirmed tmux client to be removed after reading its endpoint, while allowing the confirmation loop to retry.
- Retry pinned kwt dependency downloads up to three times with short delays, then compile once. Exhausted downloads and compiler errors still fail the build.
