### PR TITLE
Reduce sidebar selection work and restore terminal input probes

### DIFF
--- a/.github/actions/run-gui-terminal-tests/LauncherEnvironment.swift
+++ b/.github/actions/run-gui-terminal-tests/LauncherEnvironment.swift
@@ -13,6 +13,7 @@ private let requiredLauncherEnvironmentNames = [
     "SHELL",
     "TMUX_TMPDIR",
     "GHOSTHUB_TEST_TMUX_RUN_ID",
+    "GHOSTHUB_TEST_PYTHON",
     "GHOSTTY_RESOURCES_DIR",
 ]
 
@@ -20,6 +21,7 @@ private let optionalLauncherEnvironmentNames = [
     "RUNNER_ENVIRONMENT",
     "CI",
     "GITHUB_ACTIONS",
+    "GHOSTHUB_BENCHMARK_INPUT",
 ]
 
 struct LauncherEnvironmentError: Error, CustomStringConvertible {

--- a/.github/actions/run-gui-terminal-tests/run.sh
+++ b/.github/actions/run-gui-terminal-tests/run.sh
@@ -61,6 +61,8 @@ tmux_tmpdir="$(mktemp -d "$test_root/run.$$.XXXXXX")"
 test_run_id=${tmux_tmpdir##*.}
 export TMUX_TMPDIR="$tmux_tmpdir"
 export GHOSTHUB_TEST_TMUX_RUN_ID="$test_run_id"
+GHOSTHUB_TEST_PYTHON="$(uv python find)"
+export GHOSTHUB_TEST_PYTHON
 export GHOSTTY_RESOURCES_DIR="$ghostty_resources"
 
 # shellcheck disable=SC2329  # invoked by stop_launcher below

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
             swift test --skip-build --disable-swift-testing
             --filter GhosthubTerminalSmokeTests
             --skip "$GHOSTHUB_GUI_TEST_FILTER"
+            --skip TerminalSurfaceViewInputTests/testInputLatencyBenchmark
             --parallel --num-workers "$test_workers"
           )
           if [[ "${RUNNER_ENVIRONMENT:-}" == "self-hosted" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,12 @@ test-activation-gate:
 	@sh tools/run_swift_tests.sh $(SWIFT) test \
 		--filter 'ActivationWorkGateTests|SettingsStoreTests/testRefreshingAnonymousUsageDataPublishesOnlyChanges|TerminalSurfacePreviewTests/testApplicationReactivationDefersParkedRenderingUntilKeySceneResume|TerminalSurfacePreviewTests/testReacquisitionWaitsForAvailableParkingWithoutPolling'
 
+# Report input latency without enforcing machine-dependent timing thresholds.
+.PHONY: benchmark-input
+benchmark-input:
+	@GHOSTHUB_BENCHMARK_INPUT=1 sh tools/run_swift_tests.sh $(SWIFT) test \
+		--filter TerminalSurfaceViewInputTests/testInputLatencyBenchmark
+
 # Essential workflow smoke for kwt inventory and ordinary tmux attachment.
 test-essential-workflows: test-kwt-contract
 	@set -euo pipefail; \

--- a/Sources/UI/RenderWorkCounters.swift
+++ b/Sources/UI/RenderWorkCounters.swift
@@ -11,6 +11,8 @@ enum RenderWorkCounters {
     struct Counts {
         var rootBodyEvaluations = 0
         var sidebarSectionComputations = 0
+        var sidebarRowEvaluations = 0
+        var sidebarDragItems = 0
         fileprivate var isRecording = false
     }
 
@@ -34,6 +36,20 @@ enum RenderWorkCounters {
 
     static func beginRecording() {
         state.withLock { $0 = Counts(isRecording: true) }
+    }
+
+    static func countSidebarRowEvaluation() {
+        state.withLock {
+            guard $0.isRecording else { return }
+            $0.sidebarRowEvaluations += 1
+        }
+    }
+
+    static func countSidebarDragItems(_ count: Int) {
+        state.withLock {
+            guard $0.isRecording else { return }
+            $0.sidebarDragItems += count
+        }
     }
 
     static func endRecording() -> Counts {

--- a/Sources/UI/WorkspaceSidebarModel.swift
+++ b/Sources/UI/WorkspaceSidebarModel.swift
@@ -51,6 +51,7 @@ struct WorkspaceSidebarOrder: Equatable {
         _ items: [Item],
         identifiedBy identifier: (Item) -> String
     ) -> [Item] {
+        guard !itemIDs.isEmpty, items.count > 1 else { return items }
         let positions = Dictionary(
             uniqueKeysWithValues: itemIDs.enumerated().map {
                 ($0.element, $0.offset)

--- a/Sources/UI/WorkspaceSidebarView.swift
+++ b/Sources/UI/WorkspaceSidebarView.swift
@@ -519,10 +519,11 @@ struct WorkspaceSidebarView: View {
                     )
                 )
                 if isExpanded(sessionsKey) {
+                    let groupItems = sidebarDragItems(section.tmuxSessionRows)
                     ForEach(section.tmuxSessionRows) { row in
                         tmuxSessionButton(
                             row,
-                            orderedRows: section.tmuxSessionRows
+                            groupItems: groupItems
                         )
                     }
                 }
@@ -542,10 +543,11 @@ struct WorkspaceSidebarView: View {
                         )
                     )
                     if isExpanded(herdrSessionsKey) {
+                        let groupItems = sidebarDragItems(section.herdrSessionRows)
                         ForEach(section.herdrSessionRows) { row in
                             herdrSessionButton(
                                 row,
-                                orderedRows: section.herdrSessionRows
+                                groupItems: groupItems
                             )
                         }
                     }
@@ -566,10 +568,11 @@ struct WorkspaceSidebarView: View {
                         )
                     )
                     if isExpanded(zellijSessionsKey) {
+                        let groupItems = sidebarDragItems(section.zellijSessionRows)
                         ForEach(section.zellijSessionRows) { row in
                             zellijSessionButton(
                                 row,
-                                orderedRows: section.zellijSessionRows
+                                groupItems: groupItems
                             )
                         }
                     }
@@ -646,11 +649,11 @@ struct WorkspaceSidebarView: View {
                                     }
                                 }
                                 if isExpanded(projectKey) {
+                                    let groupItems = sidebarDragItems(project.worktreeRows)
                                     ForEach(project.worktreeRows) { row in
                                         worktreeButton(
                                             row,
-                                            projectWorktreeIDs:
-                                            project.worktrees.map(\.id)
+                                            groupItems: groupItems
                                         )
                                     }
                                 }
@@ -760,9 +763,23 @@ struct WorkspaceSidebarView: View {
 
     // MARK: - Row builders
 
+    private func sidebarDragItems(_ rows: [WorkspaceSidebarRow]) -> [WorkspaceSidebarDragItem] {
+        let items: [WorkspaceSidebarDragItem] = rows.compactMap { row in
+            switch row.target {
+            case let .worktree(id): .worktree(id)
+            case let .tmuxSession(hostID, name): .tmuxSession(hostID: hostID, name: name)
+            case let .herdrSession(hostID, name): .herdrSession(hostID: hostID, name: name)
+            case let .zellijSession(hostID, name): .zellijSession(hostID: hostID, name: name)
+            default: nil
+            }
+        }
+        RenderWorkCounters.countSidebarDragItems(items.count)
+        return items
+    }
+
     private func tmuxSessionButton(
         _ row: WorkspaceSidebarRow,
-        orderedRows: [WorkspaceSidebarRow]
+        groupItems: [WorkspaceSidebarDragItem]
     ) -> some View {
         guard case let .tmuxSession(hostID, name) = row.target else {
             return AnyView(sidebarButton(row))
@@ -771,16 +788,6 @@ struct WorkspaceSidebarView: View {
             hostID: hostID,
             name: name
         )
-        let groupItems: [WorkspaceSidebarDragItem] = orderedRows.compactMap {
-            orderedRow in
-            guard case let .tmuxSession(orderedHostID, orderedName) =
-                orderedRow.target
-            else { return nil }
-            return WorkspaceSidebarDragItem.tmuxSession(
-                hostID: orderedHostID,
-                name: orderedName
-            )
-        }
         let content = AnyView(reorderableRow(
             sidebarButton(row),
             item: item,
@@ -794,7 +801,7 @@ struct WorkspaceSidebarView: View {
 
     private func herdrSessionButton(
         _ row: WorkspaceSidebarRow,
-        orderedRows: [WorkspaceSidebarRow]
+        groupItems: [WorkspaceSidebarDragItem]
     ) -> some View {
         guard case let .herdrSession(hostID, name) = row.target else {
             return AnyView(sidebarButton(row))
@@ -803,16 +810,6 @@ struct WorkspaceSidebarView: View {
             hostID: hostID,
             name: name
         )
-        let groupItems: [WorkspaceSidebarDragItem] = orderedRows.compactMap {
-            orderedRow in
-            guard case let .herdrSession(orderedHostID, orderedName) =
-                orderedRow.target
-            else { return nil }
-            return WorkspaceSidebarDragItem.herdrSession(
-                hostID: orderedHostID,
-                name: orderedName
-            )
-        }
         return AnyView(
             reorderableRow(
                 sidebarButton(row),
@@ -827,7 +824,7 @@ struct WorkspaceSidebarView: View {
 
     private func zellijSessionButton(
         _ row: WorkspaceSidebarRow,
-        orderedRows: [WorkspaceSidebarRow]
+        groupItems: [WorkspaceSidebarDragItem]
     ) -> some View {
         guard case let .zellijSession(hostID, name) = row.target else {
             return AnyView(sidebarButton(row))
@@ -836,16 +833,6 @@ struct WorkspaceSidebarView: View {
             hostID: hostID,
             name: name
         )
-        let groupItems: [WorkspaceSidebarDragItem] = orderedRows.compactMap {
-            orderedRow in
-            guard case let .zellijSession(orderedHostID, orderedName) =
-                orderedRow.target
-            else { return nil }
-            return WorkspaceSidebarDragItem.zellijSession(
-                hostID: orderedHostID,
-                name: orderedName
-            )
-        }
         return AnyView(
             reorderableRow(
                 sidebarButton(row),
@@ -862,6 +849,7 @@ struct WorkspaceSidebarView: View {
         _ row: WorkspaceSidebarRow,
         reservedTrailingActionWidth: CGFloat = 0
     ) -> some View {
+        RenderWorkCounters.countSidebarRowEvaluation()
         let tmuxSession = tmuxSessionSelection(for: row)
         let runningTmuxSession = tmuxSession.flatMap {
             WorkspaceSidebarModel.canRequestKill(
@@ -872,18 +860,15 @@ struct WorkspaceSidebarView: View {
                 activeTmuxSessionIsConnected
             ) ? $0 : nil
         }
-        let herdrActions = WorkspaceSidebarRowActionModel.actions(
-            for: row,
-            in: snapshot,
-            pendingHerdrSessions: pendingHerdrSessions
-        ).filter {
-            if case .killTmuxSession = $0 {
-                return false
-            }
-            if case .killZellijSession = $0 {
-                return false
-            }
-            return true
+        let herdrActions: [WorkspaceSidebarRowAction]
+        if case .herdrSession = row.target {
+            herdrActions = WorkspaceSidebarRowActionModel.actions(
+                for: row,
+                in: snapshot,
+                pendingHerdrSessions: pendingHerdrSessions
+            )
+        } else {
+            herdrActions = []
         }
         let herdrSelection: WorkspaceHerdrSessionSelection? = {
             guard case let .herdrSession(hostID, name) = row.target else {
@@ -1432,7 +1417,7 @@ struct WorkspaceSidebarView: View {
 
     private func worktreeButton(
         _ row: WorkspaceSidebarRow,
-        projectWorktreeIDs: [UUID]
+        groupItems: [WorkspaceSidebarDragItem]
     ) -> some View {
         guard case let .worktree(worktreeID) = row.target,
               let worktree = snapshot.worktree(id: worktreeID)
@@ -1572,9 +1557,7 @@ struct WorkspaceSidebarView: View {
             .modifier(
                 WorkspaceSidebarReorderModifier(
                     item: .worktree(worktreeID),
-                    groupItems: projectWorktreeIDs.map {
-                        .worktree($0)
-                    },
+                    groupItems: groupItems,
                     orderRawValue: worktreeOrderRawValue,
                     draggedItem: $draggedSidebarItem,
                     indicator: $reorderIndicator,
@@ -1688,6 +1671,7 @@ struct WorkspaceSidebarView: View {
         _ row: WorkspaceSidebarRow,
         content: AnyView
     ) -> AnyView {
+        guard sessionPreviewMode != .off else { return content }
         guard let tmuxSession = tmuxSessionSelection(for: row),
               TmuxSessionPreviewRowPresentation.canDisclose(
                   mode: sessionPreviewMode,

--- a/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
+++ b/Tests/TerminalSmoke/TerminalSurfaceViewInputTests.swift
@@ -4,6 +4,9 @@ import Foundation
 import GhosttyKit
 @testable import GhosthubApp
 import GhosthubTestSupport
+import GhosthubSettings
+import GhosthubTmux
+import GhosthubTransport
 import GhosthubUI
 import GhosthubWorkspace
 import SwiftUI
@@ -77,6 +80,17 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             ofItemAtPath: scriptURL.path
         )
         return scriptURL
+    }
+
+    private func pythonCommand(_ arguments: String...) throws -> String {
+        let executable = try XCTUnwrap(
+            ProcessInfo.processInfo.environment["GHOSTHUB_TEST_PYTHON"],
+            "Run terminal probes through tools/run_swift_tests.sh (make swift-test)."
+        )
+        // Python also uses argv[0] to locate its standard library. Let env
+        // receive libghostty's login prefix and launch Python normally.
+        return (["/usr/bin/env", executable] + arguments)
+            .map(shellQuotedCommandArgument).joined(separator: " ")
     }
 
     private func makeRawInputProbeScript(readBytes: Int) -> URL {
@@ -693,7 +707,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         let window = hostBuilder(view, CGSize(width: 800, height: 600))
@@ -1378,6 +1392,182 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         )
     }
 
+    /// Report-only: key dispatch to PTY echo in libghostty's text viewport.
+    /// This does not measure compositor presentation or physical display latency.
+    func testInputLatencyBenchmark() async throws {
+        guard ProcessInfo.processInfo.environment["GHOSTHUB_BENCHMARK_INPUT"] == "1" else {
+            throw XCTSkip("Run make benchmark-input in a macOS desktop session.")
+        }
+        defer { fflush(nil) } // The GUI launcher remains alive until its controller stops it.
+        let appHandle = try requireAppHandle()
+        let probe = makeExecutableScript("""
+        import os, sys, termios, tty
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            print("<READY>", flush=True)
+            count = 0
+            while True:
+                data = os.read(fd, 1)
+                if not data:
+                    break
+                print(f"\\r<ECHO:{count}:{data.hex()}>", end="", flush=True)
+                count += 1
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        """)
+        defer { try? FileManager.default.removeItem(at: probe) }
+        let probeCommand = try pythonCommand(probe.path)
+        let tmuxPath = try XCTUnwrap(ProcessInfo.processInfo.environment["PATH"]?
+            .split(separator: ":")
+            .map { String($0) + "/tmux" }
+            .first { FileManager.default.isExecutableFile(atPath: $0) })
+        let server = try TestTmuxServer(
+            tmuxPath: tmuxPath,
+            socket: .runOwned(purpose: "input-latency")
+        )
+        defer { server.stop() }
+        let suite = "InputLatency-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let (pipeline, configRoot) = makeIsolatedPipeline()
+        defer { try? FileManager.default.removeItem(at: configRoot) }
+        let settings = SettingsStore(configPipeline: pipeline, userDefaults: defaults)
+        settings.setSessionPreviewMode(.off)
+        let otherWindow = makeTestWindow(contentView: NSView(), requiresActiveApplication: true)
+        defer { otherWindow.orderOut(nil) }
+        for nativeTmux in [false, true] {
+            for (rowCount, sidebarVisible) in [(100, true), (500, true), (500, false)] {
+                let name = "input-\(rowCount)-\(sidebarVisible)"
+                let command: String
+                if nativeTmux {
+                    try server.createSession(name, command: probeCommand)
+                    command = TmuxAttachmentInfo(
+                        sessionName: name, host: .local,
+                        socketName: server.socketName, launchMode: .attachOnly
+                    ).attachCommand(tmuxPath: tmuxPath)
+                } else {
+                    command = probeCommand
+                }
+                let view = makeSurface(
+                    app: appHandle,
+                    configuration: TerminalSurfaceConfiguration(command: command)
+                )
+                let hostID = UUID()
+                var host = HostSummary(
+                    id: hostID,
+                    name: "This Mac",
+                    kind: .selfHost,
+                    platform: .macOS
+                )
+                host.tmuxSessions = (0 ..< rowCount).map {
+                    TmuxSessionSummary(
+                        name: $0 == 0 ? name : "session-\($0)",
+                        managed: false,
+                        windows: [],
+                        serverPID: "101",
+                        sessionID: "$\($0)",
+                        createdAt: "1000"
+                    )
+                }
+                let snapshot = WorkspaceSnapshot(hosts: [host], projects: [], worktrees: [])
+                let root = RootView(
+                    display: WorkspaceDisplayState(
+                        snapshot: snapshot,
+                        activeTmuxSession: WorkspaceTmuxSessionSelection(
+                            hostID: hostID,
+                            name: name
+                        )
+                    ),
+                    content: ContentBuilders(tmuxSessionContentBuilder: { _, _, _, _ in
+                        AnyView(TerminalSurfaceSwiftUIView(surfaceView: view))
+                    }),
+                    settingsStore: settings,
+                    selection: .constant(WorkspaceSelection(selectedHostID: hostID)),
+                    columnVisibility: .constant(sidebarVisible ? .all : .detailOnly),
+                    isCommandPalettePresented: .constant(false)
+                ).defaultAppStorage(defaults)
+                let window = makeTestWindow(contentView: NSHostingView(rootView: root))
+                defer { window.orderOut(nil) }
+                window.makeFirstResponder(view)
+                view.focusDidChange(true)
+                waitForProbeReady(in: view)
+                XCTAssertTrue(readViewportText(from: view).contains("<READY>"))
+                var sequence = 0
+                for refocus in [false, true] {
+                    if refocus {
+                        otherWindow.makeKeyAndOrderFront(nil)
+                        try await Task.sleep(for: .milliseconds(20))
+                        guard otherWindow.isKeyWindow else {
+                            print(
+                                "INPUT backend=\(nativeTmux ? "tmux" : "pty") rows=\(rowCount) sidebar=\(sidebarVisible) refocus=unavailable (no key-window delivery)"
+                            )
+                            continue
+                        }
+                    }
+                    var echoSamples: [Double] = []
+                    var dispatchSamples: [Double] = []
+                    var longestPump = 0.0
+                    // Five warmups, then 30 measured keystrokes per scenario.
+                    for index in 0 ..< 35 {
+                        if refocus {
+                            otherWindow.makeKeyAndOrderFront(nil)
+                            XCTAssertTrue(
+                                otherWindow.isKeyWindow,
+                                "Refocus requires key-window delivery."
+                            )
+                            try await Task.sleep(for: .milliseconds(20))
+                        }
+                        let start = ProcessInfo.processInfo.systemUptime
+                        if refocus {
+                            window.makeKeyAndOrderFront(nil)
+                            XCTAssertTrue(window.isKeyWindow, "Terminal window did not become key.")
+                        }
+                        XCTAssertTrue(window.firstResponder === view)
+                        window.sendEvent(makeKeyEvent(
+                            characters: "x",
+                            charactersIgnoringModifiers: "x",
+                            modifiers: [],
+                            keyCode: 7,
+                            windowNumber: window.windowNumber
+                        ))
+                        let dispatched = ProcessInfo.processInfo.systemUptime
+                        let marker = "<ECHO:\(sequence):78>"
+                        sequence += 1
+                        while !readViewportText(from: view).contains(marker),
+                              ProcessInfo.processInfo.systemUptime - start < 2 {
+                            let pumpStart = ProcessInfo.processInfo.systemUptime
+                            try await Task.sleep(for: .milliseconds(1))
+                            if index >= 5 {
+                                longestPump = max(
+                                    longestPump,
+                                    ProcessInfo.processInfo.systemUptime - pumpStart
+                                )
+                            }
+                        }
+                        let echoed = ProcessInfo.processInfo.systemUptime
+                        XCTAssertTrue(
+                            readViewportText(from: view).contains(marker),
+                            "Missing \(marker)"
+                        )
+                        if index >= 5 {
+                            echoSamples.append((echoed - start) * 1000)
+                            dispatchSamples.append((dispatched - start) * 1000)
+                        }
+                    }
+                    echoSamples.sort()
+                    dispatchSamples.sort()
+                    print(
+                        "INPUT backend=\(nativeTmux ? "tmux" : "pty") rows=\(rowCount) sidebar=\(sidebarVisible) refocus=\(refocus) samples=30 echo_ms_p50=\(echoSamples[14]) echo_ms_p95=\(echoSamples[28]) dispatch_ms_p95=\(dispatchSamples[28]) longest_pump_ms=\(longestPump * 1000)"
+                    )
+                }
+                await view.shutdown()
+                window.orderOut(nil)
+            }
+        }
+    }
+
     func testControlASendsSOHToPTY() throws {
         try assertPTYReceives(
             readBytes: 1,
@@ -1597,7 +1787,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
     func testForeignLauncherVariablesDoNotLeakIntoChildShell() throws {
         let appHandle = try requireAppHandle()
 
-        withTemporaryEnvironment([
+        try withTemporaryEnvironment([
             "EDITOR": "vim",
             "KITTY_WINDOW_ID": "123",
             "KITTY_PID": "456",
@@ -1617,7 +1807,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
             let view = makeSurface(
                 app: appHandle,
                 configuration: TerminalSurfaceConfiguration(
-                    command: "python3 '\(scriptURL.path)'"
+                    command: try pythonCommand(scriptURL.path)
                 )
             )
             _ = hostInWindow(view, size: CGSize(width: 800, height: 600))
@@ -1660,7 +1850,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 -c 'import time; time.sleep(10)'"
+                command: try pythonCommand("-c", "import time; time.sleep(10)")
             )
         )
         _ = hostInWindow(view, size: CGSize(width: 800, height: 600))
@@ -2263,7 +2453,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var sunkData: [Data] = []
@@ -2359,7 +2549,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var sunkData: [Data] = []
@@ -2401,7 +2591,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var sunkData: [Data] = []
@@ -2442,7 +2632,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var sunkData: [Data] = []
@@ -2535,7 +2725,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         let png = Data([0x89, 0x50, 0x4E, 0x47])
@@ -2570,7 +2760,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var receivedImage: TerminalClipboardImage?
@@ -2603,7 +2793,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.remoteImagePasteHandler = { _ in }
@@ -2655,7 +2845,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         var receivedImage: TerminalClipboardImage?
@@ -2699,7 +2889,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true
@@ -2811,7 +3001,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true
@@ -2886,7 +3076,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true
@@ -2949,7 +3139,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true
@@ -3001,7 +3191,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true
@@ -3048,7 +3238,7 @@ final class TerminalSurfaceViewInputTests: XCTestCase {
         let view = makeSurface(
             app: appHandle,
             configuration: TerminalSurfaceConfiguration(
-                command: "python3 '\(scriptURL.path)'"
+                command: try pythonCommand(scriptURL.path)
             )
         )
         view.blocksClipboardReads = true

--- a/Tests/UI/ActivationWorkGateTests.swift
+++ b/Tests/UI/ActivationWorkGateTests.swift
@@ -74,6 +74,27 @@ struct ActivationWorkGateTests {
         #expect(second.value(forKey: "accessibilityValue") as? String == "Expanded")
     }
 
+    @Test("session selection builds sibling drag items once per group", arguments: [100, 500])
+    func sidebarSelectionWork(sessionCount: Int) {
+        let gate = GateEnvironment(sessionCount: sessionCount)
+        defer { gate.close() }
+        var samples: [Double] = []
+        RenderWorkCounters.beginRecording()
+        for index in 0 ..< 10 {
+            let start = ProcessInfo.processInfo.systemUptime
+            gate.selectSession(index + 2)
+            samples.append((ProcessInfo.processInfo.systemUptime - start) * 1000)
+        }
+        let counts = RenderWorkCounters.endRecording()
+        samples.sort()
+        print(
+            "SIDEBAR rows=\(sessionCount) selection_ms p50=\(samples[4]) p95=\(samples[9]) rows_built=\(counts.sidebarRowEvaluations) drag_items=\(counts.sidebarDragItems)"
+        )
+        #expect(counts.sidebarRowEvaluations > 0)
+        #expect(counts.sidebarSectionComputations == 0)
+        #expect(counts.sidebarDragItems <= counts.sidebarRowEvaluations * 2)
+    }
+
     /// Budgets are a ratchet at the measured baseline plus 30%: 10 switches
     /// cost exactly 20 root body evaluations (one per window per switch)
     /// and no sidebar section recomputation. The headroom absorbs a stray
@@ -88,9 +109,9 @@ struct ActivationWorkGateTests {
         static let sidebarSectionComputations = 0
     }
 
-    @Test("key-window switching stays within the render work budget")
-    func keyWindowSwitchingStaysWithinRenderWorkBudget() {
-        let gate = GateEnvironment()
+    @Test("key-window switching stays within the render work budget", arguments: [100, 500])
+    func keyWindowSwitchingStaysWithinRenderWorkBudget(sessionCount: Int) {
+        let gate = GateEnvironment(sessionCount: sessionCount)
         defer { gate.close() }
 
         RenderWorkCounters.beginRecording()
@@ -231,6 +252,20 @@ private final class GateEnvironment {
             model.isActive = modelIndex == index
         }
         settle()
+    }
+
+    func selectSession(_ index: Int) {
+        let model = windowModels[0]
+        let session = WorkspaceTmuxSessionSelection(
+            hostID: snapshot.hosts[0].id,
+            name: "session-\(index)"
+        )
+        model.selection.select(
+            .tmuxSession(hostID: session.hostID, name: session.name),
+            in: snapshot
+        )
+        model.activeSession = session
+        settle(for: 0.001)
     }
 
     func close() {

--- a/docs/sidebar-performance.md
+++ b/docs/sidebar-performance.md
@@ -90,41 +90,105 @@ from consumption eliminates one of the two full overlays formerly reached by
 that path. Identical subscriber registration still recomputes subscriber host
 sets; avoiding that work is a smaller remaining opportunity.
 
+## Expanded-row measurements (September 11)
+
+The follow-up compares ten session selections at 100 and 500 stable synthetic
+sessions per host. Two real `RootView` windows use isolated preferences; tmux
+groups are expanded, previews are off, and selection changes in one window.
+The baseline is `ec8f8d4b` plus the same measurement instrumentation. The
+measurements use a Debug build on Apple Silicon with macOS 26.6.2.
+
+| Sessions | Drag items built before | After | Selection median before | After |
+| --- | ---: | ---: | ---: | ---: |
+| 100 | 110,000 | 1,100 | 22 ms | 20 ms |
+| 500 | 2,750,000 | 5,500 | 186 ms | 131 ms |
+
+These are representative samples, not timing thresholds. The timed interval
+includes selection publication, a 1 ms run-loop turn, and hosting-view layout;
+it does not establish display presentation time. Row evaluations remain 1,111
+and 5,511 respectively. Cached sections are not recomputed. The remaining
+131 ms at 500 rows is still too expensive for frequent interaction.
+
+The sidebar now builds one sibling drag array per expanded group, including
+worktrees, and shares it among the group's rows. It constructs Herdr actions
+only for Herdr rows, avoiding a discarded second tmux killability scan. Preview
+rows skip session resolution when previews are off, and empty saved ordering
+preserves input order without sorting. Existing ordering and lifecycle action
+coverage remains in place.
+
+`ActivationWorkGateTests.sidebarSelectionWork` bounds drag construction relative
+to actual row evaluations at both sizes. The old implementation fails at both
+sizes. Window activation also runs against 100 and 500 sessions while retaining
+the existing root/section budgets. Timing output is report-only.
+
 ## Remaining rendering costs
 
-These costs are established by source inspection, not timing measurements.
-They mostly predate `4c8bd7ed` and deserve a separate rendering benchmark.
+These costs are established by source inspection. Their individual contributions
+to the measured selection time have not been isolated.
 
-1. **Reorder metadata grows quadratically within a group.**
-   `WorkspaceSidebarView.hostContents` maps all worktree IDs inside each row's
-   construction, and `worktreeButton` maps them again into drag items. The
-   session-row builders similarly reconstruct all siblings for every row.
-   Build one drag-item array per group and pass it to its rows.
-2. **Rows repeat linear inventory lookups.** `sidebarButton` computes tmux
-   killability, calls the general action builder, and then discards that
-   builder's tmux/Zellij actions. The second call repeats the tmux session scan.
-   Worktree and preview builders also resolve the same worktree repeatedly.
-   Reuse known row data and invoke the Herdr action builder only for Herdr rows.
-3. **Hover invalidates the whole sidebar.** Hover state and dismissal tasks
+1. **Rows repeat linear inventory lookups.** Each tmux row still scans the host's
+   sessions for killability. Worktree and enabled-preview builders resolve the
+   same worktree repeatedly. Reuse known row data where it preserves the active
+   connection and protected-workspace contracts.
+2. **Hover invalidates the whole sidebar.** Hover state and dismissal tasks
    belong to `WorkspaceSidebarView`; nested ordinary `VStack` containers eagerly
    construct expanded groups. Row views can own hover state, following the
    existing `ProjectRemovalButton` pattern. Measure row construction and layout
    before changing virtualization; an outer `LazyVStack` alone leaves eager
    descendants.
-4. **Section-cache misses scan the fleet repeatedly.**
+3. **Section-cache misses scan the fleet repeatedly.**
    `WorkspaceSidebarModel.sections` filters all worktrees per project and all
-   terminal sessions per worktree. `WorkspaceSidebarOrder.ordered` rebuilds
-   its full position index per group, even for empty saved ordering. Group
-   inputs once per computation and reuse order indexes before adding caches.
-5. **Changed-file updates observe at sidebar scope.** `WorktreeChangesStore`
+   terminal sessions per worktree. Populated saved ordering rebuilds its full
+   position index per group. Group inputs once per computation before adding
+   more retained caches.
+4. **Changed-file updates observe at sidebar scope.** `WorktreeChangesStore`
    publishes its entry dictionary to the sidebar. A changed panel can invalidate
    unrelated rows. Unchanged successful polls already suppress publication;
    blaming every five-second poll would be incorrect.
 
-`make test-activation-gate` covers root-body evaluations and section-cache
-computations for two small windows. It does not measure row construction,
-hover, layout, scrolling, or inventory merging. The next useful benchmark is
-100 versus 500 synthetic rows, with projects expanded and previews off,
-measuring selection, pointer movement, disclosure, and one changed-file result
-separately. Session fixtures need stable tmux identities so action controls
-participate in the measurement.
+Expanded worktree projects, hover, disclosure, scrolling, and one changed-file
+result still need separate interaction measurements under `s921`. The broader
+activation side-effect and causality contract remains under `360m`.
+
+## Terminal input probes
+
+The input smoke tests previously launched bare `python3`. With a mise shim,
+libghostty's login-style argument zero became `-python3`, and the probe exited
+before reading input. A direct Python path also needs a normal argument zero to
+locate its standard library. Both test launchers now select Python with
+`uv python find`; the tests launch it through `/usr/bin/env`. Production shell
+startup and shell integration are unchanged. The real Ctrl-A and Option-D
+regressions fail before this change and pass afterward.
+
+Run `make benchmark-input` after bootstrapping libghostty to measure a local
+PTY and an isolated native tmux client with 100/500 sidebar sessions, previews
+off, and the sidebar shown/hidden. It uses the standard Swift test runner,
+temporary preferences/configuration, and the standard private tmux server
+fixture. It does not attach to existing sessions. The test shuts down every
+terminal surface before returning.
+
+For each scenario, five warmup keystrokes precede 30 measured `x` events. A raw
+Python probe writes a small, uniquely numbered response on the current line.
+The benchmark reports key-dispatch and key-to-libghostty-text-viewport timing,
+plus the longest main-actor polling delay. Polling requests a 1 ms sleep, so
+scheduler delay sets a lower bound on observed echo time. The benchmark does
+not time Core Animation presentation or physical display refresh, and the
+terminal smoke runtime disables vsync.
+
+Window-refocus samples require both windows to actually become key. If this
+session cannot deliver key-window transitions, the report explicitly says
+`refocus=unavailable`; a retained first responder alone is insufficient proof.
+These switches are between test windows, not Command-Tab from another app.
+Refocus timing starts before making the terminal window key, so its dispatch
+and echo measurements include the activation work.
+Remote transport, active preview workloads, real application activation,
+full-screen terminal workloads, and display presentation remain under `w8v8`.
+
+On September 11, the six steady-input scenarios reported median echo times of
+1.2–2.2 ms and p95 times of 2.2–2.3 ms. Dispatch p95 stayed below 0.08 ms;
+the longest polling delay was 4.3 ms, including its requested sleep. This
+small-line echo workload did not reproduce the reported typing lag. These are
+text-viewport observations, not visible-frame timings. Window-refocus delivery
+was unavailable, including through the AppKit launcher; that launcher's process
+inspection/cleanup also failed after its benchmark test passed. No activation
+latency conclusion is drawn from those attempts.

--- a/tools/run_swift_tests.sh
+++ b/tools/run_swift_tests.sh
@@ -131,6 +131,10 @@ trap 'forward_signal HUP' HUP
 
 export TMUX_TMPDIR="$tmux_tmpdir"
 export GHOSTHUB_TEST_TMUX_RUN_ID="$run_id"
+# libghostty gives direct commands a login-style argv[0]. Version-manager
+# shims can reject that name, so probes need a concrete Python interpreter.
+GHOSTHUB_TEST_PYTHON=$(uv python find)
+export GHOSTHUB_TEST_PYTHON
 # Swift Testing schedules test bodies independently of SwiftPM's worker flag.
 # Bound that executor so process and cancellation tests are not starved by the
 # full package starting at once. Callers can override the cap when needed.

--- a/tools/tests/test_gui_test_launcher.py
+++ b/tools/tests/test_gui_test_launcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -53,6 +54,7 @@ def test_launcher_environment_supplies_xctest_runtime_paths(
                     "SHELL": "/bin/zsh",
                     "TMUX_TMPDIR": "/tmp/tmux",
                     "GHOSTHUB_TEST_TMUX_RUN_ID": "run-id",
+                    "GHOSTHUB_TEST_PYTHON": CommandLine.arguments[1],
                     "GHOSTTY_RESOURCES_DIR": "/tmp/resources",
                     "DYLD_LIBRARY_PATH": "/untrusted/library",
                     "DYLD_FRAMEWORK_PATH": "/untrusted/framework",
@@ -74,6 +76,17 @@ def test_launcher_environment_supplies_xctest_runtime_paths(
                 else {
                     throw NSError(domain: "LauncherEnvironmentProbe", code: 1)
                 }
+                let python = Process()
+                python.executableURL = URL(fileURLWithPath: environment["GHOSTHUB_TEST_PYTHON"]!)
+                python.arguments = ["-c", "import encodings; print('PROBE_READY')"]
+                let output = Pipe()
+                python.standardOutput = output
+                try python.run()
+                python.waitUntilExit()
+                let text = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+                guard python.terminationStatus == 0, text.trimmingCharacters(in: .whitespacesAndNewlines) == "PROBE_READY" else {
+                    throw NSError(domain: "LauncherEnvironmentProbe", code: 2)
+                }
             }
         }
         """
@@ -92,7 +105,7 @@ def test_launcher_environment_supplies_xctest_runtime_paths(
         text=True,
     )
     assert compilation.returncode == 0, compilation.stderr
-    subprocess.run([str(probe)], check=True)
+    subprocess.run([str(probe), sys.executable], check=True)
 
 
 def test_already_regular_activation_policy_is_accepted(tmp_path: Path) -> None:


### PR DESCRIPTION
- Reduce work when selecting sessions in large expanded sidebars. Build sibling drag lists once per group and skip unused action and ordering work; the 500-session fixture improved from 186 ms to 131 ms median selection/layout time.
- Restore Python-backed terminal input tests when Python is managed by mise. Both test launchers select Python through uv and preserve its normal argument zero without changing production shell startup.
- Add 100/500-session work budgets and `make benchmark-input` for opt-in measurements. Routine CI excludes the benchmark. Local text-viewport echo measured about 2 ms; remote, preview, display, and Command-Tab latency remain open investigations. See [the performance report](https://github.com/kenn-io/ghosthub/blob/87c7009e769a9583e6fafa191a5ed15e60025dfb/docs/sidebar-performance.md).
- The build, full Swift/Python suites, bootstrap checks, and workflow gates pass. The Swift run skipped five desktop-dependent tests and the opt-in benchmark; the separate local input benchmark passes and explicitly reports unavailable key-window transitions.
